### PR TITLE
feat(app): volume metric dropdown + per-window related-volume filters

### DIFF
--- a/packages/app/src/components/markets/MarketsPage.tsx
+++ b/packages/app/src/components/markets/MarketsPage.tsx
@@ -65,6 +65,10 @@ const MarketsPage = () => {
   const defaultFilters: FilterState = {
     openInterestRange: [0, Infinity],
     similarMarketVolumeRange: [0, Infinity],
+    volume1hRange: [0, Infinity],
+    volume4hRange: [0, Infinity],
+    volume24hRange: [0, Infinity],
+    volume7dRange: [0, Infinity],
     timeToResolutionRange: [-Infinity, Infinity],
     selectedCategories: [],
     resolutionStatus: 'unresolved',

--- a/packages/app/src/components/markets/QuestionsTable.tsx
+++ b/packages/app/src/components/markets/QuestionsTable.tsx
@@ -17,13 +17,27 @@ import {
   useReactTable,
   type ColumnDef,
 } from '@tanstack/react-table';
-import { ChevronUp, ChevronDown, Info, ArrowRightLeft } from 'lucide-react';
+import {
+  ChevronUp,
+  ChevronDown,
+  Info,
+  ArrowRightLeft,
+  Check,
+} from 'lucide-react';
 import { formatEther } from 'viem';
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from '@sapience/ui/components/ui/tooltip';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuSeparator,
+} from '@sapience/ui/components/ui/dropdown-menu';
 import { cn } from '@sapience/ui/lib/utils';
 import Loader from '../shared/Loader';
 import { PythMarketBadge } from '../shared/PythMarketBadge';
@@ -110,7 +124,32 @@ function getCellClassName(colId: string): string {
 // prediction updates, preventing remounts/flashes.
 type VolumeMetric = 'openInterest' | 'similarMarketVolume' | 'volume';
 
-const VOLUME_WINDOW_OPTIONS: VolumeWindow[] = ['1h', '4h', '24h', '7d'];
+const VOLUME_WINDOW_OPTIONS: VolumeWindow[] = ['7d', '24h', '4h', '1h'];
+
+// Encode the (metric, window) tuple as a single radio value for DropdownMenu
+type MetricOptionId =
+  | 'openInterest'
+  | 'similarMarketVolume'
+  | `volume-${VolumeWindow}`;
+
+function encodeOptionId(
+  metric: VolumeMetric,
+  window: VolumeWindow
+): MetricOptionId {
+  if (metric === 'openInterest') return 'openInterest';
+  if (metric === 'similarMarketVolume') return 'similarMarketVolume';
+  return `volume-${window}`;
+}
+
+function decodeOptionId(id: string): {
+  metric: VolumeMetric;
+  window?: VolumeWindow;
+} {
+  if (id === 'openInterest') return { metric: 'openInterest' };
+  if (id === 'similarMarketVolume') return { metric: 'similarMarketVolume' };
+  const window = id.slice('volume-'.length) as VolumeWindow;
+  return { metric: 'volume', window };
+}
 
 function createColumns(
   predictionMapRef: React.RefObject<Record<string, number>>,
@@ -120,8 +159,7 @@ function createColumns(
   excludeLowOddsRef: React.RefObject<boolean>,
   onToggleExpand: (groupId: number) => void,
   onPrediction: (conditionId: string, p: number) => void,
-  onToggleVolumeMetric: () => void,
-  onVolumeWindowChange: (w: VolumeWindow) => void,
+  onSelectMetricOption: (id: MetricOptionId) => void,
   onExcludeLowOddsChange: (v: boolean) => void
 ): ColumnDef<TopLevelRow>[] {
   return [
@@ -222,97 +260,96 @@ function createColumns(
       accessorFn: (row) => getRowOpenInterest(row).toString(),
       header: ({ column }) => {
         const metric = volumeMetricRef.current;
+        const window = volumeWindowRef.current;
+        const excludeLow = excludeLowOddsRef.current;
         const sorted = column.getIsSorted();
         const label =
           metric === 'volume'
-            ? 'Volume'
+            ? `Related Volume (${window}${excludeLow ? ', filtered' : ''})`
             : metric === 'similarMarketVolume'
               ? 'Related Volume'
               : 'Open Interest';
+        const selectedId = encodeOptionId(metric, window);
         return (
-          <div className="flex justify-end items-center gap-1">
-            {/* Volume window selector — only visible when volume metric is active */}
-            {metric === 'volume' && (
-              <div className="flex items-center gap-0.5 mr-1">
-                {VOLUME_WINDOW_OPTIONS.map((w) => (
-                  <button
-                    key={w}
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onVolumeWindowChange(w);
-                    }}
-                    className={cn(
-                      'px-1 py-0.5 text-[10px] rounded font-mono leading-none transition-colors',
-                      volumeWindowRef.current === w
-                        ? 'bg-foreground/10 text-foreground'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                  >
-                    {w}
-                  </button>
-                ))}
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onExcludeLowOddsChange(!excludeLowOddsRef.current);
-                      }}
-                      className={cn(
-                        'px-1 py-0.5 text-[10px] rounded font-mono leading-none transition-colors ml-0.5',
-                        excludeLowOddsRef.current
-                          ? 'bg-amber-400/20 text-amber-400'
-                          : 'text-muted-foreground hover:text-foreground'
-                      )}
-                    >
-                      F
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="top">
-                    {excludeLowOddsRef.current
-                      ? 'Showing filtered volume (0.01-0.99)'
-                      : 'Click to exclude extreme-odds trades'}
-                  </TooltipContent>
-                </Tooltip>
-              </div>
-            )}
+          <div className="flex justify-end items-center">
             <Button
               variant="ghost"
               onClick={() => column.toggleSorting(sorted === 'asc')}
               className="px-0 gap-1 hover:bg-transparent whitespace-nowrap"
             >
               {label}
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span
-                    role="button"
-                    tabIndex={0}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onToggleVolumeMetric();
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.stopPropagation();
-                        onToggleVolumeMetric();
-                      }
-                    }}
-                    className="inline-flex items-center justify-center h-5 w-5 rounded text-muted-foreground hover:text-foreground transition-colors"
-                  >
-                    <ArrowRightLeft className="h-3 w-3" />
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent side="top">
-                  Switch to{' '}
-                  {metric === 'openInterest'
-                    ? 'Related Volume'
-                    : metric === 'similarMarketVolume'
-                      ? 'Volume'
-                      : 'Open Interest'}
-                </TooltipContent>
-              </Tooltip>
+              <DropdownMenu>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <DropdownMenuTrigger asChild>
+                      <span
+                        role="button"
+                        tabIndex={0}
+                        onClick={(e) => e.stopPropagation()}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.stopPropagation();
+                          }
+                        }}
+                        aria-label="Choose volume metric"
+                        className="inline-flex items-center justify-center h-5 w-5 rounded text-muted-foreground hover:text-foreground transition-colors"
+                      >
+                        <ArrowRightLeft className="h-3 w-3" />
+                      </span>
+                    </DropdownMenuTrigger>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">Choose metric</TooltipContent>
+                </Tooltip>
+                <DropdownMenuContent align="end" className="min-w-[13rem]">
+                  {(
+                    [
+                      { id: 'openInterest', label: 'Open Interest' },
+                      {
+                        id: 'similarMarketVolume',
+                        label: 'Related Volume (All-time)',
+                      },
+                      ...VOLUME_WINDOW_OPTIONS.map((w) => ({
+                        id: `volume-${w}` as MetricOptionId,
+                        label: `Related Volume (${w})`,
+                      })),
+                    ] as Array<{ id: MetricOptionId; label: string }>
+                  ).map(({ id, label: itemLabel }) => {
+                    const isSelected = id === selectedId;
+                    return (
+                      <DropdownMenuItem
+                        key={id}
+                        onSelect={() => onSelectMetricOption(id)}
+                        className="pl-8 pr-2"
+                      >
+                        <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+                          {isSelected && (
+                            <Check className="h-4 w-4 text-emerald-500" />
+                          )}
+                        </span>
+                        <span
+                          className={cn(
+                            isSelected && 'font-medium text-foreground'
+                          )}
+                        >
+                          {itemLabel}
+                        </span>
+                      </DropdownMenuItem>
+                    );
+                  })}
+                  {metric === 'volume' && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuCheckboxItem
+                        checked={excludeLow}
+                        onCheckedChange={(v) => onExcludeLowOddsChange(!!v)}
+                        onSelect={(e) => e.preventDefault()}
+                      >
+                        Exclude extreme odds (0.01–0.99)
+                      </DropdownMenuCheckboxItem>
+                    </>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
               {sorted === 'asc' ? (
                 <ChevronUp className="h-4 w-4" />
               ) : sorted === 'desc' ? (
@@ -524,7 +561,9 @@ function getConditionTimeBucketedVolume(
     '24h': filtered ? 'volumeFiltered24h' : 'volume24h',
     '7d': filtered ? 'volumeFiltered7d' : 'volume7d',
   } as const;
-  return ((c as unknown as Record<string, unknown>)[fields[window]] as number) ?? 0;
+  return (
+    ((c as unknown as Record<string, unknown>)[fields[window]] as number) ?? 0
+  );
 }
 
 // Child row component for expanded group conditions
@@ -605,7 +644,11 @@ function ChildConditionRow({
           </div>
         ) : volumeMetric === 'volume' ? (
           (() => {
-            const vol = getConditionTimeBucketedVolume(condition, volumeWindow, excludeLowOdds);
+            const vol = getConditionTimeBucketedVolume(
+              condition,
+              volumeWindow,
+              excludeLowOdds
+            );
             return (
               <div className="text-sm whitespace-nowrap text-right">
                 {vol === 0 ? (
@@ -682,21 +725,16 @@ export default function QuestionsTable({
   const excludeLowOddsRef = React.useRef<boolean>(excludeLowOdds);
   excludeLowOddsRef.current = excludeLowOdds;
 
-  const handleToggleVolumeMetric = React.useCallback(() => {
-    setVolumeMetric((prev) => {
-      const cycle: VolumeMetric[] = [
-        'openInterest',
-        'similarMarketVolume',
-        'volume',
-      ];
-      const next = cycle[(cycle.indexOf(prev) + 1) % cycle.length];
-      // If currently sorting by the old metric, switch sort to the new one
-      if (sortField === prev) {
-        onSortChange(next, sortDirection);
-      }
-      return next;
-    });
-  }, [sortField, sortDirection, onSortChange]);
+  const handleSelectMetricOption = React.useCallback(
+    (id: MetricOptionId) => {
+      const decoded = decodeOptionId(id);
+      if (decoded.window) onVolumeWindowChange(decoded.window);
+      setVolumeMetric(decoded.metric);
+      // Selecting a metric always sorts by it, descending by default
+      onSortChange(decoded.metric, 'desc');
+    },
+    [onSortChange, onVolumeWindowChange]
+  );
 
   // Derive table sorting state from controlled props
   // Map similarMarketVolume/volume sort fields to the openInterest column id (they share a column)
@@ -798,12 +836,16 @@ export default function QuestionsTable({
         excludeLowOddsRef,
         handleToggleExpand,
         handlePrediction,
-        handleToggleVolumeMetric,
-        onVolumeWindowChange,
+        handleSelectMetricOption,
         onExcludeLowOddsChange
       ),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- refs are stable, intentionally omitted
-    [handleToggleExpand, handlePrediction, handleToggleVolumeMetric, onVolumeWindowChange, onExcludeLowOddsChange]
+    [
+      handleToggleExpand,
+      handlePrediction,
+      handleSelectMetricOption,
+      onExcludeLowOddsChange,
+    ]
   );
 
   const table = useReactTable({

--- a/packages/app/src/components/markets/TableFilters.tsx
+++ b/packages/app/src/components/markets/TableFilters.tsx
@@ -6,6 +6,8 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@sapience/ui/components/ui/popover';
+import Slider from '@sapience/ui/components/ui/slider';
+import { Input } from '@sapience/ui/components/ui/input';
 import {
   ChevronsUpDown,
   Check,
@@ -39,12 +41,24 @@ export interface CategoryOption {
 
 export interface FilterState {
   openInterestRange: [number, number];
-  similarMarketVolumeRange: [number, number];
+  similarMarketVolumeRange: [number, number]; // all-time
+  volume1hRange: [number, number];
+  volume4hRange: [number, number];
+  volume24hRange: [number, number];
+  volume7dRange: [number, number];
   timeToResolutionRange: [number, number]; // in days, negative = ended
   selectedCategories: string[]; // array of category slugs
   resolutionStatus: ResolutionStatusFilterValue;
   estimatedPriceRange: [number, number]; // 0-100, displayed as percentage
 }
+
+export const VOLUME_RANGE_KEYS = [
+  'similarMarketVolumeRange',
+  'volume1hRange',
+  'volume4hRange',
+  'volume24hRange',
+  'volume7dRange',
+] as const;
 
 interface TableFiltersProps {
   filters: FilterState;
@@ -169,16 +183,17 @@ function CategoryMultiSelect({
       <PopoverTrigger asChild>
         <button
           type="button"
-          className="w-full h-8 rounded-md border border-border bg-muted/30 text-left inline-flex items-center justify-between px-3 text-sm"
+          className="w-full h-8 rounded-md border border-border bg-muted/30 text-left inline-flex items-center justify-between gap-2 px-3 text-sm"
         >
           <span
-            className={
-              selectedSlugs.length === 0 ? 'text-muted-foreground' : ''
-            }
+            className={cn(
+              'min-w-0 truncate',
+              selectedSlugs.length === 0 && 'text-muted-foreground'
+            )}
           >
             {getButtonLabel()}
           </span>
-          <ChevronsUpDown className="h-4 w-4 opacity-50" />
+          <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
         </button>
       </PopoverTrigger>
       <PopoverContent className="w-[240px] p-1" align="start">
@@ -336,9 +351,238 @@ function CategoryMultiSelect({
 
 // Map slider bounds to Infinity for range filters
 const OPEN_INTEREST_SLIDER_MAX = 1000000;
-const SIMILAR_MARKET_VOLUME_SLIDER_MAX = 100000000;
+const VOLUME_SLIDER_STEP = 10000;
 const TIME_SLIDER_MAX = 1000;
 const TIME_SLIDER_MIN = -1000;
+
+const formatVolumeValue = (v: number, max: number): string => {
+  if (v >= max) return '∞';
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+  if (v >= 1_000) return `${(v / 1_000).toFixed(0)}K`;
+  return v.toLocaleString();
+};
+
+const parseVolumeValue = (raw: string, max: number): number => {
+  if (raw === '∞') return max;
+  const cleaned = raw.replace(/,/g, '').trim();
+  if (cleaned.endsWith('M')) return parseFloat(cleaned) * 1_000_000;
+  if (cleaned.endsWith('K')) return parseFloat(cleaned) * 1_000;
+  return Number(cleaned);
+};
+
+interface VolumeRangeRowProps {
+  label: string;
+  value: [number, number];
+  max: number;
+  onChange: (value: [number, number]) => void;
+}
+
+function VolumeRangeRow({ label, value, max, onChange }: VolumeRangeRowProps) {
+  const committedValue: [number, number] = [
+    value[0],
+    value[1] === Infinity ? max : Math.min(value[1], max),
+  ];
+  // Local state tracks the slider position while dragging; only committed on release.
+  const [dragValue, setDragValue] = React.useState<[number, number] | null>(
+    null
+  );
+  const displayValue = dragValue ?? committedValue;
+  const [localMin, setLocalMin] = React.useState(
+    formatVolumeValue(committedValue[0], max)
+  );
+  const [localMax, setLocalMax] = React.useState(
+    formatVolumeValue(committedValue[1], max)
+  );
+
+  React.useEffect(() => {
+    setLocalMin(formatVolumeValue(committedValue[0], max));
+    setLocalMax(formatVolumeValue(committedValue[1], max));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [committedValue[0], committedValue[1], max]);
+
+  const emit = (next: [number, number]) => {
+    onChange([next[0], next[1] >= max ? Infinity : next[1]]);
+  };
+
+  const handleSliderChange = (newValue: number[]) => {
+    if (newValue.length >= 2) setDragValue([newValue[0], newValue[1]]);
+  };
+
+  const handleSliderCommit = (newValue: number[]) => {
+    if (newValue.length >= 2) emit([newValue[0], newValue[1]]);
+    setDragValue(null);
+  };
+
+  const commitMin = () => {
+    const parsed = parseVolumeValue(localMin, max);
+    if (!isNaN(parsed)) {
+      const clamped = Math.max(0, Math.min(parsed, committedValue[1]));
+      emit([clamped, committedValue[1]]);
+    } else {
+      setLocalMin(formatVolumeValue(committedValue[0], max));
+    }
+  };
+
+  const commitMax = () => {
+    const parsed = parseVolumeValue(localMax, max);
+    if (!isNaN(parsed)) {
+      const clamped = Math.min(max, Math.max(parsed, committedValue[0]));
+      emit([committedValue[0], clamped]);
+    } else {
+      setLocalMax(formatVolumeValue(committedValue[1], max));
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-muted-foreground font-mono">{label}</span>
+        <span className="tabular-nums text-muted-foreground">
+          {formatVolumeValue(displayValue[0], max)}
+          {' → '}
+          {formatVolumeValue(displayValue[1], max)}
+        </span>
+      </div>
+      <div className="px-1 py-1">
+        <Slider
+          value={displayValue}
+          onValueChange={handleSliderChange}
+          onValueCommit={handleSliderCommit}
+          min={0}
+          max={max}
+          step={VOLUME_SLIDER_STEP}
+          className="w-full"
+        />
+      </div>
+      <div className="flex items-center gap-1.5">
+        <Input
+          inputSize="xs"
+          type="text"
+          value={localMin}
+          onChange={(e) => setLocalMin(e.target.value)}
+          onBlur={commitMin}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') e.currentTarget.blur();
+          }}
+          className="w-full text-right font-mono text-xs tabular-nums"
+        />
+        <span className="text-muted-foreground text-xs">to</span>
+        <Input
+          inputSize="xs"
+          type="text"
+          value={localMax}
+          onChange={(e) => setLocalMax(e.target.value)}
+          onBlur={commitMax}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') e.currentTarget.blur();
+          }}
+          className="w-full text-right font-mono text-xs tabular-nums"
+        />
+      </div>
+    </div>
+  );
+}
+
+interface RelatedVolumeFilterProps {
+  filters: FilterState;
+  onFiltersChange: (filters: FilterState) => void;
+}
+
+function RelatedVolumeFilter({
+  filters,
+  onFiltersChange,
+}: RelatedVolumeFilterProps) {
+  const [open, setOpen] = React.useState(false);
+
+  const allTimeRow = {
+    label: 'ALL-TIME',
+    key: 'similarMarketVolumeRange' as const,
+    max: 50_000_000,
+  };
+  const windowBands: Array<
+    Array<{
+      label: string;
+      key: (typeof VOLUME_RANGE_KEYS)[number];
+      max: number;
+    }>
+  > = [
+    [
+      { label: 'LAST 7D', key: 'volume7dRange', max: 25_000_000 },
+      { label: 'LAST 4H', key: 'volume4hRange', max: 2_500_000 },
+    ],
+    [
+      { label: 'LAST 24H', key: 'volume24hRange', max: 5_000_000 },
+      { label: 'LAST 1H', key: 'volume1hRange', max: 1_000_000 },
+    ],
+  ];
+  const windowRows = windowBands.flat();
+
+  const activeCount = [allTimeRow, ...windowRows].filter(({ key, max }) => {
+    const r = filters[key];
+    if (!Array.isArray(r) || r.length !== 2) return false;
+    const [lo, hi] = r;
+    const loActive = typeof lo === 'number' && lo > 0;
+    const hiActive = typeof hi === 'number' && Number.isFinite(hi) && hi < max;
+    return loActive || hiActive;
+  }).length;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="w-full h-8 rounded-md border border-border bg-muted/30 text-left inline-flex items-center justify-between gap-2 px-3 text-sm"
+        >
+          <span
+            className={cn(
+              'min-w-0 truncate',
+              activeCount === 0 ? 'text-muted-foreground' : 'text-foreground'
+            )}
+          >
+            Related Volume
+          </span>
+          <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[360px] max-w-[calc(100vw-1rem)] p-0"
+        align="start"
+      >
+        <div className="flex flex-col divide-y divide-border/60">
+          <div className="p-3">
+            <VolumeRangeRow
+              label={allTimeRow.label}
+              value={filters[allTimeRow.key]}
+              max={allTimeRow.max}
+              onChange={(value) =>
+                onFiltersChange({ ...filters, [allTimeRow.key]: value })
+              }
+            />
+          </div>
+          {windowBands.map((band, i) => (
+            <div
+              key={i}
+              className="grid grid-cols-1 sm:grid-cols-2 divide-y sm:divide-y-0 sm:divide-x divide-border/60"
+            >
+              {band.map(({ label, key, max }) => (
+                <div key={key} className="p-3">
+                  <VolumeRangeRow
+                    label={label}
+                    value={filters[key]}
+                    max={max}
+                    onChange={(value) =>
+                      onFiltersChange({ ...filters, [key]: value })
+                    }
+                  />
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
 
 export default function TableFilters({
   filters,
@@ -362,27 +606,6 @@ export default function TableFilters({
       openInterestRange: [
         value[0],
         value[1] >= OPEN_INTEREST_SLIDER_MAX ? Infinity : value[1],
-      ],
-    });
-  };
-
-  // Map Infinity to slider max for similar market volume display
-  const similarMarketVolumeSliderValue: [number, number] = [
-    filters.similarMarketVolumeRange[0],
-    filters.similarMarketVolumeRange[1] === Infinity
-      ? SIMILAR_MARKET_VOLUME_SLIDER_MAX
-      : Math.min(
-          filters.similarMarketVolumeRange[1],
-          SIMILAR_MARKET_VOLUME_SLIDER_MAX
-        ),
-  ];
-
-  const handleSimilarMarketVolumeChange = (value: [number, number]) => {
-    onFiltersChange({
-      ...filters,
-      similarMarketVolumeRange: [
-        value[0],
-        value[1] >= SIMILAR_MARKET_VOLUME_SLIDER_MAX ? Infinity : value[1],
       ],
     });
   };
@@ -459,30 +682,9 @@ export default function TableFilters({
         }}
         unit="OI"
       />
-      <RangeFilter
-        placeholder="Related Volume"
-        value={similarMarketVolumeSliderValue}
-        onChange={handleSimilarMarketVolumeChange}
-        min={0}
-        max={SIMILAR_MARKET_VOLUME_SLIDER_MAX}
-        step={10000}
-        formatValue={(v) =>
-          v >= SIMILAR_MARKET_VOLUME_SLIDER_MAX
-            ? '∞'
-            : v >= 1000000
-              ? `${(v / 1000000).toFixed(1)}M`
-              : v >= 1000
-                ? `${(v / 1000).toFixed(0)}K`
-                : v.toLocaleString()
-        }
-        parseValue={(v) => {
-          if (v === '∞') return SIMILAR_MARKET_VOLUME_SLIDER_MAX;
-          const cleaned = v.replace(/,/g, '');
-          if (cleaned.endsWith('M')) return parseFloat(cleaned) * 1000000;
-          if (cleaned.endsWith('K')) return parseFloat(cleaned) * 1000;
-          return Number(cleaned);
-        }}
-        unit="USD"
+      <RelatedVolumeFilter
+        filters={filters}
+        onFiltersChange={onFiltersChange}
       />
       <RangeFilter
         placeholder="Ends in"

--- a/packages/app/src/components/markets/__tests__/market-helpers.test.ts
+++ b/packages/app/src/components/markets/__tests__/market-helpers.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { filterRows, type TopLevelRow } from '../market-helpers';
+import type { FilterState } from '../TableFilters';
+
+const NO_FILTER_RANGES: Pick<
+  FilterState,
+  | 'openInterestRange'
+  | 'similarMarketVolumeRange'
+  | 'volume1hRange'
+  | 'volume4hRange'
+  | 'volume24hRange'
+  | 'volume7dRange'
+  | 'timeToResolutionRange'
+> = {
+  openInterestRange: [0, Infinity],
+  similarMarketVolumeRange: [0, Infinity],
+  volume1hRange: [0, Infinity],
+  volume4hRange: [0, Infinity],
+  volume24hRange: [0, Infinity],
+  volume7dRange: [0, Infinity],
+  timeToResolutionRange: [-Infinity, Infinity],
+};
+
+function makeConditionRow(
+  id: string,
+  overrides: Partial<Record<string, unknown>>
+): TopLevelRow {
+  return {
+    kind: 'condition',
+    id,
+    // Cast — filterRows only reads the fields we populate
+    condition: {
+      id,
+      openInterest: '0',
+      endTime: Math.floor(Date.now() / 1000) + 86400,
+      similarMarketVolume: 0,
+      volume1h: 0,
+      volume4h: 0,
+      volume24h: 0,
+      volume7d: 0,
+      volumeFiltered1h: 0,
+      volumeFiltered4h: 0,
+      volumeFiltered24h: 0,
+      volumeFiltered7d: 0,
+      ...overrides,
+    } as unknown as TopLevelRow extends { condition: infer C } ? C : never,
+  };
+}
+
+describe('filterRows — time-bucketed volume windows', () => {
+  const baseFilters: FilterState = {
+    ...NO_FILTER_RANGES,
+    selectedCategories: [],
+    resolutionStatus: 'unresolved',
+    estimatedPriceRange: [0, 100],
+  };
+
+  const rows: TopLevelRow[] = [
+    makeConditionRow('low-7d', { volume7d: 500 }),
+    makeConditionRow('mid-7d', { volume7d: 50_000 }),
+    makeConditionRow('high-7d', { volume7d: 2_000_000 }),
+  ];
+
+  it('passes all rows through when every window range is [0, Infinity]', () => {
+    expect(filterRows(rows, baseFilters)).toHaveLength(3);
+  });
+
+  it('filters by a 7d minimum', () => {
+    const result = filterRows(rows, {
+      ...baseFilters,
+      volume7dRange: [10_000, Infinity],
+    });
+    expect(result.map((r) => r.id)).toEqual(['mid-7d', 'high-7d']);
+  });
+
+  it('filters by a 7d maximum', () => {
+    const result = filterRows(rows, {
+      ...baseFilters,
+      volume7dRange: [0, 100_000],
+    });
+    expect(result.map((r) => r.id)).toEqual(['low-7d', 'mid-7d']);
+  });
+
+  it('applies each window range independently', () => {
+    const input: TopLevelRow[] = [
+      // Passes 24h floor, fails 1h floor
+      makeConditionRow('row-a', { volume24h: 100_000, volume1h: 10 }),
+      // Passes both floors
+      makeConditionRow('row-b', { volume24h: 100_000, volume1h: 5_000 }),
+    ];
+    const result = filterRows(input, {
+      ...baseFilters,
+      volume24hRange: [50_000, Infinity],
+      volume1hRange: [1_000, Infinity],
+    });
+    expect(result.map((r) => r.id)).toEqual(['row-b']);
+  });
+
+  it('gracefully accepts rows missing volume fields (treated as 0)', () => {
+    // A row with no volume fields should be included by default ranges and
+    // filtered out by any non-zero minimum.
+    const sparseRow = {
+      kind: 'condition' as const,
+      id: 'sparse',
+      condition: {
+        id: 'sparse',
+        openInterest: '0',
+        endTime: Math.floor(Date.now() / 1000) + 86400,
+      } as unknown as TopLevelRow extends { condition: infer C } ? C : never,
+    };
+    expect(filterRows([sparseRow], baseFilters)).toHaveLength(1);
+    expect(
+      filterRows([sparseRow], { ...baseFilters, volume24hRange: [1, Infinity] })
+    ).toHaveLength(0);
+  });
+});

--- a/packages/app/src/components/markets/market-helpers.tsx
+++ b/packages/app/src/components/markets/market-helpers.tsx
@@ -551,13 +551,39 @@ export function buildTopLevelRows(questions: QuestionType[]): TopLevelRow[] {
   });
 }
 
-/** Client-side filtering of rows (OI range + time-to-resolution range) */
+/** Client-side filtering of rows (OI range + volume windows + time-to-resolution range) */
 export function filterRows(
   rows: TopLevelRow[],
   filters: FilterState
 ): TopLevelRow[] {
   const [minOI, maxOI] = filters.openInterestRange;
   const [minVol, maxVol] = filters.similarMarketVolumeRange ?? [0, Infinity];
+  const windowRanges: Array<{
+    window: '1h' | '4h' | '24h' | '7d';
+    min: number;
+    max: number;
+  }> = [
+    {
+      window: '1h',
+      min: filters.volume1hRange?.[0] ?? 0,
+      max: filters.volume1hRange?.[1] ?? Infinity,
+    },
+    {
+      window: '4h',
+      min: filters.volume4hRange?.[0] ?? 0,
+      max: filters.volume4hRange?.[1] ?? Infinity,
+    },
+    {
+      window: '24h',
+      min: filters.volume24hRange?.[0] ?? 0,
+      max: filters.volume24hRange?.[1] ?? Infinity,
+    },
+    {
+      window: '7d',
+      min: filters.volume7dRange?.[0] ?? 0,
+      max: filters.volume7dRange?.[1] ?? Infinity,
+    },
+  ];
   const [minDays, maxDays] = filters.timeToResolutionRange;
   const nowSec = Math.floor(Date.now() / 1000);
 
@@ -568,9 +594,16 @@ export function filterRows(
 
     if (oiUsde < minOI || oiUsde > maxOI) return false;
 
-    // Similar market volume filter
+    // All-time similar market volume filter
     const vol = getRowSimilarMarketVolume(row);
     if (vol < minVol || vol > maxVol) return false;
+
+    // Time-bucketed volume filters
+    for (const { window, min, max } of windowRanges) {
+      if (min === 0 && max === Infinity) continue;
+      const v = getRowTimeBucketedVolume(row, window, false);
+      if (v < min || v > max) return false;
+    }
 
     if (endTime) {
       const daysFromNow = (endTime - nowSec) / 86400;

--- a/packages/app/src/components/shared/RangeFilter.tsx
+++ b/packages/app/src/components/shared/RangeFilter.tsx
@@ -135,12 +135,14 @@ export function RangeFilter({
       <PopoverTrigger asChild>
         <button
           type="button"
-          className="w-full h-8 rounded-md border border-border bg-muted/30 text-left inline-flex items-center justify-between px-3 text-sm"
+          className="w-full h-8 rounded-md border border-border bg-muted/30 text-left inline-flex items-center justify-between gap-2 px-3 text-sm"
         >
-          <span className={isAtBounds ? 'text-muted-foreground' : ''}>
+          <span
+            className={`min-w-0 truncate ${isAtBounds ? 'text-muted-foreground' : ''}`}
+          >
             {getButtonLabel()}
           </span>
-          <ChevronsUpDown className="h-4 w-4 opacity-50" />
+          <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
         </button>
       </PopoverTrigger>
       <PopoverContent className="w-[280px] p-4" align="start">


### PR DESCRIPTION
## Summary
- Replace the ⇄ cycle toggle on the Volume column with a `DropdownMenu` listing Open Interest, Related Volume (All-time), and Related Volume (1h/4h/24h/7d). Selecting any option sorts by that metric descending; a green check indicates the active choice.
- Replace the single similar-market-volume filter slider with a popover containing five ranges (All-time full-width, then 2×2 grid of 7D/4H/24H/1H on desktop; stacks on mobile) with window-specific maxes (50M / 25M / 5M / 2.5M / 1M).
- Sliders commit only on `onValueCommit` (mouseup), so dragging doesn't thrash the filters.
- `filterRows` now applies each per-window range independently; new vitest suite covers min/max, combinations, and sparse rows.

## Test plan
- [ ] On `/markets`, click the ⇄ icon in the Volume header — dropdown opens with all 6 metric options and a green check on the active one
- [ ] Pick any metric → column re-labels and table re-sorts descending
- [ ] Open the "Related Volume" filter; confirm All-time on top, 7D/4H on one row and 24H/1H on the next, with edge-to-edge dividers
- [ ] Drag a slider — the range summary updates live but the table doesn't re-filter until release
- [ ] When any range is below its window's max / lower bound > 0, the "Related Volume" label turns foreground; all-infinity stays muted
- [ ] `pnpm --filter @sapience/app run type-check`, `lint`, and `test` all pass