### PR TITLE
fix(api): use secondary trade price for volume queries

### DIFF
--- a/packages/api/src/helpers/timeSeriesQueries.test.ts
+++ b/packages/api/src/helpers/timeSeriesQueries.test.ts
@@ -17,6 +17,8 @@ import prisma from '../db';
 import {
   resolveDefaults,
   queryAccountPredictionCount,
+  queryAccountVolume,
+  queryProtocolVolume,
 } from './timeSeriesQueries';
 
 const mockQueryRaw = prisma.$queryRaw as unknown as ReturnType<typeof vi.fn>;
@@ -89,6 +91,41 @@ describe('resolveDefaults', () => {
 });
 
 // ─── queryAccountPredictionCount ─────────────────────────────────────────────
+
+describe('queryAccountVolume and queryProtocolVolume', () => {
+  beforeEach(() => {
+    mockQueryRaw.mockReset();
+  });
+
+  it('uses secondary trade price instead of collateral address for account volume', async () => {
+    mockQueryRaw.mockResolvedValue([]);
+
+    await queryAccountVolume(
+      '0xAbCdEf1234567890AbCdEf1234567890AbCdEf12',
+      TimeInterval.DAY,
+      new Date('2024-01-01T00:00:00Z'),
+      new Date('2024-01-10T00:00:00Z')
+    );
+
+    const queryText = mockQueryRaw.mock.calls[0][0].join(' ');
+    expect(queryText).toContain('CAST(price AS DECIMAL) AS vol');
+    expect(queryText).not.toContain('CAST(collateral AS DECIMAL) AS vol');
+  });
+
+  it('uses secondary trade price instead of collateral address for protocol volume', async () => {
+    mockQueryRaw.mockResolvedValue([]);
+
+    await queryProtocolVolume(
+      TimeInterval.DAY,
+      new Date('2024-01-01T00:00:00Z'),
+      new Date('2024-01-10T00:00:00Z')
+    );
+
+    const queryText = mockQueryRaw.mock.calls[0][0].join(' ');
+    expect(queryText).toContain('CAST(price AS DECIMAL) AS vol');
+    expect(queryText).not.toContain('CAST(collateral AS DECIMAL) AS vol');
+  });
+});
 
 describe('queryAccountPredictionCount', () => {
   beforeEach(() => {

--- a/packages/api/src/helpers/timeSeriesQueries.ts
+++ b/packages/api/src/helpers/timeSeriesQueries.ts
@@ -151,8 +151,9 @@ export async function queryAccountVolume(
       WHERE (predictor = ${addr} OR counterparty = ${addr})
         AND "onChainCreatedAt" >= ${fromEpoch} AND "onChainCreatedAt" <= ${toEpoch}
       UNION ALL
+      -- secondary_trade.collateral is the token address; price is the amount paid
       SELECT "executedAt" AS created_ts,
-        CAST(collateral AS DECIMAL) AS vol
+        CAST(price AS DECIMAL) AS vol
       FROM secondary_trade
       WHERE (buyer = ${addr} OR seller = ${addr})
         AND "executedAt" >= ${fromEpoch} AND "executedAt" <= ${toEpoch}
@@ -489,8 +490,9 @@ export async function queryProtocolVolume(
       WHERE "chainId" = ${chainId}
         AND "onChainCreatedAt" >= ${fromEpoch} AND "onChainCreatedAt" <= ${toEpoch}
       UNION ALL
+      -- secondary_trade.collateral is the token address; price is the amount paid
       SELECT "executedAt" AS created_ts,
-        CAST(collateral AS DECIMAL) AS vol
+        CAST(price AS DECIMAL) AS vol
       FROM secondary_trade
       WHERE "chainId" = ${chainId}
         AND "executedAt" >= ${fromEpoch} AND "executedAt" <= ${toEpoch}


### PR DESCRIPTION
## Summary
- fix `accountVolume` to sum secondary trade `price` instead of the `collateral` token address
- fix `protocolVolume` to use the same secondary trade amount semantics
- add regression tests asserting the SQL uses `price` and not `collateral` for secondary trade volume
- document the footgun inline so nobody turns an address back into a 10^48 volume number

## Verification
- `pnpm exec vitest run src/helpers/timeSeriesQueries.test.ts --pool=forks --poolOptions.forks.singleFork --reporter=dot`

## Notes
- no Linear ticket was provided in-thread, so this PR is opened without a `Fixes SAP-XXX` footer
- I checked for the same issue elsewhere in the live api codepath and found the bad `secondary_trade.collateral` numeric cast only in these two volume queries
