### PR TITLE
feat(api): credit sessions for x402 payments

### DIFF
--- a/packages/api/X402_INTEGRATION.md
+++ b/packages/api/X402_INTEGRATION.md
@@ -90,18 +90,18 @@ On complexity calculation error, the minimum cost (1 credit) is charged — the 
 
 ### Complexity scoring examples
 
-| Field                                    | Cost                        |
-| ---------------------------------------- | --------------------------- |
-| Regular fields                           | 1 (default)                 |
-| `__type`                                 | 50                          |
-| `__schema`                               | 100                         |
-| `questions`                              | 100 + 8 × take (list-aware) |
-| `accountTotalVolume`                     | 500                         |
-| `accountProfitRank`                      | 2,000                       |
-| `protocolStats`                          | 2,000                       |
-| `profitLeaderboard`                      | 2,000                       |
-| `_count`, `_sum`, `_avg`, `_min`, `_max` | 5,000                       |
-| `_all`                                   | 10,000                      |
+| Field                                    | Cost                     |
+| ---------------------------------------- | ------------------------ |
+| Regular fields                           | 1 (default)              |
+| `__type`                                 | 50                       |
+| `__schema`                               | 100                      |
+| `questions`                              | 100 + (8 + child) × take |
+| `accountTotalVolume`                     | 500                      |
+| `accountProfitRank`                      | 2,000                    |
+| `protocolStats`                          | 2,000                    |
+| `profitLeaderboard`                      | 2,000                    |
+| `_count`, `_sum`, `_avg`, `_min`, `_max` | 5,000                    |
+| `_all`                                   | 10,000                   |
 
 List fields multiply their children's cost by the requested list size (capped at `GRAPHQL_MAX_LIST_SIZE`). Some fields (like `questions`) handle list scaling internally via their own formula and bypass the list multiplier.
 

--- a/packages/api/X402_INTEGRATION.md
+++ b/packages/api/X402_INTEGRATION.md
@@ -118,16 +118,15 @@ List fields multiply their children's cost by the requested list size (capped at
 
 ## File Layout
 
-| File                             | Responsibility                                                                           |
-| -------------------------------- | ---------------------------------------------------------------------------------------- |
-| `src/x402.ts`                    | In-process facilitator, complexity-based pricing, gas guard, payment middleware creation |
-| `src/middleware.ts`              | CORS, helmet, rate limiters, x402 handler wiring, admin auth                             |
-| `src/creditSessions.ts`          | Credit session CRUD — create, get, deduct credits                                        |
-| `src/app.ts`                     | Express app factory — calls `setupMiddleware`, mounts router                             |
-| `src/config.ts`                  | Environment variable definitions (x402 + rate limit configs)                             |
-| `src/graphql/queryComplexity.ts` | Shared `createComplexityEstimators()` used by both Apollo validation and x402 pricing    |
-| `src/scripts/testX402Payment.ts` | End-to-end payment test script (`pnpm test:x402`)                                        |
-| `src/middleware.test.ts`         | Unit tests for the two-tier rate limiting system and credit sessions                     |
+| File                             | Responsibility                                                                        |
+| -------------------------------- | ------------------------------------------------------------------------------------- |
+| `src/x402.ts`                    | In-process facilitator, complexity-based pricing, payment middleware creation         |
+| `src/middleware.ts`              | CORS, helmet, rate limiters, x402 handler wiring, admin auth                          |
+| `src/creditSessions.ts`          | Credit session CRUD — create, get, deduct credits                                     |
+| `src/app.ts`                     | Express app factory — calls `setupMiddleware`, mounts router                          |
+| `src/config.ts`                  | Environment variable definitions (x402 + rate limit configs)                          |
+| `src/graphql/queryComplexity.ts` | Shared `createComplexityEstimators()` used by both Apollo validation and x402 pricing |
+| `src/middleware.test.ts`         | Unit tests for the two-tier rate limiting system and credit sessions                  |
 
 ## CORS
 
@@ -141,9 +140,6 @@ Payment-related headers are configured in `corsOptions`:
 ```bash
 # Unit tests (mocks x402 and viem, tests rate limit tiers)
 pnpm --filter @sapience/api test
-
-# End-to-end payment flow (requires funded wallets + Arbitrum RPC)
-pnpm --filter @sapience/api test:x402
 ```
 
 ## Dependencies

--- a/packages/api/X402_INTEGRATION.md
+++ b/packages/api/X402_INTEGRATION.md
@@ -105,17 +105,6 @@ On complexity calculation error, the minimum cost (1 credit) is charged — the 
 
 List fields multiply their children's cost by the requested list size (capped at `GRAPHQL_MAX_LIST_SIZE`). Some fields (like `questions`) handle list scaling internally via their own formula and bypass the list multiplier.
 
-## Gas Guard
-
-Before requiring payment, the middleware checks the current Arbitrum gas price. If estimated settlement gas cost exceeds the payment amount, it returns **503** instead of 402 to avoid unprofitable settlements.
-
-```
-Gas cost > payment amount → 503 Service Temporarily Unavailable
-                            (retryAfter: 300 seconds)
-```
-
-Settlement gas is estimated at 80,000 units (EIP-3009 `transferWithAuthorization`). ETH/USD rate is fetched from Chainlink (cached 60s, falls back to $3,000). On gas price check failure, it fails open (assumes gas is affordable).
-
 ## Environment Variables
 
 | Variable                       | Required                 | Default                        | Description                                                                                                                 |

--- a/packages/api/X402_INTEGRATION.md
+++ b/packages/api/X402_INTEGRATION.md
@@ -7,7 +7,7 @@ This document explains the x402 payment protocol integration in the Sapience API
 When a client exceeds the free tier rate limit, the API responds with HTTP 402 and a `PAYMENT-REQUIRED` header describing the accepted payment. The client signs a USDC `transferWithAuthorization` (EIP-3009) message and retries the request with a `Payment-Signature` header. The API verifies the signature and settles on-chain via an in-process facilitator.
 
 ```
-                   Free tier (≤200 req/min)
+                   Free tier (≤120 req/min)
 Client ──────────────────────────────────────► API (200 OK)
 
                    Over free tier, no payment
@@ -22,22 +22,22 @@ Client ──── Payment-Signature header ────────► API (ve
 
 The facilitator runs **in-process** — no separate service required. A single API server instance handles both request serving and payment settlement.
 
-| Component | Description |
-|-----------|-------------|
-| `x402ResourceServer` | Parses and validates payment headers |
-| `x402Facilitator` | Verifies EIP-3009 signatures and settles on-chain |
-| `toFacilitatorEvmSigner` | Wraps a viem wallet client for the facilitator |
-| `paymentMiddleware` | Express middleware from `@x402/express` |
+| Component                | Description                                       |
+| ------------------------ | ------------------------------------------------- |
+| `x402ResourceServer`     | Parses and validates payment headers              |
+| `x402Facilitator`        | Verifies EIP-3009 signatures and settles on-chain |
+| `toFacilitatorEvmSigner` | Wraps a viem wallet client for the facilitator    |
+| `paymentMiddleware`      | Express middleware from `@x402/express`           |
 
 ### On-chain details
 
-| | Value |
-|---|---|
-| Chain | Arbitrum One |
-| CAIP-2 network | `eip155:42161` |
-| Asset | Native USDC (`0xaf88d065e77c8cC2239327C5EDb3A432268e5831`) |
-| Transfer method | EIP-3009 `transferWithAuthorization` |
-| Payment scheme | `exact` |
+|                 | Value                                                      |
+| --------------- | ---------------------------------------------------------- |
+| Chain           | Arbitrum One                                               |
+| CAIP-2 network  | `eip155:42161`                                             |
+| Asset           | Native USDC (`0xaf88d065e77c8cC2239327C5EDb3A432268e5831`) |
+| Transfer method | EIP-3009 `transferWithAuthorization`                       |
+| Payment scheme  | `exact`                                                    |
 
 ## Tiered Rate Limiting
 
@@ -50,10 +50,7 @@ Request
 helmet / json / cors          (base middleware)
   │
   ▼
-hardLimiter (400 req/min)     → 429 if exceeded (no exceptions)
-  │
-  ▼
-freeTierLimiter (200 req/min) → sets req.requiresPayment=true if exceeded
+freeTierLimiter (120 req/min) → sets req.requiresPayment=true if exceeded
                                  (skips counting if Payment-Signature present)
   │
   ▼
@@ -68,39 +65,44 @@ Router (GraphQL, REST, etc.)
 
 ### Tiers
 
-| Tier | Requests/min | Behavior |
-|------|-------------|----------|
-| Free | 0–200 | Requests pass through normally |
-| Paid | 200–400 | Requires valid USDC payment per request |
-| Hard limit | >400 | Rejected with 429 regardless of payment |
+| Tier | Requests/min | Behavior                                                         |
+| ---- | ------------ | ---------------------------------------------------------------- |
+| Free | 0–120        | Requests pass through normally                                   |
+| Paid | >120         | Requires valid USDC payment (credit bundle) for continued access |
+
+## Credit Sessions
+
+After a successful x402 payment, the API creates a **credit session** — a server-side balance of credits tied to a session token. Sessions never expire; they persist until credits are exhausted.
+
+Each GraphQL query costs credits equal to its complexity score (minimum 1). When credits run out, the client receives a 402 response prompting another payment.
 
 ## Dynamic Pricing
 
 Payment amounts are determined by GraphQL query complexity, calculated using the same estimators as Apollo Server's validation layer (shared via `createComplexityEstimators` in `queryComplexity.ts`).
 
-| Tier | Complexity range | Price (USDC) |
-|------|-----------------|--------------|
-| Simple | 0–1,000 | $0.005 |
-| Medium | 1,000–5,000 | $0.015 |
-| Complex | 5,000+ | $0.030 |
+| Tier    | Complexity range | Price (USDC) |
+| ------- | ---------------- | ------------ |
+| Simple  | 0–1,000          | $0.005       |
+| Medium  | 1,000–5,000      | $0.015       |
+| Complex | 5,000+           | $0.030       |
 
 Non-GraphQL requests default to the simple tier.
 
-On complexity calculation error, the highest tier is charged to prevent abuse.
+On complexity calculation error, the minimum cost (1 credit) is charged — the query will fail at the GraphQL layer if it's truly malformed.
 
 ### Complexity scoring examples
 
-| Field | Cost |
-|-------|------|
-| Regular fields | 1 (default) |
-| `__type` | 50 |
-| `__schema` | 100 |
-| `tradingVolumeByAddress` | 500 |
-| `topForecasters` | 1,500 |
-| `dailyVolumes` | 1,500 |
-| `protocolStats` | 2,000 |
-| `_count`, `_sum`, `_avg`, `_min`, `_max` | 5,000 |
-| `_all` | 10,000 |
+| Field                                    | Cost        |
+| ---------------------------------------- | ----------- |
+| Regular fields                           | 1 (default) |
+| `__type`                                 | 50          |
+| `__schema`                               | 100         |
+| `tradingVolumeByAddress`                 | 500         |
+| `topForecasters`                         | 1,500       |
+| `dailyVolumes`                           | 1,500       |
+| `protocolStats`                          | 2,000       |
+| `_count`, `_sum`, `_avg`, `_min`, `_max` | 5,000       |
+| `_all`                                   | 10,000      |
 
 List fields multiply their children's cost by the requested list size (capped at `GRAPHQL_MAX_LIST_SIZE`).
 
@@ -113,36 +115,37 @@ Gas cost > payment amount → 503 Service Temporarily Unavailable
                             (retryAfter: 300 seconds)
 ```
 
-Settlement gas is estimated at 80,000 units (EIP-3009 `transferWithAuthorization`). ETH/USD rate is hardcoded at $3,000 (conservative estimate). On gas price check failure, it fails open (assumes gas is affordable).
+Settlement gas is estimated at 80,000 units (EIP-3009 `transferWithAuthorization`). ETH/USD rate is fetched from Chainlink (cached 60s, falls back to $3,000). On gas price check failure, it fails open (assumes gas is affordable).
 
 ## Environment Variables
 
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `X402_PAY_TO` | Yes (to enable) | `''` | EVM address that receives USDC payments. If empty, x402 is disabled and only the free tier limiter runs. |
-| `X402_FACILITATOR_PRIVATE_KEY` | Yes (if X402_PAY_TO set) | `''` | Private key for the facilitator wallet. This wallet submits settlement transactions — fund it with ETH on Arbitrum for gas. |
-| `X402_ARBITRUM_RPC_URL` | No | `https://arb1.arbitrum.io/rpc` | Arbitrum One RPC endpoint. |
-| `FREE_TIER_RATE_LIMIT` | No | `200` | Max requests/min before payment is required. |
-| `HARD_RATE_LIMIT` | No | `400` | Absolute max requests/min (even with payment). |
+| Variable                       | Required                 | Default                        | Description                                                                                                                 |
+| ------------------------------ | ------------------------ | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| `X402_PAY_TO`                  | Yes (to enable)          | `''`                           | EVM address that receives USDC payments. If empty, x402 is disabled and only the free tier limiter runs.                    |
+| `X402_FACILITATOR_PRIVATE_KEY` | Yes (if X402_PAY_TO set) | `''`                           | Private key for the facilitator wallet. This wallet submits settlement transactions — fund it with ETH on Arbitrum for gas. |
+| `X402_ARBITRUM_RPC_URL`        | No                       | `https://arb1.arbitrum.io/rpc` | Arbitrum One RPC endpoint.                                                                                                  |
+| `FREE_TIER_RATE_LIMIT`         | No                       | `120`                          | Max requests/min before payment is required.                                                                                |
+| `X402_CREDIT_BUNDLE_USDC`      | No                       | `1000000`                      | Credit bundle size in USDC base units (6 decimals).                                                                         |
 
 ## File Layout
 
-| File | Responsibility |
-|------|---------------|
-| `src/x402.ts` | In-process facilitator, complexity-based pricing, gas guard, payment middleware creation |
-| `src/middleware.ts` | CORS, helmet, rate limiters, x402 handler wiring, admin auth |
-| `src/app.ts` | Express app factory — calls `setupMiddleware`, mounts router |
-| `src/config.ts` | Environment variable definitions (x402 + rate limit configs) |
-| `src/graphql/queryComplexity.ts` | Shared `createComplexityEstimators()` used by both Apollo validation and x402 pricing |
-| `src/scripts/testX402Payment.ts` | End-to-end payment test script (`pnpm test:x402`) |
-| `src/__tests__/tieredRateLimiting.test.ts` | Unit tests for the three-tier rate limiting system |
+| File                             | Responsibility                                                                           |
+| -------------------------------- | ---------------------------------------------------------------------------------------- |
+| `src/x402.ts`                    | In-process facilitator, complexity-based pricing, gas guard, payment middleware creation |
+| `src/middleware.ts`              | CORS, helmet, rate limiters, x402 handler wiring, admin auth                             |
+| `src/creditSessions.ts`          | Credit session CRUD — create, get, deduct credits                                        |
+| `src/app.ts`                     | Express app factory — calls `setupMiddleware`, mounts router                             |
+| `src/config.ts`                  | Environment variable definitions (x402 + rate limit configs)                             |
+| `src/graphql/queryComplexity.ts` | Shared `createComplexityEstimators()` used by both Apollo validation and x402 pricing    |
+| `src/scripts/testX402Payment.ts` | End-to-end payment test script (`pnpm test:x402`)                                        |
+| `src/middleware.test.ts`         | Unit tests for the two-tier rate limiting system and credit sessions                     |
 
 ## CORS
 
 Payment-related headers are configured in `corsOptions`:
 
-- **Allowed**: `Payment-Signature` (client sends signed payment)
-- **Exposed**: `PAYMENT-REQUIRED`, `PAYMENT-RESPONSE`, `X-PAYMENT-RESPONSE` (server sends payment requirements/receipts)
+- **Allowed**: `Payment-Signature` (client sends signed payment), `X-Credit-Session` (client sends session token)
+- **Exposed**: `PAYMENT-REQUIRED`, `PAYMENT-RESPONSE`, `X-PAYMENT-RESPONSE`, `X-Credit-Session`, `X-Credit-Session-Status`, `X-Credit-Session-Error`, `X-Credits-Remaining`
 
 ## Testing
 

--- a/packages/api/X402_INTEGRATION.md
+++ b/packages/api/X402_INTEGRATION.md
@@ -74,19 +74,17 @@ Router (GraphQL, REST, etc.)
 
 After a successful x402 payment, the API creates a **credit session** — a server-side balance of credits tied to a session token. Sessions never expire; they persist until credits are exhausted.
 
-Each GraphQL query costs credits equal to its complexity score (minimum 1). When credits run out, the client receives a 402 response prompting another payment.
+Each bundle purchase grants `X402_CREDIT_BUNDLE_SIZE` credits (default 10,000). GraphQL query complexity is divided by 100 to determine the credit cost (minimum 1 credit per request). When credits run out, the client receives a 402 response prompting another payment.
 
-## Dynamic Pricing
+### Credit cost examples
 
-Payment amounts are determined by GraphQL query complexity, calculated using the same estimators as Apollo Server's validation layer (shared via `createComplexityEstimators` in `queryComplexity.ts`).
-
-| Tier    | Complexity range | Price (USDC) |
-| ------- | ---------------- | ------------ |
-| Simple  | 0–1,000          | $0.005       |
-| Medium  | 1,000–5,000      | $0.015       |
-| Complex | 5,000+           | $0.030       |
-
-Non-GraphQL requests default to the simple tier.
+| Query type                 | Raw complexity | Credit cost | Requests per $1 bundle |
+| -------------------------- | -------------- | ----------- | ---------------------- |
+| Simple query               | ~100           | 1           | ~10,000                |
+| Medium query               | ~1,000         | 10          | ~1,000                 |
+| Complex aggregation        | ~5,000         | 50          | ~200                   |
+| Heavy aggregation (`_all`) | ~10,000        | 100         | ~100                   |
+| Non-GraphQL request        | N/A            | 1           | ~10,000                |
 
 On complexity calculation error, the minimum cost (1 credit) is charged — the query will fail at the GraphQL layer if it's truly malformed.
 
@@ -125,7 +123,8 @@ Settlement gas is estimated at 80,000 units (EIP-3009 `transferWithAuthorization
 | `X402_FACILITATOR_PRIVATE_KEY` | Yes (if X402_PAY_TO set) | `''`                           | Private key for the facilitator wallet. This wallet submits settlement transactions — fund it with ETH on Arbitrum for gas. |
 | `X402_ARBITRUM_RPC_URL`        | No                       | `https://arb1.arbitrum.io/rpc` | Arbitrum One RPC endpoint.                                                                                                  |
 | `FREE_TIER_RATE_LIMIT`         | No                       | `120`                          | Max requests/min before payment is required.                                                                                |
-| `X402_CREDIT_BUNDLE_USDC`      | No                       | `1000000`                      | Credit bundle size in USDC base units (6 decimals).                                                                         |
+| `X402_CREDIT_BUNDLE_USDC`      | No                       | `1000000`                      | USDC price per credit bundle in base units (6 decimals).                                                                    |
+| `X402_CREDIT_BUNDLE_SIZE`      | No                       | `10000`                        | Number of credits granted per bundle purchase.                                                                              |
 
 ## File Layout
 

--- a/packages/api/X402_INTEGRATION.md
+++ b/packages/api/X402_INTEGRATION.md
@@ -90,19 +90,20 @@ On complexity calculation error, the minimum cost (1 credit) is charged — the 
 
 ### Complexity scoring examples
 
-| Field                                    | Cost        |
-| ---------------------------------------- | ----------- |
-| Regular fields                           | 1 (default) |
-| `__type`                                 | 50          |
-| `__schema`                               | 100         |
-| `tradingVolumeByAddress`                 | 500         |
-| `topForecasters`                         | 1,500       |
-| `dailyVolumes`                           | 1,500       |
-| `protocolStats`                          | 2,000       |
-| `_count`, `_sum`, `_avg`, `_min`, `_max` | 5,000       |
-| `_all`                                   | 10,000      |
+| Field                                    | Cost                        |
+| ---------------------------------------- | --------------------------- |
+| Regular fields                           | 1 (default)                 |
+| `__type`                                 | 50                          |
+| `__schema`                               | 100                         |
+| `questions`                              | 100 + 8 × take (list-aware) |
+| `accountTotalVolume`                     | 500                         |
+| `accountProfitRank`                      | 2,000                       |
+| `protocolStats`                          | 2,000                       |
+| `profitLeaderboard`                      | 2,000                       |
+| `_count`, `_sum`, `_avg`, `_min`, `_max` | 5,000                       |
+| `_all`                                   | 10,000                      |
 
-List fields multiply their children's cost by the requested list size (capped at `GRAPHQL_MAX_LIST_SIZE`).
+List fields multiply their children's cost by the requested list size (capped at `GRAPHQL_MAX_LIST_SIZE`). Some fields (like `questions`) handle list scaling internally via their own formula and bypass the list multiplier.
 
 ## Gas Guard
 

--- a/packages/api/prisma/migrations/20260327214233_add_credit_session/migration.sql
+++ b/packages/api/prisma/migrations/20260327214233_add_credit_session/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "credit_session" (
+    "token" VARCHAR(64) NOT NULL,
+    "wallet" VARCHAR NOT NULL,
+    "credits" INTEGER NOT NULL,
+    "expiresAt" TIMESTAMP(6) NOT NULL,
+    "createdAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "credit_session_pkey" PRIMARY KEY ("token")
+);
+
+-- CreateIndex
+CREATE INDEX "IDX_credit_session_expires_at" ON "credit_session"("expiresAt");
+
+-- CreateIndex
+CREATE INDEX "IDX_credit_session_wallet" ON "credit_session"("wallet");

--- a/packages/api/prisma/migrations/20260328022000_remove_credit_session_expiry/migration.sql
+++ b/packages/api/prisma/migrations/20260328022000_remove_credit_session_expiry/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX IF EXISTS "IDX_credit_session_expires_at";
+
+-- AlterTable
+ALTER TABLE "credit_session" DROP COLUMN IF EXISTS "expiresAt";

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -704,10 +704,8 @@ model CreditSession {
   token     String   @id @db.VarChar(64)
   wallet    String   @db.VarChar
   credits   Int
-  expiresAt DateTime @db.Timestamp(6)
   createdAt DateTime @default(now()) @db.Timestamp(6)
 
-  @@index([expiresAt], map: "IDX_credit_session_expires_at")
   @@index([wallet], map: "IDX_credit_session_wallet")
   @@map("credit_session")
 }

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -699,6 +699,19 @@ model SecondaryTrade {
   @@map("secondary_trade")
 }
 
+/// Credit session for x402 payments — persisted so sessions survive restarts
+model CreditSession {
+  token     String   @id @db.VarChar(64)
+  wallet    String   @db.VarChar
+  credits   Int
+  expiresAt DateTime @db.Timestamp(6)
+  createdAt DateTime @default(now()) @db.Timestamp(6)
+
+  @@index([expiresAt], map: "IDX_credit_session_expires_at")
+  @@index([wallet], map: "IDX_credit_session_wallet")
+  @@map("credit_session")
+}
+
 /// Indexed wUSDe (collateral token) Transfer events on Ethereal for historical balance queries
 model CollateralTransfer {
   id              Int      @id @default(autoincrement())

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -72,6 +72,14 @@ const validators = {
     default: 400,
     desc: 'Hard rate limit (max requests per minute even with payment)',
   }),
+  X402_CREDIT_BUNDLE_USDC: num({
+    default: 1_000_000, // $1.00 in USDC base units (6 decimals)
+    desc: 'Credit bundle size in USDC base units (amount charged per x402 payment)',
+  }),
+  X402_CREDIT_SESSION_TTL_MS: num({
+    default: 3_600_000, // 1 hour
+    desc: 'Credit session expiry in milliseconds',
+  }),
 };
 
 type Config = Readonly<ReturnType<typeof cleanEnv<typeof validators>>>;

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -70,7 +70,11 @@ const validators = {
   }),
   X402_CREDIT_BUNDLE_USDC: num({
     default: 1_000_000, // $1.00 in USDC base units (6 decimals)
-    desc: 'Credit bundle size in USDC base units (amount charged per x402 payment)',
+    desc: 'USDC price per credit bundle in base units (6 decimals)',
+  }),
+  X402_CREDIT_BUNDLE_SIZE: num({
+    default: 10_000,
+    desc: 'Number of credits granted per bundle purchase',
   }),
 };
 

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -65,20 +65,12 @@ const validators = {
   }),
   // Tiered rate limiting (x402 payment tiers)
   FREE_TIER_RATE_LIMIT: num({
-    default: 200,
+    default: 120,
     desc: 'Free tier rate limit (requests per minute before payment required)',
-  }),
-  HARD_RATE_LIMIT: num({
-    default: 400,
-    desc: 'Hard rate limit (max requests per minute even with payment)',
   }),
   X402_CREDIT_BUNDLE_USDC: num({
     default: 1_000_000, // $1.00 in USDC base units (6 decimals)
     desc: 'Credit bundle size in USDC base units (amount charged per x402 payment)',
-  }),
-  X402_CREDIT_SESSION_TTL_MS: num({
-    default: 3_600_000, // 1 hour
-    desc: 'Credit session expiry in milliseconds',
   }),
 };
 

--- a/packages/api/src/creditSessions.test.ts
+++ b/packages/api/src/creditSessions.test.ts
@@ -71,19 +71,19 @@ describe('getSession', () => {
 });
 
 describe('deductCredits', () => {
-  it('returns true when UPDATE matches a row', async () => {
-    mockPrisma.$queryRaw.mockResolvedValue([{ token: 'abc' }]);
-    expect(await deductCredits('abc', 5000)).toBe(true);
+  it('returns remaining credits when UPDATE matches a row', async () => {
+    mockPrisma.$queryRaw.mockResolvedValue([{ credits: 4995 }]);
+    expect(await deductCredits('abc', 5)).toBe(4995);
   });
 
-  it('returns false when UPDATE matches no rows', async () => {
+  it('returns null when UPDATE matches no rows (insufficient credits)', async () => {
     mockPrisma.$queryRaw.mockResolvedValue([]);
-    expect(await deductCredits('abc', 5000)).toBe(false);
+    expect(await deductCredits('abc', 5000)).toBeNull();
   });
 
-  it('returns false for unknown token', async () => {
+  it('returns null for unknown token', async () => {
     mockPrisma.$queryRaw.mockResolvedValue([]);
-    expect(await deductCredits('nonexistent', 100)).toBe(false);
+    expect(await deductCredits('nonexistent', 100)).toBeNull();
   });
 });
 

--- a/packages/api/src/creditSessions.test.ts
+++ b/packages/api/src/creditSessions.test.ts
@@ -16,7 +16,6 @@ import {
   createCreditSession,
   getSession,
   deductCredits,
-  cleanupExpiredSessions,
   extractPayerFromPaymentHeader,
 } from './creditSessions';
 
@@ -28,18 +27,16 @@ describe('createCreditSession', () => {
   it('calls prisma.creditSession.create with correct data', async () => {
     mockPrisma.creditSession.create.mockResolvedValue({});
 
-    const result = await createCreditSession('0xabc', 1_000_000, 3600_000);
+    const result = await createCreditSession('0xabc', 1_000_000);
 
     expect(result.token).toMatch(/^[0-9a-f]{64}$/);
     expect(result.credits).toBe(1_000_000);
-    expect(result.expiresAt).toBeGreaterThan(Date.now());
 
     expect(mockPrisma.creditSession.create).toHaveBeenCalledWith({
       data: {
         token: result.token,
         wallet: '0xabc',
         credits: 1_000_000,
-        expiresAt: expect.any(Date),
       },
     });
   });
@@ -47,48 +44,29 @@ describe('createCreditSession', () => {
   it('returns different tokens for each session', async () => {
     mockPrisma.creditSession.create.mockResolvedValue({});
 
-    const a = await createCreditSession('0xabc', 1000, 60000);
-    const b = await createCreditSession('0xabc', 1000, 60000);
+    const a = await createCreditSession('0xabc', 1000);
+    const b = await createCreditSession('0xabc', 1000);
     expect(a.token).not.toBe(b.token);
   });
 });
 
 describe('getSession', () => {
   it('returns session for valid token', async () => {
-    const futureDate = new Date(Date.now() + 60000);
     mockPrisma.creditSession.findUnique.mockResolvedValue({
       token: 'abc',
       wallet: '0xabc',
       credits: 5000,
-      expiresAt: futureDate,
     });
 
     const session = await getSession('abc');
     expect(session).not.toBeNull();
     expect(session!.wallet).toBe('0xabc');
     expect(session!.credits).toBe(5000);
-    expect(session!.expiresAt).toBe(futureDate.getTime());
   });
 
   it('returns null for unknown token', async () => {
     mockPrisma.creditSession.findUnique.mockResolvedValue(null);
     expect(await getSession('nonexistent')).toBeNull();
-  });
-
-  it('returns null and deletes expired session', async () => {
-    const pastDate = new Date(Date.now() - 1000);
-    mockPrisma.creditSession.findUnique.mockResolvedValue({
-      token: 'expired-token',
-      wallet: '0xabc',
-      credits: 5000,
-      expiresAt: pastDate,
-    });
-    mockPrisma.creditSession.delete.mockResolvedValue({});
-
-    expect(await getSession('expired-token')).toBeNull();
-    expect(mockPrisma.creditSession.delete).toHaveBeenCalledWith({
-      where: { token: 'expired-token' },
-    });
   });
 });
 
@@ -106,18 +84,6 @@ describe('deductCredits', () => {
   it('returns false for unknown token', async () => {
     mockPrisma.$queryRaw.mockResolvedValue([]);
     expect(await deductCredits('nonexistent', 100)).toBe(false);
-  });
-});
-
-describe('cleanupExpiredSessions', () => {
-  it('calls deleteMany with correct filter and returns count', async () => {
-    mockPrisma.creditSession.deleteMany.mockResolvedValue({ count: 3 });
-
-    const count = await cleanupExpiredSessions();
-    expect(count).toBe(3);
-    expect(mockPrisma.creditSession.deleteMany).toHaveBeenCalledWith({
-      where: { expiresAt: { lte: expect.any(Date) } },
-    });
   });
 });
 

--- a/packages/api/src/creditSessions.test.ts
+++ b/packages/api/src/creditSessions.test.ts
@@ -1,81 +1,123 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mockPrisma = vi.hoisted(() => ({
+  creditSession: {
+    create: vi.fn(),
+    findUnique: vi.fn(),
+    delete: vi.fn(),
+    deleteMany: vi.fn(),
+  },
+  $queryRaw: vi.fn(),
+}));
+
+vi.mock('./db', () => ({ default: mockPrisma }));
+
 import {
   createCreditSession,
   getSession,
   deductCredits,
+  cleanupExpiredSessions,
   extractPayerFromPaymentHeader,
-  _resetForTest,
 } from './creditSessions';
 
 beforeEach(() => {
-  _resetForTest();
-});
-
-afterEach(() => {
-  _resetForTest();
+  vi.restoreAllMocks();
 });
 
 describe('createCreditSession', () => {
-  it('creates a session with a hex token', () => {
-    const result = createCreditSession('0xabc', 1_000_000, 3600_000);
+  it('calls prisma.creditSession.create with correct data', async () => {
+    mockPrisma.creditSession.create.mockResolvedValue({});
+
+    const result = await createCreditSession('0xabc', 1_000_000, 3600_000);
+
     expect(result.token).toMatch(/^[0-9a-f]{64}$/);
     expect(result.credits).toBe(1_000_000);
     expect(result.expiresAt).toBeGreaterThan(Date.now());
+
+    expect(mockPrisma.creditSession.create).toHaveBeenCalledWith({
+      data: {
+        token: result.token,
+        wallet: '0xabc',
+        credits: 1_000_000,
+        expiresAt: expect.any(Date),
+      },
+    });
   });
 
-  it('returns different tokens for each session', () => {
-    const a = createCreditSession('0xabc', 1000, 60000);
-    const b = createCreditSession('0xabc', 1000, 60000);
+  it('returns different tokens for each session', async () => {
+    mockPrisma.creditSession.create.mockResolvedValue({});
+
+    const a = await createCreditSession('0xabc', 1000, 60000);
+    const b = await createCreditSession('0xabc', 1000, 60000);
     expect(a.token).not.toBe(b.token);
   });
 });
 
 describe('getSession', () => {
-  it('returns session for valid token', () => {
-    const { token } = createCreditSession('0xabc', 5000, 60000);
-    const session = getSession(token);
+  it('returns session for valid token', async () => {
+    const futureDate = new Date(Date.now() + 60000);
+    mockPrisma.creditSession.findUnique.mockResolvedValue({
+      token: 'abc',
+      wallet: '0xabc',
+      credits: 5000,
+      expiresAt: futureDate,
+    });
+
+    const session = await getSession('abc');
     expect(session).not.toBeNull();
     expect(session!.wallet).toBe('0xabc');
     expect(session!.credits).toBe(5000);
+    expect(session!.expiresAt).toBe(futureDate.getTime());
   });
 
-  it('returns null for unknown token', () => {
-    expect(getSession('nonexistent')).toBeNull();
+  it('returns null for unknown token', async () => {
+    mockPrisma.creditSession.findUnique.mockResolvedValue(null);
+    expect(await getSession('nonexistent')).toBeNull();
   });
 
-  it('returns null for expired session', () => {
-    vi.useFakeTimers();
-    const { token } = createCreditSession('0xabc', 5000, 1000); // 1s TTL
-    vi.advanceTimersByTime(2000);
-    expect(getSession(token)).toBeNull();
-    vi.useRealTimers();
+  it('returns null and deletes expired session', async () => {
+    const pastDate = new Date(Date.now() - 1000);
+    mockPrisma.creditSession.findUnique.mockResolvedValue({
+      token: 'expired-token',
+      wallet: '0xabc',
+      credits: 5000,
+      expiresAt: pastDate,
+    });
+    mockPrisma.creditSession.delete.mockResolvedValue({});
+
+    expect(await getSession('expired-token')).toBeNull();
+    expect(mockPrisma.creditSession.delete).toHaveBeenCalledWith({
+      where: { token: 'expired-token' },
+    });
   });
 });
 
 describe('deductCredits', () => {
-  it('deducts credits and returns true when sufficient', () => {
-    const { token } = createCreditSession('0xabc', 10000, 60000);
-    expect(deductCredits(token, 5000)).toBe(true);
-    expect(getSession(token)!.credits).toBe(5000);
+  it('returns true when UPDATE matches a row', async () => {
+    mockPrisma.$queryRaw.mockResolvedValue([{ token: 'abc' }]);
+    expect(await deductCredits('abc', 5000)).toBe(true);
   });
 
-  it('returns false when insufficient credits', () => {
-    const { token } = createCreditSession('0xabc', 3000, 60000);
-    expect(deductCredits(token, 5000)).toBe(false);
-    // Credits should not have changed
-    expect(getSession(token)!.credits).toBe(3000);
+  it('returns false when UPDATE matches no rows', async () => {
+    mockPrisma.$queryRaw.mockResolvedValue([]);
+    expect(await deductCredits('abc', 5000)).toBe(false);
   });
 
-  it('returns false for unknown token', () => {
-    expect(deductCredits('nonexistent', 100)).toBe(false);
+  it('returns false for unknown token', async () => {
+    mockPrisma.$queryRaw.mockResolvedValue([]);
+    expect(await deductCredits('nonexistent', 100)).toBe(false);
   });
+});
 
-  it('deducts exactly to zero', () => {
-    const { token } = createCreditSession('0xabc', 5000, 60000);
-    expect(deductCredits(token, 5000)).toBe(true);
-    expect(getSession(token)!.credits).toBe(0);
-    // Next deduction should fail
-    expect(deductCredits(token, 1)).toBe(false);
+describe('cleanupExpiredSessions', () => {
+  it('calls deleteMany with correct filter and returns count', async () => {
+    mockPrisma.creditSession.deleteMany.mockResolvedValue({ count: 3 });
+
+    const count = await cleanupExpiredSessions();
+    expect(count).toBe(3);
+    expect(mockPrisma.creditSession.deleteMany).toHaveBeenCalledWith({
+      where: { expiresAt: { lte: expect.any(Date) } },
+    });
   });
 });
 

--- a/packages/api/src/creditSessions.test.ts
+++ b/packages/api/src/creditSessions.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  createCreditSession,
+  getSession,
+  deductCredits,
+  extractPayerFromPaymentHeader,
+  _resetForTest,
+} from './creditSessions';
+
+beforeEach(() => {
+  _resetForTest();
+});
+
+afterEach(() => {
+  _resetForTest();
+});
+
+describe('createCreditSession', () => {
+  it('creates a session with a hex token', () => {
+    const result = createCreditSession('0xabc', 1_000_000, 3600_000);
+    expect(result.token).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.credits).toBe(1_000_000);
+    expect(result.expiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it('returns different tokens for each session', () => {
+    const a = createCreditSession('0xabc', 1000, 60000);
+    const b = createCreditSession('0xabc', 1000, 60000);
+    expect(a.token).not.toBe(b.token);
+  });
+});
+
+describe('getSession', () => {
+  it('returns session for valid token', () => {
+    const { token } = createCreditSession('0xabc', 5000, 60000);
+    const session = getSession(token);
+    expect(session).not.toBeNull();
+    expect(session!.wallet).toBe('0xabc');
+    expect(session!.credits).toBe(5000);
+  });
+
+  it('returns null for unknown token', () => {
+    expect(getSession('nonexistent')).toBeNull();
+  });
+
+  it('returns null for expired session', () => {
+    vi.useFakeTimers();
+    const { token } = createCreditSession('0xabc', 5000, 1000); // 1s TTL
+    vi.advanceTimersByTime(2000);
+    expect(getSession(token)).toBeNull();
+    vi.useRealTimers();
+  });
+});
+
+describe('deductCredits', () => {
+  it('deducts credits and returns true when sufficient', () => {
+    const { token } = createCreditSession('0xabc', 10000, 60000);
+    expect(deductCredits(token, 5000)).toBe(true);
+    expect(getSession(token)!.credits).toBe(5000);
+  });
+
+  it('returns false when insufficient credits', () => {
+    const { token } = createCreditSession('0xabc', 3000, 60000);
+    expect(deductCredits(token, 5000)).toBe(false);
+    // Credits should not have changed
+    expect(getSession(token)!.credits).toBe(3000);
+  });
+
+  it('returns false for unknown token', () => {
+    expect(deductCredits('nonexistent', 100)).toBe(false);
+  });
+
+  it('deducts exactly to zero', () => {
+    const { token } = createCreditSession('0xabc', 5000, 60000);
+    expect(deductCredits(token, 5000)).toBe(true);
+    expect(getSession(token)!.credits).toBe(0);
+    // Next deduction should fail
+    expect(deductCredits(token, 1)).toBe(false);
+  });
+});
+
+describe('extractPayerFromPaymentHeader', () => {
+  it('extracts from authorization.from', () => {
+    const header = Buffer.from(
+      JSON.stringify({ authorization: { from: '0xpayer' } })
+    ).toString('base64');
+    expect(extractPayerFromPaymentHeader(header)).toBe('0xpayer');
+  });
+
+  it('extracts from permit2Authorization.from', () => {
+    const header = Buffer.from(
+      JSON.stringify({ permit2Authorization: { from: '0xpermit2payer' } })
+    ).toString('base64');
+    expect(extractPayerFromPaymentHeader(header)).toBe('0xpermit2payer');
+  });
+
+  it('prefers authorization over permit2Authorization', () => {
+    const header = Buffer.from(
+      JSON.stringify({
+        authorization: { from: '0xauth' },
+        permit2Authorization: { from: '0xpermit2' },
+      })
+    ).toString('base64');
+    expect(extractPayerFromPaymentHeader(header)).toBe('0xauth');
+  });
+
+  it('returns null for invalid base64', () => {
+    expect(extractPayerFromPaymentHeader('not-valid-base64!!!')).toBeNull();
+  });
+
+  it('returns null for JSON without from field', () => {
+    const header = Buffer.from(JSON.stringify({ foo: 'bar' })).toString(
+      'base64'
+    );
+    expect(extractPayerFromPaymentHeader(header)).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(extractPayerFromPaymentHeader('')).toBeNull();
+  });
+});

--- a/packages/api/src/creditSessions.ts
+++ b/packages/api/src/creditSessions.ts
@@ -4,6 +4,8 @@
  * Clients pay once for a credit bundle, receive a session token,
  * then spend credits across multiple queries — amortizing a single
  * on-chain gas cost over many requests.
+ *
+ * Sessions never expire — they persist until credits are exhausted.
  */
 import { randomBytes } from 'crypto';
 import prisma from './db';
@@ -11,38 +13,28 @@ import prisma from './db';
 export type CreditSession = {
   wallet: string;
   credits: number;
-  expiresAt: number;
 };
 
 export async function createCreditSession(
   wallet: string,
-  credits: number,
-  ttlMs: number
-): Promise<{ token: string; credits: number; expiresAt: number }> {
+  credits: number
+): Promise<{ token: string; credits: number }> {
   const token = randomBytes(32).toString('hex');
-  const expiresAt = new Date(Date.now() + ttlMs);
 
   await prisma.creditSession.create({
-    data: { token, wallet, credits, expiresAt },
+    data: { token, wallet, credits },
   });
 
-  return { token, credits, expiresAt: expiresAt.getTime() };
+  return { token, credits };
 }
 
 export async function getSession(token: string): Promise<CreditSession | null> {
   const row = await prisma.creditSession.findUnique({ where: { token } });
   if (!row) return null;
 
-  if (row.expiresAt.getTime() <= Date.now()) {
-    // Lazy-delete expired session
-    await prisma.creditSession.delete({ where: { token } }).catch(() => {});
-    return null;
-  }
-
   return {
     wallet: row.wallet,
     credits: row.credits,
-    expiresAt: row.expiresAt.getTime(),
   };
 }
 
@@ -54,24 +46,14 @@ export async function deductCredits(
   token: string,
   amount: number
 ): Promise<boolean> {
-  const now = new Date();
   const result = await prisma.$queryRaw<{ token: string }[]>`
     UPDATE credit_session
     SET credits = credits - ${amount}
     WHERE token = ${token}
       AND credits >= ${amount}
-      AND "expiresAt" > ${now}
     RETURNING token
   `;
   return result.length > 0;
-}
-
-/** Delete all expired sessions (space reclamation). */
-export async function cleanupExpiredSessions(): Promise<number> {
-  const { count } = await prisma.creditSession.deleteMany({
-    where: { expiresAt: { lte: new Date() } },
-  });
-  return count;
 }
 
 /**

--- a/packages/api/src/creditSessions.ts
+++ b/packages/api/src/creditSessions.ts
@@ -41,19 +41,21 @@ export async function getSession(token: string): Promise<CreditSession | null> {
 /**
  * Atomically deduct credits from a session.
  * Uses a single UPDATE … WHERE credits >= amount to avoid races.
+ * Returns the remaining credit balance, or null if the deduction failed
+ * (unknown token or insufficient credits).
  */
 export async function deductCredits(
   token: string,
   amount: number
-): Promise<boolean> {
-  const result = await prisma.$queryRaw<{ token: string }[]>`
+): Promise<number | null> {
+  const result = await prisma.$queryRaw<{ credits: number }[]>`
     UPDATE credit_session
     SET credits = credits - ${amount}
     WHERE token = ${token}
       AND credits >= ${amount}
-    RETURNING token
+    RETURNING credits
   `;
-  return result.length > 0;
+  return result.length > 0 ? result[0].credits : null;
 }
 
 /**

--- a/packages/api/src/creditSessions.ts
+++ b/packages/api/src/creditSessions.ts
@@ -1,0 +1,101 @@
+/**
+ * In-memory credit session store for x402 payments.
+ *
+ * Clients pay once for a credit bundle, receive a session token,
+ * then spend credits across multiple queries — amortizing a single
+ * on-chain gas cost over many requests.
+ */
+import { randomBytes } from 'crypto';
+
+export type CreditSession = {
+  wallet: string;
+  credits: number;
+  expiresAt: number;
+};
+
+const sessions = new Map<string, CreditSession>();
+const MAX_CREDIT_SESSIONS = 10_000;
+const CLEANUP_INTERVAL_MS = 60_000;
+
+let cleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+function startCleanup() {
+  if (cleanupTimer) return;
+  cleanupTimer = setInterval(() => {
+    const now = Date.now();
+    for (const [token, session] of sessions) {
+      if (session.expiresAt <= now) {
+        sessions.delete(token);
+      }
+    }
+  }, CLEANUP_INTERVAL_MS);
+  cleanupTimer.unref();
+}
+
+export function createCreditSession(
+  wallet: string,
+  credits: number,
+  ttlMs: number
+): { token: string; credits: number; expiresAt: number } {
+  // Enforce hard cap — evict expired first, then reject if still full
+  if (sessions.size >= MAX_CREDIT_SESSIONS) {
+    const now = Date.now();
+    for (const [token, session] of sessions) {
+      if (session.expiresAt <= now) sessions.delete(token);
+    }
+    if (sessions.size >= MAX_CREDIT_SESSIONS) {
+      throw new Error('Credit session limit reached');
+    }
+  }
+
+  const token = randomBytes(32).toString('hex');
+  const expiresAt = Date.now() + ttlMs;
+  sessions.set(token, { wallet, credits, expiresAt });
+  startCleanup();
+
+  return { token, credits, expiresAt };
+}
+
+export function getSession(token: string): CreditSession | null {
+  const session = sessions.get(token);
+  if (!session) return null;
+  if (session.expiresAt <= Date.now()) {
+    sessions.delete(token);
+    return null;
+  }
+  return session;
+}
+
+export function deductCredits(token: string, amount: number): boolean {
+  const session = getSession(token);
+  if (!session || session.credits < amount) return false;
+  session.credits -= amount;
+  return true;
+}
+
+/**
+ * Extract the payer wallet address from a base64-encoded x402 Payment-Signature header.
+ * The header is a base64-encoded JSON object containing an `authorization` or
+ * `permit2Authorization` field with a `from` address.
+ */
+export function extractPayerFromPaymentHeader(header: string): string | null {
+  try {
+    const decoded = JSON.parse(Buffer.from(header, 'base64').toString('utf-8'));
+    return (
+      decoded?.authorization?.from ??
+      decoded?.permit2Authorization?.from ??
+      null
+    );
+  } catch {
+    return null;
+  }
+}
+
+/** Visible for testing — clear all sessions and stop cleanup timer. */
+export function _resetForTest() {
+  sessions.clear();
+  if (cleanupTimer) {
+    clearInterval(cleanupTimer);
+    cleanupTimer = null;
+  }
+}

--- a/packages/api/src/creditSessions.ts
+++ b/packages/api/src/creditSessions.ts
@@ -1,11 +1,12 @@
 /**
- * In-memory credit session store for x402 payments.
+ * Persistent credit session store for x402 payments (PostgreSQL via Prisma).
  *
  * Clients pay once for a credit bundle, receive a session token,
  * then spend credits across multiple queries — amortizing a single
  * on-chain gas cost over many requests.
  */
 import { randomBytes } from 'crypto';
+import prisma from './db';
 
 export type CreditSession = {
   wallet: string;
@@ -13,64 +14,64 @@ export type CreditSession = {
   expiresAt: number;
 };
 
-const sessions = new Map<string, CreditSession>();
-const MAX_CREDIT_SESSIONS = 10_000;
-const CLEANUP_INTERVAL_MS = 60_000;
-
-let cleanupTimer: ReturnType<typeof setInterval> | null = null;
-
-function startCleanup() {
-  if (cleanupTimer) return;
-  cleanupTimer = setInterval(() => {
-    const now = Date.now();
-    for (const [token, session] of sessions) {
-      if (session.expiresAt <= now) {
-        sessions.delete(token);
-      }
-    }
-  }, CLEANUP_INTERVAL_MS);
-  cleanupTimer.unref();
-}
-
-export function createCreditSession(
+export async function createCreditSession(
   wallet: string,
   credits: number,
   ttlMs: number
-): { token: string; credits: number; expiresAt: number } {
-  // Enforce hard cap — evict expired first, then reject if still full
-  if (sessions.size >= MAX_CREDIT_SESSIONS) {
-    const now = Date.now();
-    for (const [token, session] of sessions) {
-      if (session.expiresAt <= now) sessions.delete(token);
-    }
-    if (sessions.size >= MAX_CREDIT_SESSIONS) {
-      throw new Error('Credit session limit reached');
-    }
-  }
-
+): Promise<{ token: string; credits: number; expiresAt: number }> {
   const token = randomBytes(32).toString('hex');
-  const expiresAt = Date.now() + ttlMs;
-  sessions.set(token, { wallet, credits, expiresAt });
-  startCleanup();
+  const expiresAt = new Date(Date.now() + ttlMs);
 
-  return { token, credits, expiresAt };
+  await prisma.creditSession.create({
+    data: { token, wallet, credits, expiresAt },
+  });
+
+  return { token, credits, expiresAt: expiresAt.getTime() };
 }
 
-export function getSession(token: string): CreditSession | null {
-  const session = sessions.get(token);
-  if (!session) return null;
-  if (session.expiresAt <= Date.now()) {
-    sessions.delete(token);
+export async function getSession(token: string): Promise<CreditSession | null> {
+  const row = await prisma.creditSession.findUnique({ where: { token } });
+  if (!row) return null;
+
+  if (row.expiresAt.getTime() <= Date.now()) {
+    // Lazy-delete expired session
+    await prisma.creditSession.delete({ where: { token } }).catch(() => {});
     return null;
   }
-  return session;
+
+  return {
+    wallet: row.wallet,
+    credits: row.credits,
+    expiresAt: row.expiresAt.getTime(),
+  };
 }
 
-export function deductCredits(token: string, amount: number): boolean {
-  const session = getSession(token);
-  if (!session || session.credits < amount) return false;
-  session.credits -= amount;
-  return true;
+/**
+ * Atomically deduct credits from a session.
+ * Uses a single UPDATE … WHERE credits >= amount to avoid races.
+ */
+export async function deductCredits(
+  token: string,
+  amount: number
+): Promise<boolean> {
+  const now = new Date();
+  const result = await prisma.$queryRaw<{ token: string }[]>`
+    UPDATE credit_session
+    SET credits = credits - ${amount}
+    WHERE token = ${token}
+      AND credits >= ${amount}
+      AND "expiresAt" > ${now}
+    RETURNING token
+  `;
+  return result.length > 0;
+}
+
+/** Delete all expired sessions (space reclamation). */
+export async function cleanupExpiredSessions(): Promise<number> {
+  const { count } = await prisma.creditSession.deleteMany({
+    where: { expiresAt: { lte: new Date() } },
+  });
+  return count;
 }
 
 /**
@@ -88,14 +89,5 @@ export function extractPayerFromPaymentHeader(header: string): string | null {
     );
   } catch {
     return null;
-  }
-}
-
-/** Visible for testing — clear all sessions and stop cleanup timer. */
-export function _resetForTest() {
-  sessions.clear();
-  if (cleanupTimer) {
-    clearInterval(cleanupTimer);
-    cleanupTimer = null;
   }
 }

--- a/packages/api/src/graphql/estimators/fieldCostEstimator.ts
+++ b/packages/api/src/graphql/estimators/fieldCostEstimator.ts
@@ -2,11 +2,17 @@
  * Field cost estimator
  * Assigns custom complexity costs to specific fields by name or pattern
  */
-import type { ComplexityEstimator } from '../queryComplexity.js';
+import type {
+  ComplexityEstimator,
+  ComplexityEstimatorArgs,
+} from '../queryComplexity.js';
 
 export type FieldCostConfig =
   | { [fieldName: string]: number }
-  | ((fieldName: string) => number | undefined);
+  | ((
+      fieldName: string,
+      estimatorArgs: ComplexityEstimatorArgs
+    ) => number | undefined);
 
 export function fieldCostEstimator(
   costs: FieldCostConfig
@@ -16,7 +22,7 @@ export function fieldCostEstimator(
 
     let cost: number | undefined;
     if (typeof costs === 'function') {
-      cost = costs(fieldName);
+      cost = costs(fieldName, args);
     } else {
       cost = costs[fieldName];
     }

--- a/packages/api/src/graphql/queryComplexity.test.ts
+++ b/packages/api/src/graphql/queryComplexity.test.ts
@@ -468,7 +468,7 @@ describe('queryComplexity', () => {
   });
 
   describe('createComplexityEstimators', () => {
-    it('scales questions cost with take, default take=50 yields 502', () => {
+    it('scales questions cost with take, default take=50 yields 600', () => {
       const query = parse(
         `{ questions(take: 50) { questionType predictionCount } }`
       );
@@ -478,8 +478,9 @@ describe('queryComplexity', () => {
         query,
         estimators,
       });
-      // questions: 100 + 8*50 = 500, + childComplexity (2) = 502
-      expect(complexity).toBe(502);
+      // childComplexity = 2 (questionType + predictionCount)
+      // total = 100 + (8 + 2) * 50 = 600
+      expect(complexity).toBe(600);
     });
 
     it('assigns fixed cost to protocolStats field', () => {
@@ -512,10 +513,11 @@ describe('queryComplexity', () => {
         query: large,
         estimators,
       });
-      // questions(take:10): 100 + 8*10 = 180, + childComplexity (2) = 182
-      expect(smallComplexity).toBe(182);
-      // questions(take:100): take capped at maxListSize=100: 100 + 8*100 = 900, + 2 = 902
-      expect(largeComplexity).toBe(902);
+      // childComplexity = 2; total = 100 + (8 + 2) * take
+      // questions(take:10): 100 + 10*10 = 200
+      expect(smallComplexity).toBe(200);
+      // questions(take:100): capped at maxListSize=100: 100 + 10*100 = 1100
+      expect(largeComplexity).toBe(1100);
     });
   });
 });

--- a/packages/api/src/graphql/queryComplexity.test.ts
+++ b/packages/api/src/graphql/queryComplexity.test.ts
@@ -287,6 +287,29 @@ describe('queryComplexity', () => {
       expect(complexity).toBeGreaterThan(15000);
     });
 
+    it('function form receives estimatorArgs and can use args.take', () => {
+      const query = parse(`{ items(take: 25) { id } }`);
+      const complexity = getComplexity({
+        schema: testSchema,
+        query,
+        estimators: [
+          fieldCostEstimator((_fieldName, estimatorArgs) => {
+            if (_fieldName === 'items') {
+              const take =
+                typeof estimatorArgs.args.take === 'number'
+                  ? estimatorArgs.args.take
+                  : 10;
+              return 100 + 5 * take;
+            }
+            return undefined;
+          }),
+          simpleEstimator({ defaultComplexity: 1 }),
+        ],
+      });
+      // items: 100 + 5*25 = 225, + childComplexity (id: 1) = 226
+      expect(complexity).toBe(226);
+    });
+
     it('falls through to next estimator when no match', () => {
       const query = parse(`{ scalar }`);
       const complexity = getComplexity({
@@ -445,7 +468,7 @@ describe('queryComplexity', () => {
   });
 
   describe('createComplexityEstimators', () => {
-    it('assigns fixed cost to questions field, bypassing list multiplier', () => {
+    it('scales questions cost with take, default take=50 yields 502', () => {
       const query = parse(
         `{ questions(take: 50) { questionType predictionCount } }`
       );
@@ -455,9 +478,7 @@ describe('queryComplexity', () => {
         query,
         estimators,
       });
-      // questions gets fixed cost 500 from fieldCostEstimator
-      // + childComplexity (questionType: 1 + predictionCount: 1 = 2) = 502
-      // NOT 1 + 2 * 50 = 101 (which the list multiplier would produce)
+      // questions: 100 + 8*50 = 500, + childComplexity (2) = 502
       expect(complexity).toBe(502);
     });
 
@@ -473,7 +494,7 @@ describe('queryComplexity', () => {
       expect(complexity).toBe(2001);
     });
 
-    it('questions cost stays fixed regardless of take value', () => {
+    it('questions cost scales linearly with take', () => {
       const small = parse(
         `{ questions(take: 10) { questionType predictionCount } }`
       );
@@ -491,9 +512,10 @@ describe('queryComplexity', () => {
         query: large,
         estimators,
       });
-      // Both should have the same complexity since questions uses fixed cost
-      expect(smallComplexity).toBe(largeComplexity);
-      expect(smallComplexity).toBe(502);
+      // questions(take:10): 100 + 8*10 = 180, + childComplexity (2) = 182
+      expect(smallComplexity).toBe(182);
+      // questions(take:100): take capped at maxListSize=100: 100 + 8*100 = 900, + 2 = 902
+      expect(largeComplexity).toBe(902);
     });
   });
 });

--- a/packages/api/src/graphql/queryComplexity.ts
+++ b/packages/api/src/graphql/queryComplexity.ts
@@ -559,7 +559,7 @@ export function createComplexityEstimators(
 ): ComplexityEstimator[] {
   return [
     _fieldExt(),
-    _fieldCost((fieldName: string) => {
+    _fieldCost((fieldName, estimatorArgs) => {
       // Aggregate fields that require full table scans
       if (fieldName === '_all') return 10000;
       if (fieldName.startsWith('_count')) return 5000;
@@ -568,11 +568,17 @@ export function createComplexityEstimators(
       if (fieldName.startsWith('_min')) return 5000;
       if (fieldName.startsWith('_max')) return 5000;
       // Expensive custom queries — heavy SQL aggregations
-      if (fieldName === 'questions') return 500;
+      if (fieldName === 'questions') {
+        const take =
+          typeof estimatorArgs.args.take === 'number'
+            ? Math.min(Math.max(estimatorArgs.args.take, 1), maxListSize)
+            : 50; // resolver default
+        return 100 + 8 * take; // + childComplexity auto-added by fieldCostEstimator
+      }
       if (fieldName === 'protocolStats') return 2000;
       if (fieldName === 'profitLeaderboard') return 2000;
       if (fieldName === 'accountTotalVolume') return 500;
-      if (fieldName === 'accountProfitRank') return 500;
+      if (fieldName === 'accountProfitRank') return 2000;
       // Time-series analytics — heavy SQL with generate_series + aggregation
       if (fieldName === 'accountVolume') return 1000;
       if (fieldName === 'accountPnl') return 1500;

--- a/packages/api/src/graphql/queryComplexity.ts
+++ b/packages/api/src/graphql/queryComplexity.ts
@@ -573,7 +573,12 @@ export function createComplexityEstimators(
           typeof estimatorArgs.args.take === 'number'
             ? Math.min(Math.max(estimatorArgs.args.take, 1), maxListSize)
             : 50; // resolver default
-        return 100 + 8 * take; // + childComplexity auto-added by fieldCostEstimator
+        // childComplexity = cost of ONE Question's subfields (computed for the
+        // unwrapped type).  fieldCostEstimator auto-adds +childComplexity, so
+        // we subtract it here and multiply by take ourselves so that subfield
+        // cost scales with list size:  total = 100 + (8 + child) * take
+        const child = estimatorArgs.childComplexity;
+        return 100 + (8 + child) * take - child;
       }
       if (fieldName === 'protocolStats') return 2000;
       if (fieldName === 'profitLeaderboard') return 2000;

--- a/packages/api/src/middleware.test.ts
+++ b/packages/api/src/middleware.test.ts
@@ -18,7 +18,7 @@ function defaultCreditSessionsMock() {
   return {
     createCreditSession: vi.fn(),
     getSession: vi.fn(() => null),
-    deductCredits: vi.fn(() => false),
+    deductCredits: vi.fn(() => null),
     extractPayerFromPaymentHeader: vi.fn(() => null),
     _resetForTest: vi.fn(),
   };
@@ -40,6 +40,7 @@ function expectPaymentFields(body: Record<string, unknown>) {
   expect(bundle.currency).toBe('USDC');
   expect(bundle.decimals).toBe(6);
   expect(bundle.amountUSD).toBe('$1.00');
+  expect(bundle.credits).toBe(10_000);
   expect(cs.instructions).toBeDefined();
 }
 
@@ -114,6 +115,7 @@ describe('tiered rate limiting with trust proxy (x402 mode)', () => {
         FREE_TIER_RATE_LIMIT: 3,
         X402_PAY_TO: TEST_PAY_TO,
         X402_CREDIT_BUNDLE_USDC: 1_000_000,
+        X402_CREDIT_BUNDLE_SIZE: 10_000,
       },
     }));
     vi.doMock('./creditSessions', () => defaultCreditSessionsMock());
@@ -164,6 +166,7 @@ describe('tiered rate limiting with trust proxy (x402 mode)', () => {
         FREE_TIER_RATE_LIMIT: 5,
         X402_PAY_TO: TEST_PAY_TO,
         X402_CREDIT_BUNDLE_USDC: 1_000_000,
+        X402_CREDIT_BUNDLE_SIZE: 10_000,
       },
     }));
     vi.doMock('./creditSessions', () => defaultCreditSessionsMock());
@@ -200,6 +203,7 @@ describe('tiered rate limiting with trust proxy (x402 mode)', () => {
         FREE_TIER_RATE_LIMIT: 2,
         X402_PAY_TO: TEST_PAY_TO,
         X402_CREDIT_BUNDLE_USDC: 1_000_000,
+        X402_CREDIT_BUNDLE_SIZE: 10_000,
       },
     }));
     vi.doMock('./creditSessions', () => ({
@@ -208,7 +212,7 @@ describe('tiered rate limiting with trust proxy (x402 mode)', () => {
         wallet: '0xabc',
         credits: 0,
       })),
-      deductCredits: vi.fn(() => false), // exhausted
+      deductCredits: vi.fn(() => null), // exhausted
     }));
     vi.doMock('./x402', () => defaultX402Mock());
 
@@ -237,6 +241,7 @@ describe('credit sessions', () => {
     FREE_TIER_RATE_LIMIT: 2,
     X402_PAY_TO: '0x1234567890abcdef1234567890abcdef12345678',
     X402_CREDIT_BUNDLE_USDC: 1_000_000,
+    X402_CREDIT_BUNDLE_SIZE: 10_000,
   };
 
   it('valid credit session bypasses x402 and deducts credits', async () => {
@@ -244,7 +249,7 @@ describe('credit sessions', () => {
       wallet: '0xabc',
       credits: 50000,
     }));
-    const mockDeductCredits = vi.fn(() => true);
+    const mockDeductCredits = vi.fn(() => 49999);
 
     vi.doMock('./config', () => ({ config: X402_CONFIG }));
     vi.doMock('./creditSessions', () => ({
@@ -299,7 +304,7 @@ describe('credit sessions', () => {
     expect(res.headers['x-credit-session-status']).toBe('exhausted');
     expectPaymentFields(res.body);
     expect(res.body.creditSession.status).toBe('exhausted');
-    expect(res.body.creditSession.pricing).toContain('complexity score');
+    expect(res.body.creditSession.pricing).toContain('10,000 credits');
     expect(res.body.creditSession.instructions.step1).toContain(
       'Payment-Signature'
     );
@@ -313,7 +318,7 @@ describe('credit sessions', () => {
   it('successful payment creates credit session and returns token header', async () => {
     const mockCreateCreditSession = vi.fn(() => ({
       token: 'new-session-token',
-      credits: 1_000_000,
+      credits: 10_000,
     }));
 
     vi.doMock('./config', () => ({ config: X402_CONFIG }));
@@ -355,21 +360,21 @@ describe('credit sessions', () => {
 
     expect(res.status).toBe(200);
     expect(res.headers['x-credit-session']).toBe('new-session-token');
-    expect(res.headers['x-credits-remaining']).toBe('1000000');
-    expect(mockCreateCreditSession).toHaveBeenCalledWith('0xpayer', 1_000_000);
+    expect(res.headers['x-credits-remaining']).toBe('10000');
+    expect(mockCreateCreditSession).toHaveBeenCalledWith('0xpayer', 10_000);
   });
 
   it('credits exhausted returns 402 with exhausted status and bundle info', async () => {
     const mockGetSession = vi.fn(() => ({
       wallet: '0xabc',
-      credits: 100, // not enough for the 5000 cost
+      credits: 0, // not enough
     }));
 
     vi.doMock('./config', () => ({ config: X402_CONFIG }));
     vi.doMock('./creditSessions', () => ({
       ...defaultCreditSessionsMock(),
       getSession: mockGetSession,
-      deductCredits: vi.fn(() => false), // insufficient credits
+      deductCredits: vi.fn(() => null), // insufficient credits
     }));
 
     const x402Mock = vi.fn();
@@ -415,9 +420,9 @@ describe('credit sessions', () => {
     const mockDeductCredits = vi.fn((token: string) => {
       if (token === 'token-a') {
         sessionCreditsA -= 1;
-        return true;
+        return sessionCreditsA;
       }
-      return false;
+      return null;
     });
 
     vi.doMock('./config', () => ({ config: X402_CONFIG }));
@@ -473,7 +478,7 @@ describe('credit sessions', () => {
       wallet: '0xabc',
       credits: 50000,
     }));
-    const mockDeductCredits = vi.fn(() => true);
+    const mockDeductCredits = vi.fn(() => 49999);
 
     vi.doMock('./config', () => ({ config: X402_CONFIG }));
     vi.doMock('./creditSessions', () => ({

--- a/packages/api/src/middleware.test.ts
+++ b/packages/api/src/middleware.test.ts
@@ -23,6 +23,26 @@ function defaultCreditSessionsMock() {
   };
 }
 
+const TEST_PAY_TO = '0x1234567890abcdef1234567890abcdef12345678';
+
+/** Assert that a 402 response body contains all x402 payment fields an agent needs. */
+function expectPaymentFields(body: Record<string, unknown>) {
+  const cs = body.creditSession as Record<string, unknown>;
+  expect(cs).toBeDefined();
+  expect(cs.protocol).toBe('x402');
+  expect(cs.scheme).toBe('exact');
+  expect(cs.network).toBe('eip155:42161');
+  expect(cs.payTo).toBe(TEST_PAY_TO);
+  expect(cs.asset).toBe('0xaf88d065e77c8cC2239327C5EDb3A432268e5831');
+  const bundle = cs.bundle as Record<string, unknown>;
+  expect(bundle.amount).toBe('1000000');
+  expect(bundle.currency).toBe('USDC');
+  expect(bundle.decimals).toBe(6);
+  expect(bundle.amountUSD).toBe('$1.00');
+  expect(cs.sessionTTLSeconds).toBe(3600);
+  expect(cs.instructions).toBeDefined();
+}
+
 // Reset modules before EVERY test to get fresh rate limiter instances
 beforeEach(() => {
   vi.resetModules();
@@ -95,7 +115,7 @@ describe('tiered rate limiting with trust proxy (x402 mode)', () => {
         RATE_LIMIT_WINDOW_MS: 60000,
         FREE_TIER_RATE_LIMIT: 3,
         HARD_RATE_LIMIT: 100,
-        X402_PAY_TO: '0x1234567890abcdef1234567890abcdef12345678',
+        X402_PAY_TO: TEST_PAY_TO,
         X402_CREDIT_BUNDLE_USDC: 1_000_000,
         X402_CREDIT_SESSION_TTL_MS: 3_600_000,
       },
@@ -131,9 +151,7 @@ describe('tiered rate limiting with trust proxy (x402 mode)', () => {
       .get('/test')
       .set('X-Forwarded-For', '1.2.3.4');
     expect(paymentRes.status).toBe(402);
-    expect(paymentRes.body.creditSession).toBeDefined();
-    expect(paymentRes.body.creditSession.instructions).toBeDefined();
-    expect(paymentRes.body.creditSession.bundle.amountUSD).toBe('$1.00');
+    expectPaymentFields(paymentRes.body);
 
     // 5.6.7.8 should still get 200 — NOT pushed to payment by someone else's usage
     const otherRes = await request(app)
@@ -149,7 +167,7 @@ describe('tiered rate limiting with trust proxy (x402 mode)', () => {
         RATE_LIMIT_WINDOW_MS: 60000,
         FREE_TIER_RATE_LIMIT: 100,
         HARD_RATE_LIMIT: 5,
-        X402_PAY_TO: '0x1234567890abcdef1234567890abcdef12345678',
+        X402_PAY_TO: TEST_PAY_TO,
         X402_CREDIT_BUNDLE_USDC: 1_000_000,
         X402_CREDIT_SESSION_TTL_MS: 3_600_000,
       },
@@ -257,9 +275,8 @@ describe('credit sessions', () => {
 
     expect(res.status).toBe(402);
     expect(res.headers['x-credit-session-status']).toBe('expired');
-    expect(res.body.creditSession).toBeDefined();
+    expectPaymentFields(res.body);
     expect(res.body.creditSession.status).toBe('expired');
-    expect(res.body.creditSession.bundle.amountUSD).toBe('$1.00');
     expect(res.body.creditSession.pricing).toContain('complexity score');
     expect(res.body.creditSession.instructions.step1).toContain(
       'Payment-Signature'
@@ -355,6 +372,7 @@ describe('credit sessions', () => {
 
     expect(res.status).toBe(402);
     expect(res.headers['x-credit-session-status']).toBe('exhausted');
+    expectPaymentFields(res.body);
     expect(res.body.creditSession.status).toBe('exhausted');
     expect(res.body.creditSession.instructions.step1).toContain(
       'Payment-Signature'

--- a/packages/api/src/middleware.test.ts
+++ b/packages/api/src/middleware.test.ts
@@ -5,7 +5,7 @@ import request from 'supertest';
 // Default x402 mock that includes all exports used by middleware
 function defaultX402Mock() {
   return {
-    createGasAwareX402Middleware: vi.fn(() => {
+    createX402Middleware: vi.fn(() => {
       return (_req: Request, _res: Response, next: NextFunction) => next();
     }),
     calculateGraphQLComplexity: vi.fn(() => 0),
@@ -121,7 +121,7 @@ describe('tiered rate limiting with trust proxy (x402 mode)', () => {
     vi.doMock('./creditSessions', () => defaultCreditSessionsMock());
     vi.doMock('./x402', () => ({
       ...defaultX402Mock(),
-      createGasAwareX402Middleware: vi.fn(() => {
+      createX402Middleware: vi.fn(() => {
         return (req: Request, res: Response, next: NextFunction) => {
           if (!req.headers['payment-signature']) {
             res.status(402).json({ error: 'Payment Required' });
@@ -261,7 +261,7 @@ describe('credit sessions', () => {
     const x402Mock = vi.fn();
     vi.doMock('./x402', () => ({
       ...defaultX402Mock(),
-      createGasAwareX402Middleware: vi.fn(() => x402Mock),
+      createX402Middleware: vi.fn(() => x402Mock),
     }));
 
     const { createApp } = await import('./app');
@@ -289,7 +289,7 @@ describe('credit sessions', () => {
     const x402Mock = vi.fn();
     vi.doMock('./x402', () => ({
       ...defaultX402Mock(),
-      createGasAwareX402Middleware: vi.fn(() => x402Mock),
+      createX402Middleware: vi.fn(() => x402Mock),
     }));
 
     const { createApp } = await import('./app');
@@ -331,7 +331,7 @@ describe('credit sessions', () => {
     // x402 mock that calls next() on payment success (simulates valid payment)
     vi.doMock('./x402', () => ({
       ...defaultX402Mock(),
-      createGasAwareX402Middleware: vi.fn(() => {
+      createX402Middleware: vi.fn(() => {
         return (_req: Request, _res: Response, next: NextFunction) => {
           next();
         };
@@ -380,7 +380,7 @@ describe('credit sessions', () => {
     const x402Mock = vi.fn();
     vi.doMock('./x402', () => ({
       ...defaultX402Mock(),
-      createGasAwareX402Middleware: vi.fn(() => x402Mock),
+      createX402Middleware: vi.fn(() => x402Mock),
     }));
 
     const { createApp } = await import('./app');
@@ -439,7 +439,7 @@ describe('credit sessions', () => {
     );
     vi.doMock('./x402', () => ({
       ...defaultX402Mock(),
-      createGasAwareX402Middleware: vi.fn(() => x402Mock),
+      createX402Middleware: vi.fn(() => x402Mock),
     }));
 
     const { createApp } = await import('./app');
@@ -522,7 +522,7 @@ describe('credit sessions', () => {
     // x402 mock that calls next() on payment success
     vi.doMock('./x402', () => ({
       ...defaultX402Mock(),
-      createGasAwareX402Middleware: vi.fn(() => {
+      createX402Middleware: vi.fn(() => {
         return (_req: Request, _res: Response, next: NextFunction) => {
           next();
         };

--- a/packages/api/src/middleware.test.ts
+++ b/packages/api/src/middleware.test.ts
@@ -160,46 +160,80 @@ describe('tiered rate limiting with trust proxy (x402 mode)', () => {
     expect(otherRes.status).toBe(200);
   });
 
-  it('hard limit is per-IP — one abuser cannot 429 everyone', async () => {
+  it('hard limit returns 402 not 429 — users can always pay for access', async () => {
     vi.doMock('./config', () => ({
       config: {
         isProd: false,
         RATE_LIMIT_WINDOW_MS: 60000,
-        FREE_TIER_RATE_LIMIT: 100,
-        HARD_RATE_LIMIT: 5,
+        FREE_TIER_RATE_LIMIT: 5,
+        HARD_RATE_LIMIT: 100,
         X402_PAY_TO: TEST_PAY_TO,
         X402_CREDIT_BUNDLE_USDC: 1_000_000,
         X402_CREDIT_SESSION_TTL_MS: 3_600_000,
       },
     }));
     vi.doMock('./creditSessions', () => defaultCreditSessionsMock());
-    vi.doMock('./x402', () => ({
-      ...defaultX402Mock(),
-      createGasAwareX402Middleware: vi.fn(() => {
-        return (_req: Request, _res: Response, next: NextFunction) => next();
-      }),
-    }));
+    vi.doMock('./x402', () => defaultX402Mock());
 
     const { createApp } = await import('./app');
     const app = createApp();
     app.get('/test', (_req, res) => res.json({ ok: true }));
 
-    // Exhaust hard limit for IP 10.0.0.1
+    // Exhaust free tier for IP 10.0.0.1
     for (let i = 0; i < 5; i++) {
       await request(app).get('/test').set('X-Forwarded-For', '10.0.0.1');
     }
 
-    // 10.0.0.1 should be hard-blocked with 429
+    // 10.0.0.1 should get 402 with payment instructions, never 429
     const blockedRes = await request(app)
       .get('/test')
       .set('X-Forwarded-For', '10.0.0.1');
-    expect(blockedRes.status).toBe(429);
+    expect(blockedRes.status).toBe(402);
+    expectPaymentFields(blockedRes.body);
 
     // 10.0.0.2 should still be fine
     const otherRes = await request(app)
       .get('/test')
       .set('X-Forwarded-For', '10.0.0.2');
     expect(otherRes.status).toBe(200);
+  });
+
+  it('hard limit with credit session returns 402 not 429', async () => {
+    vi.doMock('./config', () => ({
+      config: {
+        isProd: false,
+        RATE_LIMIT_WINDOW_MS: 60000,
+        FREE_TIER_RATE_LIMIT: 2,
+        HARD_RATE_LIMIT: 100,
+        X402_PAY_TO: TEST_PAY_TO,
+        X402_CREDIT_BUNDLE_USDC: 1_000_000,
+        X402_CREDIT_SESSION_TTL_MS: 3_600_000,
+      },
+    }));
+    vi.doMock('./creditSessions', () => ({
+      ...defaultCreditSessionsMock(),
+      getSession: vi.fn(() => ({
+        wallet: '0xabc',
+        credits: 0,
+        expiresAt: Date.now() + 3_600_000,
+      })),
+      deductCredits: vi.fn(() => false), // exhausted
+    }));
+    vi.doMock('./x402', () => defaultX402Mock());
+
+    const { createApp } = await import('./app');
+    const app = createApp();
+    app.get('/test', (_req, res) => res.json({ ok: true }));
+
+    // Send request with exhausted credit session — should get 402, not 429
+    const res = await request(app)
+      .get('/test')
+      .set('X-Forwarded-For', '10.0.0.1')
+      .set('X-Credit-Session', 'exhausted-token');
+
+    expect(res.status).toBe(402);
+    expectPaymentFields(res.body);
+    expect(res.body.creditSession.status).toBe('exhausted');
   });
 });
 

--- a/packages/api/src/middleware.test.ts
+++ b/packages/api/src/middleware.test.ts
@@ -2,6 +2,27 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Request, Response, NextFunction } from 'express';
 import request from 'supertest';
 
+// Default x402 mock that includes all exports used by middleware
+function defaultX402Mock() {
+  return {
+    createGasAwareX402Middleware: vi.fn(() => {
+      return (_req: Request, _res: Response, next: NextFunction) => next();
+    }),
+    calculateGraphQLComplexity: vi.fn(() => 0),
+  };
+}
+
+// Default creditSessions mock — no active sessions
+function defaultCreditSessionsMock() {
+  return {
+    createCreditSession: vi.fn(),
+    getSession: vi.fn(() => null),
+    deductCredits: vi.fn(() => false),
+    extractPayerFromPaymentHeader: vi.fn(() => null),
+    _resetForTest: vi.fn(),
+  };
+}
+
 // Reset modules before EVERY test to get fresh rate limiter instances
 beforeEach(() => {
   vi.resetModules();
@@ -20,9 +41,8 @@ describe('rate limiting with trust proxy (simple mode)', () => {
         X402_PAY_TO: undefined,
       },
     }));
-    vi.doMock('./x402', () => ({
-      createGasAwareX402Middleware: vi.fn(),
-    }));
+    vi.doMock('./x402', () => defaultX402Mock());
+    vi.doMock('./creditSessions', () => defaultCreditSessionsMock());
 
     const { createApp } = await import('./app');
     const app = createApp();
@@ -56,9 +76,8 @@ describe('rate limiting with trust proxy (simple mode)', () => {
         X402_PAY_TO: undefined,
       },
     }));
-    vi.doMock('./x402', () => ({
-      createGasAwareX402Middleware: vi.fn(),
-    }));
+    vi.doMock('./x402', () => defaultX402Mock());
+    vi.doMock('./creditSessions', () => defaultCreditSessionsMock());
 
     const { createApp } = await import('./app');
     const app = createApp();
@@ -77,9 +96,13 @@ describe('tiered rate limiting with trust proxy (x402 mode)', () => {
         FREE_TIER_RATE_LIMIT: 3,
         HARD_RATE_LIMIT: 100,
         X402_PAY_TO: '0x1234567890abcdef1234567890abcdef12345678',
+        X402_CREDIT_BUNDLE_USDC: 1_000_000,
+        X402_CREDIT_SESSION_TTL_MS: 3_600_000,
       },
     }));
+    vi.doMock('./creditSessions', () => defaultCreditSessionsMock());
     vi.doMock('./x402', () => ({
+      ...defaultX402Mock(),
       createGasAwareX402Middleware: vi.fn(() => {
         return (req: Request, res: Response, next: NextFunction) => {
           if (!req.headers['payment-signature']) {
@@ -103,11 +126,14 @@ describe('tiered rate limiting with trust proxy (x402 mode)', () => {
       expect(res.status).toBe(200);
     }
 
-    // 1.2.3.4 should now get 402 (pushed to payment)
+    // 1.2.3.4 should now get 402 with credit session instructions
     const paymentRes = await request(app)
       .get('/test')
       .set('X-Forwarded-For', '1.2.3.4');
     expect(paymentRes.status).toBe(402);
+    expect(paymentRes.body.creditSession).toBeDefined();
+    expect(paymentRes.body.creditSession.instructions).toBeDefined();
+    expect(paymentRes.body.creditSession.bundle.amountUSD).toBe('$1.00');
 
     // 5.6.7.8 should still get 200 — NOT pushed to payment by someone else's usage
     const otherRes = await request(app)
@@ -124,9 +150,13 @@ describe('tiered rate limiting with trust proxy (x402 mode)', () => {
         FREE_TIER_RATE_LIMIT: 100,
         HARD_RATE_LIMIT: 5,
         X402_PAY_TO: '0x1234567890abcdef1234567890abcdef12345678',
+        X402_CREDIT_BUNDLE_USDC: 1_000_000,
+        X402_CREDIT_SESSION_TTL_MS: 3_600_000,
       },
     }));
+    vi.doMock('./creditSessions', () => defaultCreditSessionsMock());
     vi.doMock('./x402', () => ({
+      ...defaultX402Mock(),
       createGasAwareX402Middleware: vi.fn(() => {
         return (_req: Request, _res: Response, next: NextFunction) => next();
       }),
@@ -152,5 +182,256 @@ describe('tiered rate limiting with trust proxy (x402 mode)', () => {
       .get('/test')
       .set('X-Forwarded-For', '10.0.0.2');
     expect(otherRes.status).toBe(200);
+  });
+});
+
+// ─── Credit sessions ─────────────────────────────────────────────────────────
+
+describe('credit sessions', () => {
+  const X402_CONFIG = {
+    isProd: false,
+    RATE_LIMIT_WINDOW_MS: 60000,
+    FREE_TIER_RATE_LIMIT: 2,
+    HARD_RATE_LIMIT: 100,
+    X402_PAY_TO: '0x1234567890abcdef1234567890abcdef12345678',
+    X402_CREDIT_BUNDLE_USDC: 1_000_000,
+    X402_CREDIT_SESSION_TTL_MS: 3_600_000,
+  };
+
+  it('valid credit session bypasses x402 and deducts credits', async () => {
+    const mockGetSession = vi.fn(() => ({
+      wallet: '0xabc',
+      credits: 50000,
+      expiresAt: Date.now() + 3_600_000,
+    }));
+    const mockDeductCredits = vi.fn(() => true);
+
+    vi.doMock('./config', () => ({ config: X402_CONFIG }));
+    vi.doMock('./creditSessions', () => ({
+      ...defaultCreditSessionsMock(),
+      getSession: mockGetSession,
+      deductCredits: mockDeductCredits,
+    }));
+
+    const x402Mock = vi.fn();
+    vi.doMock('./x402', () => ({
+      ...defaultX402Mock(),
+      createGasAwareX402Middleware: vi.fn(() => x402Mock),
+    }));
+
+    const { createApp } = await import('./app');
+    const app = createApp();
+    app.get('/test', (_req, res) => res.json({ ok: true }));
+
+    const res = await request(app)
+      .get('/test')
+      .set('X-Credit-Session', 'valid-token-abc');
+
+    expect(res.status).toBe(200);
+    expect(mockDeductCredits).toHaveBeenCalledWith('valid-token-abc', 1);
+    // x402 should NOT have been called
+    expect(x402Mock).not.toHaveBeenCalled();
+    expect(res.headers['x-credits-remaining']).toBeDefined();
+  });
+
+  it('expired/invalid session token returns 402 with credit system instructions', async () => {
+    vi.doMock('./config', () => ({ config: X402_CONFIG }));
+    vi.doMock('./creditSessions', () => ({
+      ...defaultCreditSessionsMock(),
+      getSession: vi.fn(() => null), // invalid/expired
+    }));
+
+    const x402Mock = vi.fn();
+    vi.doMock('./x402', () => ({
+      ...defaultX402Mock(),
+      createGasAwareX402Middleware: vi.fn(() => x402Mock),
+    }));
+
+    const { createApp } = await import('./app');
+    const app = createApp();
+    app.get('/test', (_req, res) => res.json({ ok: true }));
+
+    const res = await request(app)
+      .get('/test')
+      .set('X-Credit-Session', 'expired-token');
+
+    expect(res.status).toBe(402);
+    expect(res.headers['x-credit-session-status']).toBe('expired');
+    expect(res.body.creditSession).toBeDefined();
+    expect(res.body.creditSession.status).toBe('expired');
+    expect(res.body.creditSession.bundle.amountUSD).toBe('$1.00');
+    expect(res.body.creditSession.pricing).toContain('complexity score');
+    expect(res.body.creditSession.instructions.step1).toContain(
+      'Payment-Signature'
+    );
+    expect(res.body.creditSession.instructions.step3).toContain(
+      'X-Credit-Session'
+    );
+    // x402 should NOT have been called — we sent our own 402
+    expect(x402Mock).not.toHaveBeenCalled();
+  });
+
+  it('successful payment creates credit session and returns token header', async () => {
+    const mockCreateCreditSession = vi.fn(() => ({
+      token: 'new-session-token',
+      credits: 1_000_000,
+      expiresAt: Date.now() + 3_600_000,
+    }));
+
+    vi.doMock('./config', () => ({ config: X402_CONFIG }));
+    vi.doMock('./creditSessions', () => ({
+      ...defaultCreditSessionsMock(),
+      createCreditSession: mockCreateCreditSession,
+      extractPayerFromPaymentHeader: vi.fn(() => '0xpayer'),
+    }));
+
+    // x402 mock that calls next() on payment success (simulates valid payment)
+    vi.doMock('./x402', () => ({
+      ...defaultX402Mock(),
+      createGasAwareX402Middleware: vi.fn(() => {
+        return (_req: Request, _res: Response, next: NextFunction) => {
+          next();
+        };
+      }),
+    }));
+
+    const { createApp } = await import('./app');
+    const app = createApp();
+    app.get('/test', (_req, res) => res.json({ ok: true }));
+
+    // Exhaust free tier
+    for (let i = 0; i < 2; i++) {
+      await request(app).get('/test').set('X-Forwarded-For', '2.2.2.2');
+    }
+
+    // Next request has payment header — should trigger credit session creation
+    const res = await request(app)
+      .get('/test')
+      .set('X-Forwarded-For', '2.2.2.2')
+      .set(
+        'Payment-Signature',
+        Buffer.from(
+          JSON.stringify({ authorization: { from: '0xpayer' } })
+        ).toString('base64')
+      );
+
+    expect(res.status).toBe(200);
+    expect(res.headers['x-credit-session']).toBe('new-session-token');
+    expect(res.headers['x-credits-remaining']).toBe('1000000');
+    expect(mockCreateCreditSession).toHaveBeenCalledWith(
+      '0xpayer',
+      1_000_000,
+      3_600_000
+    );
+  });
+
+  it('credits exhausted returns 402 with exhausted status and bundle info', async () => {
+    const mockGetSession = vi.fn(() => ({
+      wallet: '0xabc',
+      credits: 100, // not enough for the 5000 cost
+      expiresAt: Date.now() + 3_600_000,
+    }));
+
+    vi.doMock('./config', () => ({ config: X402_CONFIG }));
+    vi.doMock('./creditSessions', () => ({
+      ...defaultCreditSessionsMock(),
+      getSession: mockGetSession,
+      deductCredits: vi.fn(() => false), // insufficient credits
+    }));
+
+    const x402Mock = vi.fn();
+    vi.doMock('./x402', () => ({
+      ...defaultX402Mock(),
+      createGasAwareX402Middleware: vi.fn(() => x402Mock),
+    }));
+
+    const { createApp } = await import('./app');
+    const app = createApp();
+    app.get('/test', (_req, res) => res.json({ ok: true }));
+
+    const res = await request(app)
+      .get('/test')
+      .set('X-Credit-Session', 'exhausted-token');
+
+    expect(res.status).toBe(402);
+    expect(res.headers['x-credit-session-status']).toBe('exhausted');
+    expect(res.body.creditSession.status).toBe('exhausted');
+    expect(res.body.creditSession.instructions.step1).toContain(
+      'Payment-Signature'
+    );
+    expect(res.body.creditSession.instructions.step3).toContain(
+      'X-Credit-Session'
+    );
+    expect(res.body.message).toContain('run out of credits');
+    // x402 should NOT have been called — we sent our own 402
+    expect(x402Mock).not.toHaveBeenCalled();
+  });
+
+  it('credit sessions are per-token, not shared across IPs', async () => {
+    let sessionCreditsA = 50000;
+    const mockGetSession = vi.fn((token: string) => {
+      if (token === 'token-a') {
+        return {
+          wallet: '0xaaa',
+          credits: sessionCreditsA,
+          expiresAt: Date.now() + 3_600_000,
+        };
+      }
+      return null; // token-b is unknown
+    });
+    const mockDeductCredits = vi.fn((token: string) => {
+      if (token === 'token-a') {
+        sessionCreditsA -= 1;
+        return true;
+      }
+      return false;
+    });
+
+    vi.doMock('./config', () => ({ config: X402_CONFIG }));
+    vi.doMock('./creditSessions', () => ({
+      ...defaultCreditSessionsMock(),
+      getSession: mockGetSession,
+      deductCredits: mockDeductCredits,
+    }));
+
+    const x402Mock = vi.fn(
+      (_req: Request, res: Response, _next: NextFunction) => {
+        res.status(402).json({ error: 'Payment Required' });
+      }
+    );
+    vi.doMock('./x402', () => ({
+      ...defaultX402Mock(),
+      createGasAwareX402Middleware: vi.fn(() => x402Mock),
+    }));
+
+    const { createApp } = await import('./app');
+    const app = createApp();
+    app.get('/test', (_req, res) => res.json({ ok: true }));
+
+    // IP A with valid token-a → 200 (credits deducted)
+    const resA = await request(app)
+      .get('/test')
+      .set('X-Forwarded-For', '4.4.4.4')
+      .set('X-Credit-Session', 'token-a');
+    expect(resA.status).toBe(200);
+    expect(mockDeductCredits).toHaveBeenCalledWith('token-a', 1);
+
+    // Exhaust free tier for IP B
+    for (let i = 0; i < 2; i++) {
+      await request(app).get('/test').set('X-Forwarded-For', '5.5.5.5');
+    }
+
+    // IP B with invalid token-b → invalid session, free tier exhausted → 402
+    const resB = await request(app)
+      .get('/test')
+      .set('X-Forwarded-For', '5.5.5.5')
+      .set('X-Credit-Session', 'token-b');
+    expect(resB.status).toBe(402);
+
+    // token-a's credits were deducted; token-b never had credits
+    expect(mockDeductCredits).not.toHaveBeenCalledWith(
+      'token-b',
+      expect.anything()
+    );
   });
 });

--- a/packages/api/src/middleware.test.ts
+++ b/packages/api/src/middleware.test.ts
@@ -9,6 +9,7 @@ function defaultX402Mock() {
       return (_req: Request, _res: Response, next: NextFunction) => next();
     }),
     calculateGraphQLComplexity: vi.fn(() => 0),
+    USDC_ARBITRUM: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
   };
 }
 
@@ -39,7 +40,6 @@ function expectPaymentFields(body: Record<string, unknown>) {
   expect(bundle.currency).toBe('USDC');
   expect(bundle.decimals).toBe(6);
   expect(bundle.amountUSD).toBe('$1.00');
-  expect(cs.sessionTTLSeconds).toBe(3600);
   expect(cs.instructions).toBeDefined();
 }
 
@@ -57,7 +57,6 @@ describe('rate limiting with trust proxy (simple mode)', () => {
         isProd: false,
         RATE_LIMIT_WINDOW_MS: 60000,
         FREE_TIER_RATE_LIMIT: 3,
-        HARD_RATE_LIMIT: 10,
         X402_PAY_TO: undefined,
       },
     }));
@@ -92,7 +91,6 @@ describe('rate limiting with trust proxy (simple mode)', () => {
         isProd: false,
         RATE_LIMIT_WINDOW_MS: 60000,
         FREE_TIER_RATE_LIMIT: 3,
-        HARD_RATE_LIMIT: 10,
         X402_PAY_TO: undefined,
       },
     }));
@@ -114,10 +112,8 @@ describe('tiered rate limiting with trust proxy (x402 mode)', () => {
         isProd: false,
         RATE_LIMIT_WINDOW_MS: 60000,
         FREE_TIER_RATE_LIMIT: 3,
-        HARD_RATE_LIMIT: 100,
         X402_PAY_TO: TEST_PAY_TO,
         X402_CREDIT_BUNDLE_USDC: 1_000_000,
-        X402_CREDIT_SESSION_TTL_MS: 3_600_000,
       },
     }));
     vi.doMock('./creditSessions', () => defaultCreditSessionsMock());
@@ -160,16 +156,14 @@ describe('tiered rate limiting with trust proxy (x402 mode)', () => {
     expect(otherRes.status).toBe(200);
   });
 
-  it('hard limit returns 402 not 429 — users can always pay for access', async () => {
+  it('free tier exceeded returns 402 — users can always pay for access', async () => {
     vi.doMock('./config', () => ({
       config: {
         isProd: false,
         RATE_LIMIT_WINDOW_MS: 60000,
         FREE_TIER_RATE_LIMIT: 5,
-        HARD_RATE_LIMIT: 100,
         X402_PAY_TO: TEST_PAY_TO,
         X402_CREDIT_BUNDLE_USDC: 1_000_000,
-        X402_CREDIT_SESSION_TTL_MS: 3_600_000,
       },
     }));
     vi.doMock('./creditSessions', () => defaultCreditSessionsMock());
@@ -198,16 +192,14 @@ describe('tiered rate limiting with trust proxy (x402 mode)', () => {
     expect(otherRes.status).toBe(200);
   });
 
-  it('hard limit with credit session returns 402 not 429', async () => {
+  it('exhausted credit session returns 402 with exhausted status', async () => {
     vi.doMock('./config', () => ({
       config: {
         isProd: false,
         RATE_LIMIT_WINDOW_MS: 60000,
         FREE_TIER_RATE_LIMIT: 2,
-        HARD_RATE_LIMIT: 100,
         X402_PAY_TO: TEST_PAY_TO,
         X402_CREDIT_BUNDLE_USDC: 1_000_000,
-        X402_CREDIT_SESSION_TTL_MS: 3_600_000,
       },
     }));
     vi.doMock('./creditSessions', () => ({
@@ -215,7 +207,6 @@ describe('tiered rate limiting with trust proxy (x402 mode)', () => {
       getSession: vi.fn(() => ({
         wallet: '0xabc',
         credits: 0,
-        expiresAt: Date.now() + 3_600_000,
       })),
       deductCredits: vi.fn(() => false), // exhausted
     }));
@@ -244,17 +235,14 @@ describe('credit sessions', () => {
     isProd: false,
     RATE_LIMIT_WINDOW_MS: 60000,
     FREE_TIER_RATE_LIMIT: 2,
-    HARD_RATE_LIMIT: 100,
     X402_PAY_TO: '0x1234567890abcdef1234567890abcdef12345678',
     X402_CREDIT_BUNDLE_USDC: 1_000_000,
-    X402_CREDIT_SESSION_TTL_MS: 3_600_000,
   };
 
   it('valid credit session bypasses x402 and deducts credits', async () => {
     const mockGetSession = vi.fn(() => ({
       wallet: '0xabc',
       credits: 50000,
-      expiresAt: Date.now() + 3_600_000,
     }));
     const mockDeductCredits = vi.fn(() => true);
 
@@ -286,11 +274,11 @@ describe('credit sessions', () => {
     expect(res.headers['x-credits-remaining']).toBeDefined();
   });
 
-  it('expired/invalid session token returns 402 with credit system instructions', async () => {
+  it('invalid session token returns 402 with exhausted status', async () => {
     vi.doMock('./config', () => ({ config: X402_CONFIG }));
     vi.doMock('./creditSessions', () => ({
       ...defaultCreditSessionsMock(),
-      getSession: vi.fn(() => null), // invalid/expired
+      getSession: vi.fn(() => null), // unknown token
     }));
 
     const x402Mock = vi.fn();
@@ -305,12 +293,12 @@ describe('credit sessions', () => {
 
     const res = await request(app)
       .get('/test')
-      .set('X-Credit-Session', 'expired-token');
+      .set('X-Credit-Session', 'unknown-token');
 
     expect(res.status).toBe(402);
-    expect(res.headers['x-credit-session-status']).toBe('expired');
+    expect(res.headers['x-credit-session-status']).toBe('exhausted');
     expectPaymentFields(res.body);
-    expect(res.body.creditSession.status).toBe('expired');
+    expect(res.body.creditSession.status).toBe('exhausted');
     expect(res.body.creditSession.pricing).toContain('complexity score');
     expect(res.body.creditSession.instructions.step1).toContain(
       'Payment-Signature'
@@ -326,7 +314,6 @@ describe('credit sessions', () => {
     const mockCreateCreditSession = vi.fn(() => ({
       token: 'new-session-token',
       credits: 1_000_000,
-      expiresAt: Date.now() + 3_600_000,
     }));
 
     vi.doMock('./config', () => ({ config: X402_CONFIG }));
@@ -369,18 +356,13 @@ describe('credit sessions', () => {
     expect(res.status).toBe(200);
     expect(res.headers['x-credit-session']).toBe('new-session-token');
     expect(res.headers['x-credits-remaining']).toBe('1000000');
-    expect(mockCreateCreditSession).toHaveBeenCalledWith(
-      '0xpayer',
-      1_000_000,
-      3_600_000
-    );
+    expect(mockCreateCreditSession).toHaveBeenCalledWith('0xpayer', 1_000_000);
   });
 
   it('credits exhausted returns 402 with exhausted status and bundle info', async () => {
     const mockGetSession = vi.fn(() => ({
       wallet: '0xabc',
       credits: 100, // not enough for the 5000 cost
-      expiresAt: Date.now() + 3_600_000,
     }));
 
     vi.doMock('./config', () => ({ config: X402_CONFIG }));
@@ -426,7 +408,6 @@ describe('credit sessions', () => {
         return {
           wallet: '0xaaa',
           credits: sessionCreditsA,
-          expiresAt: Date.now() + 3_600_000,
         };
       }
       return null; // token-b is unknown
@@ -485,5 +466,87 @@ describe('credit sessions', () => {
       'token-b',
       expect.anything()
     );
+  });
+
+  it('malformed query (NaN/Infinity complexity) still gets valid numeric cost', async () => {
+    const mockGetSession = vi.fn(() => ({
+      wallet: '0xabc',
+      credits: 50000,
+    }));
+    const mockDeductCredits = vi.fn(() => true);
+
+    vi.doMock('./config', () => ({ config: X402_CONFIG }));
+    vi.doMock('./creditSessions', () => ({
+      ...defaultCreditSessionsMock(),
+      getSession: mockGetSession,
+      deductCredits: mockDeductCredits,
+    }));
+    vi.doMock('./x402', () => ({
+      ...defaultX402Mock(),
+      // Return NaN to simulate the bug
+      calculateGraphQLComplexity: vi.fn(() => NaN),
+    }));
+
+    const { createApp } = await import('./app');
+    const app = createApp();
+    app.post('/graphql', (_req, res) => res.json({ data: {} }));
+
+    const res = await request(app)
+      .post('/graphql')
+      .set('X-Credit-Session', 'valid-token')
+      .send({ query: '{ __typename }' });
+
+    expect(res.status).toBe(200);
+    // Math.max(1, NaN) = NaN, but our guard ensures complexity always returns finite
+    // so deductCredits should be called with 1 (the minimum)
+    expect(mockDeductCredits).toHaveBeenCalledWith('valid-token', 1);
+  });
+
+  it('session creation failure after payment sets error header but still succeeds', async () => {
+    const mockCreateCreditSession = vi.fn(() => {
+      throw new Error('DB connection failed');
+    });
+
+    vi.doMock('./config', () => ({ config: X402_CONFIG }));
+    vi.doMock('./creditSessions', () => ({
+      ...defaultCreditSessionsMock(),
+      createCreditSession: mockCreateCreditSession,
+      extractPayerFromPaymentHeader: vi.fn(() => '0xpayer'),
+    }));
+
+    // x402 mock that calls next() on payment success
+    vi.doMock('./x402', () => ({
+      ...defaultX402Mock(),
+      createGasAwareX402Middleware: vi.fn(() => {
+        return (_req: Request, _res: Response, next: NextFunction) => {
+          next();
+        };
+      }),
+    }));
+
+    const { createApp } = await import('./app');
+    const app = createApp();
+    app.get('/test', (_req, res) => res.json({ ok: true }));
+
+    // Exhaust free tier
+    for (let i = 0; i < 2; i++) {
+      await request(app).get('/test').set('X-Forwarded-For', '3.3.3.3');
+    }
+
+    // Payment succeeds but session creation fails
+    const res = await request(app)
+      .get('/test')
+      .set('X-Forwarded-For', '3.3.3.3')
+      .set(
+        'Payment-Signature',
+        Buffer.from(
+          JSON.stringify({ authorization: { from: '0xpayer' } })
+        ).toString('base64')
+      );
+
+    expect(res.status).toBe(200);
+    expect(res.headers['x-credit-session-error']).toBe('creation_failed');
+    // No session token should be set
+    expect(res.headers['x-credit-session']).toBeUndefined();
   });
 });

--- a/packages/api/src/middleware.ts
+++ b/packages/api/src/middleware.ts
@@ -266,28 +266,12 @@ export function setupMiddleware(app: Express) {
     },
   });
 
-  const hardLimiter = rateLimit({
-    windowMs: config.RATE_LIMIT_WINDOW_MS,
-    max: config.HARD_RATE_LIMIT,
-    standardHeaders: true,
-    legacyHeaders: false,
-    // No skip - count all requests regardless of payment status
-    message: {
-      error: 'Too Many Requests',
-      message: `Hard limit of ${config.HARD_RATE_LIMIT} requests per minute exceeded.`,
-      tier: 'hard_limit',
-    },
-  });
-
   // Tiered rate limiting system
   if (config.X402_PAY_TO) {
-    // Tier 1: Hard limit check first (reject early if >400 req/min)
-    app.use(hardLimiter);
-
-    // Tier 2: Free tier check (flag if needs payment)
+    // Single rate limiter — excess goes to 402 payment path
     app.use(freeTierLimiter);
 
-    // Tier 3: Credit session check + conditional x402 payment
+    // Credit session check + conditional x402 payment
     const x402Middleware = createGasAwareX402Middleware();
 
     app.use(async (req: Request, res: Response, next: NextFunction) => {

--- a/packages/api/src/middleware.ts
+++ b/packages/api/src/middleware.ts
@@ -6,7 +6,7 @@ import rateLimit from 'express-rate-limit';
 import { recoverMessageAddress } from 'viem';
 import { config } from './config';
 import {
-  createGasAwareX402Middleware,
+  createX402Middleware,
   calculateGraphQLComplexity,
   USDC_ARBITRUM,
 } from './x402';
@@ -281,7 +281,7 @@ export function setupMiddleware(app: Express) {
     app.use(freeTierLimiter);
 
     // Credit session check + conditional x402 payment
-    const x402Middleware = createGasAwareX402Middleware();
+    const x402Middleware = createX402Middleware();
 
     app.use(async (req: Request, res: Response, next: NextFunction) => {
       const creditToken = req.headers['x-credit-session'] as string | undefined;

--- a/packages/api/src/middleware.ts
+++ b/packages/api/src/middleware.ts
@@ -166,6 +166,14 @@ const corsOptions: cors.CorsOptions = {
   ],
 };
 
+// ─── Credit cost scaling ─────────────────────────────────────────────────────
+// Divide raw GraphQL complexity by this to get the credit cost.
+// With the default divisor of 100 and bundle size of 10,000:
+//   simple query (~100 complexity) → 1 credit  → $1 buys ~10,000 requests
+//   medium query (~1000 complexity) → 10 credits → $1 buys ~1,000 requests
+//   heavy aggregation (~10000 complexity) → 100 credits → $1 buys ~100 requests
+const CREDIT_COMPLEXITY_DIVISOR = 100;
+
 // ─── Credit session 402 response ─────────────────────────────────────────────
 
 /**
@@ -174,6 +182,7 @@ const corsOptions: cors.CorsOptions = {
  */
 function buildCreditSession402Body(message: string, status?: 'exhausted') {
   const bundleAmount = config.X402_CREDIT_BUNDLE_USDC;
+  const bundleCredits = config.X402_CREDIT_BUNDLE_SIZE;
   return {
     error: 'Payment Required',
     message,
@@ -189,10 +198,12 @@ function buildCreditSession402Body(message: string, status?: 'exhausted') {
         currency: 'USDC',
         decimals: 6,
         amountUSD: `$${(bundleAmount / 1e6).toFixed(2)}`,
+        credits: bundleCredits,
       },
       pricing:
-        'Each query costs credits equal to its GraphQL complexity score (minimum 1). ' +
-        'Simple queries (~50-100) are cheap; complex aggregations (~5000+) cost more.',
+        `Each bundle grants ${bundleCredits.toLocaleString()} credits. ` +
+        'Simple queries cost 1 credit; complex aggregations cost more (up to ~100). ' +
+        'Non-GraphQL requests cost 1 credit.',
       instructions: {
         step1:
           'Send the same request with a Payment-Signature header containing a signed x402 exact-scheme payload for the bundle amount.',
@@ -201,7 +212,7 @@ function buildCreditSession402Body(message: string, status?: 'exhausted') {
         step3:
           'On subsequent requests, include the header X-Credit-Session: <token> to spend credits without paying again.',
         step4:
-          'Each request deducts credits equal to the query complexity score. When credits run out, you will receive this 402 again.',
+          'Each request deducts credits based on query complexity. When credits run out, you will receive this 402 again.',
       },
     },
   };
@@ -283,7 +294,7 @@ export function setupMiddleware(app: Express) {
       if (creditToken) {
         const session = await getSession(creditToken);
         if (session) {
-          // Cost = query complexity score (minimum 1)
+          // Cost = scaled complexity (minimum 1 credit)
           let cost = 1;
           if (
             req.path === '/graphql' &&
@@ -294,11 +305,13 @@ export function setupMiddleware(app: Express) {
               req.body.query,
               req.body.variables
             );
-            cost = Number.isFinite(raw) ? Math.max(1, raw) : 1;
+            cost = Number.isFinite(raw)
+              ? Math.max(1, Math.round(raw / CREDIT_COMPLEXITY_DIVISOR))
+              : 1;
           }
 
-          if (await deductCredits(creditToken, cost)) {
-            const remaining = (await getSession(creditToken))?.credits ?? 0;
+          const remaining = await deductCredits(creditToken, cost);
+          if (remaining !== null) {
             res.setHeader('X-Credits-Remaining', String(remaining));
             return next();
           }
@@ -341,7 +354,7 @@ export function setupMiddleware(app: Express) {
               try {
                 const { token, credits } = await createCreditSession(
                   wallet,
-                  config.X402_CREDIT_BUNDLE_USDC
+                  config.X402_CREDIT_BUNDLE_SIZE
                 );
                 res.setHeader('X-Credit-Session', token);
                 res.setHeader('X-Credits-Remaining', String(credits));

--- a/packages/api/src/middleware.ts
+++ b/packages/api/src/middleware.ts
@@ -5,7 +5,16 @@ import express from 'express';
 import rateLimit from 'express-rate-limit';
 import { recoverMessageAddress } from 'viem';
 import { config } from './config';
-import { createGasAwareX402Middleware } from './x402';
+import {
+  createGasAwareX402Middleware,
+  calculateGraphQLComplexity,
+} from './x402';
+import {
+  createCreditSession,
+  getSession,
+  deductCredits,
+  extractPayerFromPaymentHeader,
+} from './creditSessions';
 
 // ─── Admin auth ──────────────────────────────────────────────────────────────
 
@@ -143,13 +152,60 @@ const corsOptions: cors.CorsOptions = {
     'x-admin-signature',
     'x-admin-signature-timestamp',
     'Payment-Signature', // x402 payment header
+    'X-Credit-Session', // credit session token
   ],
   exposedHeaders: [
     'PAYMENT-REQUIRED',
     'PAYMENT-RESPONSE',
     'X-PAYMENT-RESPONSE',
+    'X-Credit-Session',
+    'X-Credit-Session-Status',
+    'X-Credits-Remaining',
   ],
 };
+
+// ─── Credit session 402 response ─────────────────────────────────────────────
+
+/**
+ * Build a structured 402 response body that explains the credit session system.
+ * Designed to be understood by both AI agents and programmatic HTTP clients.
+ */
+function buildCreditSession402Body(
+  message: string,
+  status?: 'expired' | 'exhausted'
+) {
+  const bundleAmount = config.X402_CREDIT_BUNDLE_USDC;
+  return {
+    error: 'Payment Required',
+    message,
+    creditSession: {
+      ...(status && { status }),
+      protocol: 'x402',
+      scheme: 'exact',
+      network: 'eip155:42161',
+      bundle: {
+        amount: String(bundleAmount),
+        currency: 'USDC',
+        decimals: 6,
+        amountUSD: `$${(bundleAmount / 1e6).toFixed(2)}`,
+      },
+      sessionTTLSeconds: Math.floor(config.X402_CREDIT_SESSION_TTL_MS / 1000),
+      pricing:
+        'Each query costs credits equal to its GraphQL complexity score (minimum 1). ' +
+        'Simple queries (~50-100) are cheap; complex aggregations (~5000+) cost more.',
+      instructions: {
+        step1:
+          'Send the same request with a Payment-Signature header containing a signed x402 exact-scheme payload for the bundle amount.',
+        step2:
+          'On success, read the X-Credit-Session response header — this is your session token.',
+        step3:
+          'On subsequent requests, include the header X-Credit-Session: <token> to spend credits without paying again.',
+        step4:
+          'Each request deducts credits equal to the query complexity score. When credits run out, you will receive this 402 again.',
+      },
+    },
+  };
+}
 
 // ─── Middleware setup ────────────────────────────────────────────────────────
 
@@ -192,10 +248,12 @@ export function setupMiddleware(app: Express) {
     standardHeaders: true,
     legacyHeaders: false,
     skip: (req) => {
-      // Skip rate limiting if request has payment header
-      // We check for the header presence (not validated payment) because
-      // freeTierLimiter runs BEFORE x402 middleware validates the payment
-      return !!req.headers['payment-signature'];
+      // Skip rate limiting if request has payment header or valid credit session
+      // We check for header presence (not validated payment) because
+      // freeTierLimiter runs BEFORE x402/credit middleware validates them
+      return (
+        !!req.headers['payment-signature'] || !!req.headers['x-credit-session']
+      );
     },
     // Custom handler to mark for payment instead of rejecting
     handler: (req: Request, _res: Response, next: NextFunction) => {
@@ -227,24 +285,92 @@ export function setupMiddleware(app: Express) {
     // Tier 2: Free tier check (flag if needs payment)
     app.use(freeTierLimiter);
 
-    // Tier 3: Conditional x402 payment processing (in-process facilitator)
+    // Tier 3: Credit session check + conditional x402 payment
     const x402Middleware = createGasAwareX402Middleware();
 
     app.use(async (req: Request, res: Response, next: NextFunction) => {
+      const creditToken = req.headers['x-credit-session'] as string | undefined;
       const hasPaymentHeader = req.headers['payment-signature'];
+      const requiresPayment = (req as Request & { requiresPayment?: boolean })
+        .requiresPayment;
 
-      // Process payment if either:
-      // 1. Free tier exceeded (req.requiresPayment=true) OR
-      // 2. Request has payment header (even if under free tier)
-      if (
-        (req as Request & { requiresPayment?: boolean }).requiresPayment ||
-        hasPaymentHeader
-      ) {
+      // --- Credit session check ---
+      let creditSessionFailed = false;
+      let creditFailureReason: 'expired' | 'exhausted' | undefined;
+      if (creditToken) {
+        const session = getSession(creditToken);
+        if (session) {
+          // Cost = query complexity score (minimum 1)
+          let cost = 1;
+          if (
+            req.path === '/graphql' &&
+            req.method === 'POST' &&
+            req.body?.query
+          ) {
+            cost = Math.max(
+              1,
+              calculateGraphQLComplexity(req.body.query, req.body.variables)
+            );
+          }
+
+          if (deductCredits(creditToken, cost)) {
+            const remaining = getSession(creditToken)?.credits ?? 0;
+            res.setHeader('X-Credits-Remaining', String(remaining));
+            return next();
+          }
+          creditFailureReason = 'exhausted';
+        } else {
+          creditFailureReason = 'expired';
+        }
+        // Invalid/expired/exhausted — must pay again
+        creditSessionFailed = true;
+      }
+
+      // --- x402 payment path ---
+      if (requiresPayment || hasPaymentHeader || creditSessionFailed) {
+        // No payment header — send a descriptive 402 explaining the credit
+        // system so AI agents and programmatic clients know what to do.
+        if (!hasPaymentHeader) {
+          if (creditSessionFailed) {
+            res.setHeader('X-Credit-Session-Status', creditFailureReason!);
+          }
+          const message =
+            creditFailureReason === 'exhausted'
+              ? 'Your credit session has run out of credits. Make a new x402 payment to purchase a fresh credit bundle.'
+              : creditFailureReason === 'expired'
+                ? 'Your credit session has expired or is invalid. Make a new x402 payment to start a new session.'
+                : 'Free tier rate limit exceeded. Make an x402 payment to purchase a credit bundle for continued access.';
+          res
+            .status(402)
+            .json(buildCreditSession402Body(message, creditFailureReason));
+          return;
+        }
+
         try {
-          // x402 middleware handles both cases:
-          // - No payment header → sends 402 directly (callback never called)
-          // - Valid payment → calls callback, then settles on-chain
-          await x402Middleware(req, res, next);
+          await x402Middleware(req, res, (err?: unknown) => {
+            if (err) return next(err);
+
+            // Payment succeeded — create credit session for the payer
+            const paymentHeader = req.headers['payment-signature'] as string;
+            const wallet = extractPayerFromPaymentHeader(paymentHeader);
+
+            if (wallet) {
+              try {
+                const { token, credits } = createCreditSession(
+                  wallet,
+                  config.X402_CREDIT_BUNDLE_USDC,
+                  config.X402_CREDIT_SESSION_TTL_MS
+                );
+                res.setHeader('X-Credit-Session', token);
+                res.setHeader('X-Credits-Remaining', String(credits));
+              } catch (e) {
+                console.error('[x402] Failed to create credit session:', e);
+                // Continue without session — payment still succeeded
+              }
+            }
+
+            next();
+          });
         } catch (err) {
           console.error('[x402] Payment middleware error:', err);
           if (!res.headersSent) {
@@ -256,7 +382,8 @@ export function setupMiddleware(app: Express) {
         }
         return;
       }
-      // Under free tier and no payment header - continue normally
+
+      // Under free tier, no credit session, no payment header — continue normally
       next();
     });
   } else {

--- a/packages/api/src/middleware.ts
+++ b/packages/api/src/middleware.ts
@@ -298,7 +298,7 @@ export function setupMiddleware(app: Express) {
       let creditSessionFailed = false;
       let creditFailureReason: 'expired' | 'exhausted' | undefined;
       if (creditToken) {
-        const session = getSession(creditToken);
+        const session = await getSession(creditToken);
         if (session) {
           // Cost = query complexity score (minimum 1)
           let cost = 1;
@@ -313,8 +313,8 @@ export function setupMiddleware(app: Express) {
             );
           }
 
-          if (deductCredits(creditToken, cost)) {
-            const remaining = getSession(creditToken)?.credits ?? 0;
+          if (await deductCredits(creditToken, cost)) {
+            const remaining = (await getSession(creditToken))?.credits ?? 0;
             res.setHeader('X-Credits-Remaining', String(remaining));
             return next();
           }
@@ -347,7 +347,7 @@ export function setupMiddleware(app: Express) {
         }
 
         try {
-          await x402Middleware(req, res, (err?: unknown) => {
+          await x402Middleware(req, res, async (err?: unknown) => {
             if (err) return next(err);
 
             // Payment succeeded — create credit session for the payer
@@ -356,7 +356,7 @@ export function setupMiddleware(app: Express) {
 
             if (wallet) {
               try {
-                const { token, credits } = createCreditSession(
+                const { token, credits } = await createCreditSession(
                   wallet,
                   config.X402_CREDIT_BUNDLE_USDC,
                   config.X402_CREDIT_SESSION_TTL_MS

--- a/packages/api/src/middleware.ts
+++ b/packages/api/src/middleware.ts
@@ -8,6 +8,7 @@ import { config } from './config';
 import {
   createGasAwareX402Middleware,
   calculateGraphQLComplexity,
+  USDC_ARBITRUM,
 } from './x402';
 import {
   createCreditSession,
@@ -160,6 +161,7 @@ const corsOptions: cors.CorsOptions = {
     'X-PAYMENT-RESPONSE',
     'X-Credit-Session',
     'X-Credit-Session-Status',
+    'X-Credit-Session-Error',
     'X-Credits-Remaining',
   ],
 };
@@ -170,10 +172,7 @@ const corsOptions: cors.CorsOptions = {
  * Build a structured 402 response body that explains the credit session system.
  * Designed to be understood by both AI agents and programmatic HTTP clients.
  */
-function buildCreditSession402Body(
-  message: string,
-  status?: 'expired' | 'exhausted'
-) {
+function buildCreditSession402Body(message: string, status?: 'exhausted') {
   const bundleAmount = config.X402_CREDIT_BUNDLE_USDC;
   return {
     error: 'Payment Required',
@@ -184,14 +183,13 @@ function buildCreditSession402Body(
       scheme: 'exact',
       network: 'eip155:42161',
       payTo: config.X402_PAY_TO,
-      asset: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831', // USDC on Arbitrum One
+      asset: USDC_ARBITRUM,
       bundle: {
         amount: String(bundleAmount),
         currency: 'USDC',
         decimals: 6,
         amountUSD: `$${(bundleAmount / 1e6).toFixed(2)}`,
       },
-      sessionTTLSeconds: Math.floor(config.X402_CREDIT_SESSION_TTL_MS / 1000),
       pricing:
         'Each query costs credits equal to its GraphQL complexity score (minimum 1). ' +
         'Simple queries (~50-100) are cheap; complex aggregations (~5000+) cost more.',
@@ -247,7 +245,7 @@ export function setupMiddleware(app: Express) {
   const freeTierLimiter = rateLimit({
     windowMs: config.RATE_LIMIT_WINDOW_MS,
     max: config.FREE_TIER_RATE_LIMIT,
-    standardHeaders: true,
+    standardHeaders: false,
     legacyHeaders: false,
     skip: (req) => {
       // Skip rate limiting if request has payment header or valid credit session
@@ -282,7 +280,6 @@ export function setupMiddleware(app: Express) {
 
       // --- Credit session check ---
       let creditSessionFailed = false;
-      let creditFailureReason: 'expired' | 'exhausted' | undefined;
       if (creditToken) {
         const session = await getSession(creditToken);
         if (session) {
@@ -293,10 +290,11 @@ export function setupMiddleware(app: Express) {
             req.method === 'POST' &&
             req.body?.query
           ) {
-            cost = Math.max(
-              1,
-              calculateGraphQLComplexity(req.body.query, req.body.variables)
+            const raw = calculateGraphQLComplexity(
+              req.body.query,
+              req.body.variables
             );
+            cost = Number.isFinite(raw) ? Math.max(1, raw) : 1;
           }
 
           if (await deductCredits(creditToken, cost)) {
@@ -304,11 +302,8 @@ export function setupMiddleware(app: Express) {
             res.setHeader('X-Credits-Remaining', String(remaining));
             return next();
           }
-          creditFailureReason = 'exhausted';
-        } else {
-          creditFailureReason = 'expired';
         }
-        // Invalid/expired/exhausted — must pay again
+        // Unknown token or insufficient credits — must pay again
         creditSessionFailed = true;
       }
 
@@ -318,17 +313,19 @@ export function setupMiddleware(app: Express) {
         // system so AI agents and programmatic clients know what to do.
         if (!hasPaymentHeader) {
           if (creditSessionFailed) {
-            res.setHeader('X-Credit-Session-Status', creditFailureReason!);
+            res.setHeader('X-Credit-Session-Status', 'exhausted');
           }
-          const message =
-            creditFailureReason === 'exhausted'
-              ? 'Your credit session has run out of credits. Make a new x402 payment to purchase a fresh credit bundle.'
-              : creditFailureReason === 'expired'
-                ? 'Your credit session has expired or is invalid. Make a new x402 payment to start a new session.'
-                : 'Free tier rate limit exceeded. Make an x402 payment to purchase a credit bundle for continued access.';
+          const message = creditSessionFailed
+            ? 'Your credit session has run out of credits. Make a new x402 payment to purchase a fresh credit bundle.'
+            : 'Free tier rate limit exceeded. Make an x402 payment to purchase a credit bundle for continued access.';
           res
             .status(402)
-            .json(buildCreditSession402Body(message, creditFailureReason));
+            .json(
+              buildCreditSession402Body(
+                message,
+                creditSessionFailed ? 'exhausted' : undefined
+              )
+            );
           return;
         }
 
@@ -344,14 +341,13 @@ export function setupMiddleware(app: Express) {
               try {
                 const { token, credits } = await createCreditSession(
                   wallet,
-                  config.X402_CREDIT_BUNDLE_USDC,
-                  config.X402_CREDIT_SESSION_TTL_MS
+                  config.X402_CREDIT_BUNDLE_USDC
                 );
                 res.setHeader('X-Credit-Session', token);
                 res.setHeader('X-Credits-Remaining', String(credits));
               } catch (e) {
                 console.error('[x402] Failed to create credit session:', e);
-                // Continue without session — payment still succeeded
+                res.setHeader('X-Credit-Session-Error', 'creation_failed');
               }
             }
 
@@ -378,7 +374,7 @@ export function setupMiddleware(app: Express) {
       rateLimit({
         windowMs: config.RATE_LIMIT_WINDOW_MS,
         max: config.FREE_TIER_RATE_LIMIT,
-        standardHeaders: true,
+        standardHeaders: false,
         legacyHeaders: false,
       })
     );

--- a/packages/api/src/middleware.ts
+++ b/packages/api/src/middleware.ts
@@ -183,6 +183,8 @@ function buildCreditSession402Body(
       protocol: 'x402',
       scheme: 'exact',
       network: 'eip155:42161',
+      payTo: config.X402_PAY_TO,
+      asset: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831', // USDC on Arbitrum One
       bundle: {
         amount: String(bundleAmount),
         currency: 'USDC',

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -19,6 +19,7 @@ import {
   proxyAuctionWebSocket,
 } from './utils/auctionProxy';
 import { cdnCacheMiddleware } from './graphql/plugins/httpCacheHeadersPlugin';
+import { cleanupExpiredSessions } from './creditSessions';
 
 const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 3001;
 
@@ -162,6 +163,25 @@ const startServer = async () => {
       }
     }
   );
+
+  // Periodically delete expired credit sessions (space reclamation only —
+  // correctness does not depend on this; getSession lazy-deletes on read).
+  const creditCleanupTimer = setInterval(
+    async () => {
+      try {
+        const deleted = await cleanupExpiredSessions();
+        if (deleted > 0) {
+          console.log(
+            `[CreditSessions] Cleaned up ${deleted} expired sessions`
+          );
+        }
+      } catch (err) {
+        console.error('[CreditSessions] Cleanup error:', err);
+      }
+    },
+    5 * 60 * 1000
+  );
+  creditCleanupTimer.unref();
 
   httpServer.listen(PORT, () => {
     console.log(`Server is running on port ${PORT}`);

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -19,7 +19,6 @@ import {
   proxyAuctionWebSocket,
 } from './utils/auctionProxy';
 import { cdnCacheMiddleware } from './graphql/plugins/httpCacheHeadersPlugin';
-import { cleanupExpiredSessions } from './creditSessions';
 
 const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 3001;
 
@@ -163,25 +162,6 @@ const startServer = async () => {
       }
     }
   );
-
-  // Periodically delete expired credit sessions (space reclamation only —
-  // correctness does not depend on this; getSession lazy-deletes on read).
-  const creditCleanupTimer = setInterval(
-    async () => {
-      try {
-        const deleted = await cleanupExpiredSessions();
-        if (deleted > 0) {
-          console.log(
-            `[CreditSessions] Cleaned up ${deleted} expired sessions`
-          );
-        }
-      } catch (err) {
-        console.error('[CreditSessions] Cleanup error:', err);
-      }
-    },
-    5 * 60 * 1000
-  );
-  creditCleanupTimer.unref();
 
   httpServer.listen(PORT, () => {
     console.log(`Server is running on port ${PORT}`);

--- a/packages/api/src/x402.ts
+++ b/packages/api/src/x402.ts
@@ -3,7 +3,8 @@
  *
  * Protects routes behind USDC micropayments on Arbitrum One.
  * Runs the facilitator in-process (no separate service needed).
- * Uses dynamic pricing based on GraphQL query complexity.
+ * Charges a single bundle price per payment; credits are tracked by
+ * the credit session system (see creditSessions.ts).
  */
 import { paymentMiddleware } from '@x402/express';
 import { x402ResourceServer, type FacilitatorClient } from '@x402/core/server';
@@ -32,17 +33,6 @@ import { SharedSchema } from './graphql/sharedSchema';
 const NETWORK = 'eip155:42161' as const;
 // Native USDC on Arbitrum One (Circle's FiatTokenV2_2, supports EIP-3009)
 const USDC_ARBITRUM = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831';
-
-// Payment configuration - tiered by GraphQL query complexity
-// Thresholds based on actual field costs from the GraphQL schema:
-// - Simple queries (basic field selections, small lists): 1-1000
-// - Medium queries (moderate lists, some aggregations): 1000-5000
-// - Complex queries (expensive aggregations, large lists): 5000+
-const COMPLEXITY_TIERS = {
-  simple: { maxComplexity: 1000, priceUSDC: 5000, priceUSD: 0.005 }, // $0.005 for simple queries
-  medium: { maxComplexity: 5000, priceUSDC: 15000, priceUSD: 0.015 }, // $0.015 for medium queries
-  complex: { maxComplexity: Infinity, priceUSDC: 30000, priceUSD: 0.03 }, // $0.03 for complex queries
-};
 
 // Gas estimation for EIP-3009 transferWithAuthorization
 // Typical gas usage: ~60,000-80,000 gas units
@@ -102,10 +92,10 @@ async function getEthUsdPrice(): Promise<number> {
 }
 
 /**
- * Calculate GraphQL query complexity using the same estimators as Apollo validation
- * Returns a complexity score used for tiered pricing (0-10000+)
+ * Calculate GraphQL query complexity using the same estimators as Apollo validation.
+ * The score is used directly as the credit cost for a query (minimum 1).
  */
-function calculateGraphQLComplexity(
+export function calculateGraphQLComplexity(
   query: string,
   variables?: Record<string, unknown>
 ): number {
@@ -138,19 +128,6 @@ function calculateGraphQLComplexity(
     console.error('[x402] Error calculating query complexity:', error);
     // On error, charge the highest tier to prevent abuse
     return Infinity;
-  }
-}
-
-/**
- * Get the appropriate pricing tier based on query complexity
- */
-function getComplexityTier(complexity: number): typeof COMPLEXITY_TIERS.simple {
-  if (complexity <= COMPLEXITY_TIERS.simple.maxComplexity) {
-    return COMPLEXITY_TIERS.simple;
-  } else if (complexity <= COMPLEXITY_TIERS.medium.maxComplexity) {
-    return COMPLEXITY_TIERS.medium;
-  } else {
-    return COMPLEXITY_TIERS.complex;
   }
 }
 
@@ -261,9 +238,9 @@ function createX402Server() {
 }
 
 /**
- * Create x402 middleware for a specific price tier
+ * Create x402 middleware for a given USDC price
  */
-function createX402MiddlewareForTier(
+function createX402PaymentMiddleware(
   priceUSDC: number,
   description: string,
   server: x402ResourceServer
@@ -294,58 +271,31 @@ function createX402MiddlewareForTier(
 }
 
 /**
- * Middleware wrapper that:
- * 1. Analyzes GraphQL query complexity for dynamic pricing
- * 2. Checks gas costs before requiring payment
- * 3. Routes to appropriate payment tier
- * If gas > payment, returns 503 instead of 402
+ * Middleware that checks gas costs before requiring an x402 payment.
+ * If gas > bundle price, returns 503 instead of 402.
  */
 export function createGasAwareX402Middleware() {
   // Create shared x402 server instance
   const server = createX402Server();
 
-  // Create middleware instances for each pricing tier
-  const simpleMiddleware = createX402MiddlewareForTier(
-    COMPLEXITY_TIERS.simple.priceUSDC,
-    'API access - simple query',
-    server
-  );
-  const mediumMiddleware = createX402MiddlewareForTier(
-    COMPLEXITY_TIERS.medium.priceUSDC,
-    'API access - medium complexity query',
-    server
-  );
-  const complexMiddleware = createX402MiddlewareForTier(
-    COMPLEXITY_TIERS.complex.priceUSDC,
-    'API access - complex query',
+  // Single bundle-priced middleware — one payment covers many queries
+  const bundlePrice = config.X402_CREDIT_BUNDLE_USDC;
+  const bundlePriceUSD = bundlePrice / 1e6; // USDC has 6 decimals
+  const bundleMiddleware = createX402PaymentMiddleware(
+    bundlePrice,
+    'API access - credit bundle',
     server
   );
 
   return async (req: Request, res: Response, next: NextFunction) => {
-    // Determine pricing tier based on query complexity (for GraphQL requests)
-    let tier = COMPLEXITY_TIERS.simple; // Default for non-GraphQL
-    let complexity = 0;
-
-    if (req.path === '/graphql' && req.method === 'POST' && req.body?.query) {
-      complexity = calculateGraphQLComplexity(
-        req.body.query,
-        req.body.variables
-      );
-      tier = getComplexityTier(complexity);
-
-      console.log(
-        `[x402] GraphQL query complexity: ${complexity} (tier: ${tier === COMPLEXITY_TIERS.simple ? 'simple' : tier === COMPLEXITY_TIERS.medium ? 'medium' : 'complex'}, price: $${tier.priceUSD})`
-      );
-    }
-
     // Check if gas is too expensive before requiring payment
-    const { tooExpensive, gasCostUSD, gasPrice } = await isGasTooExpensive(
-      tier.priceUSD
-    );
+    // Use bundle price (larger amount = less likely to be gas-unprofitable)
+    const { tooExpensive, gasCostUSD, gasPrice } =
+      await isGasTooExpensive(bundlePriceUSD);
 
     if (tooExpensive) {
       console.warn(
-        `[x402] Gas too expensive (${gasCostUSD.toFixed(6)} USD > ${tier.priceUSD} USD payment). ` +
+        `[x402] Gas too expensive (${gasCostUSD.toFixed(6)} USD > ${bundlePriceUSD} USD bundle). ` +
           `Gas price: ${gasPrice} gwei. Returning 503.`
       );
 
@@ -355,7 +305,7 @@ export function createGasAwareX402Middleware() {
           'Payment settlement costs exceed payment amount due to high gas prices. Please try again later.',
         details: {
           gasCostUSD: gasCostUSD.toFixed(6),
-          paymentAmountUSD: tier.priceUSD.toFixed(3),
+          paymentAmountUSD: bundlePriceUSD.toFixed(3),
           gasPrice: `${gasPrice} gwei`,
           reason: 'Unprofitable to settle payment on-chain',
         },
@@ -364,15 +314,7 @@ export function createGasAwareX402Middleware() {
       return;
     }
 
-    // Select appropriate middleware based on complexity tier
-    let selectedMiddleware = simpleMiddleware;
-    if (tier === COMPLEXITY_TIERS.medium) {
-      selectedMiddleware = mediumMiddleware;
-    } else if (tier === COMPLEXITY_TIERS.complex) {
-      selectedMiddleware = complexMiddleware;
-    }
-
-    // Gas is reasonable - proceed with x402 payment flow
-    return selectedMiddleware(req, res, next);
+    // Gas is reasonable - proceed with x402 payment flow (bundle price)
+    return bundleMiddleware(req, res, next);
   };
 }

--- a/packages/api/src/x402.ts
+++ b/packages/api/src/x402.ts
@@ -13,16 +13,9 @@ import { x402Facilitator } from '@x402/core/facilitator';
 import { registerExactEvmScheme as registerFacilitatorEvmScheme } from '@x402/evm/exact/facilitator';
 import { toFacilitatorEvmSigner } from '@x402/evm';
 import { config } from './config';
-import {
-  createWalletClient,
-  http,
-  publicActions,
-  createPublicClient,
-  formatGwei,
-} from 'viem';
+import { createWalletClient, http, publicActions } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import { arbitrum } from 'viem/chains';
-import type { Request, Response, NextFunction } from 'express';
 import { parse } from 'graphql';
 import {
   getComplexity,
@@ -33,63 +26,6 @@ import { SharedSchema } from './graphql/sharedSchema';
 const NETWORK = 'eip155:42161' as const;
 // Native USDC on Arbitrum One (Circle's FiatTokenV2_2, supports EIP-3009)
 export const USDC_ARBITRUM = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831';
-
-// Gas estimation for EIP-3009 transferWithAuthorization
-// Typical gas usage: ~60,000-80,000 gas units
-const ESTIMATED_GAS_UNITS = 80000;
-
-// Chainlink ETH/USD price feed on Arbitrum One
-const CHAINLINK_ETH_USD = '0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612';
-const CHAINLINK_ABI = [
-  {
-    name: 'latestRoundData',
-    type: 'function',
-    stateMutability: 'view',
-    inputs: [],
-    outputs: [
-      { name: 'roundId', type: 'uint80' },
-      { name: 'answer', type: 'int256' },
-      { name: 'startedAt', type: 'uint256' },
-      { name: 'updatedAt', type: 'uint256' },
-      { name: 'answeredInRound', type: 'uint80' },
-    ],
-  },
-] as const;
-
-// Create public client for gas price + Chainlink reads
-const publicClient = createPublicClient({
-  chain: arbitrum,
-  transport: http(config.X402_ARBITRUM_RPC_URL),
-});
-
-// Cache ETH/USD price for 60 seconds to avoid hitting the oracle on every request
-let cachedEthPrice: { price: number; fetchedAt: number } | null = null;
-const ETH_PRICE_CACHE_MS = 60_000;
-const ETH_PRICE_FALLBACK = 3000;
-
-async function getEthUsdPrice(): Promise<number> {
-  if (
-    cachedEthPrice &&
-    Date.now() - cachedEthPrice.fetchedAt < ETH_PRICE_CACHE_MS
-  ) {
-    return cachedEthPrice.price;
-  }
-
-  try {
-    const [, answer] = await publicClient.readContract({
-      address: CHAINLINK_ETH_USD,
-      abi: CHAINLINK_ABI,
-      functionName: 'latestRoundData',
-    });
-    // Chainlink ETH/USD uses 8 decimals
-    const price = Number(answer) / 1e8;
-    cachedEthPrice = { price, fetchedAt: Date.now() };
-    return price;
-  } catch (error) {
-    console.error('[x402] Error fetching ETH/USD price from Chainlink:', error);
-    return cachedEthPrice?.price ?? ETH_PRICE_FALLBACK;
-  }
-}
 
 /**
  * Calculate GraphQL query complexity using the same estimators as Apollo validation.
@@ -128,42 +64,6 @@ export function calculateGraphQLComplexity(
     console.error('[x402] Error calculating query complexity:', error);
     // On error, return minimum — the query will fail at the GraphQL layer anyway if malformed
     return 1;
-  }
-}
-
-/**
- * Check if current gas costs exceed the payment amount
- * Returns true if gas cost > payment (unprofitable to settle)
- */
-async function isGasTooExpensive(
-  paymentAmountUSD: number
-): Promise<{ tooExpensive: boolean; gasCostUSD: number; gasPrice: string }> {
-  try {
-    // Get current gas price on Arbitrum
-    const gasPrice = await publicClient.getGasPrice();
-
-    // Calculate gas cost in wei
-    const gasCostWei = gasPrice * BigInt(ESTIMATED_GAS_UNITS);
-
-    // Convert to ETH
-    const gasCostETH = Number(gasCostWei) / 1e18;
-
-    // Real-time ETH/USD from Chainlink (cached 60s, falls back to $3000)
-    const ethUsdRate = await getEthUsdPrice();
-    const gasCostUSD = gasCostETH * ethUsdRate;
-
-    // Gas is too expensive if it costs more than the payment
-    const tooExpensive = gasCostUSD > paymentAmountUSD;
-
-    return {
-      tooExpensive,
-      gasCostUSD,
-      gasPrice: formatGwei(gasPrice),
-    };
-  } catch (error) {
-    console.error('Error checking gas price:', error);
-    // On error, assume gas is not too expensive (fail open)
-    return { tooExpensive: false, gasCostUSD: 0, gasPrice: '0' };
   }
 }
 
@@ -271,50 +171,15 @@ function createX402PaymentMiddleware(
 }
 
 /**
- * Middleware that checks gas costs before requiring an x402 payment.
- * If gas > bundle price, returns 503 instead of 402.
+ * Create the x402 payment middleware for credit bundle purchases.
  */
-export function createGasAwareX402Middleware() {
-  // Create shared x402 server instance
+export function createX402Middleware() {
   const server = createX402Server();
-
-  // Single bundle-priced middleware — one payment covers many queries
   const bundlePrice = config.X402_CREDIT_BUNDLE_USDC;
-  const bundlePriceUSD = bundlePrice / 1e6; // USDC has 6 decimals
-  const bundleMiddleware = createX402PaymentMiddleware(
+
+  return createX402PaymentMiddleware(
     bundlePrice,
     'API access - credit bundle',
     server
   );
-
-  return async (req: Request, res: Response, next: NextFunction) => {
-    // Check if gas is too expensive before requiring payment
-    // Use bundle price (larger amount = less likely to be gas-unprofitable)
-    const { tooExpensive, gasCostUSD, gasPrice } =
-      await isGasTooExpensive(bundlePriceUSD);
-
-    if (tooExpensive) {
-      console.warn(
-        `[x402] Gas too expensive (${gasCostUSD.toFixed(6)} USD > ${bundlePriceUSD} USD bundle). ` +
-          `Gas price: ${gasPrice} gwei. Returning 503.`
-      );
-
-      res.status(503).json({
-        error: 'Service Temporarily Unavailable',
-        message:
-          'Payment settlement costs exceed payment amount due to high gas prices. Please try again later.',
-        details: {
-          gasCostUSD: gasCostUSD.toFixed(6),
-          paymentAmountUSD: bundlePriceUSD.toFixed(3),
-          gasPrice: `${gasPrice} gwei`,
-          reason: 'Unprofitable to settle payment on-chain',
-        },
-        retryAfter: 300, // Suggest retry in 5 minutes
-      });
-      return;
-    }
-
-    // Gas is reasonable - proceed with x402 payment flow (bundle price)
-    return bundleMiddleware(req, res, next);
-  };
 }

--- a/packages/api/src/x402.ts
+++ b/packages/api/src/x402.ts
@@ -32,7 +32,7 @@ import { SharedSchema } from './graphql/sharedSchema';
 
 const NETWORK = 'eip155:42161' as const;
 // Native USDC on Arbitrum One (Circle's FiatTokenV2_2, supports EIP-3009)
-const USDC_ARBITRUM = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831';
+export const USDC_ARBITRUM = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831';
 
 // Gas estimation for EIP-3009 transferWithAuthorization
 // Typical gas usage: ~60,000-80,000 gas units
@@ -123,11 +123,11 @@ export function calculateGraphQLComplexity(
       estimators: createComplexityEstimators(config.GRAPHQL_MAX_LIST_SIZE),
     });
 
-    return complexity;
+    return Number.isFinite(complexity) ? complexity : 1;
   } catch (error) {
     console.error('[x402] Error calculating query complexity:', error);
-    // On error, charge the highest tier to prevent abuse
-    return Infinity;
+    // On error, return minimum — the query will fail at the GraphQL layer anyway if malformed
+    return 1;
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds credit session system so clients pay once for a credit bundle ($1.00 USDC default), then spend credits across multiple queries — amortizing a single on-chain gas cost over many requests
- Replaces per-query tiered x402 pricing with a single bundle payment; each query costs credits equal to its GraphQL complexity score (minimum 1)
- Returns structured 402 response body with step-by-step instructions designed for AI agents and programmatic clients
- Adds `X-Credit-Session` / `X-Credits-Remaining` / `X-Credit-Session-Status` response headers

### New files
- `creditSessions.ts` — in-memory session store with periodic cleanup and 10k hard cap
- `creditSessions.test.ts` — 15 unit tests

### Modified files
- `config.ts` — `X402_CREDIT_BUNDLE_USDC`, `X402_CREDIT_SESSION_TTL_MS` env vars
- `x402.ts` — removed tiered pricing, single bundle middleware
- `middleware.ts` — credit check before x402, session creation on payment success, descriptive 402 bodies
- `middleware.test.ts` — 5 new integration tests (valid session bypass, expired/exhausted 402s, payment creates session, per-token isolation)

## Test plan

- [x] `pnpm --filter @sapience/api run test` — all 385 tests pass
- [ ] Manual: exhaust free tier → get 402 with bundle price and instructions
- [ ] Manual: pay via x402 → response includes `X-Credit-Session` header
- [ ] Manual: send subsequent request with `X-Credit-Session` → 200 (no payment)
- [ ] Manual: exhaust credits → get 402 with `exhausted` status

🤖 Generated with [Claude Code](https://claude.com/claude-code)