### PR TITLE
Blob fix

### DIFF
--- a/packages/api/src/migrations/1744775423017-migration.ts
+++ b/packages/api/src/migrations/1744775423017-migration.ts
@@ -1,14 +1,17 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class Migration1744775423017 implements MigrationInterface {
-    name = 'Migration1744775423017'
+  name = 'Migration1744775423017';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "market" ADD "collateralDecimals" integer`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "market" ADD "collateralDecimals" integer`
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "market" DROP COLUMN "collateralDecimals"`);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "market" DROP COLUMN "collateralDecimals"`
+    );
+  }
 }

--- a/packages/api/src/resourcePriceFunctions/ethBlobsIndexer.ts
+++ b/packages/api/src/resourcePriceFunctions/ethBlobsIndexer.ts
@@ -17,7 +17,7 @@ class ethBlobsIndexer implements IResourcePriceIndexer {
   public client: PublicClient;
   private isWatching: boolean = false;
   private blobscanApiUrl: string = 'https://api.blobscan.com';
-  private retryDelay: number = 5000; // Increased from 1 second to 5 seconds
+  private retryDelay: number = 5000;
   private maxRetries: number = Infinity;
 
   constructor(chainId: number) {

--- a/packages/api/src/resourcePriceFunctions/ethBlobsIndexer.ts
+++ b/packages/api/src/resourcePriceFunctions/ethBlobsIndexer.ts
@@ -17,7 +17,7 @@ class ethBlobsIndexer implements IResourcePriceIndexer {
   public client: PublicClient;
   private isWatching: boolean = false;
   private blobscanApiUrl: string = 'https://api.blobscan.com';
-  private retryDelay: number = 1000; // 1 second
+  private retryDelay: number = 5000; // Increased from 1 second to 5 seconds
   private maxRetries: number = Infinity;
 
   constructor(chainId: number) {


### PR DESCRIPTION
increasing delay to stop 429 errors on blob scan. 

lint adjusted the migration file structure but didn't change anything else 