### PR TITLE
fix(tags): normalize first-letter case on ingest + backfill

### DIFF
--- a/packages/api/prisma/migrations/20260416000000_normalize_condition_tag_case/migration.sql
+++ b/packages/api/prisma/migrations/20260416000000_normalize_condition_tag_case/migration.sql
@@ -1,0 +1,18 @@
+-- Normalize tag case: capitalize the first character of every tag label,
+-- preserving the rest (so acronyms like "UFC" stay intact and labels that
+-- Polymarket returns miscased, e.g. "temperature", become "Temperature").
+UPDATE "condition"
+SET "tags" = sub.normalized
+FROM (
+  SELECT
+    "id",
+    ARRAY(
+      SELECT UPPER(LEFT(t, 1)) || SUBSTRING(t FROM 2)
+      FROM unnest("tags") AS t
+      WHERE t IS NOT NULL AND t <> ''
+    ) AS normalized
+  FROM "condition"
+  WHERE array_length("tags", 1) > 0
+) AS sub
+WHERE "condition"."id" = sub."id"
+  AND "condition"."tags" IS DISTINCT FROM sub.normalized;

--- a/packages/api/src/routes/conditions.test.ts
+++ b/packages/api/src/routes/conditions.test.ts
@@ -133,16 +133,16 @@ describe('conditions routes', () => {
       expect(res.body.message).toMatch(/already exists/i);
     });
 
-    it('stores tags array when provided', async () => {
+    it('stores tags array when provided (first-letter capitalized)', async () => {
       mockPrisma.condition.create.mockResolvedValue({ id: '0x1' });
 
       const res = await request(app)
         .post('/admin/conditions')
-        .send(baseBody({ tags: ['bitcoin', 'crypto'] }));
+        .send(baseBody({ tags: ['bitcoin', 'crypto', 'UFC'] }));
 
       expect(res.status).toBe(201);
       const createCall = mockPrisma.condition.create.mock.calls[0][0];
-      expect(createCall.data.tags).toEqual(['bitcoin', 'crypto']);
+      expect(createCall.data.tags).toEqual(['Bitcoin', 'Crypto', 'UFC']);
     });
 
     it('defaults tags to empty array when not provided', async () => {
@@ -477,11 +477,11 @@ describe('conditions routes', () => {
       expect(updateCall.data.endTime).toBe(FUTURE_END_TIME + 10000);
     });
 
-    it('updates tags when provided', async () => {
+    it('updates tags when provided (first-letter capitalized)', async () => {
       mockPrisma.condition.findUnique.mockResolvedValue(existingCondition());
       mockPrisma.condition.update.mockResolvedValue({
         ...existingCondition(),
-        tags: ['updated-tag'],
+        tags: ['Updated-tag'],
       });
 
       const res = await request(app)
@@ -490,7 +490,7 @@ describe('conditions routes', () => {
 
       expect(res.status).toBe(200);
       const updateCall = mockPrisma.condition.update.mock.calls[0][0];
-      expect(updateCall.data.tags).toEqual(['updated-tag']);
+      expect(updateCall.data.tags).toEqual(['Updated-tag']);
     });
 
     it('does not overwrite tags when not provided', async () => {

--- a/packages/api/src/routes/conditions.ts
+++ b/packages/api/src/routes/conditions.ts
@@ -13,6 +13,16 @@ function isHttpUrl(value: unknown): boolean {
   }
 }
 
+// Polymarket returns some tag labels miscased (e.g. `temperature`). Uppercase
+// the first char and preserve the rest so acronyms like `UFC` stay intact.
+// Mirrors normalizeTagLabel in packages/market-keeper/src/generate/tags.ts.
+function normalizeTags(tags: unknown): string[] {
+  if (!Array.isArray(tags)) return [];
+  return tags
+    .filter((t): t is string => typeof t === 'string' && t.length > 0)
+    .map((t) => t.charAt(0).toUpperCase() + t.slice(1));
+}
+
 // GET route removed in favor of GraphQL. Use GraphQL `conditions` query for reads.
 
 interface BatchCreateConditionInput {
@@ -161,7 +171,7 @@ router.post('/batch-create', async (req: Request, res: Response) => {
             similarMarkets: Array.isArray(item.similarMarkets)
               ? item.similarMarkets
               : [],
-            tags: Array.isArray(item.tags) ? item.tags : [],
+            tags: normalizeTags(item.tags),
             chainId: item.chainId ?? 42161,
             estimatedPrice:
               typeof item.estimatedPrice === 'number' &&
@@ -358,7 +368,7 @@ router.post('/', async (req: Request, res: Response) => {
           public: Boolean(isPublic),
           description,
           similarMarkets: Array.isArray(similarMarkets) ? similarMarkets : [],
-          tags: Array.isArray(tags) ? tags : [],
+          tags: normalizeTags(tags),
           chainId: chainId ?? 42161, // Default to Arbitrum if not provided
           estimatedPrice:
             typeof estimatedPrice === 'number' &&
@@ -647,7 +657,7 @@ router.put('/batch-metadata', async (req: Request, res: Response) => {
       if (typeof f.description === 'string') data.description = f.description;
       if (Array.isArray(f.similarMarkets))
         data.similarMarkets = f.similarMarkets;
-      if (Array.isArray(f.tags)) data.tags = f.tags;
+      if (Array.isArray(f.tags)) data.tags = normalizeTags(f.tags);
       if (
         typeof f.similarMarketVolume === 'number' &&
         f.similarMarketVolume >= 0
@@ -902,9 +912,7 @@ router.put('/:id', async (req: Request, res: Response) => {
                   : [],
               }
             : {}),
-          ...(typeof tags !== 'undefined'
-            ? { tags: Array.isArray(tags) ? tags : [] }
-            : {}),
+          ...(typeof tags !== 'undefined' ? { tags: normalizeTags(tags) } : {}),
           // Update estimatedPrice if provided and valid
           ...(typeof estimatedPrice === 'number' &&
           estimatedPrice >= 0 &&

--- a/packages/app/src/components/markets/MarketsPage.tsx
+++ b/packages/app/src/components/markets/MarketsPage.tsx
@@ -58,8 +58,10 @@ const MarketsPage = () => {
     'sapience.markets.searchTerm',
     ''
   );
+  // Key bumped to v2 after tag-case normalization (lowercase values like
+  // "temperature" no longer match; force a reset of stale selections).
   const [selectedTag, setSelectedTag] = useSessionState<string | null>(
-    'sapience.markets.selectedTag',
+    'sapience.markets.selectedTag.v2',
     null
   );
   const defaultFilters: FilterState = {

--- a/packages/market-keeper/src/__tests__/tags.test.ts
+++ b/packages/market-keeper/src/__tests__/tags.test.ts
@@ -92,6 +92,48 @@ describe('fetchEventTags', () => {
     expect(result.get('dup-event')).toEqual(['Crypto']);
   });
 
+  it('deduplicates after normalization (temperature + Temperature collapse)', async () => {
+    mockResponse([
+      {
+        slug: 'case-dup',
+        tags: [
+          { label: 'temperature', slug: 'temperature' },
+          { label: 'Temperature', slug: 'temperature-2' },
+        ],
+      },
+    ]);
+
+    const result = await fetchEventTags(opts);
+
+    expect(result.get('case-dup')).toEqual(['Temperature']);
+  });
+
+  it('capitalizes the first letter of each label (preserves rest)', async () => {
+    // Polymarket returns some labels miscased, e.g. `temperature` lowercase.
+    // We normalize the first character so acronyms like "UFC" are untouched
+    // but "temperature" becomes "Temperature".
+    mockResponse([
+      {
+        slug: 'weather-event',
+        tags: [
+          { label: 'temperature', slug: 'temperature' },
+          { label: 'Highest temperature', slug: 'highest-temperature' },
+          { label: 'UFC', slug: 'ufc' },
+          { label: 'Weather', slug: 'weather' },
+        ],
+      },
+    ]);
+
+    const result = await fetchEventTags(opts);
+
+    expect(result.get('weather-event')).toEqual([
+      'Temperature',
+      'Highest temperature',
+      'UFC',
+      'Weather',
+    ]);
+  });
+
   it('returns empty map on API error', async () => {
     mockFetchWithRetry.mockResolvedValue({
       ok: false,

--- a/packages/market-keeper/src/generate/tags.ts
+++ b/packages/market-keeper/src/generate/tags.ts
@@ -9,6 +9,14 @@ interface PolymarketEventTag {
   slug?: string;
 }
 
+// Polymarket returns some tag labels with an inconsistent lowercase first
+// letter (e.g. `temperature`). Uppercase the first character and preserve
+// the rest so acronyms like `UFC` stay intact.
+export function normalizeTagLabel(label: string): string {
+  if (!label) return label;
+  return label.charAt(0).toUpperCase() + label.slice(1);
+}
+
 interface PolymarketEvent {
   slug?: string;
   tags?: PolymarketEventTag[];
@@ -50,7 +58,8 @@ export async function fetchEventTags(opts: {
 
       const labels = (event.tags ?? [])
         .map((t) => t.label)
-        .filter((label): label is string => !!label && label !== 'All');
+        .filter((label): label is string => !!label && label !== 'All')
+        .map(normalizeTagLabel);
 
       // Deduplicate
       tagMap.set(event.slug, [...new Set(labels)]);


### PR DESCRIPTION
## Summary
- Polymarket returns some event tag labels with a lowercase first letter (e.g. `temperature` vs properly-cased `Weather`, `Politics`, `Sports`). The `/popularTags` chip strip surfaced `temperature` while every other tag came back capitalized.
- Capitalize the first character (preserving the rest, so `UFC`/`NBA` stay intact) at both ingest paths:
  - `market-keeper/src/generate/tags.ts` — `fetchEventTags` now runs `normalizeTagLabel` on every label, then dedupes. Acronyms unchanged; `temperature` → `Temperature`.
  - `api/src/routes/conditions.ts` — the POST-bulk, POST-single, PATCH-bulk, and PUT admin routes now pipe `tags` through the same normalizer before writing, so no other caller can leak raw Polymarket casing back in.
- Backfill existing rows via a Prisma migration that capitalizes the first char of each element of `condition.tags` (skips nulls/empty, idempotent via `IS DISTINCT FROM`).
- Bump `selectedTag` sessionStorage key to `.v2` so users with a stale lowercase selection (e.g. `temperature`) don't silently filter to zero results post-deploy.

## Test plan
- [x] `pnpm --filter market-keeper run test -- tags` (11 passed, incl. new `capitalizes first letter` + `dedup across case` cases)
- [x] `pnpm --filter @sapience/api run test -- conditions.test` (38 passed; tag assertions updated)
- [x] `pnpm --filter @sapience/app run type-check`
- [ ] After merge: verify migration applies cleanly on staging DB and `popularTags` returns `Temperature` instead of `temperature`
- [ ] Smoke-test tag chip filtering still returns matching markets for a few popular tags