### PR TITLE
feat(app): show max-payout vault tooltip in create position form

### DIFF
--- a/packages/app/src/components/markets/CreatePositionForm/PositionForm.tsx
+++ b/packages/app/src/components/markets/CreatePositionForm/PositionForm.tsx
@@ -13,6 +13,7 @@ import { FormProvider, type UseFormReturn, useWatch } from 'react-hook-form';
 import { parseUnits } from 'viem';
 import { useAccount } from 'wagmi';
 import { generateRandomNonce } from '@sapience/sdk';
+import { predictionMarketVault } from '@sapience/sdk/contracts';
 import {
   COLLATERAL_SYMBOLS,
   CHAIN_ID_ETHEREAL,
@@ -722,6 +723,22 @@ export default function PositionForm({
   // Since automatic auction trigger is disabled, show button immediately when no bids
   const showNoBidsHint = !bestBid && !recentlyRequested;
 
+  const showMaxPayoutTooltip = useMemo(() => {
+    const vaultAddress = predictionMarketVault[chainId]?.address?.toLowerCase();
+
+    if (!bestBid || !vaultAddress) return false;
+    if (bestBid.counterparty?.toLowerCase() !== vaultAddress) return false;
+
+    try {
+      return (
+        BigInt(bestBid.counterpartyCollateral) ===
+        parseUnits('100', collateralDecimals ?? 18)
+      );
+    } catch {
+      return false;
+    }
+  }, [bestBid, chainId, collateralDecimals]);
+
   // Show "Some combinations may not receive bids" hint after 3 seconds of no bids
   // This replaces the disclaimer after waiting for bids without success
   const HINT_DELAY_MS = 3000;
@@ -912,6 +929,7 @@ export default function PositionForm({
               positionSize={positionSizeValue || '0'}
               collateralSymbol={collateralSymbol}
               collateralDecimals={collateralDecimals}
+              showMaxPayoutTooltip={showMaxPayoutTooltip}
               nowMs={nowMs}
               showRequestBidsButton={showNoBidsHint}
               onRequestBids={handleRequestBids}

--- a/packages/app/src/components/markets/CreatePositionForm/__tests__/PositionForm.test.tsx
+++ b/packages/app/src/components/markets/CreatePositionForm/__tests__/PositionForm.test.tsx
@@ -116,6 +116,11 @@ vi.mock('@sapience/sdk/contracts', () => ({
   pythConditionResolver: {},
   conditionalTokensConditionResolver: {},
   collateralToken: { 42161: { address: '0xCollateral' } },
+  predictionMarketVault: {
+    42161: { address: '0xVault' },
+    5064014: { address: '0xVault' },
+    13374202: { address: '0xVault' },
+  },
 }));
 
 // buildAuctionPayload — return minimal valid payloads
@@ -151,6 +156,7 @@ vi.mock('~/components/markets/forms/shared/BidDisplay', () => {
       data-is-auction-pending={String(props.isAuctionPending)}
       data-has-best-bid={String(!!props.bestBid)}
       data-has-estimate-bid={String(!!props.estimateBid)}
+      data-show-max-payout-tooltip={String(props.showMaxPayoutTooltip)}
       data-estimate-counterparty={
         (props.estimateBid as { counterparty?: string } | null)?.counterparty ??
         ''
@@ -1078,9 +1084,96 @@ describe('PositionForm', () => {
   });
 
   // =========================================================================
-  // G. Geofence enforcement
+  // G. Max-payout vault tooltip
   // =========================================================================
-  describe('G. Geofence enforcement', () => {
+  describe('G. Max-payout vault tooltip', () => {
+    it('flags the bid display when the vault offers exactly 100 collateral', async () => {
+      const vaultBid = {
+        counterparty: '0xVault',
+        counterpartyCollateral: '100000000000000000000',
+        counterpartyDeadline: Math.floor(Date.now() / 1000) + 60,
+        counterpartyNonce: 1,
+        counterpartySignature: '0xSig',
+        validationStatus: 'valid' as const,
+        counterpartyChainId: 42161,
+        predictorCollateral: '10000000000000000000',
+      };
+
+      const { getByTestId, rerender } = renderForm();
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      await act(async () => {
+        rerender(
+          <PositionForm
+            methods={makeFormMethods()}
+            onSubmit={vi.fn()}
+            isSubmitting={false}
+            chainId={42161}
+            requestQuotes={mockRequestQuotes}
+            collateralDecimals={18}
+            bids={[vaultBid]}
+          />
+        );
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(100);
+      });
+
+      expect(getByTestId('bid-display').dataset.showMaxPayoutTooltip).toBe(
+        'true'
+      );
+    });
+
+    it('does not flag the bid display for non-vault or non-100 collateral bids', async () => {
+      const notMaxVaultBid = {
+        counterparty: '0xNotVault',
+        counterpartyCollateral: '99000000000000000000',
+        counterpartyDeadline: Math.floor(Date.now() / 1000) + 60,
+        counterpartyNonce: 1,
+        counterpartySignature: '0xSig',
+        validationStatus: 'valid' as const,
+        counterpartyChainId: 42161,
+        predictorCollateral: '10000000000000000000',
+      };
+
+      const { getByTestId, rerender } = renderForm();
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      await act(async () => {
+        rerender(
+          <PositionForm
+            methods={makeFormMethods()}
+            onSubmit={vi.fn()}
+            isSubmitting={false}
+            chainId={42161}
+            requestQuotes={mockRequestQuotes}
+            collateralDecimals={18}
+            bids={[notMaxVaultBid]}
+          />
+        );
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(100);
+      });
+
+      expect(getByTestId('bid-display').dataset.showMaxPayoutTooltip).toBe(
+        'false'
+      );
+    });
+  });
+
+  // =========================================================================
+  // H. Geofence enforcement
+  // =========================================================================
+  describe('H. Geofence enforcement', () => {
     it('shows banner and disables submit when jurisdiction is restricted', () => {
       mockUseSapience.mockReturnValue({
         permitData: { permitted: false },

--- a/packages/app/src/components/markets/forms/shared/BidDisplay.test.tsx
+++ b/packages/app/src/components/markets/forms/shared/BidDisplay.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import BidDisplay from './BidDisplay';
+import type { QuoteBid } from '~/lib/auction/useAuctionStart';
+
+vi.mock('@sapience/ui/components/ui/button', () => ({
+  Button: ({ children, ...props }: React.ComponentProps<'button'>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock('@sapience/ui/components/ui/tooltip', () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock('lucide-react', () => ({
+  ChevronDown: () => <span data-testid="chevron-down" />,
+  Info: () => <span data-testid="info-icon" />,
+}));
+
+vi.mock('./RiskDisclaimer', () => ({
+  default: () => <div data-testid="risk-disclaimer" />,
+}));
+
+vi.mock('~/components/shared/Loader', () => ({
+  default: () => <div data-testid="loader" />,
+}));
+
+vi.mock('~/components/shared/AuctionBidsChart', () => ({
+  default: () => <div data-testid="auction-bids-chart" />,
+}));
+
+vi.mock('~/lib/auction/bidAdapter', () => ({
+  quoteBidsToAuctionBids: () => [],
+}));
+
+const bestBid: QuoteBid = {
+  auctionId: 'auction-1',
+  counterparty: '0x1f5fF6074095cd27A7EaBd75F0A1Ac4243ecCE91',
+  counterpartyCollateral: '100000000000000000000',
+  counterpartyDeadline: 9999999999,
+  counterpartySignature: '0xsig',
+  counterpartyNonce: 1,
+  validationStatus: 'valid',
+};
+
+describe('BidDisplay', () => {
+  it('shows the max-payout tooltip when flagged on a valid best bid', () => {
+    render(
+      <BidDisplay
+        bestBid={bestBid}
+        positionSize="25"
+        collateralSymbol="USDe"
+        collateralDecimals={18}
+        showMaxPayoutTooltip
+        nowMs={0}
+        showRequestBidsButton={false}
+        onRequestBids={vi.fn()}
+        isSubmitting={false}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Payout')).toBeInTheDocument();
+    expect(
+      screen.getByText('This is max payout ever offered by the bidder.')
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Max payout info')).toBeInTheDocument();
+  });
+
+  it('does not show the max-payout tooltip when not flagged', () => {
+    render(
+      <BidDisplay
+        bestBid={bestBid}
+        positionSize="25"
+        collateralSymbol="USDe"
+        collateralDecimals={18}
+        showMaxPayoutTooltip={false}
+        nowMs={0}
+        showRequestBidsButton={false}
+        onRequestBids={vi.fn()}
+        isSubmitting={false}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.queryByText('This is max payout ever offered by the bidder.')
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Max payout info')).not.toBeInTheDocument();
+  });
+});

--- a/packages/app/src/components/markets/forms/shared/BidDisplay.tsx
+++ b/packages/app/src/components/markets/forms/shared/BidDisplay.tsx
@@ -2,6 +2,12 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import { Button } from '@sapience/ui/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@sapience/ui/components/ui/tooltip';
 import { formatUnits, parseUnits } from 'viem';
 import { ChevronDown, Info } from 'lucide-react';
 import RiskDisclaimer from './RiskDisclaimer';
@@ -22,6 +28,8 @@ interface BidDisplayProps {
   collateralSymbol: string;
   /** Collateral decimals (default 18) */
   collateralDecimals?: number;
+  /** Show info tooltip when payout is the vault's max offer */
+  showMaxPayoutTooltip?: boolean;
   /** Current time in ms for expiration calculation */
   nowMs: number;
   /** Whether to show "Request Bids" button */
@@ -72,6 +80,7 @@ export default function BidDisplay({
   positionSize,
   collateralSymbol,
   collateralDecimals = 18,
+  showMaxPayoutTooltip = false,
   nowMs,
   showRequestBidsButton,
   onRequestBids,
@@ -96,11 +105,11 @@ export default function BidDisplay({
 
   // Helper function to calculate payout amount
   const calculatePayoutAmount = useCallback(
-    (bid: QuoteBid, positionSize: string): string => {
+    (bid: QuoteBid, positionSizeValue: string): string => {
       let userPositionSizeWei: bigint = 0n;
       try {
         userPositionSizeWei = parseUnits(
-          positionSize || '0',
+          positionSizeValue || '0',
           collateralDecimals
         );
       } catch {
@@ -237,6 +246,24 @@ export default function BidDisplay({
 
   const buttonState = getButtonState();
 
+  const maxPayoutTooltip = showMaxPayoutTooltip ? (
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className="inline-flex cursor-help text-brand-white/70 transition-colors hover:text-brand-white"
+            aria-label="Max payout info"
+          >
+            <Info className="h-3.5 w-3.5" />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>
+          This is max payout ever offered by the bidder.
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  ) : null;
+
   return (
     <div
       className={`text-center ${payoutTakesSpace ? '' : 'relative'} ${className ?? ''}`}
@@ -254,8 +281,9 @@ export default function BidDisplay({
                   <span className="font-light text-brand-white uppercase tracking-wider">
                     Payout
                   </span>
-                  <span className="text-brand-white font-semibold inline-flex items-center whitespace-nowrap">
+                  <span className="text-brand-white font-semibold inline-flex items-center gap-1 whitespace-nowrap">
                     {`${humanTotal} ${collateralSymbol}`}
+                    {maxPayoutTooltip}
                   </span>
                 </span>
                 {/* View Auction Toggle - directly under Payout */}
@@ -347,8 +375,9 @@ export default function BidDisplay({
                   <span className="font-light text-muted-foreground uppercase tracking-wider">
                     ESTIMATED PAYOUT
                   </span>
-                  <span className="text-muted-foreground font-semibold whitespace-nowrap">
+                  <span className="text-muted-foreground font-semibold inline-flex items-center gap-1 whitespace-nowrap">
                     {`${humanTotal} ${collateralSymbol}`}
+                    {maxPayoutTooltip}
                   </span>
                 </span>
               </div>


### PR DESCRIPTION
## Why
When the protocol vault is offering its max 100 collateral bid in `CreatePositionForm`, the UI should call that out so users understand why that quote is special.

## What changed
- detect when the current valid best bid comes from the vault address and its offered collateral is exactly 100
- show an info-circle tooltip beside the payout amount with: `This is max payout ever offered by the bidder.`
- cover the shared bid display rendering and the `PositionForm` detection logic with tests

## Verification
- `pnpm --filter @sapience/app exec vitest run src/components/markets/forms/shared/BidDisplay.test.tsx src/components/markets/CreatePositionForm/__tests__/PositionForm.test.tsx`
- `pnpm --filter @sapience/app run lint`
- `pnpm --filter @sapience/app run type-check`