### PR TITLE
feat(market-keeper): always include Maine and Michigan

### DIFF
--- a/packages/market-keeper/src/constants.ts
+++ b/packages/market-keeper/src/constants.ts
@@ -47,6 +47,8 @@ export const ALWAYS_INCLUDE_PATTERNS = [
   /\bspx\b/i, // S&P 500 (ticker)
   /price of Bitcoin.+on \w+ \d+/i, // "Will the price of Bitcoin be... on January 28?"
   /price of Ethereum.+on \w+ \d+/i, // "Will the price of Ethereum be above... on January 28?"
+  /\bMaine\b/i, // Maine
+  /\bMichigan\b/i, // Michigan
 ];
 
 // Supplementary event tag slugs to fetch from /events endpoint


### PR DESCRIPTION
## Summary
Add Maine and Michigan to the `ALWAYS_INCLUDE_PATTERNS` in market-keeper so markets mentioning these states are always included regardless of volume thresholds.

## Test plan
- [ ] Verify markets with "Maine" or "Michigan" in the question bypass volume filters