### PR TITLE
fix(app): assorted markets & vaults polish

### DIFF
--- a/packages/app/src/components/layout/StatusIndicators.tsx
+++ b/packages/app/src/components/layout/StatusIndicators.tsx
@@ -9,7 +9,7 @@ import Image from 'next/image';
 import { PeerIndicator } from '~/components/relay/PeerIndicator';
 import { useRpcPing } from '~/hooks/blockchain/useRpcPing';
 
-export const ETHENA_BASE_APY = 4;
+export const ETHENA_BASE_APY = 3.8;
 
 export function StatusIndicators() {
   const pingMs = useRpcPing();

--- a/packages/app/src/components/markets/MarketsPage.tsx
+++ b/packages/app/src/components/markets/MarketsPage.tsx
@@ -382,7 +382,7 @@ const MarketsPage = () => {
 
           {/* Predict Prices (shared) */}
           {showPredictPrices && (
-            <div className={`w-full mb-2 ${useCardGrid ? 'px-4' : ''}`}>
+            <div className={`w-full mt-4 mb-2 ${useCardGrid ? 'px-4' : ''}`}>
               <div className="flex items-center justify-between mb-2 px-1">
                 <h2
                   className={`sc-heading ${useCardGrid ? 'text-white/80' : 'text-foreground'}`}

--- a/packages/app/src/components/markets/QuestionsTable.tsx
+++ b/packages/app/src/components/markets/QuestionsTable.tsx
@@ -386,8 +386,8 @@ function createColumns(
                         side="left"
                         className="max-w-[200px] text-xs whitespace-normal"
                       >
-                        Excludes volume from trades where the outcome price is
-                        below $0.01 or above $0.99
+                        Excludes volume from trades when the price was below
+                        $0.01 or above $0.99
                       </TooltipContent>
                     </Tooltip>
                   </DropdownMenuItem>

--- a/packages/app/src/components/markets/TableFilters.tsx
+++ b/packages/app/src/components/markets/TableFilters.tsx
@@ -612,8 +612,8 @@ function RelatedVolumeFilter({
                     side="top"
                     className="max-w-[220px] text-xs whitespace-normal"
                   >
-                    Excludes volume from trades where the outcome price is below
-                    $0.01 or above $0.99
+                    Excludes volume from trades when the price was below $0.01
+                    or above $0.99
                   </TooltipContent>
                 </Tooltip>
               </div>

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -618,6 +618,11 @@ const VaultsPageContent = () => {
                           </span>
                         </h4>
                         <div className="relative">
+                          {tvlWei <= VAULT_CAPACITY_WEI && (
+                            <div className="mb-1 text-right font-mono text-[10px] text-muted-foreground/50 uppercase">
+                              {depositCapDisplay} cap
+                            </div>
+                          )}
                           <div className="w-full h-3 rounded-sm bg-[hsl(var(--primary)/_0.09)] overflow-hidden shadow-inner relative">
                             <div
                               className="h-3 bg-accent-gold rounded-sm transition-all gold-sheen"
@@ -659,11 +664,6 @@ const VaultsPageContent = () => {
                                 </span>
                               </div>
                             </>
-                          )}
-                          {tvlWei <= VAULT_CAPACITY_WEI && (
-                            <div className="mt-1 text-right font-mono text-[10px] text-muted-foreground/50 uppercase">
-                              {depositCapDisplay} cap
-                            </div>
                           )}
                         </div>
                         <div className="mt-2 flex flex-col items-start sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-0 text-sm">

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -37,6 +37,7 @@ import {
 import RiskDisclaimer from '~/components/markets/forms/shared/RiskDisclaimer';
 import Loader from '~/components/shared/Loader';
 import VaultPnlChart from '~/components/vaults/VaultPnlChart';
+import { ETHENA_BASE_APY } from '~/components/layout/StatusIndicators';
 
 const DEPOSIT_WHITELIST: `0x${string}`[] = [
   '0xdb5af497a73620d881561edb508012a5f84e9ba2',
@@ -530,7 +531,6 @@ const VaultsPageContent = () => {
     const protocolTvlNum = Number(formatAssetAmount(protocolTvlWei));
     const vaultTvlNum = Number(formatAssetAmount(tvlWei));
 
-    const ETHENA_BASE_APY = 4;
     const effectiveApy =
       vaultTvlNum > 0 ? (protocolTvlNum / vaultTvlNum) * ETHENA_BASE_APY : 0;
     const annualYieldToVault = vaultTvlNum * (effectiveApy / 100);
@@ -619,7 +619,7 @@ const VaultsPageContent = () => {
                         </h4>
                         <div className="relative">
                           {tvlWei <= VAULT_CAPACITY_WEI && (
-                            <div className="mb-1 text-right font-mono text-[10px] text-muted-foreground/50 uppercase">
+                            <div className="absolute -top-4 right-0 font-mono text-[10px] text-muted-foreground/50 uppercase">
                               {depositCapDisplay} cap
                             </div>
                           )}


### PR DESCRIPTION
## Summary
- Vault cap label: absolute-positioned above the progress bar so it doesn't push content down.
- Ethena base APY lowered from 4% to 3.8%; removed duplicate local constant in `VaultsPageContent` and imported from shared `StatusIndicators`.
- Volume-filter tooltip copy updated: "where the outcome price is below" → "when the price was below".
- `/markets`: added top spacing to Predict Prices so spacing is even between Example Combos / Predict Prices / Prediction Markets.

## Test plan
- [ ] `/vault` — verify cap label sits above progress bar, doesn't shift other content
- [ ] `/vault` — approximate APY reflects 3.8% base
- [ ] Header Ethena APY badge shows 3.8%
- [ ] `/markets` — volume filter tooltip shows new copy (both the filter chip and column dropdown)
- [ ] `/markets` — vertical spacing is consistent between Example Combos, Predict Prices, and Prediction Markets