### PR TITLE
fix(app): base Protocol TVL on escrow balance, not open interest

### DIFF
--- a/packages/app/src/components/analytics/pages/AnalyticsPageContent.tsx
+++ b/packages/app/src/components/analytics/pages/AnalyticsPageContent.tsx
@@ -223,7 +223,7 @@ function AnalyticsPageContent(): React.ReactElement {
       return {
         timestamp: point.timestamp,
         openInterest,
-        totalBalance: escrowBalance + vaultAvailableAssets,
+        protocolTvl: escrowBalance + vaultAvailableAssets,
         vaultAvailableAssets,
       };
     });
@@ -247,7 +247,7 @@ function AnalyticsPageContent(): React.ReactElement {
     () =>
       filterDataByPeriod(statsChartData, oiPeriod, {
         openInterest: 0,
-        totalBalance: 0,
+        protocolTvl: 0,
         vaultAvailableAssets: 0,
       }),
     [statsChartData, oiPeriod]
@@ -257,7 +257,7 @@ function AnalyticsPageContent(): React.ReactElement {
     () =>
       filterDataByPeriod(statsChartData, tvlPeriod, {
         openInterest: 0,
-        totalBalance: 0,
+        protocolTvl: 0,
         vaultAvailableAssets: 0,
       }),
     [statsChartData, tvlPeriod]
@@ -294,10 +294,10 @@ function AnalyticsPageContent(): React.ReactElement {
                     <div className="space-y-3">
                       <div className="flex flex-col gap-1">
                         <span className="uppercase font-mono tracking-wide text-muted-foreground text-xs whitespace-nowrap">
-                          Open Interest
+                          Escrow Balance
                         </span>
                         <span className="font-mono whitespace-nowrap text-xl">
-                          {formatNumber(summary?.openInterest || '0')}{' '}
+                          {formatNumber(summary?.escrowBalance || '0')}{' '}
                           {collateralSymbol}
                         </span>
                       </div>
@@ -605,14 +605,14 @@ function AnalyticsPageContent(): React.ReactElement {
                           content={(props) => (
                             <ChartTooltip
                               {...props}
-                              dataKey="totalBalance"
+                              dataKey="protocolTvl"
                               collateralSymbol={collateralSymbol}
                             />
                           )}
                         />
                         <Area
                           type="monotone"
-                          dataKey="totalBalance"
+                          dataKey="protocolTvl"
                           stroke="hsl(var(--accent-gold))"
                           strokeWidth={2}
                           fill="url(#protocolTVLGradient)"

--- a/packages/app/src/components/analytics/pages/AnalyticsPageContent.tsx
+++ b/packages/app/src/components/analytics/pages/AnalyticsPageContent.tsx
@@ -217,12 +217,13 @@ function AnalyticsPageContent(): React.ReactElement {
 
     return protocolStats.map((point) => {
       const openInterest = parseFloat(point.openInterest) / 1e18;
+      const escrowBalance = parseFloat(point.escrowBalance) / 1e18;
       const vaultAvailableAssets =
         parseFloat(point.vaultAvailableAssets) / 1e18;
       return {
         timestamp: point.timestamp,
         openInterest,
-        totalBalance: openInterest + vaultAvailableAssets,
+        totalBalance: escrowBalance + vaultAvailableAssets,
         vaultAvailableAssets,
       };
     });

--- a/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
+++ b/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
@@ -36,10 +36,10 @@ vi.mock('~/hooks/blockchain/useCurrentAddress', () => ({
 vi.mock('~/hooks/graphql/useAnalytics', () => ({
   useProtocolStats: () => mockUseProtocolStats(),
   getProtocolTvlWei: (
-    stat: { openInterest?: string; vaultAvailableAssets?: string } | null
+    stat: { escrowBalance?: string; vaultAvailableAssets?: string } | null
   ) =>
     stat
-      ? BigInt(stat.openInterest || '0') +
+      ? BigInt(stat.escrowBalance || '0') +
         BigInt(stat.vaultAvailableAssets || '0')
       : 0n,
 }));

--- a/packages/app/src/hooks/graphql/__tests__/useAnalytics.test.ts
+++ b/packages/app/src/hooks/graphql/__tests__/useAnalytics.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { getProtocolTvlWei } from '../useAnalytics';
+
+describe('getProtocolTvlWei', () => {
+  it('returns 0n for null/undefined', () => {
+    expect(getProtocolTvlWei(null)).toBe(0n);
+    expect(getProtocolTvlWei(undefined)).toBe(0n);
+  });
+
+  it('sums escrowBalance and vaultAvailableAssets', () => {
+    expect(
+      getProtocolTvlWei({
+        escrowBalance: '100',
+        vaultAvailableAssets: '250',
+      })
+    ).toBe(350n);
+  });
+
+  it('treats missing fields as zero', () => {
+    expect(
+      getProtocolTvlWei({
+        escrowBalance: '',
+        vaultAvailableAssets: '42',
+      })
+    ).toBe(42n);
+    expect(
+      getProtocolTvlWei({
+        escrowBalance: '42',
+        vaultAvailableAssets: '',
+      })
+    ).toBe(42n);
+  });
+
+  it('handles large wei values', () => {
+    const oneEther = 10n ** 18n;
+    expect(
+      getProtocolTvlWei({
+        escrowBalance: oneEther.toString(),
+        vaultAvailableAssets: oneEther.toString(),
+      })
+    ).toBe(2n * oneEther);
+  });
+});

--- a/packages/app/src/hooks/graphql/useAnalytics.ts
+++ b/packages/app/src/hooks/graphql/useAnalytics.ts
@@ -15,17 +15,22 @@ export function useProtocolStats() {
 export type { ProtocolStat };
 
 /**
- * Protocol TVL = open interest + undeployed vault funds (wei).
- * Matches the analytics-page definition; see AnalyticsResolver.protocolStats.
+ * Protocol TVL = escrow balance + undeployed vault funds (wei).
+ *
+ * `escrowBalance` is the live on-chain collateral balance held by the current
+ * and legacy escrow contracts, so it includes settled-but-unclaimed winnings.
+ * Open interest drops the moment a condition settles, which is not what we
+ * want TVL to reflect — funds haven't actually left the protocol until the
+ * user redeems.
  */
 export function getProtocolTvlWei(
   stat:
-    | Pick<ProtocolStat, 'openInterest' | 'vaultAvailableAssets'>
+    | Pick<ProtocolStat, 'escrowBalance' | 'vaultAvailableAssets'>
     | null
     | undefined
 ): bigint {
   if (!stat) return 0n;
   return (
-    BigInt(stat.openInterest || '0') + BigInt(stat.vaultAvailableAssets || '0')
+    BigInt(stat.escrowBalance || '0') + BigInt(stat.vaultAvailableAssets || '0')
   );
 }


### PR DESCRIPTION
## Summary
- Swap Protocol TVL formula from `openInterest + vaultAvailableAssets` to `escrowBalance + vaultAvailableAssets`.
- OI drops the moment a condition settles, but winners' collateral stays in the escrow contract until they redeem — so the chart (and the summary card + vault-page APY calc that share `getProtocolTvlWei`) were under-counting real on-chain TVL.
- `escrowBalance` is already captured daily by the snapshot cron across the current + legacy escrow contracts, and is already returned by `AnalyticsResolver.protocolStats` for both historical rows and the live 'today' bucket — no API / schema / backfill needed.
- Open Interest is still exposed and used by the dedicated OI chart.
- Update the Protocol TVL popover breakdown (Open Interest → Escrow Balance) to stay consistent with the new headline.
- Rename the TVL chart data key `totalBalance` → `protocolTvl` for clarity.
- Add unit tests for `getProtocolTvlWei`.

## Side effect to flag
The vault page shows an approximate APY computed as `(protocolTvl / vaultTvl) * ETHENA_BASE_APY` (see `VaultsPageContent.tsx`). Because `escrowBalance ≥ openInterest` in the post-settlement / pre-redemption window, the displayed APY will nudge **up** slightly in those windows. This is arguably more correct (escrowed collateral is still earning Ethena yield on the vault's behalf), but it is user-visible.

## Files touched
- `packages/app/src/hooks/graphql/useAnalytics.ts` — `getProtocolTvlWei` sums `escrowBalance + vaultAvailableAssets`.
- `packages/app/src/components/analytics/pages/AnalyticsPageContent.tsx` — chart key rename + popover copy + escrowBalance in the stats-chart transform.
- `packages/app/src/hooks/graphql/__tests__/useAnalytics.test.ts` — new unit test.
- `packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx` — mock updated.

## Known follow-ups (not in this PR)
- Live 'today' bucket in `AnalyticsResolver` only reads the current escrow; the daily cron sums current + legacy. Minor under-count on the rightmost candle if legacy escrows still hold dust.

## Test plan
- [ ] `/analytics` — Protocol TVL chart no longer drops when a condition settles (until winners actually redeem).
- [ ] `/analytics` — hovering the 'i' shows Escrow Balance + Undeployed Vault Funds, and they sum to the headline.
- [ ] `/analytics` — Open Interest chart still reflects active-only collateral.
- [ ] `/vault` — Approximate APY is sensible (may tick up slightly post-settlement).