### PR TITLE
feat(app,api): sortable positions table columns

### DIFF
--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -1324,6 +1324,7 @@ type Position {
   pickConfigId: String!
   tokenAddress: String!
   totalPayout: String
+  updatedAt: DateTimeISO!
   userCollateral: String
 }
 

--- a/packages/api/src/graphql/resolvers/EscrowResolver.ts
+++ b/packages/api/src/graphql/resolvers/EscrowResolver.ts
@@ -298,6 +298,9 @@ class PositionType {
   @Field(() => Date)
   createdAt!: Date;
 
+  @Field(() => Date)
+  updatedAt!: Date;
+
   @Field(() => PickConfigurationType, { nullable: true })
   pickConfig?: PickConfigurationType | null;
 }
@@ -904,6 +907,7 @@ export class EscrowResolver {
         userCollateral: userCollateral > 0n ? userCollateral.toString() : null,
         totalPayout: totalPayout > 0n ? totalPayout.toString() : null,
         createdAt: r.createdAt,
+        updatedAt: r.updatedAt,
         pickConfig: pc ? mapPickConfig(pc, { predictionId }) : null,
       };
     });

--- a/packages/app/src/components/positions/PositionsTable.tsx
+++ b/packages/app/src/components/positions/PositionsTable.tsx
@@ -16,7 +16,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@sapience/ui/components/ui/tooltip';
-import { Info } from 'lucide-react';
+import { Info, ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react';
 import * as React from 'react';
 import { formatDistanceToNow } from 'date-fns';
 import { COLLATERAL_SYMBOLS, DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
@@ -343,6 +343,50 @@ function PositionRow({
   );
 }
 
+type SortKey = 'updatedAt' | 'positionSize' | 'payout' | 'pnl' | 'ends';
+type SortDir = 'asc' | 'desc';
+type SortState = { key: SortKey; dir: SortDir };
+
+const DEFAULT_SORT_DIRS: Record<SortKey, SortDir> = {
+  updatedAt: 'desc',
+  positionSize: 'desc',
+  payout: 'desc',
+  pnl: 'desc',
+  ends: 'asc',
+};
+
+function SortableHeader({
+  label,
+  sortKey,
+  sort,
+  onSort,
+}: {
+  label: React.ReactNode;
+  sortKey: SortKey;
+  sort: SortState | null;
+  onSort: (key: SortKey) => void;
+}) {
+  const active = sort?.key === sortKey;
+  return (
+    <button
+      type="button"
+      className="flex items-center gap-1 hover:text-foreground text-muted-foreground"
+      onClick={() => onSort(sortKey)}
+    >
+      {label}
+      {active ? (
+        sort.dir === 'asc' ? (
+          <ArrowUp className="h-3 w-3" />
+        ) : (
+          <ArrowDown className="h-3 w-3" />
+        )
+      ) : (
+        <ArrowUpDown className="h-3 w-3 opacity-50" />
+      )}
+    </button>
+  );
+}
+
 export default function PositionsTable({
   account,
   conditionId,
@@ -482,6 +526,64 @@ export default function PositionsTable({
     return result;
   }, [positions, filters, conditionsMap]);
 
+  // Sorting
+  const [sort, setSort] = React.useState<SortState | null>(null);
+  const handleSort = React.useCallback((key: SortKey) => {
+    setSort((prev) => {
+      if (prev?.key === key) {
+        return { key, dir: prev.dir === 'asc' ? 'desc' : 'asc' };
+      }
+      return { key, dir: DEFAULT_SORT_DIRS[key] };
+    });
+  }, []);
+
+  const sortedPositions = React.useMemo(() => {
+    if (!sort) return filteredPositions;
+    const { key, dir } = sort;
+    const multiplier = dir === 'asc' ? 1 : -1;
+    const getValue = (p: PositionBalance): number => {
+      const rawPicks = p.pickConfig?.picks ?? [];
+      const size = parseFloat(formatEther(BigInt(p.userCollateral || '0')));
+      const payout = parseFloat(formatEther(BigInt(p.totalPayout || '0')));
+      switch (key) {
+        case 'updatedAt':
+          return new Date(p.updatedAt).getTime();
+        case 'positionSize':
+          return size;
+        case 'payout':
+          return payout;
+        case 'pnl': {
+          const onChainResolved = p.pickConfig?.resolved ?? false;
+          const computed = !onChainResolved
+            ? computeResultFromConditions(rawPicks, conditionsMap)
+            : null;
+          const res = onChainResolved
+            ? (p.pickConfig?.result ?? 'UNRESOLVED')
+            : (computed?.result ?? 'UNRESOLVED');
+          const isResolved = onChainResolved || res !== 'UNRESOLVED';
+          if (!isResolved) return 0;
+          const holderWon =
+            (p.isPredictorToken && res === 'PREDICTOR_WINS') ||
+            (!p.isPredictorToken && res === 'COUNTERPARTY_WINS');
+          return holderWon ? payout - size : -size;
+        }
+        case 'ends': {
+          const endsAt = Math.max(
+            0,
+            ...rawPicks.map(
+              (pk) => conditionsMap.get(pk.conditionId)?.endTime ?? 0
+            )
+          );
+          // Missing end time sinks to the bottom regardless of direction
+          return endsAt === 0 ? Number.POSITIVE_INFINITY : endsAt;
+        }
+      }
+    };
+    return [...filteredPositions].sort(
+      (a, b) => (getValue(a) - getValue(b)) * multiplier
+    );
+  }, [filteredPositions, sort, conditionsMap]);
+
   // Share dialog state
   const [sharePosition, setSharePosition] =
     React.useState<PositionBalance | null>(null);
@@ -584,30 +686,65 @@ export default function PositionsTable({
         <Table>
           <TableHeader>
             <TableRow className="hover:!bg-white/[0.03] bg-white/[0.03] border-b border-border/60">
-              <TableHead className="h-auto py-3">Position</TableHead>
-              <TableHead className="h-auto py-3">Position Size</TableHead>
-              <TableHead className="h-auto py-3">Payout</TableHead>
-              <TableHead className="h-auto py-3">Profit/Loss</TableHead>
               <TableHead className="h-auto py-3">
-                <span className="flex items-center gap-1">
-                  Ends
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span className="inline-flex cursor-help">
-                        <Info className="h-3.5 w-3.5 text-muted-foreground" />
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent side="top">
-                      End times are estimates and may vary
-                    </TooltipContent>
-                  </Tooltip>
-                </span>
+                <SortableHeader
+                  label="Position"
+                  sortKey="updatedAt"
+                  sort={sort}
+                  onSort={handleSort}
+                />
+              </TableHead>
+              <TableHead className="h-auto py-3">
+                <SortableHeader
+                  label="Position Size"
+                  sortKey="positionSize"
+                  sort={sort}
+                  onSort={handleSort}
+                />
+              </TableHead>
+              <TableHead className="h-auto py-3">
+                <SortableHeader
+                  label="Payout"
+                  sortKey="payout"
+                  sort={sort}
+                  onSort={handleSort}
+                />
+              </TableHead>
+              <TableHead className="h-auto py-3">
+                <SortableHeader
+                  label="Profit/Loss"
+                  sortKey="pnl"
+                  sort={sort}
+                  onSort={handleSort}
+                />
+              </TableHead>
+              <TableHead className="h-auto py-3">
+                <SortableHeader
+                  label={
+                    <span className="flex items-center gap-1">
+                      Ends
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="inline-flex cursor-help">
+                            <Info className="h-3.5 w-3.5 text-muted-foreground" />
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent side="top">
+                          End times are estimates and may vary
+                        </TooltipContent>
+                      </Tooltip>
+                    </span>
+                  }
+                  sortKey="ends"
+                  sort={sort}
+                  onSort={handleSort}
+                />
               </TableHead>
               <TableHead className="h-auto py-3"></TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
-            {filteredPositions.map((position) => (
+            {sortedPositions.map((position) => (
               <PositionRow
                 key={position.id}
                 position={position}

--- a/packages/app/src/hooks/graphql/usePositions.ts
+++ b/packages/app/src/hooks/graphql/usePositions.ts
@@ -78,6 +78,7 @@ export type PositionBalance = {
   userCollateral?: string | null;
   totalPayout?: string | null;
   createdAt: string;
+  updatedAt: string;
   pickConfig?: PickConfigData | null;
 };
 
@@ -232,6 +233,7 @@ const POSITION_BALANCES_QUERY = /* GraphQL */ `
       userCollateral
       totalPayout
       createdAt
+      updatedAt
       pickConfig {
         id
         chainId
@@ -283,6 +285,7 @@ const POSITION_BALANCES_BY_CONDITION_QUERY = /* GraphQL */ `
       userCollateral
       totalPayout
       createdAt
+      updatedAt
       pickConfig {
         id
         chainId

--- a/packages/sdk/types/graphql.ts
+++ b/packages/sdk/types/graphql.ts
@@ -1464,6 +1464,7 @@ export type Position = {
   pickConfigId: Scalars['String']['output'];
   tokenAddress: Scalars['String']['output'];
   totalPayout?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['DateTimeISO']['output'];
   userCollateral?: Maybe<Scalars['String']['output']>;
 };
 


### PR DESCRIPTION
## Summary
- Click column headers on the positions table to sort client-side: **Position** (by `updatedAt`), **Position Size**, **Payout**, **Profit/Loss**, **Ends**. Asc/desc toggles on repeat clicks; default directions match each column's semantics (money → desc, ends → asc).
- Exposes `updatedAt` on the GraphQL `Position` type and selects it in both position queries so the **Position** column has a sortable "recent activity" key. Additive schema change — no existing clients are affected.
- Used by both the condition/question page and the user profile page, since both share `PositionsTable`.

## Test plan
- [ ] Visit a user profile → Positions tab and verify each column header toggles sort direction with asc/desc indicators.
- [ ] Visit a condition/question page → Positions section and verify the same behavior.
- [ ] Confirm the "Position" header sort orders most-recently-updated rows first (default desc).
- [ ] Confirm existing GraphQL clients that don't select `updatedAt` are unaffected.