### PR TITLE
feat(secondary): add quoteOnly support for price discovery

### DIFF
--- a/packages/relayer/src/__tests__/secondaryMarket.test.ts
+++ b/packages/relayer/src/__tests__/secondaryMarket.test.ts
@@ -492,6 +492,42 @@ describe('SecondaryMarketHandlers', () => {
       expect(broadcast!.topic).toBe('secondary:global');
     });
 
+    it('broadcasts quote-only requests with quote metadata and returns non-penalty success', async () => {
+      const client = createMockClient();
+      const subs = createMockSubs();
+      const ctx = createMockCtx(client);
+
+      const payload = createListing({ quoteOnly: true });
+      const rejected = await handleSecondaryAuctionStart(
+        client,
+        payload,
+        subs,
+        ctx
+      );
+
+      expect(rejected).toBe(false);
+
+      const ack = findMsg(
+        client._messages,
+        (m) => m.type === 'secondary.auction.ack' && !!m.payload.auctionId
+      );
+      expect(ack).toBeDefined();
+
+      const broadcast = subs._broadcasts.find(
+        (b) => (b.msg as WsMsg).type === 'secondary.auction.started'
+      );
+      expect(broadcast).toBeDefined();
+      expect(broadcast!.topic).toBe('secondary:global');
+      expect((broadcast!.msg as WsMsg).payload).toMatchObject({
+        auctionId: ack!.payload.auctionId,
+        quoteOnly: true,
+        escrowContract: payload.escrowContract,
+      });
+      expect(
+        subs._topics.get(`secondary:${ack!.payload.auctionId}`)?.has(client)
+      ).toBe(true);
+    });
+
     it('rejects duplicate seller nonce', async () => {
       const client = createMockClient();
       const subs = createMockSubs();
@@ -784,7 +820,6 @@ describe('SecondaryMarketHandlers', () => {
       const subs = createMockSubs();
       const ctx = createMockCtx(client);
 
-      // Create two listings
       await handleSecondaryAuctionStart(
         client,
         createListing({ sellerNonce: 1 }),
@@ -807,6 +842,35 @@ describe('SecondaryMarketHandlers', () => {
       );
       expect(snapshot).toBeDefined();
       expect(snapshot!.payload.listings).toHaveLength(2);
+    });
+
+    it('excludes quote-only requests from listings snapshots', async () => {
+      const client = createMockClient();
+      const subs = createMockSubs();
+      const ctx = createMockCtx(client);
+
+      await handleSecondaryAuctionStart(
+        client,
+        createListing({ sellerNonce: 1 }),
+        subs,
+        ctx
+      );
+      await handleSecondaryAuctionStart(
+        client,
+        createListing({ sellerNonce: 2, quoteOnly: true }),
+        subs,
+        ctx
+      );
+
+      const reqClient = createMockClient();
+      handleSecondaryListingsRequest(reqClient);
+
+      const snapshot = findMsg(
+        reqClient._messages,
+        (m) => m.type === 'secondary.listings.snapshot'
+      );
+      expect(snapshot).toBeDefined();
+      expect(snapshot!.payload.listings).toHaveLength(1);
     });
   });
 });

--- a/packages/relayer/src/secondaryMarketHandlers.ts
+++ b/packages/relayer/src/secondaryMarketHandlers.ts
@@ -105,6 +105,58 @@ export async function handleSecondaryAuctionStart(
     return true;
   }
 
+  // ── Quote-only path ──
+  // Price discovery request: register in registry (so bid routing works) but
+  // mark as quoteOnly so it's excluded from the listings snapshot.
+  // Broadcast to feed subscribers, but exclude from the listings snapshot.
+  if (payload.quoteOnly) {
+    const quoteId = addSecondaryListing(payload);
+    if (!quoteId) {
+      client.send({
+        type: 'secondary.auction.ack',
+        payload: { error: 'duplicate_nonce' },
+      });
+      return false;
+    }
+
+    // Auto-subscribe the requester so they receive bid responses
+    const isNew = subs.subscribe(auctionTopic(quoteId), client);
+    if (isNew) subscriptionsActive.inc({ subscription_type: 'secondary' });
+
+    // Ack to sender
+    client.send({
+      type: 'secondary.auction.ack',
+      payload: { auctionId: quoteId },
+    });
+
+    // Build quote details — includes quoteOnly flag so vault-bot can detect
+    const quoteDetails: SecondaryAuctionDetails = {
+      auctionId: quoteId,
+      token: payload.token,
+      collateral: payload.collateral,
+      tokenAmount: payload.tokenAmount,
+      seller: payload.seller,
+      sellerDeadline: payload.sellerDeadline,
+      chainId: payload.chainId,
+      escrowContract: payload.escrowContract,
+      createdAt: new Date().toISOString(),
+      quoteOnly: true,
+    };
+
+    // Broadcast to feed subscribers (vault-bot observers see quoteOnly=true)
+    subs.broadcast(GLOBAL_FEED_TOPIC, {
+      type: 'secondary.auction.started',
+      payload: quoteDetails,
+    });
+
+    console.log(
+      `[Secondary] Quote request: ${quoteId} seller=${payload.seller.slice(0, 10)} token=${payload.token.slice(0, 10)}`
+    );
+    return false;
+  }
+
+  // ── Real listing path (existing logic) ──
+
   // Add to registry
   const auctionId = addSecondaryListing(payload);
   if (!auctionId) {
@@ -338,7 +390,10 @@ export function handleSecondaryFeedUnsubscribe(
  * Handle secondary.listings.request — return all active (non-expired) listings
  */
 export function handleSecondaryListingsRequest(client: ClientConnection): void {
-  const listings = getAllSecondaryListings();
+  // Filter out quoteOnly listings — they shouldn't appear in the public snapshot
+  const listings = getAllSecondaryListings().filter(
+    (rec) => !rec.auction.quoteOnly
+  );
 
   const details = listings.map((rec) => ({
     auctionId: rec.auctionId,

--- a/packages/sdk/types/secondary.ts
+++ b/packages/sdk/types/secondary.ts
@@ -71,6 +71,11 @@ export interface SecondaryAuctionRequestPayload {
   escrowContract: string; // Secondary escrow contract address
   refCode?: string;
   sellerSessionKeyData?: string;
+  /** When true, this is a price discovery request — not a real listing.
+   *  Relayer will exclude it from the listings snapshot and include quoteOnly
+   *  on feed broadcasts so observers can identify it as quote traffic.
+   *  The vault quoter responds with a simplified price. */
+  quoteOnly?: boolean;
 }
 
 /**
@@ -111,6 +116,8 @@ export interface SecondaryAuctionDetails {
   chainId: number;
   escrowContract: string;
   createdAt: string; // ISO timestamp
+  /** True when this is a price discovery request (not a real listing) */
+  quoteOnly?: boolean;
 }
 
 /** Validated secondary bid */


### PR DESCRIPTION
## Summary

Adds `quoteOnly` field to secondary market protocol for price discovery.

### SDK Changes

- `SecondaryAuctionRequestPayload.quoteOnly?: boolean` — client sets this to `true` for price discovery requests
- `SecondaryAuctionDetails.quoteOnly?: boolean` — relayer passes it through so vault-bot can detect quote mode

### Relayer Changes

When `quoteOnly=true` on `secondary.auction.start`:

1. **Registers** in the listing registry (so bid routing works — vault-bot responds via `secondary.bid.submit` which needs the auction to exist)
2. **Excluded from listings snapshot** — `handleSecondaryListingsRequest` filters out `quoteOnly` records, keeping `/secondary` page clean
3. **Broadcasts** to feed subscribers with `quoteOnly: true` flag — vault quoter detects and responds with simplified pricing

Real listings (`quoteOnly=false/undefined`) are completely unchanged.

### What this enables

The vault-bot's new `secondary-quoter` service (see [vault-bot PR #171](https://github.com/sapiencexyz/vault-bot/pull/171)) responds to `quoteOnly: true` listings with a simplified price (fair value × haircut, no risk controls). Sellers see what the vault would pay before committing to a real listing.

### Frontend (not in this PR)

New `useSecondaryQuote` hook needed — sends `secondary.auction.start` with `quoteOnly: true` and `tokenAmount=1e18`, reads the bid price for display.

### Spec

See `docs/secondary-market-quoter-alt.md` in [vault-bot PR #169](https://github.com/sapiencexyz/vault-bot/pull/169)