### PR TITLE
fix(app): repair markets volume filter rollout for staging promotion

### DIFF
--- a/packages/app/src/components/markets/MarketsPage.tsx
+++ b/packages/app/src/components/markets/MarketsPage.tsx
@@ -33,6 +33,20 @@ import { useFeatureFlag } from '~/hooks/useFeatureFlag';
 import { useSessionState } from '~/hooks/useSessionState';
 import { useCreatePositionContext } from '~/lib/context/CreatePositionContext';
 
+const VALID_SORT_FIELDS: SortField[] = [
+  'openInterest',
+  'endTime',
+  'createdAt',
+  'predictionCount',
+  'similarMarketVolume',
+];
+
+function migrateMarketSortField(value: unknown): SortField {
+  return VALID_SORT_FIELDS.includes(value as SortField)
+    ? (value as SortField)
+    : 'openInterest';
+}
+
 const MarketsPage = () => {
   const { data: allCategories = [], isLoading: isLoadingCategories } =
     useCategories();
@@ -116,7 +130,10 @@ const MarketsPage = () => {
   // Sorting state - lifted here so backend can respect it during pagination
   const [sortField, setSortField] = useSessionState<SortField>(
     'sapience.markets.sortField',
-    'openInterest'
+    'openInterest',
+    {
+      migrate: migrateMarketSortField,
+    }
   );
   const [sortDirection, setSortDirection] = useSessionState<SortDirection>(
     'sapience.markets.sortDirection',

--- a/packages/app/src/components/markets/QuestionsTable.tsx
+++ b/packages/app/src/components/markets/QuestionsTable.tsx
@@ -130,6 +130,17 @@ type VolumeMetric =
 
 const VOLUME_WINDOW_OPTIONS: VolumeWindow[] = ['7d', '24h', '4h', '1h'];
 
+export function getEffectiveVolumeWindow(
+  window: VolumeWindow | null,
+  filterVolume: boolean
+): VolumeWindow {
+  const resolvedWindow = window ?? '24h';
+  if (!filterVolume || resolvedWindow.endsWith('Filtered')) {
+    return resolvedWindow;
+  }
+  return `${resolvedWindow}Filtered` as VolumeWindow;
+}
+
 // Encode the (metric, window) tuple as a single radio value for DropdownMenu
 type MetricOptionId =
   | 'openInterest'
@@ -398,6 +409,10 @@ function createColumns(
       },
       cell: ({ row }) => {
         const metric = volumeMetricRef.current;
+        const effectiveVolumeWindow = getEffectiveVolumeWindow(
+          volumeWindowRef.current,
+          filterVolumeRef.current
+        );
         if (metric === 'similarMarketVolumeAllTime') {
           const vol = getRowSimilarMarketVolume(row.original);
           if (vol === 0) {
@@ -418,7 +433,7 @@ function createColumns(
         if (metric === 'similarMarketVolumeWindowed') {
           const vol = getRowTimeBucketedVolume(
             row.original,
-            volumeWindowRef.current ?? '24h'
+            effectiveVolumeWindow
           );
           if (vol === 0) {
             return (
@@ -465,15 +480,13 @@ function createColumns(
           );
         }
         if (volumeMetricRef.current === 'similarMarketVolumeWindowed') {
+          const effectiveVolumeWindow = getEffectiveVolumeWindow(
+            volumeWindowRef.current,
+            filterVolumeRef.current
+          );
           return (
-            getRowTimeBucketedVolume(
-              rowA.original,
-              volumeWindowRef.current ?? '24h'
-            ) -
-            getRowTimeBucketedVolume(
-              rowB.original,
-              volumeWindowRef.current ?? '24h'
-            )
+            getRowTimeBucketedVolume(rowA.original, effectiveVolumeWindow) -
+            getRowTimeBucketedVolume(rowB.original, effectiveVolumeWindow)
           );
         }
         const a = getRowOpenInterest(rowA.original);
@@ -592,9 +605,8 @@ function createColumns(
   ];
 }
 
-/** Get time-bucketed volume for a single condition (used in child rows).
- *  Always uses the base (unfiltered) window key for display. */
-function getConditionTimeBucketedVolume(
+/** Get time-bucketed volume for a single condition (used in child rows). */
+export function getConditionTimeBucketedVolume(
   c: ConditionGroupConditionType,
   window: VolumeWindow | null
 ): number {
@@ -620,6 +632,7 @@ function ChildConditionRow({
   onPrediction,
   volumeMetric,
   volumeWindow,
+  filterVolume,
   isLast = false,
 }: {
   condition: ConditionGroupConditionType;
@@ -627,6 +640,7 @@ function ChildConditionRow({
   onPrediction: (conditionId: string, p: number) => void;
   volumeMetric: VolumeMetric;
   volumeWindow: VolumeWindow | null;
+  filterVolume: boolean;
   isLast?: boolean;
 }) {
   const conditionType = groupConditionToConditionType(condition);
@@ -639,6 +653,10 @@ function ChildConditionRow({
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   });
+  const effectiveVolumeWindow = getEffectiveVolumeWindow(
+    volumeWindow,
+    filterVolume
+  );
 
   return (
     <TableRow
@@ -690,7 +708,10 @@ function ChildConditionRow({
           </div>
         ) : volumeMetric === 'similarMarketVolumeWindowed' ? (
           (() => {
-            const vol = getConditionTimeBucketedVolume(condition, volumeWindow);
+            const vol = getConditionTimeBucketedVolume(
+              condition,
+              effectiveVolumeWindow
+            );
             return (
               <div className="text-sm whitespace-nowrap text-right">
                 {vol === 0 ? (
@@ -1004,6 +1025,7 @@ export default function QuestionsTable({
                             onPrediction={handlePrediction}
                             volumeMetric={volumeMetric}
                             volumeWindow={volumeWindow}
+                            filterVolume={filterVolume}
                             isLast={idx === data.conditions.length - 1}
                           />
                         ))}

--- a/packages/app/src/components/markets/__tests__/QuestionsTable.test.ts
+++ b/packages/app/src/components/markets/__tests__/QuestionsTable.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getConditionTimeBucketedVolume,
+  getEffectiveVolumeWindow,
+} from '../QuestionsTable';
+
+describe('QuestionsTable volume window semantics', () => {
+  it('uses filtered window keys when filter volume is enabled', () => {
+    expect(getEffectiveVolumeWindow('1h', true)).toBe('1hFiltered');
+    expect(getEffectiveVolumeWindow('4h', true)).toBe('4hFiltered');
+    expect(getEffectiveVolumeWindow('24h', true)).toBe('24hFiltered');
+    expect(getEffectiveVolumeWindow('7d', true)).toBe('7dFiltered');
+  });
+
+  it('preserves the base window when filter volume is disabled', () => {
+    expect(getEffectiveVolumeWindow('1h', false)).toBe('1h');
+    expect(getEffectiveVolumeWindow('24h', false)).toBe('24h');
+  });
+
+  it('reads the matching filtered field for child row volume display', () => {
+    const condition = {
+      similarMarketVolume24h: 125,
+      similarMarketVolumeFiltered24h: 75,
+    };
+
+    expect(getConditionTimeBucketedVolume(condition as never, '24h')).toBe(125);
+    expect(
+      getConditionTimeBucketedVolume(condition as never, '24hFiltered')
+    ).toBe(75);
+  });
+});

--- a/packages/app/src/hooks/useSessionState.test.tsx
+++ b/packages/app/src/hooks/useSessionState.test.tsx
@@ -1,0 +1,34 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useSessionState } from './useSessionState';
+
+describe('useSessionState', () => {
+  it('migrates invalid persisted values back to a valid default', async () => {
+    window.sessionStorage.setItem(
+      'sapience.markets.sortField',
+      JSON.stringify('volume')
+    );
+
+    const { result } = renderHook(() =>
+      useSessionState('sapience.markets.sortField', 'openInterest', {
+        migrate: (value) =>
+          value === 'openInterest' ||
+          value === 'endTime' ||
+          value === 'createdAt' ||
+          value === 'predictionCount' ||
+          value === 'similarMarketVolume'
+            ? value
+            : 'openInterest',
+      })
+    );
+
+    expect(result.current[0]).toBe('openInterest');
+
+    await waitFor(() => {
+      expect(window.sessionStorage.getItem('sapience.markets.sortField')).toBe(
+        JSON.stringify('openInterest')
+      );
+    });
+  });
+});

--- a/packages/app/src/hooks/useSessionState.ts
+++ b/packages/app/src/hooks/useSessionState.ts
@@ -30,13 +30,19 @@ function deserialize<T>(raw: string): T {
  */
 export function useSessionState<T>(
   key: string,
-  defaultValue: T
+  defaultValue: T,
+  options?: {
+    migrate?: (value: unknown) => T;
+  }
 ): [T, React.Dispatch<React.SetStateAction<T>>] {
   const [value, setValue] = useState<T>(() => {
     if (typeof window === 'undefined') return defaultValue;
     try {
       const stored = window.sessionStorage.getItem(key);
-      if (stored !== null) return deserialize<T>(stored);
+      if (stored !== null) {
+        const parsed = deserialize<unknown>(stored);
+        return options?.migrate ? options.migrate(parsed) : (parsed as T);
+      }
     } catch {
       // Storage unavailable or corrupt — fall through
     }


### PR DESCRIPTION
## Why

PR #1561 (staging -> main) is blocked by two app regressions:

1. the markets table can ask the backend for filtered related-volume windows while still rendering/sorting raw window values locally
2. existing users can keep a legacy `volume` sort value in `sessionStorage` after the GraphQL enum removed it

This patch fixes both on `staging` so the promotion PR can pick them up cleanly.

## What changed

- align table display + local sorting with the effective filtered/unfiltered volume window
- apply the same window semantics to expanded child rows
- add `useSessionState` migration support
- migrate legacy `sapience.markets.sortField` values to a valid sort field on load
- add regression tests for both behaviors

## Verification

- `node node_modules/typescript/bin/tsc --noEmit --pretty false` (from `packages/app`)
- targeted ESLint / Prettier checks passed before commit on the touched files
- attempted targeted Vitest, but this sandbox is currently thread/process-limited (`Cannot fork` / `failed to create new OS thread`), so I could not get reliable local test execution after wiring the new test files

Refs PR #1561.