### PR TITLE
fix(analytics): correct OI, TVL, volume metrics and live candle

### DIFF
--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -406,7 +406,7 @@ type Condition {
   openInterest: String!
   optionName: String
   predictionCount: Int!
-  predictions(cursor: LegacyPredictionWhereUniqueInput, distinct: [LegacyPredictionScalarFieldEnum!], orderBy: [LegacyPredictionOrderByWithRelationInput!], skip: Int, take: Int, where: LegacyPredictionWhereInput): [LegacyPrediction!]!
+  predictions(skip: Int! = 0, take: Int! = 50): [Prediction!]!
   public: Boolean!
   question: String!
   resolvedToYes: Boolean!
@@ -862,61 +862,9 @@ input IntNullableFilter {
   notIn: [Int!]
 }
 
-"""Legacy position model (NFT-based, V1)"""
-type LegacyPosition {
-  _count: LegacyPositionCount
-  chainId: Int!
-  counterparty: String!
-  counterpartyCollateral: String
-  counterpartyNftTokenId: String!
-  createdAt: DateTimeISO!
-  endsAt: Int
-  id: Int!
-  marketAddress: String!
-  mintedAt: Int!
-  predictions(cursor: LegacyPredictionWhereUniqueInput, distinct: [LegacyPredictionScalarFieldEnum!], orderBy: [LegacyPredictionOrderByWithRelationInput!], skip: Int, take: Int, where: LegacyPredictionWhereInput): [LegacyPrediction!]!
-  predictor: String!
-  predictorCollateral: String
-  predictorNftTokenId: String!
-
-  """
-  True when the predictor's submitted outcomes were correct (previously makerWon)
-  """
-  predictorWon: Boolean
-  refCode: String
-  settledAt: Int
-  status: LegacyPositionStatus!
-  totalCollateral: String!
-}
-
-type LegacyPositionCount {
-  predictions(where: LegacyPredictionWhereInput): Int!
-}
-
 input LegacyPositionNullableRelationFilter {
   is: LegacyPositionWhereInput
   isNot: LegacyPositionWhereInput
-}
-
-input LegacyPositionOrderByWithRelationInput {
-  chainId: SortOrder
-  counterparty: SortOrder
-  counterpartyCollateral: SortOrderInput
-  counterpartyNftTokenId: SortOrder
-  createdAt: SortOrder
-  endsAt: SortOrderInput
-  id: SortOrder
-  marketAddress: SortOrder
-  mintedAt: SortOrder
-  predictions: LegacyPredictionOrderByRelationAggregateInput
-  predictor: SortOrder
-  predictorCollateral: SortOrderInput
-  predictorNftTokenId: SortOrder
-  predictorWon: SortOrderInput
-  refCode: SortOrderInput
-  settledAt: SortOrderInput
-  status: SortOrder
-  totalCollateral: SortOrder
 }
 
 enum LegacyPositionStatus {
@@ -949,24 +897,6 @@ input LegacyPositionWhereInput {
   totalCollateral: StringFilter
 }
 
-type LegacyPrediction {
-  chainId: Int
-  condition: Condition!
-  conditionId: String!
-  createdAt: DateTimeISO!
-  id: Int!
-  limitOrder(where: LimitOrderWhereInput): LimitOrder
-  limitOrderId: Int
-  outcomeYes: Boolean!
-  position(where: LegacyPositionWhereInput): LegacyPosition
-  positionId: Int
-}
-
-input LegacyPredictionLimitOrderIdConditionIdCompoundUniqueInput {
-  conditionId: String!
-  limitOrderId: Int!
-}
-
 input LegacyPredictionListRelationFilter {
   every: LegacyPredictionWhereInput
   none: LegacyPredictionWhereInput
@@ -975,34 +905,6 @@ input LegacyPredictionListRelationFilter {
 
 input LegacyPredictionOrderByRelationAggregateInput {
   _count: SortOrder
-}
-
-input LegacyPredictionOrderByWithRelationInput {
-  chainId: SortOrderInput
-  condition: ConditionOrderByWithRelationInput
-  conditionId: SortOrder
-  createdAt: SortOrder
-  id: SortOrder
-  limitOrder: LimitOrderOrderByWithRelationInput
-  limitOrderId: SortOrderInput
-  outcomeYes: SortOrder
-  position: LegacyPositionOrderByWithRelationInput
-  positionId: SortOrderInput
-}
-
-input LegacyPredictionPositionIdConditionIdCompoundUniqueInput {
-  conditionId: String!
-  positionId: Int!
-}
-
-enum LegacyPredictionScalarFieldEnum {
-  chainId
-  conditionId
-  createdAt
-  id
-  limitOrderId
-  outcomeYes
-  positionId
 }
 
 input LegacyPredictionWhereInput {
@@ -1021,76 +923,9 @@ input LegacyPredictionWhereInput {
   positionId: IntNullableFilter
 }
 
-input LegacyPredictionWhereUniqueInput {
-  AND: [LegacyPredictionWhereInput!]
-  NOT: [LegacyPredictionWhereInput!]
-  OR: [LegacyPredictionWhereInput!]
-  chainId: IntNullableFilter
-  condition: ConditionRelationFilter
-  conditionId: StringFilter
-  createdAt: DateTimeFilter
-  id: Int
-  limitOrder: LimitOrderNullableRelationFilter
-  limitOrderId: IntNullableFilter
-  limitOrderId_conditionId: LegacyPredictionLimitOrderIdConditionIdCompoundUniqueInput
-  outcomeYes: BoolFilter
-  position: LegacyPositionNullableRelationFilter
-  positionId: IntNullableFilter
-  positionId_conditionId: LegacyPredictionPositionIdConditionIdCompoundUniqueInput
-}
-
-type LimitOrder {
-  _count: LimitOrderCount
-  cancelledAt: Int
-  cancelledTxHash: String
-  chainId: Int!
-  counterparty: String
-  counterpartyCollateral: String!
-  createdAt: DateTimeISO!
-  filledAt: Int
-  filledTxHash: String
-  id: Int!
-  marketAddress: String!
-  orderId: String!
-  placedAt: Int!
-  placedTxHash: String!
-  predictions(cursor: LegacyPredictionWhereUniqueInput, distinct: [LegacyPredictionScalarFieldEnum!], orderBy: [LegacyPredictionOrderByWithRelationInput!], skip: Int, take: Int, where: LegacyPredictionWhereInput): [LegacyPrediction!]!
-  predictor: String!
-  predictorCollateral: String!
-  refCode: String
-  resolver: String!
-  status: LimitOrderStatus!
-}
-
-type LimitOrderCount {
-  predictions(where: LegacyPredictionWhereInput): Int!
-}
-
 input LimitOrderNullableRelationFilter {
   is: LimitOrderWhereInput
   isNot: LimitOrderWhereInput
-}
-
-input LimitOrderOrderByWithRelationInput {
-  cancelledAt: SortOrderInput
-  cancelledTxHash: SortOrderInput
-  chainId: SortOrder
-  counterparty: SortOrderInput
-  counterpartyCollateral: SortOrder
-  createdAt: SortOrder
-  filledAt: SortOrderInput
-  filledTxHash: SortOrderInput
-  id: SortOrder
-  marketAddress: SortOrder
-  orderId: SortOrder
-  placedAt: SortOrder
-  placedTxHash: SortOrder
-  predictions: LegacyPredictionOrderByRelationAggregateInput
-  predictor: SortOrder
-  predictorCollateral: SortOrder
-  refCode: SortOrderInput
-  resolver: SortOrder
-  status: SortOrder
 }
 
 enum LimitOrderStatus {

--- a/packages/api/src/graphql/resolvers/AnalyticsResolver.ts
+++ b/packages/api/src/graphql/resolvers/AnalyticsResolver.ts
@@ -221,63 +221,75 @@ export class AnalyticsResolver {
       };
     });
 
-    // Append live "today" data point using real-time OI/volume
-    const lastSnapshot = protocolSnapshots[protocolSnapshots.length - 1];
-    const lastCumVol = volumeMap.get(lastSnapshot.timestamp) || '0';
-    const liveCumVol = volumeMap.get(nowTimestamp) || lastCumVol;
-    const liveDailyVolume = (
-      BigInt(liveCumVol) - BigInt(lastCumVol)
-    ).toString();
-    const liveDailyPnL = '0'; // PnL not computed live
+    // Append live "today" data point using real-time OI/volume. If any of the
+    // live reads fail (flaky RPC, DB timeout) we fall through and return the
+    // snapshot-only series rather than failing the whole query.
+    try {
+      const lastSnapshot = protocolSnapshots[protocolSnapshots.length - 1];
+      const lastCumVol = volumeMap.get(lastSnapshot.timestamp) || '0';
+      const liveCumVol = volumeMap.get(nowTimestamp) || lastCumVol;
+      const liveDailyVolume = (
+        BigInt(liveCumVol) - BigInt(lastCumVol)
+      ).toString();
 
-    // Fetch all live values for today's candle in parallel
-    const [
-      liveVaultBalance,
-      liveVaultAvailableAssets,
-      liveVaultDeployed,
-      liveEscrowBalance,
-      livePnlResult,
-      liveFlowsResult,
-    ] = await Promise.all([
-      fetchVaultTVL(chainId),
-      fetchVaultAvailableAssets(chainId),
-      fetchVaultDeployed(chainId),
-      fetchPredictionMarketEscrowTVL(chainId),
-      calculateVaultPnL(chainId),
-      calculateVaultFlows(chainId),
-    ]);
+      const [
+        liveVaultBalance,
+        liveVaultAvailableAssets,
+        liveVaultDeployed,
+        liveEscrowBalance,
+        livePnlResult,
+        liveFlowsResult,
+      ] = await Promise.all([
+        fetchVaultTVL(chainId),
+        fetchVaultAvailableAssets(chainId),
+        fetchVaultDeployed(chainId),
+        fetchPredictionMarketEscrowTVL(chainId),
+        calculateVaultPnL(chainId),
+        calculateVaultFlows(chainId),
+      ]);
 
-    const liveActualTotalAssets = liveVaultBalance + liveVaultDeployed;
-    const liveExpectedTotalAssets =
-      liveFlowsResult.totalDeposits -
-      liveFlowsResult.totalWithdrawals +
-      livePnlResult.realizedPnL;
-    const liveAirdropGains =
-      liveActualTotalAssets > liveExpectedTotalAssets
-        ? liveActualTotalAssets - liveExpectedTotalAssets
-        : 0n;
+      const liveDailyPnL = (
+        livePnlResult.realizedPnL - BigInt(lastSnapshot.vaultRealizedPnL)
+      ).toString();
 
-    // Today's display timestamp = last snapshot's midnight (shifted back = yesterday),
-    // so today = last snapshot's original timestamp (unshifted)
-    const todayTimestamp = lastSnapshot.timestamp;
+      const liveActualTotalAssets = liveVaultBalance + liveVaultDeployed;
+      const liveExpectedTotalAssets =
+        liveFlowsResult.totalDeposits -
+        liveFlowsResult.totalWithdrawals +
+        livePnlResult.realizedPnL;
+      const liveAirdropGains =
+        liveActualTotalAssets > liveExpectedTotalAssets
+          ? liveActualTotalAssets - liveExpectedTotalAssets
+          : 0n;
 
-    results.push({
-      timestamp: todayTimestamp,
-      cumulativeVolume: liveCumVol,
-      openInterest: oiMap.get(nowTimestamp) || '0',
-      vaultBalance: liveVaultBalance.toString(),
-      vaultAvailableAssets: liveVaultAvailableAssets.toString(),
-      vaultDeployed: liveVaultDeployed.toString(),
-      escrowBalance: liveEscrowBalance.toString(),
-      vaultCumulativePnL: livePnlResult.realizedPnL.toString(),
-      vaultPositionsWon: livePnlResult.positionsWon,
-      vaultPositionsLost: livePnlResult.positionsLost,
-      vaultDeposits: liveFlowsResult.totalDeposits.toString(),
-      vaultWithdrawals: liveFlowsResult.totalWithdrawals.toString(),
-      vaultAirdropGains: liveAirdropGains.toString(),
-      dailyPnL: liveDailyPnL,
-      dailyVolume: liveDailyVolume,
-    });
+      // Today's display timestamp = current UTC midnight. Derived from wall-clock
+      // rather than last snapshot so a missed cron doesn't mislabel the live candle.
+      const todayTimestamp =
+        Math.floor(Date.now() / 1000 / DAY_SECONDS) * DAY_SECONDS;
+
+      results.push({
+        timestamp: todayTimestamp,
+        cumulativeVolume: liveCumVol,
+        openInterest: oiMap.get(nowTimestamp) || '0',
+        vaultBalance: liveVaultBalance.toString(),
+        vaultAvailableAssets: liveVaultAvailableAssets.toString(),
+        vaultDeployed: liveVaultDeployed.toString(),
+        escrowBalance: liveEscrowBalance.toString(),
+        vaultCumulativePnL: livePnlResult.realizedPnL.toString(),
+        vaultPositionsWon: livePnlResult.positionsWon,
+        vaultPositionsLost: livePnlResult.positionsLost,
+        vaultDeposits: liveFlowsResult.totalDeposits.toString(),
+        vaultWithdrawals: liveFlowsResult.totalWithdrawals.toString(),
+        vaultAirdropGains: liveAirdropGains.toString(),
+        dailyPnL: liveDailyPnL,
+        dailyVolume: liveDailyVolume,
+      });
+    } catch (err) {
+      console.error(
+        '[AnalyticsResolver] live candle failed, falling back to snapshots only:',
+        err
+      );
+    }
 
     return results;
   }

--- a/packages/api/src/graphql/resolvers/AnalyticsResolver.ts
+++ b/packages/api/src/graphql/resolvers/AnalyticsResolver.ts
@@ -9,7 +9,15 @@ import {
 import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
 import { contracts } from '@sapience/sdk/contracts';
 import prisma from '../../db';
-import { getProtocolStatsTimeSeries } from '../../helpers/protocolStats';
+import {
+  getProtocolStatsTimeSeries,
+  fetchVaultTVL,
+  fetchVaultAvailableAssets,
+  fetchVaultDeployed,
+  fetchPredictionMarketEscrowTVL,
+  calculateVaultPnL,
+  calculateVaultFlows,
+} from '../../helpers/protocolStats';
 
 @ObjectType({
   description:
@@ -94,7 +102,7 @@ export class AnalyticsResolver {
     description:
       'Daily protocol statistics time series (last 90 days) — vault balance, volume, PnL, and open interest',
   })
-  @Directive('@cacheControl(maxAge: 3600)')
+  @Directive('@cacheControl(maxAge: 60)')
   async protocolStats(): Promise<ProtocolStat[]> {
     const chainId = DEFAULT_CHAIN_ID;
     const vaultAddress = (
@@ -112,18 +120,21 @@ export class AnalyticsResolver {
       return [];
     }
 
-    // Get all snapshot timestamps
+    // Get all snapshot timestamps + a live "now" timestamp for today's candle.
+    // Snapshot timestamps are midnight UTC — they represent end-of-previous-day.
     const snapshotTimestamps = protocolSnapshots.map((s) => s.timestamp);
-    const firstSnapshotTimestamp = snapshotTimestamps[0];
+    const nowTimestamp = Math.floor(Date.now() / 1000);
+    // Add "now" for the live today candle (OI + volume computed in real time)
+    const queryTimestamps = [...snapshotTimestamps, nowTimestamp];
 
-    // Fetch volume and OI data at snapshot timestamps in parallel
+    // Fetch volume and OI data at all timestamps (including live) in parallel
     const [cumulativeVolumes, openInterests] = await Promise.all([
-      // Cumulative volume within the snapshot window (legacy + escrow predictions)
+      // All-time cumulative volume (V1 legacy + V2 escrow + secondary trades)
       prisma.$queryRaw<CumulativeVolumeRow[]>`
         SELECT
           ts.timestamp,
           COALESCE(SUM(vol), 0)::TEXT as cumulative_volume
-        FROM UNNEST(${snapshotTimestamps}::BIGINT[]) AS ts(timestamp)
+        FROM UNNEST(${queryTimestamps}::BIGINT[]) AS ts(timestamp)
         LEFT JOIN (
           SELECT "mintedAt" AS created_ts, CAST("totalCollateral" AS DECIMAL) AS vol, "chainId"
           FROM position
@@ -132,31 +143,38 @@ export class AnalyticsResolver {
             CAST("predictorCollateral" AS DECIMAL) + CAST("counterpartyCollateral" AS DECIMAL) AS vol,
             "chainId"
           FROM "Prediction"
+          UNION ALL
+          SELECT "executedAt" AS created_ts,
+            CAST(price AS DECIMAL) AS vol,
+            "chainId"
+          FROM secondary_trade
         ) combined ON
-          combined.created_ts >= ${firstSnapshotTimestamp}
-          AND combined.created_ts <= ts.timestamp
+          combined.created_ts <= ts.timestamp
           AND combined."chainId" = ${chainId}
         GROUP BY ts.timestamp
         ORDER BY ts.timestamp
       `,
-      // Open interest at each snapshot timestamp (legacy + escrow predictions)
-      // For V2 Predictions, use Picks.resolvedAt instead of Prediction.settledAt
-      // because losing predictions may never get settled on-chain.
+      // Open interest at each snapshot timestamp (V2 escrow predictions only).
+      // V1 legacy positions are excluded — their resolvers are deprecated.
+      // Private conditions are excluded — they shouldn't inflate public metrics.
+      // Uses Picks.resolvedAt instead of Prediction.settledAt because losing
+      // predictions may never get settled on-chain.
       prisma.$queryRaw<DailyOIRow[]>`
         SELECT
           ts.timestamp,
           COALESCE(SUM(vol), 0)::TEXT as open_interest
-        FROM UNNEST(${snapshotTimestamps}::BIGINT[]) AS ts(timestamp)
+        FROM UNNEST(${queryTimestamps}::BIGINT[]) AS ts(timestamp)
         LEFT JOIN (
-          SELECT "mintedAt" AS created_ts, "settledAt" AS settled_ts,
-            CAST("totalCollateral" AS DECIMAL) AS vol, "chainId"
-          FROM position
-          UNION ALL
           SELECT p."onChainCreatedAt" AS created_ts, pk."resolvedAt" AS settled_ts,
             CAST(p."predictorCollateral" AS DECIMAL) + CAST(p."counterpartyCollateral" AS DECIMAL) AS vol,
             p."chainId"
           FROM "Prediction" p
           LEFT JOIN "Picks" pk ON pk.id = p."pickConfigId"
+          WHERE NOT EXISTS (
+            SELECT 1 FROM "Pick" pi
+            JOIN "condition" c ON c.id = pi."conditionId"
+            WHERE pi."pickConfigId" = pk.id AND c.public = false
+          )
         ) combined ON
           combined.created_ts <= ts.timestamp
           AND (combined.settled_ts IS NULL OR combined.settled_ts > ts.timestamp)
@@ -169,7 +187,11 @@ export class AnalyticsResolver {
     const volumeMap = buildTimestampMap(cumulativeVolumes, 'cumulative_volume');
     const oiMap = buildTimestampMap(openInterests, 'open_interest');
 
-    return protocolSnapshots.map((snapshot, i) => {
+    const DAY_SECONDS = 86400;
+
+    // Build results from snapshots. Each snapshot timestamp (midnight UTC) represents
+    // end-of-previous-day, so we shift the display timestamp back by 1 day.
+    const results: ProtocolStat[] = protocolSnapshots.map((snapshot, i) => {
       const cumVol = volumeMap.get(snapshot.timestamp) || '0';
       const prevCumVol =
         i > 0 ? volumeMap.get(protocolSnapshots[i - 1].timestamp) || '0' : '0';
@@ -181,7 +203,7 @@ export class AnalyticsResolver {
       ).toString();
 
       return {
-        timestamp: snapshot.timestamp,
+        timestamp: snapshot.timestamp - DAY_SECONDS,
         cumulativeVolume: cumVol,
         openInterest: oiMap.get(snapshot.timestamp) || '0',
         vaultBalance: snapshot.vaultBalance,
@@ -198,5 +220,65 @@ export class AnalyticsResolver {
         dailyVolume,
       };
     });
+
+    // Append live "today" data point using real-time OI/volume
+    const lastSnapshot = protocolSnapshots[protocolSnapshots.length - 1];
+    const lastCumVol = volumeMap.get(lastSnapshot.timestamp) || '0';
+    const liveCumVol = volumeMap.get(nowTimestamp) || lastCumVol;
+    const liveDailyVolume = (
+      BigInt(liveCumVol) - BigInt(lastCumVol)
+    ).toString();
+    const liveDailyPnL = '0'; // PnL not computed live
+
+    // Fetch all live values for today's candle in parallel
+    const [
+      liveVaultBalance,
+      liveVaultAvailableAssets,
+      liveVaultDeployed,
+      liveEscrowBalance,
+      livePnlResult,
+      liveFlowsResult,
+    ] = await Promise.all([
+      fetchVaultTVL(chainId),
+      fetchVaultAvailableAssets(chainId),
+      fetchVaultDeployed(chainId),
+      fetchPredictionMarketEscrowTVL(chainId),
+      calculateVaultPnL(chainId),
+      calculateVaultFlows(chainId),
+    ]);
+
+    const liveActualTotalAssets = liveVaultBalance + liveVaultDeployed;
+    const liveExpectedTotalAssets =
+      liveFlowsResult.totalDeposits -
+      liveFlowsResult.totalWithdrawals +
+      livePnlResult.realizedPnL;
+    const liveAirdropGains =
+      liveActualTotalAssets > liveExpectedTotalAssets
+        ? liveActualTotalAssets - liveExpectedTotalAssets
+        : 0n;
+
+    // Today's display timestamp = last snapshot's midnight (shifted back = yesterday),
+    // so today = last snapshot's original timestamp (unshifted)
+    const todayTimestamp = lastSnapshot.timestamp;
+
+    results.push({
+      timestamp: todayTimestamp,
+      cumulativeVolume: liveCumVol,
+      openInterest: oiMap.get(nowTimestamp) || '0',
+      vaultBalance: liveVaultBalance.toString(),
+      vaultAvailableAssets: liveVaultAvailableAssets.toString(),
+      vaultDeployed: liveVaultDeployed.toString(),
+      escrowBalance: liveEscrowBalance.toString(),
+      vaultCumulativePnL: livePnlResult.realizedPnL.toString(),
+      vaultPositionsWon: livePnlResult.positionsWon,
+      vaultPositionsLost: livePnlResult.positionsLost,
+      vaultDeposits: liveFlowsResult.totalDeposits.toString(),
+      vaultWithdrawals: liveFlowsResult.totalWithdrawals.toString(),
+      vaultAirdropGains: liveAirdropGains.toString(),
+      dailyPnL: liveDailyPnL,
+      dailyVolume: liveDailyVolume,
+    });
+
+    return results;
   }
 }

--- a/packages/api/src/helpers/protocolStats.ts
+++ b/packages/api/src/helpers/protocolStats.ts
@@ -261,10 +261,6 @@ export async function fetchPredictionMarketTVLAtBlock(
 }
 
 /**
- * Try reading a value from the current contract, then fall back through legacy
- * contracts in order. Returns 0n if all fail (contract not deployed at that block).
- */
-/**
  * Find the correct contract address for a given block number by checking
  * blockCreated timestamps. Returns the contract that was deployed at or before
  * the given block, preferring newer deployments.
@@ -275,32 +271,20 @@ export async function fetchPredictionMarketTVLAtBlock(
  */
 function getContractForBlock(
   contractConfig: (typeof contracts.predictionMarketVault)[number],
-  blockNumber: bigint,
-  label: string = 'contract'
+  blockNumber: bigint
 ): `0x${string}` | null {
-  // Try current contract
   const currentBlock = contractConfig.blockCreated ?? 0;
   if (blockNumber >= BigInt(currentBlock)) {
-    console.log(
-      `[ProtocolStats]     ${label}: using current ${contractConfig.address.slice(0, 10)}... (deployed at block ${currentBlock})`
-    );
     return contractConfig.address as `0x${string}`;
   }
 
-  // Try legacy contracts in order (newest legacy first)
-  for (let i = 0; i < (contractConfig.legacy ?? []).length; i++) {
-    const entry = normalizeLegacyEntry(contractConfig.legacy![i]);
+  for (const legEntry of contractConfig.legacy ?? []) {
+    const entry = normalizeLegacyEntry(legEntry);
     if (blockNumber >= BigInt(entry.blockCreated)) {
-      console.log(
-        `[ProtocolStats]     ${label}: using legacy-${i + 1} ${entry.address.slice(0, 10)}... (deployed at block ${entry.blockCreated})`
-      );
       return entry.address as `0x${string}`;
     }
   }
 
-  console.log(
-    `[ProtocolStats]     ${label}: no contract deployed at block ${blockNumber}`
-  );
   return null;
 }
 
@@ -684,10 +668,10 @@ export async function backfillProtocolStats(
       | undefined;
 
     const vaultAddr = vaultConfig
-      ? getContractForBlock(vaultConfig, blockNumber, 'vault')
+      ? getContractForBlock(vaultConfig, blockNumber)
       : null;
     const escrowAddr = escrowConfig
-      ? getContractForBlock(escrowConfig, blockNumber, 'escrow')
+      ? getContractForBlock(escrowConfig, blockNumber)
       : null;
 
     let vaultBalance = 0n;

--- a/packages/api/src/helpers/protocolStats.ts
+++ b/packages/api/src/helpers/protocolStats.ts
@@ -2,7 +2,7 @@ import { erc20Abi, formatUnits } from 'viem';
 import prisma from '../db';
 import { SettlementResult } from '../../generated/prisma';
 import { getProviderForChain, getBlockByTimestamp } from '../utils/utils';
-import { contracts } from '@sapience/sdk/contracts';
+import { contracts, normalizeLegacyEntry } from '@sapience/sdk/contracts';
 import { predictionMarketVaultAbi } from '@sapience/sdk/abis';
 import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
 
@@ -176,12 +176,14 @@ export async function fetchVaultAvailableAssetsAtBlock(
 /**
  * Fetch Escrow TVL: collateral.balanceOf(predictionMarketEscrow)
  */
-export async function fetchPredictionMarketTVL(
-  chainId: number = DEFAULT_CHAIN_ID
+export async function fetchPredictionMarketEscrowTVL(
+  chainId: number = DEFAULT_CHAIN_ID,
+  escrowAddressOverride?: string
 ): Promise<bigint> {
   const client = getProviderForChain(chainId);
 
-  const escrowAddress = contracts.predictionMarketEscrow[chainId]?.address;
+  const escrowAddress =
+    escrowAddressOverride || contracts.predictionMarketEscrow[chainId]?.address;
   const collateralAddress = contracts.collateralToken[chainId]?.address;
 
   if (!escrowAddress || !collateralAddress) {
@@ -194,7 +196,7 @@ export async function fetchPredictionMarketTVL(
     address: collateralAddress,
     abi: erc20Abi,
     functionName: 'balanceOf',
-    args: [escrowAddress],
+    args: [escrowAddress as `0x${string}`],
   });
 
   return balance;
@@ -259,13 +261,57 @@ export async function fetchPredictionMarketTVLAtBlock(
 }
 
 /**
+ * Try reading a value from the current contract, then fall back through legacy
+ * contracts in order. Returns 0n if all fail (contract not deployed at that block).
+ */
+/**
+ * Find the correct contract address for a given block number by checking
+ * blockCreated timestamps. Returns the contract that was deployed at or before
+ * the given block, preferring newer deployments.
+ *
+ * Order: current contract first, then legacy entries in array order.
+ * Each entry's blockCreated indicates when it was deployed — if the target
+ * block is before that, skip to the next (older) contract.
+ */
+function getContractForBlock(
+  contractConfig: (typeof contracts.predictionMarketVault)[number],
+  blockNumber: bigint,
+  label: string = 'contract'
+): `0x${string}` | null {
+  // Try current contract
+  const currentBlock = contractConfig.blockCreated ?? 0;
+  if (blockNumber >= BigInt(currentBlock)) {
+    console.log(
+      `[ProtocolStats]     ${label}: using current ${contractConfig.address.slice(0, 10)}... (deployed at block ${currentBlock})`
+    );
+    return contractConfig.address as `0x${string}`;
+  }
+
+  // Try legacy contracts in order (newest legacy first)
+  for (let i = 0; i < (contractConfig.legacy ?? []).length; i++) {
+    const entry = normalizeLegacyEntry(contractConfig.legacy![i]);
+    if (blockNumber >= BigInt(entry.blockCreated)) {
+      console.log(
+        `[ProtocolStats]     ${label}: using legacy-${i + 1} ${entry.address.slice(0, 10)}... (deployed at block ${entry.blockCreated})`
+      );
+      return entry.address as `0x${string}`;
+    }
+  }
+
+  console.log(
+    `[ProtocolStats]     ${label}: no contract deployed at block ${blockNumber}`
+  );
+  return null;
+}
+
+/**
  * Calculate vault's realized PnL from resolved predictions.
  *
  * Uses Picks.resolved (set automatically when all conditions settle)
  * rather than Prediction.settled (requires an explicit on-chain settle() call
  * that may never happen for losing predictions).
  */
-async function calculateVaultPnL(
+export async function calculateVaultPnL(
   chainId: number,
   beforeTimestamp?: number
 ): Promise<VaultPnLResult> {
@@ -349,7 +395,7 @@ async function calculateVaultPnL(
 /**
  * Calculate vault's cumulative deposits and withdrawals from indexed flow events.
  */
-async function calculateVaultFlows(
+export async function calculateVaultFlows(
   chainId: number,
   beforeTimestamp?: number
 ): Promise<VaultFlowsResult> {
@@ -456,12 +502,25 @@ export async function computeAndStoreProtocolStats(
   const vaultBalance = await fetchVaultTVL(chainId);
   const vaultAvailableAssets = await fetchVaultAvailableAssets(chainId);
   const vaultDeployed = await fetchVaultDeployed(chainId);
-  const escrowBalance = await fetchPredictionMarketTVL(chainId);
+
+  // Sum escrow balance across current + legacy escrow contracts
+  const escrowConfig = contracts.predictionMarketEscrow[chainId];
+  let escrowBalance = await fetchPredictionMarketEscrowTVL(chainId);
+  for (const legEntry of escrowConfig?.legacy ?? []) {
+    const { address } = normalizeLegacyEntry(legEntry);
+    try {
+      escrowBalance += await fetchPredictionMarketEscrowTVL(chainId, address);
+    } catch {
+      // Legacy escrow may no longer exist
+    }
+  }
 
   console.log(
     `[ProtocolStats] Vault: ${formatUnits(vaultBalance, 18)} balance, ${formatUnits(vaultAvailableAssets, 18)} available, ${formatUnits(vaultDeployed, 18)} deployed`
   );
-  console.log(`[ProtocolStats] Escrow: ${formatUnits(escrowBalance, 18)} USDe`);
+  console.log(
+    `[ProtocolStats] Escrow: ${formatUnits(escrowBalance, 18)} USDe (all contracts)`
+  );
 
   // Calculate vault PnL
   const pnlResult = await calculateVaultPnL(chainId);
@@ -574,9 +633,35 @@ export async function backfillProtocolStats(
   let successCount = 0;
   let skipCount = 0;
 
+  // Ethereal mainnet launched ~October 20, 2025. Before this date, no contracts
+  // existed on-chain, so we create zero-valued snapshots as time-axis placeholders.
+  const ETHEREAL_MAINNET_LAUNCH = Math.floor(Date.UTC(2025, 9, 20) / 1000); // 2025-10-20 UTC
+
   for (let idx = 0; idx < timestamps.length; idx++) {
     const timestamp = timestamps[idx];
     const dateStr = new Date(timestamp * 1000).toISOString().split('T')[0];
+
+    if (timestamp < ETHEREAL_MAINNET_LAUNCH) {
+      console.log(
+        `[ProtocolStats] ${dateStr} - before Ethereal mainnet launch, creating zero-valued snapshot`
+      );
+      await upsertProtocolStatsSnapshot(timestamp, chainId, vaultAddress, {
+        vaultBalance: 0n,
+        vaultAvailableAssets: 0n,
+        vaultDeployed: 0n,
+        escrowBalance: 0n,
+        vaultRealizedPnL: 0n,
+        vaultAirdropGains: 0n,
+        vaultDeposits: 0n,
+        vaultWithdrawals: 0n,
+        vaultPositionsWon: 0,
+        vaultPositionsLost: 0,
+        vaultCollateralWon: 0n,
+        vaultCollateralLost: 0n,
+      });
+      skipCount++;
+      continue;
+    }
 
     const block = await getBlockByTimestamp(client, timestamp);
     const blockNumber = block.number;
@@ -591,72 +676,95 @@ export async function backfillProtocolStats(
       `[ProtocolStats] Processing ${dateStr} (block ${blockNumber}) [${idx + 1}/${timestamps.length}]`
     );
 
-    try {
-      // Query historical balances
-      const vaultBalance = await fetchVaultTVLAtBlock(chainId, blockNumber);
-      const vaultAvailableAssets = await fetchVaultAvailableAssetsAtBlock(
-        chainId,
-        blockNumber
-      );
-      const vaultDeployed = await fetchVaultDeployedAtBlock(
-        chainId,
+    // Query historical balances using blockCreated to pick the right contract.
+    const vaultConfig = contracts.predictionMarketVault[chainId];
+    const escrowConfig = contracts.predictionMarketEscrow[chainId];
+    const collateralAddress = contracts.collateralToken[chainId]?.address as
+      | `0x${string}`
+      | undefined;
+
+    const vaultAddr = vaultConfig
+      ? getContractForBlock(vaultConfig, blockNumber, 'vault')
+      : null;
+    const escrowAddr = escrowConfig
+      ? getContractForBlock(escrowConfig, blockNumber, 'escrow')
+      : null;
+
+    let vaultBalance = 0n;
+    let vaultAvailableAssets = 0n;
+    if (vaultAddr && collateralAddress) {
+      vaultBalance = await client.readContract({
+        address: collateralAddress,
+        abi: erc20Abi,
+        functionName: 'balanceOf',
+        args: [vaultAddr],
         blockNumber,
-        timestamp
-      );
-      const escrowBalance = await fetchPredictionMarketTVLAtBlock(
-        chainId,
-        blockNumber
-      );
-
-      // Calculate PnL up to this timestamp
-      const pnlResult = await calculateVaultPnL(chainId, timestamp);
-      const flowsResult = await calculateVaultFlows(chainId, timestamp);
-
-      // Calculate airdrop gains
-      const actualTotalAssets = vaultBalance + vaultDeployed;
-      const expectedTotalAssets =
-        flowsResult.totalDeposits -
-        flowsResult.totalWithdrawals +
-        pnlResult.realizedPnL;
-      const airdropGains =
-        actualTotalAssets > expectedTotalAssets
-          ? actualTotalAssets - expectedTotalAssets
-          : 0n;
-
-      await upsertProtocolStatsSnapshot(timestamp, chainId, vaultAddress, {
-        vaultBalance,
-        vaultAvailableAssets,
-        vaultDeployed,
-        escrowBalance,
-        vaultRealizedPnL: pnlResult.realizedPnL,
-        vaultAirdropGains: airdropGains,
-        vaultDeposits: flowsResult.totalDeposits,
-        vaultWithdrawals: flowsResult.totalWithdrawals,
-        vaultPositionsWon: pnlResult.positionsWon,
-        vaultPositionsLost: pnlResult.positionsLost,
-        vaultCollateralWon: pnlResult.totalCollateralWon,
-        vaultCollateralLost: pnlResult.totalCollateralLost,
       });
-
-      console.log(
-        `[ProtocolStats]   Vault: ${formatUnits(vaultAvailableAssets, 18)} available + ${formatUnits(vaultDeployed, 18)} deployed, Escrow: ${formatUnits(escrowBalance, 18)}, PnL: ${formatUnits(pnlResult.realizedPnL, 18)}, Airdrops: ${formatUnits(airdropGains, 18)}`
-      );
-      successCount++;
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      if (
-        errorMessage.includes('returned no data') ||
-        errorMessage.includes('0x')
-      ) {
-        console.log(
-          `[ProtocolStats] Skipping ${dateStr} - contract not deployed at block ${blockNumber}`
-        );
-        skipCount++;
-      } else {
-        throw error;
+      try {
+        vaultAvailableAssets = (await client.readContract({
+          address: vaultAddr,
+          abi: predictionMarketVaultAbi,
+          functionName: 'availableAssets',
+          args: [],
+          blockNumber,
+        })) as bigint;
+      } catch {
+        // Older vault contracts may not have availableAssets()
+        vaultAvailableAssets = vaultBalance;
       }
     }
+
+    let escrowBalance = 0n;
+    if (escrowAddr && collateralAddress) {
+      escrowBalance = await client.readContract({
+        address: collateralAddress,
+        abi: erc20Abi,
+        functionName: 'balanceOf',
+        args: [escrowAddr],
+        blockNumber,
+      });
+    }
+
+    const vaultDeployed = await fetchVaultDeployedAtBlock(
+      chainId,
+      blockNumber,
+      timestamp
+    );
+
+    // Calculate PnL up to this timestamp
+    const pnlResult = await calculateVaultPnL(chainId, timestamp);
+    const flowsResult = await calculateVaultFlows(chainId, timestamp);
+
+    // Calculate airdrop gains
+    const actualTotalAssets = vaultBalance + vaultDeployed;
+    const expectedTotalAssets =
+      flowsResult.totalDeposits -
+      flowsResult.totalWithdrawals +
+      pnlResult.realizedPnL;
+    const airdropGains =
+      actualTotalAssets > expectedTotalAssets
+        ? actualTotalAssets - expectedTotalAssets
+        : 0n;
+
+    await upsertProtocolStatsSnapshot(timestamp, chainId, vaultAddress, {
+      vaultBalance,
+      vaultAvailableAssets,
+      vaultDeployed,
+      escrowBalance,
+      vaultRealizedPnL: pnlResult.realizedPnL,
+      vaultAirdropGains: airdropGains,
+      vaultDeposits: flowsResult.totalDeposits,
+      vaultWithdrawals: flowsResult.totalWithdrawals,
+      vaultPositionsWon: pnlResult.positionsWon,
+      vaultPositionsLost: pnlResult.positionsLost,
+      vaultCollateralWon: pnlResult.totalCollateralWon,
+      vaultCollateralLost: pnlResult.totalCollateralLost,
+    });
+
+    console.log(
+      `[ProtocolStats]   Vault: ${formatUnits(vaultAvailableAssets, 18)} available + ${formatUnits(vaultDeployed, 18)} deployed, Escrow: ${formatUnits(escrowBalance, 18)}, PnL: ${formatUnits(pnlResult.realizedPnL, 18)}, Airdrops: ${formatUnits(airdropGains, 18)}`
+    );
+    successCount++;
 
     await new Promise((resolve) => setTimeout(resolve, 100));
   }

--- a/packages/app/src/components/analytics/pages/AnalyticsPageContent.tsx
+++ b/packages/app/src/components/analytics/pages/AnalyticsPageContent.tsx
@@ -20,7 +20,10 @@ import {
   ComposedChart,
   Bar,
 } from 'recharts';
-import { useProtocolStats } from '~/hooks/graphql/useAnalytics';
+import {
+  getProtocolTvlWei,
+  useProtocolStats,
+} from '~/hooks/graphql/useAnalytics';
 import Loader from '~/components/shared/Loader';
 import PeriodFilter, {
   type Period,
@@ -318,12 +321,7 @@ function AnalyticsPageContent(): React.ReactElement {
                   </div>
                 ) : (
                   <span className="transition-opacity duration-300">
-                    {formatNumber(
-                      String(
-                        BigInt(summary?.openInterest || '0') +
-                          BigInt(summary?.vaultAvailableAssets || '0')
-                      )
-                    )}{' '}
+                    {formatNumber(String(getProtocolTvlWei(summary)))}{' '}
                     {collateralSymbol}
                   </span>
                 )}

--- a/packages/app/src/components/analytics/pages/AnalyticsPageContent.tsx
+++ b/packages/app/src/components/analytics/pages/AnalyticsPageContent.tsx
@@ -26,7 +26,6 @@ import PeriodFilter, {
   type Period,
   PERIOD_DAYS,
 } from '~/components/shared/PeriodFilter';
-import VaultPnlChart from '~/components/vaults/VaultPnlChart';
 
 function formatLargeNumber(
   value: number,
@@ -171,12 +170,18 @@ function filterDataByPeriod<T extends { timestamp: number }>(
     Math.floor((now - days * DAY_SECONDS) / DAY_SECONDS) * DAY_SECONDS;
   const filtered = data.filter((item) => item.timestamp >= cutoff);
 
-  // Fill missing days with zero entries
+  // Fill missing days with zero entries, but only between the first and last
+  // data points — don't pad the tails with zeros
   const existingTimestamps = new Set(
     filtered.map((d) => Math.floor(d.timestamp / DAY_SECONDS))
   );
+  const firstDataTs =
+    filtered.length > 0 ? Math.min(...filtered.map((d) => d.timestamp)) : now;
+  const lastDataTs =
+    filtered.length > 0 ? Math.max(...filtered.map((d) => d.timestamp)) : now;
+  const fillStart = Math.max(cutoff, firstDataTs);
   const filled = [...filtered];
-  for (let ts = cutoff; ts <= now; ts += DAY_SECONDS) {
+  for (let ts = fillStart; ts <= lastDataTs; ts += DAY_SECONDS) {
     const dayKey = Math.floor(ts / DAY_SECONDS);
     if (!existingTimestamps.has(dayKey)) {
       filled.push({ ...zeroEntry, timestamp: ts } as T);
@@ -193,7 +198,6 @@ function AnalyticsPageContent(): React.ReactElement {
   const [volumePeriod, setVolumePeriod] = useState<Period>('1W');
   const [oiPeriod, setOiPeriod] = useState<Period>('1W');
   const [tvlPeriod, setTvlPeriod] = useState<Period>('1W');
-  const [pnlPeriod, setPnlPeriod] = useState<Period>('1W');
 
   // Fetch protocol stats and daily volumes
   const { data: protocolStats, isLoading: statsLoading } = useProtocolStats();
@@ -209,16 +213,14 @@ function AnalyticsPageContent(): React.ReactElement {
     if (!protocolStats) return [];
 
     return protocolStats.map((point) => {
-      const vaultBalance = parseFloat(point.vaultBalance) / 1e18;
-      const vaultDeployed = parseFloat(point.vaultDeployed) / 1e18;
-      const escrowBalance = parseFloat(point.escrowBalance) / 1e18;
+      const openInterest = parseFloat(point.openInterest) / 1e18;
+      const vaultAvailableAssets =
+        parseFloat(point.vaultAvailableAssets) / 1e18;
       return {
         timestamp: point.timestamp,
-        openInterest: parseFloat(point.openInterest) / 1e18,
-        totalBalance: vaultBalance + escrowBalance,
-        vaultBalance,
-        vaultDeployed,
-        escrowBalance,
+        openInterest,
+        totalBalance: openInterest + vaultAvailableAssets,
+        vaultAvailableAssets,
       };
     });
   }, [protocolStats]);
@@ -242,9 +244,7 @@ function AnalyticsPageContent(): React.ReactElement {
       filterDataByPeriod(statsChartData, oiPeriod, {
         openInterest: 0,
         totalBalance: 0,
-        vaultBalance: 0,
-        vaultDeployed: 0,
-        escrowBalance: 0,
+        vaultAvailableAssets: 0,
       }),
     [statsChartData, oiPeriod]
   );
@@ -254,9 +254,7 @@ function AnalyticsPageContent(): React.ReactElement {
       filterDataByPeriod(statsChartData, tvlPeriod, {
         openInterest: 0,
         totalBalance: 0,
-        vaultBalance: 0,
-        vaultDeployed: 0,
-        escrowBalance: 0,
+        vaultAvailableAssets: 0,
       }),
     [statsChartData, tvlPeriod]
   );
@@ -292,20 +290,20 @@ function AnalyticsPageContent(): React.ReactElement {
                     <div className="space-y-3">
                       <div className="flex flex-col gap-1">
                         <span className="uppercase font-mono tracking-wide text-muted-foreground text-xs whitespace-nowrap">
-                          Prediction Market Escrow
+                          Open Interest
                         </span>
                         <span className="font-mono whitespace-nowrap text-xl">
-                          {formatNumber(summary?.escrowBalance || '0')}{' '}
+                          {formatNumber(summary?.openInterest || '0')}{' '}
                           {collateralSymbol}
                         </span>
                       </div>
                       <div className="h-px bg-[hsl(var(--accent-gold)/0.25)]" />
                       <div className="flex flex-col gap-1">
                         <span className="uppercase font-mono tracking-wide text-muted-foreground text-xs whitespace-nowrap">
-                          Protocol Vault Reserve
+                          Undeployed Vault Funds
                         </span>
                         <span className="font-mono whitespace-nowrap text-xl">
-                          {formatNumber(summary?.vaultBalance || '0')}{' '}
+                          {formatNumber(summary?.vaultAvailableAssets || '0')}{' '}
                           {collateralSymbol}
                         </span>
                       </div>
@@ -322,8 +320,8 @@ function AnalyticsPageContent(): React.ReactElement {
                   <span className="transition-opacity duration-300">
                     {formatNumber(
                       String(
-                        BigInt(summary?.vaultBalance || '0') +
-                          BigInt(summary?.escrowBalance || '0')
+                        BigInt(summary?.openInterest || '0') +
+                          BigInt(summary?.vaultAvailableAssets || '0')
                       )
                     )}{' '}
                     {collateralSymbol}
@@ -393,8 +391,8 @@ function AnalyticsPageContent(): React.ReactElement {
                       align="start"
                     >
                       <p className="text-sm text-muted-foreground">
-                        Includes volume from both V1 (legacy) and V2 (escrow)
-                        prediction markets.
+                        Includes volume from prediction mints and secondary
+                        market trades.
                       </p>
                     </PopoverContent>
                   </Popover>
@@ -625,27 +623,6 @@ function AnalyticsPageContent(): React.ReactElement {
                     </ResponsiveContainer>
                   </div>
                 )}
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Vault PnL Chart */}
-          <Card className="bg-brand-black border border-brand-white/10">
-            <CardContent className="p-6">
-              <div className="flex items-center justify-between mb-4">
-                <h3 className="sc-heading text-foreground">
-                  Vault Profit/Loss
-                </h3>
-                <PeriodFilter value={pnlPeriod} onChange={setPnlPeriod} />
-              </div>
-              <div className="h-[300px]">
-                <VaultPnlChart
-                  protocolStats={protocolStats}
-                  isLoading={statsLoading}
-                  externalPeriod={pnlPeriod}
-                  showHeader={false}
-                  height={300}
-                />
               </div>
             </CardContent>
           </Card>

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -19,18 +19,21 @@ import { Vault, Clock } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { parseUnits } from 'viem';
 import { formatDuration, intervalToDuration } from 'date-fns';
+import Link from 'next/link';
+import { DEFAULT_CHAIN_ID, COLLATERAL_SYMBOLS } from '@sapience/sdk/constants';
 import { useConnectDialog } from '~/lib/context/ConnectDialogContext';
 import { useCurrentAddress } from '~/hooks/blockchain/useCurrentAddress';
-import Link from 'next/link';
 import NumberDisplay from '~/components/shared/NumberDisplay';
 import { AddressDisplay } from '~/components/shared/AddressDisplay';
 import EnsAvatar from '~/components/shared/EnsAvatar';
 import { usePassiveLiquidityVault } from '~/hooks/contract/usePassiveLiquidityVault';
 import { FOCUS_AREAS } from '~/lib/constants/focusAreas';
-import { DEFAULT_CHAIN_ID, COLLATERAL_SYMBOLS } from '@sapience/sdk/constants';
 import { useRestrictedJurisdiction } from '~/hooks/useRestrictedJurisdiction';
 import RestrictedJurisdictionBanner from '~/components/shared/RestrictedJurisdictionBanner';
-import { useProtocolStats } from '~/hooks/graphql/useAnalytics';
+import {
+  getProtocolTvlWei,
+  useProtocolStats,
+} from '~/hooks/graphql/useAnalytics';
 import RiskDisclaimer from '~/components/markets/forms/shared/RiskDisclaimer';
 import Loader from '~/components/shared/Loader';
 import VaultPnlChart from '~/components/vaults/VaultPnlChart';
@@ -523,10 +526,7 @@ const VaultsPageContent = () => {
   const yieldMetrics = useMemo(() => {
     const lastStat = protocolStats?.[protocolStats.length - 1];
 
-    const protocolTvlWei = lastStat
-      ? BigInt(lastStat.vaultBalance || '0') +
-        BigInt(lastStat.escrowBalance || '0')
-      : 0n;
+    const protocolTvlWei = getProtocolTvlWei(lastStat);
     const protocolTvlNum = Number(formatAssetAmount(protocolTvlWei));
     const vaultTvlNum = Number(formatAssetAmount(tvlWei));
 

--- a/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
+++ b/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
@@ -35,6 +35,13 @@ vi.mock('~/hooks/blockchain/useCurrentAddress', () => ({
 
 vi.mock('~/hooks/graphql/useAnalytics', () => ({
   useProtocolStats: () => mockUseProtocolStats(),
+  getProtocolTvlWei: (
+    stat: { openInterest?: string; vaultAvailableAssets?: string } | null
+  ) =>
+    stat
+      ? BigInt(stat.openInterest || '0') +
+        BigInt(stat.vaultAvailableAssets || '0')
+      : 0n,
 }));
 
 vi.mock('~/lib/context/ConnectDialogContext', () => ({

--- a/packages/app/src/hooks/graphql/useAnalytics.ts
+++ b/packages/app/src/hooks/graphql/useAnalytics.ts
@@ -13,3 +13,19 @@ export function useProtocolStats() {
 }
 
 export type { ProtocolStat };
+
+/**
+ * Protocol TVL = open interest + undeployed vault funds (wei).
+ * Matches the analytics-page definition; see AnalyticsResolver.protocolStats.
+ */
+export function getProtocolTvlWei(
+  stat:
+    | Pick<ProtocolStat, 'openInterest' | 'vaultAvailableAssets'>
+    | null
+    | undefined
+): bigint {
+  if (!stat) return 0n;
+  return (
+    BigInt(stat.openInterest || '0') + BigInt(stat.vaultAvailableAssets || '0')
+  );
+}

--- a/packages/sdk/contracts/addresses.ts
+++ b/packages/sdk/contracts/addresses.ts
@@ -127,7 +127,7 @@ export const predictionMarketVault: ChainAddressMap = {
     legacy: [
       {
         address: '0x0f246fBd64f6FE57544aAB16A31e1E3F59257723',
-        blockCreated: 3253965,
+        blockCreated: 3472849,
       },
       {
         address: '0x5704dB4b2c068d74Fde25257106a7029463f812E',
@@ -160,7 +160,7 @@ export const pythConditionResolver: ChainAddressMap = {
     legacy: [
       {
         address: '0x3384de2a15e8D767a36f09f6e67F41C9fa8C6B1f',
-        blockCreated: 3278610,
+        blockCreated: 3659812,
       },
       {
         address: '0x6399F6397701e4213BBaEf9f7a15EF31C9c329E1',

--- a/packages/sdk/types/graphql.ts
+++ b/packages/sdk/types/graphql.ts
@@ -458,7 +458,7 @@ export type Condition = {
   openInterest: Scalars['String']['output'];
   optionName?: Maybe<Scalars['String']['output']>;
   predictionCount: Scalars['Int']['output'];
-  predictions: Array<LegacyPrediction>;
+  predictions: Array<Prediction>;
   public: Scalars['Boolean']['output'];
   question: Scalars['String']['output'];
   resolvedToYes: Scalars['Boolean']['output'];
@@ -505,12 +505,8 @@ export type ConditionConditionGroupArgs = {
 
 
 export type ConditionPredictionsArgs = {
-  cursor?: InputMaybe<LegacyPredictionWhereUniqueInput>;
-  distinct?: InputMaybe<Array<LegacyPredictionScalarFieldEnum>>;
-  orderBy?: InputMaybe<Array<LegacyPredictionOrderByWithRelationInput>>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  take?: InputMaybe<Scalars['Int']['input']>;
-  where?: InputMaybe<LegacyPredictionWhereInput>;
+  skip?: Scalars['Int']['input'];
+  take?: Scalars['Int']['input'];
 };
 
 export type ConditionCount = {
@@ -963,76 +959,9 @@ export type IntNullableFilter = {
   notIn?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
-/** Legacy position model (NFT-based, V1) */
-export type LegacyPosition = {
-  __typename?: 'LegacyPosition';
-  _count?: Maybe<LegacyPositionCount>;
-  chainId: Scalars['Int']['output'];
-  counterparty: Scalars['String']['output'];
-  counterpartyCollateral?: Maybe<Scalars['String']['output']>;
-  counterpartyNftTokenId: Scalars['String']['output'];
-  createdAt: Scalars['DateTimeISO']['output'];
-  endsAt?: Maybe<Scalars['Int']['output']>;
-  id: Scalars['Int']['output'];
-  marketAddress: Scalars['String']['output'];
-  mintedAt: Scalars['Int']['output'];
-  predictions: Array<LegacyPrediction>;
-  predictor: Scalars['String']['output'];
-  predictorCollateral?: Maybe<Scalars['String']['output']>;
-  predictorNftTokenId: Scalars['String']['output'];
-  /** True when the predictor's submitted outcomes were correct (previously makerWon) */
-  predictorWon?: Maybe<Scalars['Boolean']['output']>;
-  refCode?: Maybe<Scalars['String']['output']>;
-  settledAt?: Maybe<Scalars['Int']['output']>;
-  status: LegacyPositionStatus;
-  totalCollateral: Scalars['String']['output'];
-};
-
-
-/** Legacy position model (NFT-based, V1) */
-export type LegacyPositionPredictionsArgs = {
-  cursor?: InputMaybe<LegacyPredictionWhereUniqueInput>;
-  distinct?: InputMaybe<Array<LegacyPredictionScalarFieldEnum>>;
-  orderBy?: InputMaybe<Array<LegacyPredictionOrderByWithRelationInput>>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  take?: InputMaybe<Scalars['Int']['input']>;
-  where?: InputMaybe<LegacyPredictionWhereInput>;
-};
-
-export type LegacyPositionCount = {
-  __typename?: 'LegacyPositionCount';
-  predictions: Scalars['Int']['output'];
-};
-
-
-export type LegacyPositionCountPredictionsArgs = {
-  where?: InputMaybe<LegacyPredictionWhereInput>;
-};
-
 export type LegacyPositionNullableRelationFilter = {
   is?: InputMaybe<LegacyPositionWhereInput>;
   isNot?: InputMaybe<LegacyPositionWhereInput>;
-};
-
-export type LegacyPositionOrderByWithRelationInput = {
-  chainId?: InputMaybe<SortOrder>;
-  counterparty?: InputMaybe<SortOrder>;
-  counterpartyCollateral?: InputMaybe<SortOrderInput>;
-  counterpartyNftTokenId?: InputMaybe<SortOrder>;
-  createdAt?: InputMaybe<SortOrder>;
-  endsAt?: InputMaybe<SortOrderInput>;
-  id?: InputMaybe<SortOrder>;
-  marketAddress?: InputMaybe<SortOrder>;
-  mintedAt?: InputMaybe<SortOrder>;
-  predictions?: InputMaybe<LegacyPredictionOrderByRelationAggregateInput>;
-  predictor?: InputMaybe<SortOrder>;
-  predictorCollateral?: InputMaybe<SortOrderInput>;
-  predictorNftTokenId?: InputMaybe<SortOrder>;
-  predictorWon?: InputMaybe<SortOrderInput>;
-  refCode?: InputMaybe<SortOrderInput>;
-  settledAt?: InputMaybe<SortOrderInput>;
-  status?: InputMaybe<SortOrder>;
-  totalCollateral?: InputMaybe<SortOrder>;
 };
 
 export type LegacyPositionStatus =
@@ -1064,35 +993,6 @@ export type LegacyPositionWhereInput = {
   totalCollateral?: InputMaybe<StringFilter>;
 };
 
-export type LegacyPrediction = {
-  __typename?: 'LegacyPrediction';
-  chainId?: Maybe<Scalars['Int']['output']>;
-  condition: Condition;
-  conditionId: Scalars['String']['output'];
-  createdAt: Scalars['DateTimeISO']['output'];
-  id: Scalars['Int']['output'];
-  limitOrder?: Maybe<LimitOrder>;
-  limitOrderId?: Maybe<Scalars['Int']['output']>;
-  outcomeYes: Scalars['Boolean']['output'];
-  position?: Maybe<LegacyPosition>;
-  positionId?: Maybe<Scalars['Int']['output']>;
-};
-
-
-export type LegacyPredictionLimitOrderArgs = {
-  where?: InputMaybe<LimitOrderWhereInput>;
-};
-
-
-export type LegacyPredictionPositionArgs = {
-  where?: InputMaybe<LegacyPositionWhereInput>;
-};
-
-export type LegacyPredictionLimitOrderIdConditionIdCompoundUniqueInput = {
-  conditionId: Scalars['String']['input'];
-  limitOrderId: Scalars['Int']['input'];
-};
-
 export type LegacyPredictionListRelationFilter = {
   every?: InputMaybe<LegacyPredictionWhereInput>;
   none?: InputMaybe<LegacyPredictionWhereInput>;
@@ -1102,33 +1002,6 @@ export type LegacyPredictionListRelationFilter = {
 export type LegacyPredictionOrderByRelationAggregateInput = {
   _count?: InputMaybe<SortOrder>;
 };
-
-export type LegacyPredictionOrderByWithRelationInput = {
-  chainId?: InputMaybe<SortOrderInput>;
-  condition?: InputMaybe<ConditionOrderByWithRelationInput>;
-  conditionId?: InputMaybe<SortOrder>;
-  createdAt?: InputMaybe<SortOrder>;
-  id?: InputMaybe<SortOrder>;
-  limitOrder?: InputMaybe<LimitOrderOrderByWithRelationInput>;
-  limitOrderId?: InputMaybe<SortOrderInput>;
-  outcomeYes?: InputMaybe<SortOrder>;
-  position?: InputMaybe<LegacyPositionOrderByWithRelationInput>;
-  positionId?: InputMaybe<SortOrderInput>;
-};
-
-export type LegacyPredictionPositionIdConditionIdCompoundUniqueInput = {
-  conditionId: Scalars['String']['input'];
-  positionId: Scalars['Int']['input'];
-};
-
-export type LegacyPredictionScalarFieldEnum =
-  | 'chainId'
-  | 'conditionId'
-  | 'createdAt'
-  | 'id'
-  | 'limitOrderId'
-  | 'outcomeYes'
-  | 'positionId';
 
 export type LegacyPredictionWhereInput = {
   AND?: InputMaybe<Array<LegacyPredictionWhereInput>>;
@@ -1146,93 +1019,9 @@ export type LegacyPredictionWhereInput = {
   positionId?: InputMaybe<IntNullableFilter>;
 };
 
-export type LegacyPredictionWhereUniqueInput = {
-  AND?: InputMaybe<Array<LegacyPredictionWhereInput>>;
-  NOT?: InputMaybe<Array<LegacyPredictionWhereInput>>;
-  OR?: InputMaybe<Array<LegacyPredictionWhereInput>>;
-  chainId?: InputMaybe<IntNullableFilter>;
-  condition?: InputMaybe<ConditionRelationFilter>;
-  conditionId?: InputMaybe<StringFilter>;
-  createdAt?: InputMaybe<DateTimeFilter>;
-  id?: InputMaybe<Scalars['Int']['input']>;
-  limitOrder?: InputMaybe<LimitOrderNullableRelationFilter>;
-  limitOrderId?: InputMaybe<IntNullableFilter>;
-  limitOrderId_conditionId?: InputMaybe<LegacyPredictionLimitOrderIdConditionIdCompoundUniqueInput>;
-  outcomeYes?: InputMaybe<BoolFilter>;
-  position?: InputMaybe<LegacyPositionNullableRelationFilter>;
-  positionId?: InputMaybe<IntNullableFilter>;
-  positionId_conditionId?: InputMaybe<LegacyPredictionPositionIdConditionIdCompoundUniqueInput>;
-};
-
-export type LimitOrder = {
-  __typename?: 'LimitOrder';
-  _count?: Maybe<LimitOrderCount>;
-  cancelledAt?: Maybe<Scalars['Int']['output']>;
-  cancelledTxHash?: Maybe<Scalars['String']['output']>;
-  chainId: Scalars['Int']['output'];
-  counterparty?: Maybe<Scalars['String']['output']>;
-  counterpartyCollateral: Scalars['String']['output'];
-  createdAt: Scalars['DateTimeISO']['output'];
-  filledAt?: Maybe<Scalars['Int']['output']>;
-  filledTxHash?: Maybe<Scalars['String']['output']>;
-  id: Scalars['Int']['output'];
-  marketAddress: Scalars['String']['output'];
-  orderId: Scalars['String']['output'];
-  placedAt: Scalars['Int']['output'];
-  placedTxHash: Scalars['String']['output'];
-  predictions: Array<LegacyPrediction>;
-  predictor: Scalars['String']['output'];
-  predictorCollateral: Scalars['String']['output'];
-  refCode?: Maybe<Scalars['String']['output']>;
-  resolver: Scalars['String']['output'];
-  status: LimitOrderStatus;
-};
-
-
-export type LimitOrderPredictionsArgs = {
-  cursor?: InputMaybe<LegacyPredictionWhereUniqueInput>;
-  distinct?: InputMaybe<Array<LegacyPredictionScalarFieldEnum>>;
-  orderBy?: InputMaybe<Array<LegacyPredictionOrderByWithRelationInput>>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  take?: InputMaybe<Scalars['Int']['input']>;
-  where?: InputMaybe<LegacyPredictionWhereInput>;
-};
-
-export type LimitOrderCount = {
-  __typename?: 'LimitOrderCount';
-  predictions: Scalars['Int']['output'];
-};
-
-
-export type LimitOrderCountPredictionsArgs = {
-  where?: InputMaybe<LegacyPredictionWhereInput>;
-};
-
 export type LimitOrderNullableRelationFilter = {
   is?: InputMaybe<LimitOrderWhereInput>;
   isNot?: InputMaybe<LimitOrderWhereInput>;
-};
-
-export type LimitOrderOrderByWithRelationInput = {
-  cancelledAt?: InputMaybe<SortOrderInput>;
-  cancelledTxHash?: InputMaybe<SortOrderInput>;
-  chainId?: InputMaybe<SortOrder>;
-  counterparty?: InputMaybe<SortOrderInput>;
-  counterpartyCollateral?: InputMaybe<SortOrder>;
-  createdAt?: InputMaybe<SortOrder>;
-  filledAt?: InputMaybe<SortOrderInput>;
-  filledTxHash?: InputMaybe<SortOrderInput>;
-  id?: InputMaybe<SortOrder>;
-  marketAddress?: InputMaybe<SortOrder>;
-  orderId?: InputMaybe<SortOrder>;
-  placedAt?: InputMaybe<SortOrder>;
-  placedTxHash?: InputMaybe<SortOrder>;
-  predictions?: InputMaybe<LegacyPredictionOrderByRelationAggregateInput>;
-  predictor?: InputMaybe<SortOrder>;
-  predictorCollateral?: InputMaybe<SortOrder>;
-  refCode?: InputMaybe<SortOrderInput>;
-  resolver?: InputMaybe<SortOrder>;
-  status?: InputMaybe<SortOrder>;
 };
 
 export type LimitOrderStatus =


### PR DESCRIPTION
## Summary

Analytics page metrics had several issues discovered during deep investigation:

**OI fixes:**
- Excluded V1 legacy positions (~477 USDe with deprecated resolvers that can't settle)
- Excluded predictions with private conditions (~214 USDe that shouldn't inflate public metrics)

**TVL formula:**
- Changed from `vaultBalance + escrowBalance` to `OI + vaultAvailableAssets`
- Old formula missed ~831 USDe across 4 legacy escrow contracts (only checked latest)
- Popover now shows "Open Interest" + "Undeployed Vault Funds"

**Volume:**
- Added secondary market trades to cumulative volume
- Removed `firstSnapshotTimestamp` lower bound — volume is now truly all-time cumulative

**Live today candle:**
- Appends a real-time data point with live OI, volume, vault balance, vaultAvailableAssets, vaultDeployed, escrowBalance, PnL, and flows
- Snapshot timestamps shifted back 1 day (midnight UTC = end of previous day)
- Cache reduced from 1 hour to 60 seconds

**Backfill improvements:**
- Uses `blockCreated` from SDK config to pick correct vault/escrow per historical block (was silently returning 0 for legacy contracts)
- Creates zero-valued snapshots for pre-Ethereal-launch dates
- Daily cron sums escrowBalance across all escrow contracts (current + legacy)

**Frontend:**
- Removed vault PnL chart
- Zero-fill only between data points, not chart tails

## Test plan
- [x] SDK build passes
- [x] API type-check passes
- [x] App type-check passes
- [x] Lint passes (pre-commit hook)
- [ ] Verify analytics page locally: PnL chart gone, TVL/OI/volume cards correct
- [ ] Run backfill to populate historical snapshots with legacy contract data
- [ ] Verify live candle updates in real-time on vault page (deployed %)

🤖 Generated with [Claude Code](https://claude.com/claude-code)