### PR TITLE
fix(app): align Predict Prices top with Your Position sidebar

### DIFF
--- a/packages/app/src/components/markets/MarketsPage.tsx
+++ b/packages/app/src/components/markets/MarketsPage.tsx
@@ -320,7 +320,7 @@ const MarketsPage = () => {
 
           {/* Predict Prices (shared) */}
           {showPredictPrices && (
-            <div className={`w-full mt-4 mb-2 ${useCardGrid ? 'px-4' : ''}`}>
+            <div className={`w-full mb-2 ${useCardGrid ? 'px-4' : ''}`}>
               <div className="flex items-center justify-between mb-2 px-1">
                 <h2
                   className={`sc-heading ${useCardGrid ? 'text-white/80' : 'text-foreground'}`}


### PR DESCRIPTION
## Summary
- Remove hardcoded `mt-4` from the Predict Prices section wrapper
- The parent flex container already uses `gap-4` in table view, which handles inter-sibling spacing automatically
- This ensures Predict Prices aligns with the Your Position sidebar at the top, and only has spacing above it when Example Combos is rendered

## Test plan
- [ ] Verify Predict Prices heading aligns with Your Position heading when Example Combos is not shown
- [ ] Verify correct spacing between Example Combos and Predict Prices when both are shown
- [ ] Check card grid view still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)