### PR TITLE
fix(keeper): settle conditions on legacy resolvers

### DIFF
--- a/packages/market-keeper/scripts/settle-manual.ts
+++ b/packages/market-keeper/scripts/settle-manual.ts
@@ -50,8 +50,11 @@ import { privateKeyToAccount } from 'viem/accounts';
 import { polygon } from 'viem/chains';
 import { fetchWithRetry } from '../src/utils/fetch.js';
 import { logSeparator } from '../src/utils/log.js';
-import { manualConditionResolver } from '@sapience/sdk';
-import { conditionalTokensReader } from '@sapience/sdk/contracts/addresses';
+import {
+  manualConditionResolver,
+  conditionalTokensReader,
+  normalizeLegacyEntry,
+} from '@sapience/sdk/contracts/addresses';
 import {
   determineOutcomeFromPolymarket,
   outcomeToString,
@@ -63,9 +66,31 @@ import {
 
 const CHAIN_ID = Number(process.env.CHAIN_ID || '13374202');
 
-const RESOLVER_ADDRESS = (process.env.RESOLVER_ADDRESS ||
-  manualConditionResolver[CHAIN_ID]?.address ||
-  '') as Address;
+/**
+ * Get all manual resolver addresses for the configured chain (current + legacy).
+ */
+function getManualResolverAddresses(): { address: Address; label: string }[] {
+  const config = manualConditionResolver[CHAIN_ID];
+  if (!config) {
+    throw new Error(
+      `No ManualConditionResolver configured for chain ${CHAIN_ID}`
+    );
+  }
+
+  const addresses: { address: Address; label: string }[] = [
+    { address: config.address as Address, label: 'current' },
+  ];
+
+  for (const legEntry of config.legacy ?? []) {
+    const { address } = normalizeLegacyEntry(legEntry);
+    addresses.push({
+      address: address as Address,
+      label: `legacy-${address.slice(0, 8)}`,
+    });
+  }
+
+  return addresses;
+}
 
 const ETHEREAL_RPC = 'https://rpc.etherealtest.net';
 
@@ -205,12 +230,13 @@ Examples:
 const CONDITIONS_PAGE_SIZE = 30;
 
 const UNRESOLVED_CONDITIONS_QUERY = `
-query UnresolvedConditions($take: Int!, $skip: Int!) {
+query UnresolvedConditions($take: Int!, $skip: Int!, $resolver: String!) {
   conditions(
     where: {
       AND: [
         { settled: { equals: false } }
         { public: { equals: true } }
+        { resolver: { equals: $resolver, mode: insensitive } }
         {
           OR: [
             { openInterest: { gt: "0" } }
@@ -233,6 +259,7 @@ query UnresolvedConditions($take: Int!, $skip: Int!) {
 
 async function fetchConditionsPage(
   apiUrl: string,
+  resolver: string,
   take: number,
   skip: number
 ): Promise<SapienceCondition[]> {
@@ -244,7 +271,7 @@ async function fetchConditionsPage(
     },
     body: JSON.stringify({
       query: UNRESOLVED_CONDITIONS_QUERY,
-      variables: { take, skip },
+      variables: { resolver, take, skip },
     }),
   });
 
@@ -288,7 +315,8 @@ async function fetchConditionsPage(
 }
 
 async function fetchUnresolvedConditions(
-  apiUrl: string
+  apiUrl: string,
+  resolver: string
 ): Promise<SapienceCondition[]> {
   const allConditions: SapienceCondition[] = [];
   let skip = 0;
@@ -298,6 +326,7 @@ async function fetchUnresolvedConditions(
   while (true) {
     const page = await fetchConditionsPage(
       apiUrl,
+      resolver,
       CONDITIONS_PAGE_SIZE + 1,
       skip
     );
@@ -382,19 +411,22 @@ async function checkPolymarketApiResolution(
 async function resolveCondition(
   polygonClient: PublicClient,
   etherealClient: PublicClient,
-  conditionId: Hex
+  conditionId: Hex,
+  resolverAddress: Address
 ): Promise<SettlementCandidate | 'already-settled' | 'not-resolved' | string> {
   // Check if already settled on ManualConditionResolver
   try {
     const [isResolved] = await etherealClient.readContract({
-      address: RESOLVER_ADDRESS,
+      address: resolverAddress,
       abi: manualConditionResolverAbi,
       functionName: 'getResolution',
       args: [conditionId],
     });
 
     if (isResolved) {
-      console.log(`[${conditionId}] Already settled on ManualConditionResolver`);
+      console.log(
+        `[${conditionId}] Already settled on ManualConditionResolver`
+      );
       return 'already-settled';
     }
   } catch {
@@ -402,7 +434,9 @@ async function resolveCondition(
   }
 
   // Check if resolved on Polymarket via Polygon
-  console.log(`[${conditionId}] Checking canRequestResolution on Polygon (reader=${CONDITIONAL_TOKENS_READER_ADDRESS})...`);
+  console.log(
+    `[${conditionId}] Checking canRequestResolution on Polygon (reader=${CONDITIONAL_TOKENS_READER_ADDRESS})...`
+  );
   const canResolve = await polygonClient.readContract({
     address: CONDITIONAL_TOKENS_READER_ADDRESS,
     abi: conditionalTokensReaderAbi,
@@ -450,6 +484,181 @@ async function resolveCondition(
   return 'not-resolved';
 }
 
+// ============ Per-resolver processing ============
+
+interface ResolverResults {
+  label: string;
+  total: number;
+  alreadySettled: number;
+  settled: number;
+  notResolved: number;
+  errors: number;
+}
+
+async function processResolver(
+  resolverAddress: Address,
+  label: string,
+  options: CLIOptions,
+  sapienceApiUrl: string,
+  polygonClient: PublicClient,
+  etherealClient: PublicClient,
+  walletClient: WalletClient<Transport, Chain, Account> | null
+): Promise<ResolverResults> {
+  const results: ResolverResults = {
+    label,
+    total: 0,
+    alreadySettled: 0,
+    settled: 0,
+    notResolved: 0,
+    errors: 0,
+  };
+
+  const conditions = await fetchUnresolvedConditions(
+    sapienceApiUrl,
+    resolverAddress
+  );
+  results.total = conditions.length;
+
+  if (conditions.length === 0) {
+    console.log('No unsettled conditions for this resolver');
+    return results;
+  }
+
+  console.log(
+    `Processing ${conditions.length} conditions (mode: ${options.dryRun ? 'dry-run' : 'execute'})...`
+  );
+
+  const candidates: SettlementCandidate[] = [];
+
+  // Phase 1: Resolve all conditions, collecting settlement candidates
+  for (const condition of conditions) {
+    try {
+      console.log(`[${condition.id}] "${condition.question}"`);
+      const result = await resolveCondition(
+        polygonClient,
+        etherealClient,
+        condition.id as Hex,
+        resolverAddress
+      );
+
+      if (result === 'already-settled') {
+        results.alreadySettled++;
+      } else if (result === 'not-resolved') {
+        results.notResolved++;
+      } else if (typeof result === 'string') {
+        console.error(`Error for ${condition.id}: ${result}`);
+        results.errors++;
+      } else {
+        candidates.push(result);
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.error(`Error for ${condition.id}: ${msg}`);
+      results.errors++;
+    }
+  }
+
+  console.log(
+    `\nResolution check complete: ${candidates.length} ready to settle, ${results.alreadySettled} already settled, ${results.notResolved} not resolved yet, ${results.errors} errors`
+  );
+
+  if (candidates.length === 0) {
+    console.log('Nothing to settle');
+    return results;
+  }
+
+  // Log what we're settling
+  for (const c of candidates) {
+    console.log(
+      `  ${c.conditionId} → ${outcomeToString(c.outcome)} (via ${c.source})`
+    );
+  }
+
+  if (options.dryRun) {
+    console.log(
+      `\nDRY RUN — would settle ${candidates.length} conditions via settleConditions()`
+    );
+    results.settled = candidates.length;
+    return results;
+  }
+
+  if (!walletClient) {
+    console.error('No wallet client (missing ADMIN_PRIVATE_KEY)');
+    results.errors += candidates.length;
+    return results;
+  }
+
+  // Phase 2: Batch settle
+  const conditionIds = candidates.map((c) => c.conditionId);
+  const outcomes = candidates.map((c) => c.outcome);
+
+  if (candidates.length === 1) {
+    const { conditionId, outcome } = candidates[0];
+    console.log(
+      `\nSettling 1 condition: ${conditionId} → ${outcomeToString(outcome)}`
+    );
+
+    const estimatedGas = await etherealClient.estimateContractGas({
+      address: resolverAddress,
+      abi: manualConditionResolverAbi,
+      functionName: 'settleCondition',
+      args: [conditionId, outcome],
+      account: walletClient.account,
+    });
+    const gasLimit = (estimatedGas * 130n) / 100n;
+
+    const hash = await walletClient.writeContract({
+      address: resolverAddress,
+      abi: manualConditionResolverAbi,
+      functionName: 'settleCondition',
+      args: [conditionId, outcome],
+      gas: gasLimit,
+    });
+
+    console.log(`Transaction sent: ${hash}`);
+
+    if (options.wait) {
+      console.log('Waiting for confirmation...');
+      const receipt = await etherealClient.waitForTransactionReceipt({ hash });
+      console.log(`Confirmed in block ${receipt.blockNumber}`);
+    }
+
+    results.settled = 1;
+  } else {
+    console.log(`\nBatch settling ${candidates.length} conditions...`);
+
+    const estimatedGas = await etherealClient.estimateContractGas({
+      address: resolverAddress,
+      abi: manualConditionResolverAbi,
+      functionName: 'settleConditions',
+      args: [conditionIds, outcomes],
+      account: walletClient.account,
+    });
+    const gasLimit = (estimatedGas * 130n) / 100n;
+    console.log(`Estimated gas: ${estimatedGas}, using limit: ${gasLimit}`);
+
+    const hash = await walletClient.writeContract({
+      address: resolverAddress,
+      abi: manualConditionResolverAbi,
+      functionName: 'settleConditions',
+      args: [conditionIds, outcomes],
+      gas: gasLimit,
+    });
+
+    console.log(`Transaction sent: ${hash}`);
+
+    if (options.wait) {
+      console.log('Waiting for confirmation...');
+      const receipt = await etherealClient.waitForTransactionReceipt({ hash });
+      console.log(`Confirmed in block ${receipt.blockNumber}`);
+    }
+
+    results.settled = candidates.length;
+  }
+
+  return results;
+}
+
 // ============ Main ============
 
 async function main() {
@@ -460,25 +669,7 @@ async function main() {
     process.exit(0);
   }
 
-  // Guard: staging only
-  const expectedAddress = manualConditionResolver[CHAIN_ID]?.address;
-  if (
-    expectedAddress &&
-    RESOLVER_ADDRESS.toLowerCase() !== expectedAddress.toLowerCase()
-  ) {
-    console.error(
-      `RESOLVER_ADDRESS ${RESOLVER_ADDRESS} does not match ManualConditionResolver ${expectedAddress} for chain ${CHAIN_ID}.` +
-        ` This script is for staging/testnet only.`
-    );
-    process.exit(1);
-  }
-
-  if (!RESOLVER_ADDRESS) {
-    console.error(
-      `No ManualConditionResolver address found for chain ${CHAIN_ID}. Set RESOLVER_ADDRESS or CHAIN_ID.`
-    );
-    process.exit(1);
-  }
+  const resolvers = getManualResolverAddresses();
 
   const polygonRpcUrl = process.env.POLYGON_RPC_URL;
   const privateKey = process.env.ADMIN_PRIVATE_KEY;
@@ -501,8 +692,8 @@ async function main() {
     process.exit(1);
   }
 
-  console.log(`ManualConditionResolver: ${RESOLVER_ADDRESS}`);
-  console.log(`Chain: ${CHAIN_ID} (Ethereal Testnet)`);
+  console.log(`Chain: ${CHAIN_ID}`);
+  console.log(`Manual resolvers: ${resolvers.length} (current + legacy)`);
   console.log(`Mode: ${options.dryRun ? 'dry-run' : 'execute'}`);
 
   // Polygon client — read Polymarket resolution data
@@ -540,154 +731,53 @@ async function main() {
   }
 
   try {
-    const conditions = await fetchUnresolvedConditions(sapienceApiUrl);
+    const allResults: ResolverResults[] = [];
 
-    if (conditions.length === 0) {
-      console.log('No unsettled conditions found');
-      return;
-    }
+    for (const resolver of resolvers) {
+      console.log(`\n=== Manual resolver: ${resolver.label} ===`);
+      console.log(`  Address: ${resolver.address}`);
 
-    console.log(`Processing ${conditions.length} conditions...`);
-
-    const candidates: SettlementCandidate[] = [];
-    let alreadySettled = 0;
-    let notResolved = 0;
-    let errors = 0;
-
-    // Phase 1: Resolve all conditions, collecting settlement candidates
-    for (const condition of conditions) {
-      try {
-        console.log(`[${condition.id}] "${condition.question}"`);
-        const result = await resolveCondition(
-          polygonClient,
-          etherealClient,
-          condition.id as Hex
-        );
-
-        if (result === 'already-settled') {
-          alreadySettled++;
-        } else if (result === 'not-resolved') {
-          notResolved++;
-        } else if (typeof result === 'string') {
-          console.error(`Error for ${condition.id}: ${result}`);
-          errors++;
-        } else {
-          candidates.push(result);
-        }
-      } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error);
-        console.error(`Error for ${condition.id}: ${msg}`);
-        errors++;
-      }
-    }
-
-    console.log(
-      `\nResolution check complete: ${candidates.length} ready to settle, ${alreadySettled} already settled, ${notResolved} not resolved yet, ${errors} errors`
-    );
-
-    if (candidates.length === 0) {
-      console.log('Nothing to settle');
-      return;
-    }
-
-    // Log what we're settling
-    for (const c of candidates) {
-      console.log(
-        `  ${c.conditionId} → ${outcomeToString(c.outcome)} (via ${c.source})`
+      const results = await processResolver(
+        resolver.address,
+        resolver.label,
+        options,
+        sapienceApiUrl,
+        polygonClient,
+        etherealClient,
+        walletClient
       );
-    }
-
-    if (options.dryRun) {
-      console.log(
-        `\nDRY RUN — would settle ${candidates.length} conditions via settleConditions()`
-      );
-      return;
-    }
-
-    if (!walletClient) {
-      console.error('No wallet client (missing ADMIN_PRIVATE_KEY)');
-      return;
-    }
-
-    // Phase 2: Batch settle
-    const conditionIds = candidates.map((c) => c.conditionId);
-    const outcomes = candidates.map((c) => c.outcome);
-
-    if (candidates.length === 1) {
-      // Single settlement
-      const { conditionId, outcome } = candidates[0];
-      console.log(
-        `\nSettling 1 condition: ${conditionId} → ${outcomeToString(outcome)}`
-      );
-
-      const estimatedGas = await etherealClient.estimateContractGas({
-        address: RESOLVER_ADDRESS,
-        abi: manualConditionResolverAbi,
-        functionName: 'settleCondition',
-        args: [conditionId, outcome],
-        account: walletClient.account,
-      });
-      const gasLimit = (estimatedGas * 130n) / 100n;
-
-      const hash = await walletClient.writeContract({
-        address: RESOLVER_ADDRESS,
-        abi: manualConditionResolverAbi,
-        functionName: 'settleCondition',
-        args: [conditionId, outcome],
-        gas: gasLimit,
-      });
-
-      console.log(`Transaction sent: ${hash}`);
-
-      if (options.wait) {
-        console.log('Waiting for confirmation...');
-        const receipt = await etherealClient.waitForTransactionReceipt({
-          hash,
-        });
-        console.log(`Confirmed in block ${receipt.blockNumber}`);
-      }
-    } else {
-      // Batch settlement
-      console.log(`\nBatch settling ${candidates.length} conditions...`);
-
-      const estimatedGas = await etherealClient.estimateContractGas({
-        address: RESOLVER_ADDRESS,
-        abi: manualConditionResolverAbi,
-        functionName: 'settleConditions',
-        args: [conditionIds, outcomes],
-        account: walletClient.account,
-      });
-      const gasLimit = (estimatedGas * 130n) / 100n;
-      console.log(
-        `Estimated gas: ${estimatedGas}, using limit: ${gasLimit}`
-      );
-
-      const hash = await walletClient.writeContract({
-        address: RESOLVER_ADDRESS,
-        abi: manualConditionResolverAbi,
-        functionName: 'settleConditions',
-        args: [conditionIds, outcomes],
-        gas: gasLimit,
-      });
-
-      console.log(`Transaction sent: ${hash}`);
-
-      if (options.wait) {
-        console.log('Waiting for confirmation...');
-        const receipt = await etherealClient.waitForTransactionReceipt({
-          hash,
-        });
-        console.log(`Confirmed in block ${receipt.blockNumber}`);
-      }
+      allResults.push(results);
     }
 
     // Summary
     console.log('\n--- Summary ---');
-    console.log(`Total conditions:        ${conditions.length}`);
-    console.log(`Already settled:         ${alreadySettled}`);
-    console.log(`Settled (tx sent):       ${candidates.length}`);
-    console.log(`Not resolved (skipped):  ${notResolved}`);
-    console.log(`Errors:                  ${errors}`);
+    for (const r of allResults) {
+      if (r.total === 0) {
+        console.log(`[${r.label}] No conditions`);
+        continue;
+      }
+      console.log(
+        `[${r.label}] Total: ${r.total}, Already settled: ${r.alreadySettled}, Settled: ${r.settled}, Not resolved: ${r.notResolved}, Errors: ${r.errors}`
+      );
+    }
+
+    const totals = allResults.reduce(
+      (acc, r) => ({
+        total: acc.total + r.total,
+        alreadySettled: acc.alreadySettled + r.alreadySettled,
+        settled: acc.settled + r.settled,
+        notResolved: acc.notResolved + r.notResolved,
+        errors: acc.errors + r.errors,
+      }),
+      { total: 0, alreadySettled: 0, settled: 0, notResolved: 0, errors: 0 }
+    );
+
+    console.log(`\nTotal across all resolvers:`);
+    console.log(`  Conditions:          ${totals.total}`);
+    console.log(`  Already settled:     ${totals.alreadySettled}`);
+    console.log(`  Settled (tx sent):   ${totals.settled}`);
+    console.log(`  Not resolved:        ${totals.notResolved}`);
+    console.log(`  Errors:              ${totals.errors}`);
   } catch (error) {
     console.error('Error:', error);
     process.exit(1);

--- a/packages/market-keeper/scripts/settle-polymarket.ts
+++ b/packages/market-keeper/scripts/settle-polymarket.ts
@@ -31,6 +31,7 @@
 
 import 'dotenv/config';
 
+import { getConditionalTokensPairs } from '@sapience/sdk/contracts/addresses';
 import {
   createPublicClient,
   http,
@@ -44,23 +45,44 @@ import {
   formatEther,
   defineChain,
 } from 'viem';
-import { fetchWithRetry } from '../src/utils/fetch.js';
-import { confirmProductionAccess } from '../src/utils/index.js';
-import { conditionalTokensConditionResolver } from '@sapience/sdk';
+import { batchCheckGammaResolution } from '../src/polymarket-api.js';
 import {
   createPolygonClient,
   createPolygonWalletClient,
   batchCanRequestResolution,
   requestResolution as sendRequestResolution,
 } from '../src/polygon/client.js';
-import { batchCheckGammaResolution } from '../src/polymarket-api.js';
+import { fetchWithRetry } from '../src/utils/fetch.js';
+import { confirmProductionAccess } from '../src/utils/index.js';
 
 // ============ Constants ============
 
 const RESOLVER_CHAIN_ID = Number(process.env.CHAIN_ID || '5064014');
 
-const RESOLVER_ADDRESS = (process.env.RESOLVER_ADDRESS ||
-  conditionalTokensConditionResolver[RESOLVER_CHAIN_ID]?.address) as Address;
+/**
+ * Reader↔Resolver pairs: each Polygon reader bridges to a specific Ethereal resolver.
+ * The settlement script iterates over all pairs so legacy resolvers are also handled.
+ */
+interface ResolverPair {
+  reader: Address;
+  resolver: Address;
+  label: string;
+}
+
+function getResolverPairs(): ResolverPair[] {
+  const sdkPairs = getConditionalTokensPairs(RESOLVER_CHAIN_ID);
+  if (sdkPairs.length === 0) {
+    throw new Error(
+      `No ConditionalTokens pairs configured for chain ${RESOLVER_CHAIN_ID}`
+    );
+  }
+
+  return sdkPairs.map((p, i) => ({
+    reader: p.reader,
+    resolver: p.resolver,
+    label: p.current ? 'current' : `legacy-${i}`,
+  }));
+}
 
 const ETHEREAL_RPC = 'https://rpc.ethereal.trade';
 
@@ -322,7 +344,8 @@ const BATCH_SIZE = 50;
  */
 async function filterAlreadySettled(
   etherealClient: PublicClient,
-  conditionIds: string[]
+  conditionIds: string[],
+  resolverAddress: Address
 ): Promise<Set<string>> {
   const settled = new Set<string>();
 
@@ -331,7 +354,7 @@ async function filterAlreadySettled(
 
     try {
       const [resolvedArr] = await etherealClient.readContract({
-        address: RESOLVER_ADDRESS,
+        address: resolverAddress,
         abi: resolverAbi,
         functionName: 'getResolutions',
         args: [batch as Hex[]],
@@ -339,7 +362,9 @@ async function filterAlreadySettled(
 
       for (let j = 0; j < batch.length; j++) {
         if (resolvedArr[j]) {
-          console.log(`[${batch[j]}] Already settled on ConditionalTokensConditionResolver`);
+          console.log(
+            `[${batch[j]}] Already settled on ConditionalTokensConditionResolver`
+          );
           settled.add(batch[j]);
         }
       }
@@ -355,13 +380,15 @@ async function filterAlreadySettled(
       for (const id of batch) {
         try {
           const [isResolvedArr] = await etherealClient.readContract({
-            address: RESOLVER_ADDRESS,
+            address: resolverAddress,
             abi: resolverAbi,
             functionName: 'getResolutions',
             args: [[id] as Hex[]],
           });
           if (isResolvedArr[0]) {
-            console.log(`[${id}] Already settled on ConditionalTokensConditionResolver`);
+            console.log(
+              `[${id}] Already settled on ConditionalTokensConditionResolver`
+            );
             settled.add(id);
           }
         } catch (perIdErr) {
@@ -384,11 +411,17 @@ async function settleCondition(
   polygonClient: PublicClient,
   walletClient: WalletClient<Transport, Chain, Account>,
   conditionId: string,
-  options: CLIOptions
+  options: CLIOptions,
+  readerAddress: Address
 ): Promise<SettlementResult> {
   try {
     console.log(`[${conditionId}] Sending requestResolution...`);
-    const hash = await sendRequestResolution(polygonClient, walletClient, conditionId);
+    const hash = await sendRequestResolution(
+      polygonClient,
+      walletClient,
+      conditionId,
+      readerAddress
+    );
     console.log(`[${conditionId}] Transaction sent: ${hash}`);
 
     if (options.wait) {
@@ -397,11 +430,153 @@ async function settleCondition(
       console.log(`[${conditionId}] Confirmed in block ${receipt.blockNumber}`);
     }
 
-    return { conditionId, alreadyResolved: false, canResolve: true, settled: true, txHash: hash };
+    return {
+      conditionId,
+      alreadyResolved: false,
+      canResolve: true,
+      settled: true,
+      txHash: hash,
+    };
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-    return { conditionId, alreadyResolved: false, canResolve: true, settled: false, error: msg };
+    return {
+      conditionId,
+      alreadyResolved: false,
+      canResolve: true,
+      settled: false,
+      error: msg,
+    };
   }
+}
+
+// ============ Per-pair processing ============
+
+interface PairResults {
+  label: string;
+  total: number;
+  alreadyResolved: number;
+  canResolve: number;
+  settled: number;
+  skipped: number;
+  errors: number;
+}
+
+async function processResolverPair(
+  pair: ResolverPair,
+  options: CLIOptions,
+  sapienceApiUrl: string,
+  polygonClient: PublicClient,
+  etherealClient: PublicClient,
+  walletClient: WalletClient<Transport, Chain, Account> | null
+): Promise<PairResults> {
+  const results: PairResults = {
+    label: pair.label,
+    total: 0,
+    alreadyResolved: 0,
+    canResolve: 0,
+    settled: 0,
+    skipped: 0,
+    errors: 0,
+  };
+
+  const conditions = await fetchUnresolvedConditions(
+    sapienceApiUrl,
+    pair.resolver
+  );
+  results.total = conditions.length;
+
+  if (conditions.length === 0) {
+    console.log('No unsettled conditions for this resolver');
+    return results;
+  }
+
+  console.log(
+    `Processing ${conditions.length} conditions (mode: ${options.dryRun ? 'dry-run' : 'execute'})`
+  );
+
+  const allIds = conditions.map((c) => c.id);
+
+  // Step 1: Filter out already-settled on Ethereal
+  const alreadySettled = await filterAlreadySettled(
+    etherealClient,
+    allIds,
+    pair.resolver
+  );
+  results.alreadyResolved = alreadySettled.size;
+  const unsettledIds = allIds.filter((id) => !alreadySettled.has(id));
+
+  if (unsettledIds.length === 0) {
+    console.log('All conditions already settled on resolver');
+    return results;
+  }
+
+  // Step 2: Check Gamma API (free, no RPC)
+  console.log(`Checking Gamma API for ${unsettledIds.length} conditions...`);
+  const gamma = await batchCheckGammaResolution(unsettledIds);
+
+  const toSettle: string[] = [];
+
+  // Log Gamma classifications (hint only — RPC is truth for settle)
+  for (const id of unsettledIds) {
+    const status = gamma.statuses.get(id) ?? 'not_found';
+    console.log(`[${id}] Gamma: ${status}`);
+  }
+
+  // Step 3: Batch on-chain check via multicall for ALL unsettled conditions.
+  // Gamma is a classification hint, not authority over whether to burn POL.
+  // Every condition must pass canRequestResolution before we send requestResolution.
+  console.log(
+    `Checking ${unsettledIds.length} conditions on-chain via multicall...`
+  );
+  try {
+    const onChainResults = await batchCanRequestResolution(
+      polygonClient,
+      unsettledIds,
+      50,
+      pair.reader
+    );
+
+    for (const [id, canResolve] of onChainResults) {
+      console.log(`[${id}] canRequestResolution = ${canResolve}`);
+      if (canResolve) {
+        console.log(
+          `[${id}] ${options.dryRun ? 'DRY RUN — would send requestResolution' : 'will send requestResolution'}`
+        );
+        toSettle.push(id);
+        results.canResolve++;
+      } else {
+        results.skipped++;
+      }
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error(`Multicall error: ${msg}`);
+    results.errors += unsettledIds.length;
+  }
+
+  // Step 4: Send requestResolution for all resolved conditions
+  if (toSettle.length > 0 && options.execute && walletClient) {
+    for (const id of toSettle) {
+      const result = await settleCondition(
+        polygonClient,
+        walletClient,
+        id,
+        options,
+        pair.reader
+      );
+      if (result.settled) {
+        results.settled++;
+      } else if (result.error) {
+        console.error(`[${id}] Settlement error: ${result.error}`);
+        results.errors++;
+      }
+    }
+  } else if (toSettle.length > 0 && options.execute && !walletClient) {
+    console.error('No wallet client (missing ADMIN_PRIVATE_KEY)');
+    results.errors += toSettle.length;
+  }
+
+  return results;
 }
 
 // ============ Main ============
@@ -438,6 +613,8 @@ async function main() {
   // Confirm production access if pointing to production
   await confirmProductionAccess(process.env.SAPIENCE_API_URL);
 
+  const pairs = getResolverPairs();
+
   // Polygon client — read ConditionalTokensReader
   const polygonClient = createPolygonClient(polygonRpcUrl);
 
@@ -448,7 +625,7 @@ async function main() {
   });
 
   console.log(
-    `Ethereal client connected (chain ${RESOLVER_CHAIN_ID}, resolver ${RESOLVER_ADDRESS})`
+    `Ethereal client connected (chain ${RESOLVER_CHAIN_ID}, ${pairs.length} resolver pair(s))`
   );
 
   // Wallet on Polygon for requestResolution (LZ bridging)
@@ -466,106 +643,62 @@ async function main() {
   }
 
   try {
-    const conditions = await fetchUnresolvedConditions(sapienceApiUrl, RESOLVER_ADDRESS);
+    const allResults: PairResults[] = [];
 
-    if (conditions.length === 0) {
-      console.log('No unsettled CT conditions found');
-      return;
-    }
+    for (const pair of pairs) {
+      console.log(`\n=== Resolver pair: ${pair.label} ===`);
+      console.log(`  Reader (Polygon):   ${pair.reader}`);
+      console.log(`  Resolver (Ethereal): ${pair.resolver}`);
 
-    console.log(
-      `Processing ${conditions.length} conditions (mode: ${options.dryRun ? 'dry-run' : 'execute'})`
-    );
-
-    const results = {
-      total: conditions.length,
-      alreadyResolved: 0,
-      canResolve: 0,
-      settled: 0,
-      skipped: 0,
-      errors: 0,
-    };
-
-    const allIds = conditions.map((c) => c.id);
-
-    // Step 1: Filter out already-settled on Ethereal
-    const alreadySettled = await filterAlreadySettled(etherealClient, allIds);
-    results.alreadyResolved = alreadySettled.size;
-    const unsettledIds = allIds.filter((id) => !alreadySettled.has(id));
-
-    if (unsettledIds.length === 0) {
-      console.log('All conditions already settled on resolver');
-    } else {
-      // Step 2: Check Gamma API (free, no RPC)
-      console.log(`Checking Gamma API for ${unsettledIds.length} conditions...`);
-      const gamma = await batchCheckGammaResolution(unsettledIds);
-
-      const toSettle: string[] = [];
-
-      // Log Gamma classifications (hint only — RPC is truth for settle)
-      for (const id of unsettledIds) {
-        const status = gamma.statuses.get(id) ?? 'not_found';
-        console.log(`[${id}] Gamma: ${status}`);
-      }
-
-      // Step 3: Batch on-chain check via multicall for ALL unsettled conditions.
-      // Gamma is a classification hint, not authority over whether to burn POL.
-      // Every condition must pass canRequestResolution before we send requestResolution.
-      console.log(
-        `Checking ${unsettledIds.length} conditions on-chain via multicall...`
+      const results = await processResolverPair(
+        pair,
+        options,
+        sapienceApiUrl,
+        polygonClient,
+        etherealClient,
+        walletClient
       );
-      try {
-        const onChainResults = await batchCanRequestResolution(
-          polygonClient,
-          unsettledIds
-        );
-
-        for (const [id, canResolve] of onChainResults) {
-          console.log(`[${id}] canRequestResolution = ${canResolve}`);
-          if (canResolve) {
-            console.log(`[${id}] ${options.dryRun ? 'DRY RUN — would send requestResolution' : 'will send requestResolution'}`);
-            toSettle.push(id);
-            results.canResolve++;
-          } else {
-            results.skipped++;
-          }
-        }
-      } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error);
-        console.error(`Multicall error: ${msg}`);
-        results.errors += unsettledIds.length;
-      }
-
-      // Step 4: Send requestResolution for all resolved conditions
-      if (toSettle.length > 0 && options.execute && walletClient) {
-        for (const id of toSettle) {
-          const result = await settleCondition(
-            polygonClient,
-            walletClient,
-            id,
-            options
-          );
-          if (result.settled) {
-            results.settled++;
-          } else if (result.error) {
-            console.error(`[${id}] Settlement error: ${result.error}`);
-            results.errors++;
-          }
-        }
-      } else if (toSettle.length > 0 && options.execute && !walletClient) {
-        console.error('No wallet client (missing ADMIN_PRIVATE_KEY)');
-        results.errors += toSettle.length;
-      }
+      allResults.push(results);
     }
 
     // Summary
     console.log('\n--- Summary ---');
-    console.log(`Total conditions:        ${results.total}`);
-    console.log(`Already on resolver:     ${results.alreadyResolved}`);
-    console.log(`Resolved on Polygon:     ${results.canResolve}`);
-    console.log(`Settled (tx sent):       ${results.settled}`);
-    console.log(`Skipped (not resolved):  ${results.skipped}`);
-    console.log(`Errors:                  ${results.errors}`);
+    for (const r of allResults) {
+      if (r.total === 0) {
+        console.log(`[${r.label}] No conditions`);
+        continue;
+      }
+      console.log(
+        `[${r.label}] Total: ${r.total}, Already resolved: ${r.alreadyResolved}, Can resolve: ${r.canResolve}, Settled: ${r.settled}, Skipped: ${r.skipped}, Errors: ${r.errors}`
+      );
+    }
+
+    const totals = allResults.reduce(
+      (acc, r) => ({
+        total: acc.total + r.total,
+        alreadyResolved: acc.alreadyResolved + r.alreadyResolved,
+        canResolve: acc.canResolve + r.canResolve,
+        settled: acc.settled + r.settled,
+        skipped: acc.skipped + r.skipped,
+        errors: acc.errors + r.errors,
+      }),
+      {
+        total: 0,
+        alreadyResolved: 0,
+        canResolve: 0,
+        settled: 0,
+        skipped: 0,
+        errors: 0,
+      }
+    );
+
+    console.log(`\nTotal across all pairs:`);
+    console.log(`  Conditions:          ${totals.total}`);
+    console.log(`  Already on resolver: ${totals.alreadyResolved}`);
+    console.log(`  Resolved on Polygon: ${totals.canResolve}`);
+    console.log(`  Settled (tx sent):   ${totals.settled}`);
+    console.log(`  Skipped:             ${totals.skipped}`);
+    console.log(`  Errors:              ${totals.errors}`);
   } catch (error) {
     console.error('Error:', error);
     process.exit(1);

--- a/packages/market-keeper/src/polygon/client.ts
+++ b/packages/market-keeper/src/polygon/client.ts
@@ -99,10 +99,11 @@ export function createPolygonWalletClient(
 
 export async function canRequestResolution(
   polygonClient: PublicClient,
-  conditionId: string
+  conditionId: string,
+  readerAddress: Address = CONDITIONAL_TOKENS_READER_ADDRESS
 ): Promise<boolean> {
   return polygonClient.readContract({
-    address: CONDITIONAL_TOKENS_READER_ADDRESS,
+    address: readerAddress,
     abi: conditionalTokensReaderAbi,
     functionName: 'canRequestResolution',
     args: [conditionId as Hex],
@@ -117,14 +118,15 @@ export async function canRequestResolution(
 export async function batchCanRequestResolution(
   polygonClient: PublicClient,
   conditionIds: string[],
-  batchSize: number = 50
+  batchSize: number = 50,
+  readerAddress: Address = CONDITIONAL_TOKENS_READER_ADDRESS
 ): Promise<Map<string, boolean>> {
   const results = new Map<string, boolean>();
 
   for (let i = 0; i < conditionIds.length; i += batchSize) {
     const batch = conditionIds.slice(i, i + batchSize);
     const contracts = batch.map((id) => ({
-      address: CONDITIONAL_TOKENS_READER_ADDRESS,
+      address: readerAddress,
       abi: conditionalTokensReaderAbi,
       functionName: 'canRequestResolution' as const,
       args: [id as Hex],
@@ -147,10 +149,11 @@ export async function batchCanRequestResolution(
 export async function requestResolution(
   polygonClient: PublicClient,
   walletClient: WalletClient<Transport, Chain, Account>,
-  conditionId: string
+  conditionId: string,
+  readerAddress: Address = CONDITIONAL_TOKENS_READER_ADDRESS
 ): Promise<`0x${string}`> {
   const fee = await polygonClient.readContract({
-    address: CONDITIONAL_TOKENS_READER_ADDRESS,
+    address: readerAddress,
     abi: conditionalTokensReaderAbi,
     functionName: 'quoteResolution',
     args: [conditionId as Hex],
@@ -160,7 +163,7 @@ export async function requestResolution(
   console.log(`[${conditionId}] LayerZero fee: ${formatEther(nativeFee)} POL`);
 
   const estimatedGas = await polygonClient.estimateContractGas({
-    address: CONDITIONAL_TOKENS_READER_ADDRESS,
+    address: readerAddress,
     abi: conditionalTokensReaderAbi,
     functionName: 'requestResolution',
     args: [conditionId as Hex],
@@ -170,7 +173,7 @@ export async function requestResolution(
   const gasLimit = (estimatedGas * 130n) / 100n;
 
   const hash = await walletClient.writeContract({
-    address: CONDITIONAL_TOKENS_READER_ADDRESS,
+    address: readerAddress,
     abi: conditionalTokensReaderAbi,
     functionName: 'requestResolution',
     args: [conditionId as Hex],

--- a/packages/sdk/contracts/__tests__/addresses.test.ts
+++ b/packages/sdk/contracts/__tests__/addresses.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import {
   getResolverAddressesForChain,
+  getConditionalTokensPairs,
   pythConditionResolver,
   conditionalTokensConditionResolver,
+  conditionalTokensReader,
   manualConditionResolver,
 } from '../addresses';
 
@@ -56,5 +58,47 @@ describe('getResolverAddressesForChain', () => {
 
   it('returns empty array for unknown chain', () => {
     expect(getResolverAddressesForChain(999999)).toEqual([]);
+  });
+});
+
+describe('getConditionalTokensPairs', () => {
+  const MAINNET = 5064014;
+
+  it('returns at least the current pair on mainnet', () => {
+    const pairs = getConditionalTokensPairs(MAINNET);
+    expect(pairs.length).toBeGreaterThanOrEqual(1);
+
+    const current = pairs.find((p) => p.current);
+    expect(current).toBeDefined();
+  });
+
+  it('current pair matches SDK config addresses', () => {
+    const pairs = getConditionalTokensPairs(MAINNET);
+    const current = pairs.find((p) => p.current)!;
+
+    expect(current.resolver.toLowerCase()).toBe(
+      conditionalTokensConditionResolver[MAINNET].address.toLowerCase()
+    );
+    expect(current.reader.toLowerCase()).toBe(
+      conditionalTokensReader[137].address.toLowerCase()
+    );
+  });
+
+  it('includes legacy pairs', () => {
+    const pairs = getConditionalTokensPairs(MAINNET);
+    const legacy = pairs.filter((p) => !p.current);
+    expect(legacy.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('all pairs have valid addresses', () => {
+    const pairs = getConditionalTokensPairs(MAINNET);
+    for (const pair of pairs) {
+      expect(pair.reader).toMatch(/^0x[0-9a-fA-F]{40}$/);
+      expect(pair.resolver).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    }
+  });
+
+  it('returns empty array for unknown chain', () => {
+    expect(getConditionalTokensPairs(999999)).toEqual([]);
   });
 });

--- a/packages/sdk/contracts/addresses.ts
+++ b/packages/sdk/contracts/addresses.ts
@@ -733,6 +733,54 @@ export function getLegacyResolverAddressesForChain(
   return result;
 }
 
+// ============================================================================
+// ConditionalTokens Reader↔Resolver Pairs
+// ============================================================================
+
+export interface ConditionalTokensPair {
+  /** Polygon ConditionalTokensReader address */
+  reader: Address;
+  /** Ethereal ConditionalTokensConditionResolver address */
+  resolver: Address;
+  /** Whether this is the current (active) deployment */
+  current: boolean;
+}
+
+/**
+ * Verified reader↔resolver pairs for ConditionalTokens settlement.
+ * Each Polygon reader bridges via LayerZero to its paired Ethereal resolver.
+ * Pairing verified on-chain via reader.getBridgeConfig().
+ */
+const CONDITIONAL_TOKENS_PAIRS: Record<ChainId, ConditionalTokensPair[]> = {
+  5064014: [
+    {
+      reader: '0xCBDc09b831f53EeD2409f32896850dd10801851E',
+      resolver: '0xc7A489F8b5CEf914fcA2511a84cdC0221cD9a0F4',
+      current: true,
+    },
+    {
+      reader: '0x79cB914f3F336426E89FaB55A9488AB25770552D',
+      resolver: '0x19e34DB5bef20EF0613854c3670cD809DEFf4035',
+      current: false,
+    },
+    {
+      reader: '0x882288A664e29aEBC654Fa9679697d23716fcCD1',
+      resolver: '0x130598b7334901077cA5369b098Fd47F042CdcC9',
+      current: false,
+    },
+  ],
+};
+
+/**
+ * Get all verified ConditionalTokens reader↔resolver pairs for a chain.
+ * Returns current pair first, then legacy pairs.
+ */
+export function getConditionalTokensPairs(
+  chainId: number
+): ConditionalTokensPair[] {
+  return CONDITIONAL_TOKENS_PAIRS[chainId] ?? [];
+}
+
 /** Identify the resolver type from an on-chain address (current or legacy). */
 export function identifyResolver(
   address: string,


### PR DESCRIPTION
## Summary

The settlement scripts (`settle-polymarket.ts` and `settle-manual.ts`) only processed conditions on the **current** resolver address, ignoring legacy resolvers entirely. This left ~587 USDe (prod) and ~1,555 USDe (staging) of expired conditions permanently stuck.

**Root cause:** Each script hardcoded a single `RESOLVER_ADDRESS` from the SDK config. Conditions assigned to legacy resolvers were never queried or settled.

**Fix:**
- **`settle-polymarket.ts`**: Now loops over all verified ConditionalTokens reader↔resolver pairs (current + 2 legacy). Pairs are defined in the SDK via `getConditionalTokensPairs()`, verified on-chain via `getBridgeConfig()`.
- **`settle-manual.ts`**: Now loops over all manual resolver addresses (current + legacy). GraphQL query filters by resolver so each resolver only sees its own conditions.
- **`polygon/client.ts`**: `canRequestResolution`, `batchCanRequestResolution`, and `requestResolution` now accept an optional `readerAddress` parameter (defaults to current for backwards compat).
- **SDK**: Added `getConditionalTokensPairs()` with the verified reader↔resolver mapping + tests.

**Dry run on production confirmed:** legacy-1 resolver has 5 conditions ready to settle that were previously invisible to the cron.

## Test plan
- [x] SDK tests pass (577 tests, including new `getConditionalTokensPairs` tests)
- [x] Market-keeper tests pass (283 tests)
- [x] Type-check passes
- [x] Dry run on production shows legacy conditions found
- [ ] Run `settle-polymarket --execute` on prod (5 conditions on legacy-1)
- [ ] Run `settle-manual --execute` on staging (conditions on legacy manual resolver)
- [ ] Verify OI drops after settlement clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)