### PR TITLE
feat(app): treat testnet manual resolver as Polymarket resolver

### DIFF
--- a/packages/app/src/lib/constants/index.ts
+++ b/packages/app/src/lib/constants/index.ts
@@ -1,8 +1,17 @@
 import {
   conditionalTokensConditionResolver,
+  manualConditionResolver,
   pythConditionResolver,
   type ChainAddressMap,
 } from '@sapience/sdk/contracts';
+
+// On Ethereal testnet, the LayerZero bridge that pipes Polymarket conditions in
+// on mainnet does not exist. The market-keeper instead uses the manual resolver
+// as a stand-in, so Polymarket-imported conditions on staging carry the manual
+// resolver address. Treat the testnet manual resolver as a Polymarket resolver so
+// the resolution UI surfaces the Polymarket link. On mainnet the manual resolver
+// is reserved for genuine admin-resolved conditions and must not be relabeled.
+const ETHEREAL_TESTNET_CHAIN_ID = 13374202;
 
 // address of anonymous quoter bot
 export const PREFERRED_ESTIMATE_QUOTER =
@@ -38,6 +47,25 @@ function collectAddresses(...maps: ChainAddressMap[]): string[] {
   return addrs;
 }
 
+// Same as collectAddresses but limited to a single chain id.
+function collectAddressesForChain(
+  chainId: number,
+  ...maps: ChainAddressMap[]
+): string[] {
+  const addrs: string[] = [];
+  for (const map of maps) {
+    const entry = map[chainId];
+    if (!entry) continue;
+    if (entry.address) addrs.push(entry.address);
+    if (entry.legacy) {
+      for (const leg of entry.legacy) {
+        addrs.push(typeof leg === 'string' ? leg : leg.address);
+      }
+    }
+  }
+  return addrs;
+}
+
 function buildDisplayMap(
   display: ResolverDisplay,
   ...maps: ChainAddressMap[]
@@ -49,11 +77,17 @@ function buildDisplayMap(
   return result;
 }
 
-// Known Polymarket resolver addresses — CT condition resolver (all chains + legacy)
+// Known Polymarket resolver addresses — CT condition resolver (all chains + legacy),
+// plus the testnet manual resolver which acts as the staging stand-in for the LZ
+// bridge from Polygon (see comment near ETHEREAL_TESTNET_CHAIN_ID above).
 export const POLYMARKET_RESOLVER_ADDRESSES = new Set(
-  collectAddresses(conditionalTokensConditionResolver).map((a) =>
-    a.toLowerCase()
-  )
+  [
+    ...collectAddresses(conditionalTokensConditionResolver),
+    ...collectAddressesForChain(
+      ETHEREAL_TESTNET_CHAIN_ID,
+      manualConditionResolver
+    ),
+  ].map((a) => a.toLowerCase())
 );
 
 const polymarketDisplay: ResolverDisplay = {
@@ -63,8 +97,15 @@ const polymarketDisplay: ResolverDisplay = {
   iconAlt: 'Polymarket',
   url: 'https://polymarket.com/',
 };
-export const POLYMARKET_RESOLVER_DISPLAY: Record<string, ResolverDisplay> =
-  buildDisplayMap(polymarketDisplay, conditionalTokensConditionResolver);
+export const POLYMARKET_RESOLVER_DISPLAY: Record<string, ResolverDisplay> = {
+  ...buildDisplayMap(polymarketDisplay, conditionalTokensConditionResolver),
+  ...Object.fromEntries(
+    collectAddressesForChain(
+      ETHEREAL_TESTNET_CHAIN_ID,
+      manualConditionResolver
+    ).map((addr) => [addr, polymarketDisplay])
+  ),
+};
 
 const pythDisplay: ResolverDisplay = {
   name: 'Pyth Network',


### PR DESCRIPTION
## Why

On Ethereal testnet there's no LayerZero bridge relaying Polymarket conditions in from Polygon. The market-keeper writes Polymarket-imported conditions to the **manual resolver** as a stand-in. As a result, the resolution UI on staging didn't recognize those conditions as Polymarket-backed — the *View on Polymarket* link and Polymarket badge never rendered.

## What

Extends `POLYMARKET_RESOLVER_ADDRESSES` and `POLYMARKET_RESOLVER_DISPLAY` in `packages/app/src/lib/constants/index.ts` to include the **testnet** entries (current + legacy) of `manualConditionResolver`.

Both UI consumers — `QuestionPageContent.tsx` (the resolver chip + Polymarket link in the Resolution tab) and `TechSpecTable.tsx` (the resolver badge) — already cascade off these constants, so the single-file edit lights up both surfaces with no component changes.

A small `collectAddressesForChain` helper is added next to the existing `collectAddresses` to keep the chain-filtered pluck readable.

## Why it's safe on mainnet

Chain-gated to chain id `13374202`. On mainnet (`5064014`) the manual resolver is reserved for genuine admin-resolved conditions and is **not** added to the Polymarket sets — those markets keep their normal labeling. The mainnet flow is unchanged.

## How to verify on staging

1. Open any condition that was imported from Polymarket by market-keeper.
2. Resolution tab → resolver address row should show the Polymarket logomark.
3. If the condition's `similarMarkets` contains a `polymarket.com/event/...` URL, the *View on Polymarket* chip renders next to the page actions.

## Checks

- `pnpm --filter @sapience/app run lint` ✅
- `pnpm --filter @sapience/app run type-check` ✅
- Targeted vitest on the two affected suites (`decodePredictedOutcomes`, `shareDialogPicks`) ✅

Pre-existing `choiceLabel.test.ts` failures on staging are unrelated to this change.