### PR TITLE
fix(analytics): prevent first-bar inflation on daily charts

### DIFF
--- a/packages/api/src/graphql/resolvers/AnalyticsResolver.ts
+++ b/packages/api/src/graphql/resolvers/AnalyticsResolver.ts
@@ -193,14 +193,24 @@ export class AnalyticsResolver {
     // end-of-previous-day, so we shift the display timestamp back by 1 day.
     const results: ProtocolStat[] = protocolSnapshots.map((snapshot, i) => {
       const cumVol = volumeMap.get(snapshot.timestamp) || '0';
-      const prevCumVol =
-        i > 0 ? volumeMap.get(protocolSnapshots[i - 1].timestamp) || '0' : '0';
-      const dailyVolume = (BigInt(cumVol) - BigInt(prevCumVol)).toString();
+      // i === 0 has no prior snapshot to diff against; defaulting the delta to
+      // cumVol would dump all pre-window activity onto the first bar, so we
+      // explicitly emit 0 and let the series start one day later.
+      const dailyVolume =
+        i === 0
+          ? '0'
+          : (
+              BigInt(cumVol) -
+              BigInt(volumeMap.get(protocolSnapshots[i - 1].timestamp) || '0')
+            ).toString();
 
-      const prevPnL = i > 0 ? protocolSnapshots[i - 1].vaultRealizedPnL : '0';
-      const dailyPnL = (
-        BigInt(snapshot.vaultRealizedPnL) - BigInt(prevPnL)
-      ).toString();
+      const dailyPnL =
+        i === 0
+          ? '0'
+          : (
+              BigInt(snapshot.vaultRealizedPnL) -
+              BigInt(protocolSnapshots[i - 1].vaultRealizedPnL)
+            ).toString();
 
       return {
         timestamp: snapshot.timestamp - DAY_SECONDS,

--- a/packages/api/src/helpers/protocolStats.ts
+++ b/packages/api/src/helpers/protocolStats.ts
@@ -617,32 +617,47 @@ export async function backfillProtocolStats(
   let successCount = 0;
   let skipCount = 0;
 
-  // Ethereal mainnet launched ~October 20, 2025. Before this date, no contracts
-  // existed on-chain, so we create zero-valued snapshots as time-axis placeholders.
-  const ETHEREAL_MAINNET_LAUNCH = Math.floor(Date.UTC(2025, 9, 20) / 1000); // 2025-10-20 UTC
+  // Snapshots are keyed by the current vault address. For dates before it was
+  // deployed, write zero placeholders so the analytics chart has a continuous
+  // x-axis and the first-day delta isn't a cumulative dump of pre-deploy activity.
+  const vaultConfig = contracts.predictionMarketVault[chainId];
+  let currentVaultDeployTimestamp = 0;
+  if (vaultConfig?.blockCreated) {
+    const deployBlock = await client.getBlock({
+      blockNumber: BigInt(vaultConfig.blockCreated),
+    });
+    currentVaultDeployTimestamp = Number(deployBlock.timestamp);
+  }
+
+  const zeroSnapshot = {
+    vaultBalance: 0n,
+    vaultAvailableAssets: 0n,
+    vaultDeployed: 0n,
+    escrowBalance: 0n,
+    vaultRealizedPnL: 0n,
+    vaultAirdropGains: 0n,
+    vaultDeposits: 0n,
+    vaultWithdrawals: 0n,
+    vaultPositionsWon: 0,
+    vaultPositionsLost: 0,
+    vaultCollateralWon: 0n,
+    vaultCollateralLost: 0n,
+  };
 
   for (let idx = 0; idx < timestamps.length; idx++) {
     const timestamp = timestamps[idx];
     const dateStr = new Date(timestamp * 1000).toISOString().split('T')[0];
 
-    if (timestamp < ETHEREAL_MAINNET_LAUNCH) {
+    if (timestamp < currentVaultDeployTimestamp) {
       console.log(
-        `[ProtocolStats] ${dateStr} - before Ethereal mainnet launch, creating zero-valued snapshot`
+        `[ProtocolStats] ${dateStr} - before current vault deploy, creating zero-valued snapshot`
       );
-      await upsertProtocolStatsSnapshot(timestamp, chainId, vaultAddress, {
-        vaultBalance: 0n,
-        vaultAvailableAssets: 0n,
-        vaultDeployed: 0n,
-        escrowBalance: 0n,
-        vaultRealizedPnL: 0n,
-        vaultAirdropGains: 0n,
-        vaultDeposits: 0n,
-        vaultWithdrawals: 0n,
-        vaultPositionsWon: 0,
-        vaultPositionsLost: 0,
-        vaultCollateralWon: 0n,
-        vaultCollateralLost: 0n,
-      });
+      await upsertProtocolStatsSnapshot(
+        timestamp,
+        chainId,
+        vaultAddress,
+        zeroSnapshot
+      );
       skipCount++;
       continue;
     }


### PR DESCRIPTION
## Summary

The daily volume/PnL bars on /analytics were dumping every trade that happened *before* the first returned snapshot onto the first visible bar, giving a misleading spike (observed ~9.3K USDe on 3/25 when the real day was ~31 USDe).

Root cause is two-part:
- The resolver defaulted `prevCumVol` to `'0'` for `i === 0`, so `dailyVolume[0] = cumVol[0] - 0` = all prior activity.
- Backfill keys snapshots by the *current* vault address. After a vault redeploy, the snapshot series abruptly starts on deploy day, and cumVol at that first snapshot still includes every chain-wide trade that predates the redeploy — so the bug manifests hard every time the vault is redeployed.

## Changes

- **`AnalyticsResolver.protocolStats`** — for `i === 0`, emit `'0'` for `dailyVolume` and `dailyPnL` explicitly. Can't compute a true delta without a prior snapshot, so don't pretend.
- **`backfillProtocolStats`** — look up the current vault's deploy timestamp from `contracts.predictionMarketVault[chainId].blockCreated`, then write zero-valued snapshots for any day before that point. Replaces the older ETHEREAL_MAINNET_LAUNCH cutoff. After re-running backfill on prod, the chart x-axis extends the full 90 days with zero bars filling the pre-deploy tail.

## Test plan

- [x] `pnpm --filter @sapience/api run test` — 446 passing
- [x] `pnpm --filter @sapience/api run type-check` — clean
- [ ] After merge + deploy: re-run `backfillProtocolStats` on prod so pre-3/25 snapshots get zero values
- [ ] Verify /analytics daily-volume chart: no spike on first bar; x-axis in 1M/3M views reaches back past 3/25