### PR TITLE
fix(app): restore example combos for probability-scale prices

### DIFF
--- a/packages/app/src/hooks/graphql/__tests__/useRecentCombos.test.ts
+++ b/packages/app/src/hooks/graphql/__tests__/useRecentCombos.test.ts
@@ -73,14 +73,12 @@ function makeCondition(
     settled: false,
     resolvedToYes: false,
     nonDecisive: false,
-    estimatedPrice: 50,
+    estimatedPrice: 0.5,
     ...overrides,
   };
 }
 
-function conditionMap(
-  conditions: ConditionById[]
-): Map<string, ConditionById> {
+function conditionMap(conditions: ConditionById[]): Map<string, ConditionById> {
   return new Map(conditions.map((c) => [c.id, c]));
 }
 
@@ -260,14 +258,14 @@ describe('useRecentCombos', () => {
     expect(result.current.combos[0].pickConfigId).toBe('active-combo');
   });
 
-  it('filters out combos where any condition has estimatedPrice < 1', async () => {
+  it('filters out combos where any condition has estimatedPrice < 0.01', async () => {
     const useRecentCombos = await getHook();
 
     const configs = [makeConfig({ id: 'low-price' })];
     mockFetchPickConfigurations.mockResolvedValue(configs);
     const conds = [
-      makeCondition({ id: 'c1', estimatedPrice: 0.5 }), // < 1
-      makeCondition({ id: 'c2', estimatedPrice: 50 }),
+      makeCondition({ id: 'c1', estimatedPrice: 0.005 }), // < 0.01
+      makeCondition({ id: 'c2', estimatedPrice: 0.5 }),
     ];
     mockUseConditionsByIds.mockReturnValue({
       map: conditionMap(conds),
@@ -283,20 +281,19 @@ describe('useRecentCombos', () => {
       expect(mockFetchPickConfigurations).toHaveBeenCalled();
     });
 
-    // Wait a tick for state to settle
     await waitFor(() => {
       expect(result.current.combos).toEqual([]);
     });
   });
 
-  it('filters out combos where any condition has estimatedPrice > 99', async () => {
+  it('filters out combos where any condition has estimatedPrice > 0.99', async () => {
     const useRecentCombos = await getHook();
 
     const configs = [makeConfig({ id: 'high-price' })];
     mockFetchPickConfigurations.mockResolvedValue(configs);
     const conds = [
-      makeCondition({ id: 'c1', estimatedPrice: 50 }),
-      makeCondition({ id: 'c2', estimatedPrice: 99.5 }), // > 99
+      makeCondition({ id: 'c1', estimatedPrice: 0.5 }),
+      makeCondition({ id: 'c2', estimatedPrice: 0.995 }), // > 0.99
     ];
     mockUseConditionsByIds.mockReturnValue({
       map: conditionMap(conds),
@@ -315,6 +312,32 @@ describe('useRecentCombos', () => {
     await waitFor(() => {
       expect(result.current.combos).toEqual([]);
     });
+  });
+
+  it('keeps combos whose estimatedPrice values are within the 1%-99% band', async () => {
+    const useRecentCombos = await getHook();
+
+    const configs = [makeConfig({ id: 'mid-band' })];
+    mockFetchPickConfigurations.mockResolvedValue(configs);
+    const conds = [
+      makeCondition({ id: 'c1', estimatedPrice: 0.0185 }),
+      makeCondition({ id: 'c2', estimatedPrice: 0.9895 }),
+    ];
+    mockUseConditionsByIds.mockReturnValue({
+      map: conditionMap(conds),
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useRecentCombos({ chainId: 1 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.combos.length).toBe(1);
+    });
+
+    expect(result.current.combos[0].pickConfigId).toBe('mid-band');
   });
 
   it('allows combos where estimatedPrice is null', async () => {
@@ -324,7 +347,7 @@ describe('useRecentCombos', () => {
     mockFetchPickConfigurations.mockResolvedValue(configs);
     const conds = [
       makeCondition({ id: 'c1', estimatedPrice: null }),
-      makeCondition({ id: 'c2', estimatedPrice: 50 }),
+      makeCondition({ id: 'c2', estimatedPrice: 0.5 }),
     ];
     mockUseConditionsByIds.mockReturnValue({
       map: conditionMap(conds),

--- a/packages/app/src/hooks/graphql/useRecentCombos.ts
+++ b/packages/app/src/hooks/graphql/useRecentCombos.ts
@@ -4,8 +4,8 @@ import {
   fetchPickConfigurations,
   type PickConfigurationResult,
 } from '@sapience/sdk/queries';
-import { useConditionsByIds } from './useConditionsByIds';
 import type { ConditionById } from '@sapience/sdk/queries/conditions';
+import { useConditionsByIds } from './useConditionsByIds';
 
 export type RecentCombo = {
   pickConfigId: string;
@@ -85,9 +85,10 @@ export function useRecentCombos(opts: { chainId: number; count?: number }) {
         pc.picks.every((p) => {
           const c = conditionMap.get(p.conditionId);
           if (!c || c.settled) return false;
-          // Filter out extreme prices — not useful as examples
+          // estimatedPrice is stored as a 0-1 probability; filter out only
+          // near-certain outcomes outside the 1%-99% band.
           const price = c.estimatedPrice ?? null;
-          if (price !== null && (price < 1 || price > 99)) return false;
+          if (price !== null && (price < 0.01 || price > 0.99)) return false;
           return true;
         })
       )


### PR DESCRIPTION
## Why

`useRecentCombos` was filtering `estimatedPrice` as if it were on a 0-100 scale. Prod GraphQL returns probabilities on a 0-1 scale, so valid recent multi-pick combos from `/feed` were getting filtered out and the Example Combos section on `/markets` disappeared.

## What

- update the extreme-price filter to use the 1%-99% band on a 0-1 probability scale
- update the hook tests to use probability-scale fixtures
- add coverage that values like `0.0185` and `0.9895` are still allowed

## Verification

- confirmed against `https://api.sapience.xyz/graphql` that `estimatedPrice` values are fractional probabilities
- `pnpm exec vitest run src/hooks/graphql/__tests__/useRecentCombos.test.ts --pool=forks --poolOptions.forks.singleFork`

_No Linear ticket attached for this PR per request in thread._