### PR TITLE
Chart fix

### DIFF
--- a/packages/app/src/app/resources/[id]/page.tsx
+++ b/packages/app/src/app/resources/[id]/page.tsx
@@ -279,8 +279,14 @@ const MarketContent = ({ params }: { params: { id: string } }) => {
               }}
               activeWindow={TimeWindow.D}
               isLoading={isResourcePricesLoading}
-              seriesVisibility={seriesVisibility}
+              seriesVisibility={{
+                candles: false,
+                index: false,
+                resource: true,
+              }}
               toggleSeries={toggleSeries}
+              filterResourcePrices={false}
+              resourceOnly={true}
             />
           </div>
         </div>

--- a/packages/app/src/lib/components/chart.tsx
+++ b/packages/app/src/lib/components/chart.tsx
@@ -181,6 +181,9 @@ const CandlestickChart: React.FC<Props> = ({
         resourcePriceSeriesRef.current.applyOptions({
           visible: seriesVisibility.resource,
         });
+        
+       
+        chartRef.current.timeScale().fitContent();
       }
       return;
     }
@@ -262,17 +265,10 @@ const CandlestickChart: React.FC<Props> = ({
     }
 
     if (chartRef.current) {
+      chartRef.current.timeScale().resetTimeScale();
       chartRef.current.timeScale().fitContent();
-
-      const visibleLogicalRange = chartRef.current.timeScale().getVisibleLogicalRange();
-      if (visibleLogicalRange !== null) {
-        chartRef.current.timeScale().setVisibleLogicalRange({
-          from: visibleLogicalRange.from,
-          to: visibleLogicalRange.to + 5,
-        });
-      }
     }
-  }, [data, isLoading, stEthPerToken, useMarketUnits, seriesVisibility, filterResourcePrices, resourceOnly]);
+  }, [data, isLoading, stEthPerToken, useMarketUnits, seriesVisibility, filterResourcePrices, resourceOnly, activeWindow]);
 
   return (
     <div className="flex flex-col flex-1">


### PR DESCRIPTION
Trade chart now displays resource price, index price, and candles properly. 

Few fixes are needed. Load time for index and resource price needs to be faster. Sometimes resource price comes up as 0 in the trade page and adjusts when data is loading.  