### PR TITLE
Track vault uPnL via relayer quote and surface in chart

### DIFF
--- a/packages/api/prisma/migrations/20260210202355_add_vault_upnl_columns/migration.sql
+++ b/packages/api/prisma/migrations/20260210202355_add_vault_upnl_columns/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "protocol_stats_snapshot" ADD COLUMN     "uPnLQuoteFromRelayer" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "vaultCollateralPerShare" VARCHAR NOT NULL DEFAULT '0',
+ADD COLUMN     "vaultFairValueAssets" VARCHAR NOT NULL DEFAULT '0',
+ADD COLUMN     "vaultTotalSupply" VARCHAR NOT NULL DEFAULT '0',
+ADD COLUMN     "vaultUPnL" VARCHAR NOT NULL DEFAULT '0';

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -434,6 +434,17 @@ model ProtocolStatsSnapshot {
   vaultCollateralWon    String   @default("0") @db.VarChar
   vaultCollateralLost   String   @default("0") @db.VarChar
 
+  /// Vault collateral per share from relayer quote (decimal string, e.g. "1.05")
+  vaultCollateralPerShare  String   @default("0") @db.VarChar
+  /// Vault totalSupply on-chain (in wei)
+  vaultTotalSupply         String   @default("0") @db.VarChar
+  /// Vault total assets at fair value: collateralPerShare * totalSupply (in wei)
+  vaultFairValueAssets     String   @default("0") @db.VarChar
+  /// uPnL = fairValueAssets - bookValue (in wei, can be negative)
+  vaultUPnL                String   @default("0") @db.VarChar
+  /// Whether the quote was fetched from relayer (false = fallback to book value)
+  uPnLQuoteFromRelayer     Boolean  @default(false)
+
   @@unique([chainId, vaultAddress, timestamp], map: "UQ_protocol_stats_snapshot_chain_vault_timestamp")
   @@index([timestamp], map: "IDX_protocol_stats_snapshot_timestamp")
   @@index([chainId])

--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -1196,16 +1196,22 @@ type ProtocolStat {
   escrowBalance: String!
   openInterest: String!
 
+
   """Unix epoch timestamp (seconds) for midnight UTC of the snapshot day"""
   timestamp: Int!
+  uPnLQuoteFromRelayer: Boolean!
   vaultAirdropGains: String!
   vaultAvailableAssets: String!
   vaultBalance: String!
+  vaultCollateralPerShare: String!
   vaultCumulativePnL: String!
   vaultDeployed: String!
   vaultDeposits: String!
+  vaultFairValueAssets: String!
   vaultPositionsLost: Int!
   vaultPositionsWon: Int!
+  vaultTotalSupply: String!
+  vaultUPnL: String!
   vaultWithdrawals: String!
 }
 

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -46,6 +46,10 @@ const validators = {
     default: 50,
     desc: 'Max concurrent GraphQL operations before shedding load with 503',
   }),
+  RELAYER_WS_URL: str({
+    default: 'wss://relayer.sapience.xyz/auction',
+    desc: 'WebSocket URL for the relayer (vault quotes, auctions)',
+  }),
   // x402 payment integration
   X402_PAY_TO: str({
     default: '',

--- a/packages/api/src/graphql/resolvers/AnalyticsResolver.ts
+++ b/packages/api/src/graphql/resolvers/AnalyticsResolver.ts
@@ -59,6 +59,21 @@ class ProtocolStat {
   vaultAirdropGains!: string;
 
   @Field(() => String)
+  vaultCollateralPerShare!: string;
+
+  @Field(() => String)
+  vaultTotalSupply!: string;
+
+  @Field(() => String)
+  vaultFairValueAssets!: string;
+
+  @Field(() => String)
+  vaultUPnL!: string;
+
+  @Field(() => Boolean)
+  uPnLQuoteFromRelayer!: boolean;
+
+  @Field(() => String)
   dailyPnL!: string;
 
   @Field(() => String)
@@ -193,6 +208,11 @@ export class AnalyticsResolver {
         vaultDeposits: snapshot.vaultDeposits,
         vaultWithdrawals: snapshot.vaultWithdrawals,
         vaultAirdropGains: snapshot.vaultAirdropGains,
+        vaultCollateralPerShare: snapshot.vaultCollateralPerShare,
+        vaultTotalSupply: snapshot.vaultTotalSupply,
+        vaultFairValueAssets: snapshot.vaultFairValueAssets,
+        vaultUPnL: snapshot.vaultUPnL,
+        uPnLQuoteFromRelayer: snapshot.uPnLQuoteFromRelayer,
         dailyPnL,
         dailyVolume,
       };

--- a/packages/api/src/helpers/protocolStats.test.ts
+++ b/packages/api/src/helpers/protocolStats.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
 
-const { mockPrisma, mockReadContract } = vi.hoisted(() => {
+const { mockPrisma, mockReadContract, MockWebSocket } = vi.hoisted(() => {
   const mockReadContract = vi.fn().mockResolvedValue(1000000000000000000n);
   const mockPrisma = {
     prediction: { findMany: vi.fn() },
@@ -15,7 +15,26 @@ const { mockPrisma, mockReadContract } = vi.hoisted(() => {
       findMany: vi.fn(),
     },
   };
-  return { mockPrisma, mockReadContract };
+  // Minimal mock that immediately fires 'close' so fetchVaultQuoteFromRelayer resolves with null
+  class MockWebSocket {
+    private handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+    constructor() {
+      // Schedule open + close so the promise settles immediately
+      setTimeout(() => {
+        this.emit('open');
+        this.emit('close');
+      }, 0);
+    }
+    on(event: string, handler: (...args: unknown[]) => void) {
+      (this.handlers[event] ??= []).push(handler);
+    }
+    send() {}
+    close() {}
+    private emit(event: string) {
+      for (const h of this.handlers[event] ?? []) h();
+    }
+  }
+  return { mockPrisma, mockReadContract, MockWebSocket };
 });
 
 vi.mock('../db', () => ({ default: mockPrisma }));
@@ -51,6 +70,12 @@ vi.mock('@sapience/sdk/abis', () => ({
 
 vi.mock('@sapience/sdk/constants', () => ({
   DEFAULT_CHAIN_ID: 42161,
+}));
+
+vi.mock('ws', () => ({ default: MockWebSocket }));
+
+vi.mock('../config', () => ({
+  config: { RELAYER_WS_URL: 'ws://localhost:0/test' },
 }));
 
 import {
@@ -208,6 +233,13 @@ describe('computeAndStoreProtocolStats', () => {
     expect(create.vaultCollateralWon).toBe('0');
     expect(create.vaultCollateralLost).toBe('0');
 
+    // uPnL fields (relayer mock returns null, so defaults)
+    expect(create.vaultCollateralPerShare).toBe('0');
+    expect(create.vaultTotalSupply).toBe('1000000000000000000'); // mockReadContract returns 1e18
+    expect(create.vaultFairValueAssets).toBeDefined();
+    expect(create.vaultUPnL).toBeDefined();
+    expect(create.uPnLQuoteFromRelayer).toBe(false);
+
     // Verify update payload matches create payload for all value fields
     const update = upsertCall.update;
     expect(update.vaultBalance).toBe(create.vaultBalance);
@@ -222,6 +254,11 @@ describe('computeAndStoreProtocolStats', () => {
     expect(update.vaultPositionsLost).toBe(create.vaultPositionsLost);
     expect(update.vaultCollateralWon).toBe(create.vaultCollateralWon);
     expect(update.vaultCollateralLost).toBe(create.vaultCollateralLost);
+    expect(update.vaultCollateralPerShare).toBe(create.vaultCollateralPerShare);
+    expect(update.vaultTotalSupply).toBe(create.vaultTotalSupply);
+    expect(update.vaultFairValueAssets).toBe(create.vaultFairValueAssets);
+    expect(update.vaultUPnL).toBe(create.vaultUPnL);
+    expect(update.uPnLQuoteFromRelayer).toBe(create.uPnLQuoteFromRelayer);
   });
 });
 

--- a/packages/api/src/helpers/protocolStats.ts
+++ b/packages/api/src/helpers/protocolStats.ts
@@ -202,12 +202,17 @@ export async function fetchVaultQuoteFromRelayer(
     }
 
     ws.on('open', () => {
-      ws.send(
-        JSON.stringify({
-          type: 'vault_quote.subscribe',
-          payload: { chainId, vaultAddress },
-        })
-      );
+      try {
+        ws.send(
+          JSON.stringify({
+            type: 'vault_quote.subscribe',
+            payload: { chainId, vaultAddress },
+          })
+        );
+      } catch (err) {
+        console.warn('[ProtocolStats] Failed to send subscribe message:', err);
+        settle(null);
+      }
     });
 
     ws.on('message', (raw: WebSocket.Data) => {

--- a/packages/api/src/helpers/protocolStats.ts
+++ b/packages/api/src/helpers/protocolStats.ts
@@ -1,10 +1,12 @@
-import { erc20Abi, formatUnits } from 'viem';
+import { erc20Abi, formatUnits, parseUnits } from 'viem';
+import WebSocket from 'ws';
 import prisma from '../db';
 import { LegacyPositionStatus } from '../../generated/prisma';
 import { getProviderForChain, getBlockByTimestamp } from '../utils/utils';
 import { contracts } from '@sapience/sdk/contracts';
 import { predictionMarketVaultAbi } from '@sapience/sdk/abis';
 import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
+import { config } from '../config';
 
 interface VaultPnLResult {
   realizedPnL: bigint;
@@ -32,6 +34,11 @@ interface ProtocolStatsData {
   vaultPositionsLost: number;
   vaultCollateralWon: bigint;
   vaultCollateralLost: bigint;
+  vaultCollateralPerShare: string;
+  vaultTotalSupply: bigint;
+  vaultFairValueAssets: bigint;
+  vaultUPnL: bigint;
+  uPnLQuoteFromRelayer: boolean;
 }
 
 /**
@@ -129,6 +136,123 @@ export async function fetchVaultAvailableAssets(
   })) as bigint;
 
   return availableAssets;
+}
+
+/**
+ * Fetch Vault totalSupply (shares outstanding, in wei).
+ */
+export async function fetchVaultTotalSupply(
+  chainId: number = DEFAULT_CHAIN_ID
+): Promise<bigint> {
+  const client = getProviderForChain(chainId);
+  const vaultAddress = contracts.predictionMarketVault[chainId]?.address;
+
+  if (!vaultAddress) {
+    throw new Error(`Vault not configured for chain ${chainId}`);
+  }
+
+  const totalSupply = (await client.readContract({
+    address: vaultAddress,
+    abi: predictionMarketVaultAbi,
+    functionName: 'totalSupply',
+    args: [],
+  })) as bigint;
+
+  return totalSupply;
+}
+
+/**
+ * Fetch vault collateralPerShare from relayer via ephemeral WebSocket.
+ * Returns the decimal string (e.g. "1.05") or null on timeout/error.
+ */
+export async function fetchVaultQuoteFromRelayer(
+  chainId: number,
+  vaultAddress: string,
+  timeoutMs: number = 30_000
+): Promise<{ vaultCollateralPerShare: string } | null> {
+  const wsUrl = config.RELAYER_WS_URL;
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (value: { vaultCollateralPerShare: string } | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        ws.close();
+      } catch {
+        // ignore close errors
+      }
+      resolve(value);
+    };
+
+    const timer = setTimeout(() => {
+      console.warn('[ProtocolStats] Relayer vault quote timed out');
+      settle(null);
+    }, timeoutMs);
+
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(wsUrl);
+    } catch (err) {
+      console.warn('[ProtocolStats] Failed to create WebSocket:', err);
+      clearTimeout(timer);
+      resolve(null);
+      return;
+    }
+
+    ws.on('open', () => {
+      ws.send(
+        JSON.stringify({
+          type: 'vault_quote.subscribe',
+          payload: { chainId, vaultAddress },
+        })
+      );
+    });
+
+    ws.on('message', (raw: WebSocket.Data) => {
+      try {
+        const msg = JSON.parse(raw.toString()) as {
+          type?: string;
+          payload?: { vaultCollateralPerShare?: string };
+        };
+        if (
+          msg.type === 'vault_quote.update' &&
+          msg.payload?.vaultCollateralPerShare
+        ) {
+          settle({
+            vaultCollateralPerShare: msg.payload.vaultCollateralPerShare,
+          });
+        }
+      } catch {
+        // ignore parse errors
+      }
+    });
+
+    ws.on('error', (err: Error) => {
+      console.warn('[ProtocolStats] Relayer WebSocket error:', err.message);
+      settle(null);
+    });
+
+    ws.on('close', () => {
+      settle(null);
+    });
+  });
+}
+
+/**
+ * Compute fair-value total assets from collateralPerShare (decimal string) and totalSupply (wei).
+ * collateralPerShare is a decimal like "1.05" representing assets per 1e18 shares.
+ * Result = collateralPerShare * totalSupply (in wei).
+ */
+function computeFairValueAssets(
+  collateralPerShare: string,
+  totalSupply: bigint
+): bigint {
+  // Convert the decimal string to a fixed-point bigint with 18 decimals
+  const cpsWei = parseUnits(collateralPerShare, 18);
+  // fairValue = cps * totalSupply / 1e18
+  return (cpsWei * totalSupply) / 10n ** 18n;
 }
 
 /**
@@ -442,6 +566,11 @@ async function upsertProtocolStatsSnapshot(
       vaultPositionsLost: data.vaultPositionsLost,
       vaultCollateralWon: data.vaultCollateralWon.toString(),
       vaultCollateralLost: data.vaultCollateralLost.toString(),
+      vaultCollateralPerShare: data.vaultCollateralPerShare,
+      vaultTotalSupply: data.vaultTotalSupply.toString(),
+      vaultFairValueAssets: data.vaultFairValueAssets.toString(),
+      vaultUPnL: data.vaultUPnL.toString(),
+      uPnLQuoteFromRelayer: data.uPnLQuoteFromRelayer,
     },
     update: {
       vaultBalance: data.vaultBalance.toString(),
@@ -456,6 +585,11 @@ async function upsertProtocolStatsSnapshot(
       vaultPositionsLost: data.vaultPositionsLost,
       vaultCollateralWon: data.vaultCollateralWon.toString(),
       vaultCollateralLost: data.vaultCollateralLost.toString(),
+      vaultCollateralPerShare: data.vaultCollateralPerShare,
+      vaultTotalSupply: data.vaultTotalSupply.toString(),
+      vaultFairValueAssets: data.vaultFairValueAssets.toString(),
+      vaultUPnL: data.vaultUPnL.toString(),
+      uPnLQuoteFromRelayer: data.uPnLQuoteFromRelayer,
     },
   });
 }
@@ -518,6 +652,45 @@ export async function computeAndStoreProtocolStats(
     `[ProtocolStats] Airdrop gains: ${formatUnits(airdropGains, 18)} USDe`
   );
 
+  // Fetch vault totalSupply and relayer quote for uPnL
+  let totalSupply = 0n;
+  let collateralPerShare = '0';
+  let fairValueAssets = actualTotalAssets; // book value fallback
+  let uPnLQuoteFromRelayer = false;
+  let uPnL = 0n;
+
+  try {
+    totalSupply = await fetchVaultTotalSupply(chainId);
+    console.log(
+      `[ProtocolStats] Vault totalSupply: ${formatUnits(totalSupply, 18)}`
+    );
+
+    if (vaultAddress) {
+      const relayerQuote = await fetchVaultQuoteFromRelayer(
+        chainId,
+        vaultAddress
+      );
+      if (relayerQuote) {
+        collateralPerShare = relayerQuote.vaultCollateralPerShare;
+        fairValueAssets = computeFairValueAssets(
+          collateralPerShare,
+          totalSupply
+        );
+        uPnLQuoteFromRelayer = true;
+        uPnL = fairValueAssets - actualTotalAssets;
+        console.log(
+          `[ProtocolStats] Relayer quote: cps=${collateralPerShare}, fairValue=${formatUnits(fairValueAssets, 18)}, uPnL=${formatUnits(uPnL, 18)}`
+        );
+      } else {
+        console.log(
+          '[ProtocolStats] No relayer quote available, uPnL defaults to 0'
+        );
+      }
+    }
+  } catch (err) {
+    console.warn('[ProtocolStats] Failed to fetch uPnL data:', err);
+  }
+
   await upsertProtocolStatsSnapshot(timestamp, chainId, vaultAddress, {
     vaultBalance,
     vaultAvailableAssets,
@@ -531,6 +704,11 @@ export async function computeAndStoreProtocolStats(
     vaultPositionsLost: pnlResult.positionsLost,
     vaultCollateralWon: pnlResult.totalCollateralWon,
     vaultCollateralLost: pnlResult.totalCollateralLost,
+    vaultCollateralPerShare: collateralPerShare,
+    vaultTotalSupply: totalSupply,
+    vaultFairValueAssets: fairValueAssets,
+    vaultUPnL: uPnL,
+    uPnLQuoteFromRelayer,
   });
 
   console.log(`[ProtocolStats] Snapshot stored successfully`);
@@ -656,6 +834,11 @@ export async function backfillProtocolStats(
         vaultPositionsLost: pnlResult.positionsLost,
         vaultCollateralWon: pnlResult.totalCollateralWon,
         vaultCollateralLost: pnlResult.totalCollateralLost,
+        vaultCollateralPerShare: '0',
+        vaultTotalSupply: 0n,
+        vaultFairValueAssets: 0n,
+        vaultUPnL: 0n,
+        uPnLQuoteFromRelayer: false,
       });
 
       console.log(

--- a/packages/app/src/components/vaults/VaultPnlChart.tsx
+++ b/packages/app/src/components/vaults/VaultPnlChart.tsx
@@ -13,125 +13,21 @@ import {
 } from 'recharts';
 import { Tabs, TabsTrigger } from '@sapience/ui/components/ui/tabs';
 import {
+  formatLargeNumber,
+  formatTimestampTick,
+  AnimatedCursor,
+  ChartTooltip,
+  CHART_AXIS_STYLE,
+  CHART_MARGIN,
+  CURSOR_ANIMATION_STYLE,
+} from './chartUtils';
+import {
   useProtocolStats,
   type ProtocolStat,
 } from '~/hooks/graphql/useAnalytics';
 import Loader from '~/components/shared/Loader';
 import SegmentedTabsList from '~/components/shared/SegmentedTabsList';
 import { type Period, PERIOD_DAYS } from '~/components/shared/PeriodFilter';
-
-function formatLargeNumber(value: number): string {
-  if (value >= 1_000_000) {
-    return `${(value / 1_000_000).toFixed(1)}M`;
-  }
-  if (value >= 1_000) {
-    return `${(value / 1_000).toFixed(1)}K`;
-  }
-  if (value >= 1) {
-    return value.toFixed(1);
-  }
-  return value.toFixed(2);
-}
-
-function formatTimestampTick(value: number): string {
-  const date = new Date(value * 1000);
-  return `${date.getUTCMonth() + 1}/${date.getUTCDate()}`;
-}
-
-type AnimatedCursorProps = {
-  top?: number;
-  height?: number;
-  points?: Array<{ x: number; y: number }>;
-};
-
-function AnimatedCursor({ points, top, height }: AnimatedCursorProps) {
-  if (!points || points.length === 0) return null;
-
-  return (
-    <line
-      x1={points[0].x}
-      y1={top ?? 0}
-      x2={points[0].x}
-      y2={(top ?? 0) + (height ?? 0)}
-      stroke="hsl(var(--brand-white))"
-      strokeWidth={1}
-      strokeDasharray="1 3"
-      className="pnl-chart-cursor"
-    />
-  );
-}
-
-type ChartTooltipProps = {
-  active?: boolean;
-  payload?: Array<{
-    value?: number | string | (number | string)[];
-    dataKey?: string | number;
-  }>;
-  label?: string;
-  collateralSymbol: string;
-};
-
-function ChartTooltip({
-  active,
-  payload,
-  label,
-  collateralSymbol,
-}: ChartTooltipProps): React.ReactNode {
-  if (!active || !payload?.length) return null;
-
-  const dataPoint = payload.find((p) => p.dataKey === 'pnl');
-  if (!dataPoint || dataPoint.value == null) return null;
-
-  const value = Number(dataPoint.value);
-  const isPositive = value >= 0;
-  const formattedValue = value.toLocaleString(undefined, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  });
-
-  // Format timestamp (Unix seconds) to date string
-  let dateLabel = '';
-  if (label != null) {
-    const date = new Date(Number(label) * 1000);
-    const months = [
-      'Jan',
-      'Feb',
-      'Mar',
-      'Apr',
-      'May',
-      'Jun',
-      'Jul',
-      'Aug',
-      'Sep',
-      'Oct',
-      'Nov',
-      'Dec',
-    ];
-    dateLabel = `${months[date.getUTCMonth()]} ${date.getUTCDate()}, ${date.getUTCFullYear()}`;
-  }
-
-  return (
-    <div className="bg-background border border-border rounded-md px-3 py-2">
-      <div className="text-xs font-medium text-muted-foreground mb-1">
-        {dateLabel}
-      </div>
-      <div
-        className={`text-sm font-mono ${isPositive ? 'text-green-500' : 'text-red-500'}`}
-      >
-        {isPositive ? '+' : ''}
-        {formattedValue} {collateralSymbol}
-      </div>
-    </div>
-  );
-}
-
-const CHART_AXIS_STYLE = {
-  tick: { fill: 'hsl(var(--muted-foreground))', fontSize: 11 },
-  axisLine: { stroke: 'hsl(var(--brand-white) / 0.3)' },
-  tickLine: { stroke: 'hsl(var(--brand-white) / 0.3)' },
-};
-
-const CHART_MARGIN = { top: 10, right: 0, left: -15, bottom: 0 };
 
 type VaultPnlChartProps = {
   /** Optional external protocol stats data. If not provided, will fetch internally. */
@@ -365,6 +261,7 @@ export default function VaultPnlChart({
                     <ChartTooltip
                       {...props}
                       collateralSymbol={collateralSymbol}
+                      dataKey="pnl"
                     />
                   )}
                 />
@@ -387,16 +284,7 @@ export default function VaultPnlChart({
         )}
       </div>
 
-      <style jsx>{`
-        :global(.pnl-chart-cursor) {
-          animation: cursorDash 1.4s linear infinite;
-        }
-        @keyframes cursorDash {
-          to {
-            stroke-dashoffset: 8;
-          }
-        }
-      `}</style>
+      <style jsx>{CURSOR_ANIMATION_STYLE}</style>
     </div>
   );
 }

--- a/packages/app/src/components/vaults/VaultUPnLChart.tsx
+++ b/packages/app/src/components/vaults/VaultUPnLChart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CHAIN_ID_ETHEREAL, COLLATERAL_SYMBOLS } from '@sapience/sdk/constants';
+import { DEFAULT_CHAIN_ID, COLLATERAL_SYMBOLS } from '@sapience/sdk/constants';
 import { useMemo } from 'react';
 import {
   AreaChart,
@@ -11,120 +11,18 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts';
+import {
+  formatLargeNumber,
+  formatTimestampTick,
+  AnimatedCursor,
+  ChartTooltip,
+  CHART_AXIS_STYLE,
+  CHART_MARGIN,
+  CURSOR_ANIMATION_STYLE,
+} from './chartUtils';
 import { type ProtocolStat } from '~/hooks/graphql/useAnalytics';
 import Loader from '~/components/shared/Loader';
 import { type Period, PERIOD_DAYS } from '~/components/shared/PeriodFilter';
-
-function formatLargeNumber(value: number): string {
-  if (value >= 1_000_000) {
-    return `${(value / 1_000_000).toFixed(1)}M`;
-  }
-  if (value >= 1_000) {
-    return `${(value / 1_000).toFixed(1)}K`;
-  }
-  if (value >= 1) {
-    return value.toFixed(1);
-  }
-  if (value <= -1_000_000) {
-    return `${(value / 1_000_000).toFixed(1)}M`;
-  }
-  if (value <= -1_000) {
-    return `${(value / 1_000).toFixed(1)}K`;
-  }
-  if (value <= -1) {
-    return value.toFixed(1);
-  }
-  return value.toFixed(2);
-}
-
-function formatTimestampTick(value: string): string {
-  const date = new Date(parseInt(value, 10) * 1000);
-  return `${date.getUTCMonth() + 1}/${date.getUTCDate()}`;
-}
-
-type AnimatedCursorProps = {
-  top?: number;
-  height?: number;
-  points?: Array<{ x: number; y: number }>;
-};
-
-function AnimatedCursor({ points, top, height }: AnimatedCursorProps) {
-  if (!points || points.length === 0) return null;
-
-  return (
-    <line
-      x1={points[0].x}
-      y1={top ?? 0}
-      x2={points[0].x}
-      y2={(top ?? 0) + (height ?? 0)}
-      stroke="hsl(var(--brand-white))"
-      strokeWidth={1}
-      strokeDasharray="1 3"
-      className="upnl-chart-cursor"
-    />
-  );
-}
-
-type ChartTooltipProps = {
-  active?: boolean;
-  payload?: Array<{
-    value?: number | string | (number | string)[];
-    dataKey?: string | number;
-  }>;
-  label?: string;
-  collateralSymbol: string;
-};
-
-function ChartTooltip({
-  active,
-  payload,
-  label,
-  collateralSymbol,
-}: ChartTooltipProps): React.ReactNode {
-  if (!active || !payload?.length) return null;
-
-  const dataPoint = payload.find((p) => p.dataKey === 'upnl');
-  if (!dataPoint || dataPoint.value == null) return null;
-
-  const value = Number(dataPoint.value);
-  const isPositive = value >= 0;
-  const formattedValue = value.toLocaleString(undefined, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  });
-
-  let dateLabel = '';
-  if (label) {
-    const date = new Date(parseInt(label, 10) * 1000);
-    const months = [
-      'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
-    ];
-    dateLabel = `${months[date.getUTCMonth()]} ${date.getUTCDate()}, ${date.getUTCFullYear()}`;
-  }
-
-  return (
-    <div className="bg-background border border-border rounded-md px-3 py-2">
-      <div className="text-xs font-medium text-muted-foreground mb-1">
-        {dateLabel}
-      </div>
-      <div
-        className={`text-sm font-mono ${isPositive ? 'text-green-500' : 'text-red-500'}`}
-      >
-        {isPositive ? '+' : ''}
-        {formattedValue} {collateralSymbol}
-      </div>
-    </div>
-  );
-}
-
-const CHART_AXIS_STYLE = {
-  tick: { fill: 'hsl(var(--muted-foreground))', fontSize: 11 },
-  axisLine: { stroke: 'hsl(var(--brand-white) / 0.3)' },
-  tickLine: { stroke: 'hsl(var(--brand-white) / 0.3)' },
-};
-
-const CHART_MARGIN = { top: 10, right: 0, left: -15, bottom: 0 };
 
 type VaultUPnLChartProps = {
   protocolStats?: ProtocolStat[];
@@ -143,7 +41,7 @@ export default function VaultUPnLChart({
   externalPeriod,
   showHeader = true,
 }: VaultUPnLChartProps) {
-  const collateralSymbol = COLLATERAL_SYMBOLS[CHAIN_ID_ETHEREAL] || 'USDe';
+  const collateralSymbol = COLLATERAL_SYMBOLS[DEFAULT_CHAIN_ID] || 'USDe';
   const period = externalPeriod ?? '3M';
 
   const chartData = useMemo(() => {
@@ -156,7 +54,7 @@ export default function VaultUPnLChart({
         : Math.floor(Date.now() / 1000) - periodDays * 24 * 60 * 60;
 
     const filteredStats = protocolStats.filter(
-      (stat) => parseInt(stat.timestamp, 10) >= cutoffTimestamp
+      (stat) => stat.timestamp >= cutoffTimestamp
     );
 
     if (filteredStats.length === 0) return [];
@@ -275,6 +173,7 @@ export default function VaultUPnLChart({
                     <ChartTooltip
                       {...props}
                       collateralSymbol={collateralSymbol}
+                      dataKey="upnl"
                     />
                   )}
                 />
@@ -297,16 +196,7 @@ export default function VaultUPnLChart({
         )}
       </div>
 
-      <style jsx>{`
-        :global(.upnl-chart-cursor) {
-          animation: cursorDash 1.4s linear infinite;
-        }
-        @keyframes cursorDash {
-          to {
-            stroke-dashoffset: 8;
-          }
-        }
-      `}</style>
+      <style jsx>{CURSOR_ANIMATION_STYLE}</style>
     </div>
   );
 }

--- a/packages/app/src/components/vaults/VaultUPnLChart.tsx
+++ b/packages/app/src/components/vaults/VaultUPnLChart.tsx
@@ -1,0 +1,312 @@
+'use client';
+
+import { CHAIN_ID_ETHEREAL, COLLATERAL_SYMBOLS } from '@sapience/sdk/constants';
+import { useMemo } from 'react';
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { type ProtocolStat } from '~/hooks/graphql/useAnalytics';
+import Loader from '~/components/shared/Loader';
+import { type Period, PERIOD_DAYS } from '~/components/shared/PeriodFilter';
+
+function formatLargeNumber(value: number): string {
+  if (value >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(1)}M`;
+  }
+  if (value >= 1_000) {
+    return `${(value / 1_000).toFixed(1)}K`;
+  }
+  if (value >= 1) {
+    return value.toFixed(1);
+  }
+  if (value <= -1_000_000) {
+    return `${(value / 1_000_000).toFixed(1)}M`;
+  }
+  if (value <= -1_000) {
+    return `${(value / 1_000).toFixed(1)}K`;
+  }
+  if (value <= -1) {
+    return value.toFixed(1);
+  }
+  return value.toFixed(2);
+}
+
+function formatTimestampTick(value: string): string {
+  const date = new Date(parseInt(value, 10) * 1000);
+  return `${date.getUTCMonth() + 1}/${date.getUTCDate()}`;
+}
+
+type AnimatedCursorProps = {
+  top?: number;
+  height?: number;
+  points?: Array<{ x: number; y: number }>;
+};
+
+function AnimatedCursor({ points, top, height }: AnimatedCursorProps) {
+  if (!points || points.length === 0) return null;
+
+  return (
+    <line
+      x1={points[0].x}
+      y1={top ?? 0}
+      x2={points[0].x}
+      y2={(top ?? 0) + (height ?? 0)}
+      stroke="hsl(var(--brand-white))"
+      strokeWidth={1}
+      strokeDasharray="1 3"
+      className="upnl-chart-cursor"
+    />
+  );
+}
+
+type ChartTooltipProps = {
+  active?: boolean;
+  payload?: Array<{
+    value?: number | string | (number | string)[];
+    dataKey?: string | number;
+  }>;
+  label?: string;
+  collateralSymbol: string;
+};
+
+function ChartTooltip({
+  active,
+  payload,
+  label,
+  collateralSymbol,
+}: ChartTooltipProps): React.ReactNode {
+  if (!active || !payload?.length) return null;
+
+  const dataPoint = payload.find((p) => p.dataKey === 'upnl');
+  if (!dataPoint || dataPoint.value == null) return null;
+
+  const value = Number(dataPoint.value);
+  const isPositive = value >= 0;
+  const formattedValue = value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
+  let dateLabel = '';
+  if (label) {
+    const date = new Date(parseInt(label, 10) * 1000);
+    const months = [
+      'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+    ];
+    dateLabel = `${months[date.getUTCMonth()]} ${date.getUTCDate()}, ${date.getUTCFullYear()}`;
+  }
+
+  return (
+    <div className="bg-background border border-border rounded-md px-3 py-2">
+      <div className="text-xs font-medium text-muted-foreground mb-1">
+        {dateLabel}
+      </div>
+      <div
+        className={`text-sm font-mono ${isPositive ? 'text-green-500' : 'text-red-500'}`}
+      >
+        {isPositive ? '+' : ''}
+        {formattedValue} {collateralSymbol}
+      </div>
+    </div>
+  );
+}
+
+const CHART_AXIS_STYLE = {
+  tick: { fill: 'hsl(var(--muted-foreground))', fontSize: 11 },
+  axisLine: { stroke: 'hsl(var(--brand-white) / 0.3)' },
+  tickLine: { stroke: 'hsl(var(--brand-white) / 0.3)' },
+};
+
+const CHART_MARGIN = { top: 10, right: 0, left: -15, bottom: 0 };
+
+type VaultUPnLChartProps = {
+  protocolStats?: ProtocolStat[];
+  isLoading?: boolean;
+  height?: number;
+  className?: string;
+  externalPeriod?: Period;
+  showHeader?: boolean;
+};
+
+export default function VaultUPnLChart({
+  protocolStats,
+  isLoading,
+  height = 200,
+  className,
+  externalPeriod,
+  showHeader = true,
+}: VaultUPnLChartProps) {
+  const collateralSymbol = COLLATERAL_SYMBOLS[CHAIN_ID_ETHEREAL] || 'USDe';
+  const period = externalPeriod ?? '3M';
+
+  const chartData = useMemo(() => {
+    if (!protocolStats || protocolStats.length === 0) return [];
+
+    const periodDays = PERIOD_DAYS[period];
+    const cutoffTimestamp =
+      periodDays === Infinity
+        ? 0
+        : Math.floor(Date.now() / 1000) - periodDays * 24 * 60 * 60;
+
+    const filteredStats = protocolStats.filter(
+      (stat) => parseInt(stat.timestamp, 10) >= cutoffTimestamp
+    );
+
+    if (filteredStats.length === 0) return [];
+
+    return filteredStats.map((point) => ({
+      timestamp: point.timestamp,
+      upnl: parseFloat(point.vaultUPnL) / 1e18,
+      fromRelayer: point.uPnLQuoteFromRelayer,
+    }));
+  }, [protocolStats, period]);
+
+  const yDomain = useMemo(() => {
+    if (chartData.length === 0) return [-1, 1];
+
+    const values = chartData.map((d) => d.upnl);
+    const minVal = Math.min(...values);
+    const maxVal = Math.max(...values);
+
+    const range = maxVal - minVal;
+    const padding = range * 0.1 || 0.1;
+
+    return [minVal - padding, maxVal + padding];
+  }, [chartData]);
+
+  const currentUPnL =
+    chartData.length > 0 ? chartData[chartData.length - 1].upnl : 0;
+  const isPositive = currentUPnL >= 0;
+
+  const useFlexHeight = className?.includes('flex-1');
+
+  return (
+    <div
+      className={`w-full ${useFlexHeight ? 'flex flex-col' : ''} ${className ?? ''}`.trim()}
+    >
+      {showHeader && (
+        <div className="flex items-center justify-between mb-1">
+          <h4 className="text-base font-mono uppercase tracking-wider text-brand-white">
+            Unrealized PnL
+          </h4>
+        </div>
+      )}
+      <div
+        className={`${useFlexHeight ? 'flex-1' : ''} relative`}
+        style={{
+          height: useFlexHeight ? undefined : height,
+          minHeight: height,
+        }}
+      >
+        {isLoading ? (
+          <div className="absolute inset-0 flex items-center justify-center">
+            <Loader className="w-6 h-6" />
+          </div>
+        ) : chartData.length === 0 ? (
+          <div className="absolute inset-0 flex items-center justify-center text-muted-foreground text-sm">
+            No data for this period
+          </div>
+        ) : (
+          <div className="absolute inset-0 transition-opacity duration-300">
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={chartData} margin={CHART_MARGIN}>
+                <defs>
+                  <linearGradient
+                    id="upnlGradientPositive"
+                    x1="0"
+                    y1="0"
+                    x2="0"
+                    y2="1"
+                  >
+                    <stop
+                      offset="0%"
+                      stopColor="hsl(142 76% 36%)"
+                      stopOpacity={0.4}
+                    />
+                    <stop
+                      offset="100%"
+                      stopColor="hsl(142 76% 36%)"
+                      stopOpacity={0}
+                    />
+                  </linearGradient>
+                  <linearGradient
+                    id="upnlGradientNegative"
+                    x1="0"
+                    y1="0"
+                    x2="0"
+                    y2="1"
+                  >
+                    <stop
+                      offset="0%"
+                      stopColor="hsl(0 84% 60%)"
+                      stopOpacity={0.4}
+                    />
+                    <stop
+                      offset="100%"
+                      stopColor="hsl(0 84% 60%)"
+                      stopOpacity={0}
+                    />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  stroke="hsl(var(--brand-white) / 0.1)"
+                />
+                <XAxis
+                  dataKey="timestamp"
+                  {...CHART_AXIS_STYLE}
+                  tickFormatter={formatTimestampTick}
+                />
+                <YAxis
+                  {...CHART_AXIS_STYLE}
+                  domain={yDomain}
+                  tickFormatter={(v) => formatLargeNumber(v)}
+                />
+                <Tooltip
+                  cursor={<AnimatedCursor />}
+                  content={(props) => (
+                    <ChartTooltip
+                      {...props}
+                      collateralSymbol={collateralSymbol}
+                    />
+                  )}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="upnl"
+                  stroke={isPositive ? 'hsl(142 76% 36%)' : 'hsl(0 84% 60%)'}
+                  strokeWidth={2}
+                  fill={
+                    isPositive
+                      ? 'url(#upnlGradientPositive)'
+                      : 'url(#upnlGradientNegative)'
+                  }
+                  baseValue={yDomain[0]}
+                  activeDot={{ r: 4, strokeWidth: 0 }}
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </div>
+
+      <style jsx>{`
+        :global(.upnl-chart-cursor) {
+          animation: cursorDash 1.4s linear infinite;
+        }
+        @keyframes cursorDash {
+          to {
+            stroke-dashoffset: 8;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/packages/app/src/components/vaults/chartUtils.tsx
+++ b/packages/app/src/components/vaults/chartUtils.tsx
@@ -1,0 +1,136 @@
+import type React from 'react';
+
+const MONTHS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+export function formatLargeNumber(value: number): string {
+  if (value >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(1)}M`;
+  }
+  if (value >= 1_000) {
+    return `${(value / 1_000).toFixed(1)}K`;
+  }
+  if (value >= 1) {
+    return value.toFixed(1);
+  }
+  if (value <= -1_000_000) {
+    return `${(value / 1_000_000).toFixed(1)}M`;
+  }
+  if (value <= -1_000) {
+    return `${(value / 1_000).toFixed(1)}K`;
+  }
+  if (value <= -1) {
+    return value.toFixed(1);
+  }
+  return value.toFixed(2);
+}
+
+export function formatTimestampTick(value: number): string {
+  const date = new Date(value * 1000);
+  return `${date.getUTCMonth() + 1}/${date.getUTCDate()}`;
+}
+
+type AnimatedCursorProps = {
+  top?: number;
+  height?: number;
+  points?: Array<{ x: number; y: number }>;
+};
+
+export function AnimatedCursor({ points, top, height }: AnimatedCursorProps) {
+  if (!points || points.length === 0) return null;
+
+  return (
+    <line
+      x1={points[0].x}
+      y1={top ?? 0}
+      x2={points[0].x}
+      y2={(top ?? 0) + (height ?? 0)}
+      stroke="hsl(var(--brand-white))"
+      strokeWidth={1}
+      strokeDasharray="1 3"
+      className="vault-chart-cursor"
+    />
+  );
+}
+
+type ChartTooltipProps = {
+  active?: boolean;
+  payload?: Array<{
+    value?: number | string | (number | string)[];
+    dataKey?: string | number;
+  }>;
+  label?: number;
+  collateralSymbol: string;
+  dataKey: string;
+};
+
+export function ChartTooltip({
+  active,
+  payload,
+  label,
+  collateralSymbol,
+  dataKey,
+}: ChartTooltipProps): React.ReactNode {
+  if (!active || !payload?.length) return null;
+
+  const dataPoint = payload.find((p) => p.dataKey === dataKey);
+  if (!dataPoint || dataPoint.value == null) return null;
+
+  const value = Number(dataPoint.value);
+  const isPositive = value >= 0;
+  const formattedValue = value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
+  let dateLabel = '';
+  if (label != null) {
+    const date = new Date(label * 1000);
+    dateLabel = `${MONTHS[date.getUTCMonth()]} ${date.getUTCDate()}, ${date.getUTCFullYear()}`;
+  }
+
+  return (
+    <div className="bg-background border border-border rounded-md px-3 py-2">
+      <div className="text-xs font-medium text-muted-foreground mb-1">
+        {dateLabel}
+      </div>
+      <div
+        className={`text-sm font-mono ${isPositive ? 'text-green-500' : 'text-red-500'}`}
+      >
+        {isPositive ? '+' : ''}
+        {formattedValue} {collateralSymbol}
+      </div>
+    </div>
+  );
+}
+
+export const CHART_AXIS_STYLE = {
+  tick: { fill: 'hsl(var(--muted-foreground))', fontSize: 11 },
+  axisLine: { stroke: 'hsl(var(--brand-white) / 0.3)' },
+  tickLine: { stroke: 'hsl(var(--brand-white) / 0.3)' },
+};
+
+export const CHART_MARGIN = { top: 10, right: 0, left: -15, bottom: 0 };
+
+export const CURSOR_ANIMATION_STYLE = `
+  :global(.vault-chart-cursor) {
+    animation: cursorDash 1.4s linear infinite;
+  }
+  @keyframes cursorDash {
+    to {
+      stroke-dashoffset: 8;
+    }
+  }
+`;

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -34,6 +34,9 @@ import { useProtocolStats } from '~/hooks/graphql/useAnalytics';
 import RiskDisclaimer from '~/components/markets/forms/shared/RiskDisclaimer';
 import Loader from '~/components/shared/Loader';
 import VaultPnlChart from '~/components/vaults/VaultPnlChart';
+import VaultUPnLChart from '~/components/vaults/VaultUPnLChart';
+import SegmentedTabsList from '~/components/shared/SegmentedTabsList';
+import PeriodFilter, { type Period } from '~/components/shared/PeriodFilter';
 
 const DEPOSIT_WHITELIST: `0x${string}`[] = [
   '0xdb5af497a73620d881561edb508012a5f84e9ba2',
@@ -77,6 +80,9 @@ const VaultsPageContent = () => {
   const { isRestricted, isPermitLoading } = useRestrictedJurisdiction();
   const { data: protocolStats, isLoading: isAnalyticsLoading } =
     useProtocolStats();
+
+  // PnL chart period state (shared between Realized and uPnL tabs)
+  const [pnlPeriod, setPnlPeriod] = useState<Period>('3M');
 
   const [depositAmount, setDepositAmount] = useState('');
   const [withdrawAmount, setWithdrawAmount] = useState('');
@@ -609,6 +615,38 @@ const VaultsPageContent = () => {
 
                   <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
                     <div className="flex flex-col gap-6 order-2 lg:order-1 lg:min-h-0">
+                      {/* Vault PnL Charts (Realized / uPnL) */}
+                      <div className="p-5 pt-4 rounded-lg bg-[hsl(var(--primary)/_0.05)] border border-brand-white/10 lg:flex-1 lg:flex lg:flex-col lg:min-h-0 lg:overflow-hidden">
+                        <Tabs defaultValue="realized">
+                          <div className="flex items-center justify-between mb-1">
+                            <SegmentedTabsList triggerClassName="text-xs px-2 h-7">
+                              <TabsTrigger value="realized">Realized</TabsTrigger>
+                              <TabsTrigger value="unrealized">uPnL</TabsTrigger>
+                            </SegmentedTabsList>
+                            <PeriodFilter value={pnlPeriod} onChange={setPnlPeriod} />
+                          </div>
+                          <TabsContent value="realized" className="mt-0">
+                            <VaultPnlChart
+                              protocolStats={protocolStats ?? undefined}
+                              isLoading={isAnalyticsLoading}
+                              showHeader={false}
+                              externalPeriod={pnlPeriod}
+                              className="flex-1"
+                            />
+                          </TabsContent>
+                          <TabsContent value="unrealized" className="mt-0">
+                            <VaultUPnLChart
+                              protocolStats={protocolStats ?? undefined}
+                              isLoading={isAnalyticsLoading}
+                              showHeader={false}
+                              externalPeriod={pnlPeriod}
+                              className="flex-1"
+                            />
+                          </TabsContent>
+                        </Tabs>
+                      </div>
+
+                      {/* Utilization Block */}
                       <div className="p-5 pt-4 rounded-lg bg-[hsl(var(--primary)/_0.05)] border border-brand-white/10">
                         <h4 className="font-mono text-base uppercase tracking-wider text-brand-white mb-3 sm:mb-2">
                           Vault Balance

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -35,7 +35,6 @@ import RiskDisclaimer from '~/components/markets/forms/shared/RiskDisclaimer';
 import Loader from '~/components/shared/Loader';
 import VaultPnlChart from '~/components/vaults/VaultPnlChart';
 import VaultUPnLChart from '~/components/vaults/VaultUPnLChart';
-import SegmentedTabsList from '~/components/shared/SegmentedTabsList';
 import PeriodFilter, { type Period } from '~/components/shared/PeriodFilter';
 
 const DEPOSIT_WHITELIST: `0x${string}`[] = [
@@ -83,6 +82,7 @@ const VaultsPageContent = () => {
 
   // PnL chart period state (shared between Realized and uPnL tabs)
   const [pnlPeriod, setPnlPeriod] = useState<Period>('3M');
+  const [showUnrealized, setShowUnrealized] = useState(false);
 
   const [depositAmount, setDepositAmount] = useState('');
   const [withdrawAmount, setWithdrawAmount] = useState('');
@@ -617,33 +617,38 @@ const VaultsPageContent = () => {
                     <div className="flex flex-col gap-6 order-2 lg:order-1 lg:min-h-0">
                       {/* Vault PnL Charts (Realized / uPnL) */}
                       <div className="p-5 pt-4 rounded-lg bg-[hsl(var(--primary)/_0.05)] border border-brand-white/10 lg:flex-1 lg:flex lg:flex-col lg:min-h-0 lg:overflow-hidden">
-                        <Tabs defaultValue="realized">
-                          <div className="flex items-center justify-between mb-1">
-                            <SegmentedTabsList triggerClassName="text-xs px-2 h-7">
-                              <TabsTrigger value="realized">Realized</TabsTrigger>
-                              <TabsTrigger value="unrealized">uPnL</TabsTrigger>
-                            </SegmentedTabsList>
-                            <PeriodFilter value={pnlPeriod} onChange={setPnlPeriod} />
+                        <div className="flex items-center justify-between mb-1">
+                          <div className="flex items-center gap-2">
+                            <h4 className="text-base font-mono uppercase tracking-wider text-brand-white">
+                              Profit/Loss
+                            </h4>
+                            <button
+                              type="button"
+                              onClick={() => setShowUnrealized((v) => !v)}
+                              className="text-xs font-mono px-2.5 py-0.5 rounded-full border border-brand-white/20 text-muted-foreground hover:text-brand-white hover:border-brand-white/40 transition-colors cursor-pointer"
+                            >
+                              {showUnrealized ? 'Unrealized' : 'Realized'}
+                            </button>
                           </div>
-                          <TabsContent value="realized" className="mt-0">
-                            <VaultPnlChart
-                              protocolStats={protocolStats ?? undefined}
-                              isLoading={isAnalyticsLoading}
-                              showHeader={false}
-                              externalPeriod={pnlPeriod}
-                              className="flex-1"
-                            />
-                          </TabsContent>
-                          <TabsContent value="unrealized" className="mt-0">
-                            <VaultUPnLChart
-                              protocolStats={protocolStats ?? undefined}
-                              isLoading={isAnalyticsLoading}
-                              showHeader={false}
-                              externalPeriod={pnlPeriod}
-                              className="flex-1"
-                            />
-                          </TabsContent>
-                        </Tabs>
+                          <PeriodFilter value={pnlPeriod} onChange={setPnlPeriod} />
+                        </div>
+                        {showUnrealized ? (
+                          <VaultUPnLChart
+                            protocolStats={protocolStats ?? undefined}
+                            isLoading={isAnalyticsLoading}
+                            showHeader={false}
+                            externalPeriod={pnlPeriod}
+                            className="flex-1"
+                          />
+                        ) : (
+                          <VaultPnlChart
+                            protocolStats={protocolStats ?? undefined}
+                            isLoading={isAnalyticsLoading}
+                            showHeader={false}
+                            externalPeriod={pnlPeriod}
+                            className="flex-1"
+                          />
+                        )}
                       </div>
 
                       {/* Utilization Block */}

--- a/packages/sdk/queries/analytics.ts
+++ b/packages/sdk/queries/analytics.ts
@@ -14,6 +14,11 @@ export interface ProtocolStat {
   vaultDeposits: string;
   vaultWithdrawals: string;
   vaultAirdropGains: string;
+  vaultCollateralPerShare: string;
+  vaultTotalSupply: string;
+  vaultFairValueAssets: string;
+  vaultUPnL: string;
+  uPnLQuoteFromRelayer: boolean;
   dailyPnL: string;
   dailyVolume: string;
 }
@@ -34,6 +39,11 @@ const GET_PROTOCOL_STATS = /* GraphQL */ `
       vaultDeposits
       vaultWithdrawals
       vaultAirdropGains
+      vaultCollateralPerShare
+      vaultTotalSupply
+      vaultFairValueAssets
+      vaultUPnL
+      uPnLQuoteFromRelayer
       dailyPnL
       dailyVolume
     }

--- a/packages/sdk/types/graphql.ts
+++ b/packages/sdk/types/graphql.ts
@@ -1339,14 +1339,19 @@ export type ProtocolStat = {
   openInterest: Scalars['String']['output'];
   /** Unix epoch timestamp (seconds) for midnight UTC of the snapshot day */
   timestamp: Scalars['Int']['output'];
+  uPnLQuoteFromRelayer: Scalars['Boolean']['output'];
   vaultAirdropGains: Scalars['String']['output'];
   vaultAvailableAssets: Scalars['String']['output'];
   vaultBalance: Scalars['String']['output'];
+  vaultCollateralPerShare: Scalars['String']['output'];
   vaultCumulativePnL: Scalars['String']['output'];
   vaultDeployed: Scalars['String']['output'];
   vaultDeposits: Scalars['String']['output'];
+  vaultFairValueAssets: Scalars['String']['output'];
   vaultPositionsLost: Scalars['Int']['output'];
   vaultPositionsWon: Scalars['Int']['output'];
+  vaultTotalSupply: Scalars['String']['output'];
+  vaultUPnL: Scalars['String']['output'];
   vaultWithdrawals: Scalars['String']['output'];
 };
 


### PR DESCRIPTION
## Summary
- Extend `ProtocolStatsSnapshot` with 5 new columns (`vaultCollateralPerShare`, `vaultTotalSupply`, `vaultFairValueAssets`, `vaultUPnL`, `uPnLQuoteFromRelayer`) to persist the vault's mark-to-market value from relayer quotes
- Add `fetchVaultTotalSupply()` and `fetchVaultQuoteFromRelayer()` helpers to the hourly cron — opens an ephemeral WebSocket to the relayer, computes fair-value assets and uPnL, falls back to book value on timeout/error
- Surface a **Realized / uPnL** tab on `/vaults` with a shared period filter and matching chart styling

## Test plan
- [ ] Run migration locally, then `start:compute-stats` with relayer + parlay-bot running — verify new columns populated in `protocol_stats_snapshot`
- [ ] Query `protocolStats` via GraphQL — verify `vaultUPnL`, `vaultCollateralPerShare`, `vaultFairValueAssets`, `vaultTotalSupply`, `uPnLQuoteFromRelayer` fields present
- [ ] `/vaults` page — click **uPnL** tab, confirm chart renders with data
- [ ] Fallback: stop parlay-bot, run cron — verify `uPnLQuoteFromRelayer = false` and `vaultUPnL = "0"`
- [ ] Check mobile responsiveness of the new tab layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)