### PR TITLE
fix: leaderboard PnL math and vault balance display

### DIFF
--- a/packages/api/scripts/backfillVaultFlows.ts
+++ b/packages/api/scripts/backfillVaultFlows.ts
@@ -1,0 +1,190 @@
+/**
+ * One-shot backfill for vault_flow_event on the current vault deployment.
+ * Reads PendingRequestProcessed + EmergencyWithdrawal events from chain.
+ *
+ * Why: no indexer writes to this table today. The rows that exist predate the
+ * current vault redeployment (2026-03-25, block 3890223). Running this lets
+ * analytics queries (airdrop gains, cumulative flows) reflect reality.
+ *
+ * Usage:
+ *   pnpm --filter @sapience/api exec tsx scripts/backfillVaultFlows.ts
+ *   pnpm --filter @sapience/api exec tsx scripts/backfillVaultFlows.ts --chainId 5064014
+ *   pnpm --filter @sapience/api exec tsx scripts/backfillVaultFlows.ts --dry-run
+ *
+ * --dry-run prints what would be upserted without touching the database. Use it to
+ * verify event discovery and data shape before running with write credentials.
+ */
+import { parseAbiItem } from 'viem';
+import prisma from '../src/db';
+import { getProviderForChain } from '../src/utils/utils';
+import { contracts } from '@sapience/sdk/contracts';
+
+const CHAIN_ID = (() => {
+  const eq = process.argv.find((a) => a.startsWith('--chainId='));
+  if (eq) return Number(eq.split('=')[1]);
+  const idx = process.argv.indexOf('--chainId');
+  if (idx > 0 && process.argv[idx + 1]) return Number(process.argv[idx + 1]);
+  return 5064014;
+})();
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+const BATCH_BLOCKS = 10_000n;
+
+const processedEvent = parseAbiItem(
+  'event PendingRequestProcessed(address indexed user, bool direction, uint256 shares, uint256 assets)'
+);
+const emergencyEvent = parseAbiItem(
+  'event EmergencyWithdrawal(address indexed user, uint256 shares, uint256 assets)'
+);
+
+async function main() {
+  const vaultEntry = contracts.predictionMarketVault[CHAIN_ID];
+  if (!vaultEntry) throw new Error(`No vault configured for chain ${CHAIN_ID}`);
+
+  const vaultAddress = vaultEntry.address as `0x${string}`;
+  const fromBlock = BigInt(vaultEntry.blockCreated);
+  const client = getProviderForChain(CHAIN_ID);
+  const toBlock = await client.getBlockNumber();
+
+  console.log(
+    `[backfillVaultFlows] chain=${CHAIN_ID} vault=${vaultAddress} blocks=${fromBlock}..${toBlock}${DRY_RUN ? ' [DRY RUN]' : ''}`
+  );
+
+  let upserted = 0;
+  const previewRows: Array<{
+    block: number;
+    ts: string;
+    type: string;
+    user: string;
+    assets: string;
+    shares: string;
+  }> = [];
+  for (let start = fromBlock; start <= toBlock; start += BATCH_BLOCKS) {
+    const end = start + BATCH_BLOCKS - 1n > toBlock ? toBlock : start + BATCH_BLOCKS - 1n;
+
+    const [processedLogs, emergencyLogs] = await Promise.all([
+      client.getLogs({
+        address: vaultAddress,
+        event: processedEvent,
+        fromBlock: start,
+        toBlock: end,
+      }),
+      client.getLogs({
+        address: vaultAddress,
+        event: emergencyEvent,
+        fromBlock: start,
+        toBlock: end,
+      }),
+    ]);
+
+    const blockTimestamps = new Map<bigint, number>();
+    const uniqueBlocks = new Set<bigint>([
+      ...processedLogs.map((l) => l.blockNumber!),
+      ...emergencyLogs.map((l) => l.blockNumber!),
+    ]);
+    for (const bn of uniqueBlocks) {
+      const b = await client.getBlock({ blockNumber: bn });
+      blockTimestamps.set(bn, Number(b.timestamp));
+    }
+
+    for (const log of processedLogs) {
+      const { user, direction, shares, assets } = log.args;
+      if (!user || !shares || !assets || log.logIndex == null) continue;
+      const ts = blockTimestamps.get(log.blockNumber!)!;
+      const row = {
+        chainId: CHAIN_ID,
+        blockNumber: Number(log.blockNumber!),
+        transactionHash: log.transactionHash!,
+        timestamp: ts,
+        logIndex: log.logIndex,
+        eventType: direction ? 'deposit' : 'withdrawal',
+        user: user.toLowerCase(),
+        assets: assets.toString(),
+        shares: shares.toString(),
+      };
+      if (DRY_RUN) {
+        previewRows.push({
+          block: row.blockNumber,
+          ts: new Date(ts * 1000).toISOString(),
+          type: row.eventType,
+          user: row.user,
+          assets: (Number(row.assets) / 1e18).toFixed(4),
+          shares: (Number(row.shares) / 1e18).toFixed(4),
+        });
+      } else {
+        await prisma.vaultFlowEvent.upsert({
+          where: {
+            chainId_transactionHash_logIndex: {
+              chainId: row.chainId,
+              transactionHash: row.transactionHash,
+              logIndex: row.logIndex,
+            },
+          },
+          create: row,
+          update: {},
+        });
+      }
+      upserted++;
+    }
+
+    for (const log of emergencyLogs) {
+      const { user, shares, assets } = log.args;
+      if (!user || !shares || !assets || log.logIndex == null) continue;
+      const ts = blockTimestamps.get(log.blockNumber!)!;
+      const row = {
+        chainId: CHAIN_ID,
+        blockNumber: Number(log.blockNumber!),
+        transactionHash: log.transactionHash!,
+        timestamp: ts,
+        logIndex: log.logIndex,
+        eventType: 'withdrawal',
+        user: user.toLowerCase(),
+        assets: assets.toString(),
+        shares: shares.toString(),
+      };
+      if (DRY_RUN) {
+        previewRows.push({
+          block: row.blockNumber,
+          ts: new Date(ts * 1000).toISOString(),
+          type: 'emergency_withdrawal',
+          user: row.user,
+          assets: (Number(row.assets) / 1e18).toFixed(4),
+          shares: (Number(row.shares) / 1e18).toFixed(4),
+        });
+      } else {
+        await prisma.vaultFlowEvent.upsert({
+          where: {
+            chainId_transactionHash_logIndex: {
+              chainId: row.chainId,
+              transactionHash: row.transactionHash,
+              logIndex: row.logIndex,
+            },
+          },
+          create: row,
+          update: {},
+        });
+      }
+      upserted++;
+    }
+
+    if (processedLogs.length || emergencyLogs.length) {
+      console.log(
+        `  block ${start}..${end}: +${processedLogs.length} processed, +${emergencyLogs.length} emergency`
+      );
+    }
+  }
+
+  if (DRY_RUN) {
+    console.log(`\n[DRY RUN] Would upsert ${upserted} vault flow rows:`);
+    console.table(previewRows);
+  } else {
+    console.log(`\nDone. Upserted ${upserted} vault flow rows.`);
+  }
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/api/src/helpers/positionPnL.ts
+++ b/packages/api/src/helpers/positionPnL.ts
@@ -347,44 +347,44 @@ export async function calculateCombinedPositionPnL(): Promise<
       FROM position
       WHERE status IN ('settled', 'consolidated') AND "predictorWon" IS NOT NULL
       UNION ALL
-      -- Claims: holder redeems settled prediction
-      -- Note: Claim.predictionId stores pickConfigId, so we use tokensBurned as cost basis
-      -- (position tokens are minted 1:1 with collateral)
-      SELECT cl.holder AS address,
-        CAST(cl."collateralPaid" AS DECIMAL) - CAST(cl."tokensBurned" AS DECIMAL) AS pnl
-      FROM "Claim" cl
-      UNION ALL
-      -- Closes: predictor payout
-      SELECT c."predictorHolder" AS address,
-        CAST(c."predictorPayout" AS DECIMAL) - CAST(c."predictorTokensBurned" AS DECIMAL) AS pnl
-      FROM "Close" c
-      UNION ALL
-      -- Closes: counterparty payout
-      SELECT c."counterpartyHolder" AS address,
-        CAST(c."counterpartyPayout" AS DECIMAL) - CAST(c."counterpartyTokensBurned" AS DECIMAL) AS pnl
-      FROM "Close" c
-      UNION ALL
-      -- Unclaimed settled: predictor side (exclude already-claimed)
-      -- Join Picks to get token addresses since Prediction no longer stores them
+      -- V2 Resolved: deterministic per-prediction PnL (predictor side).
+      -- In the parimutuel model, each side receives position tokens equal to the
+      -- prediction's total pot (pc + cc), not their individual stake. So Claim.tokensBurned
+      -- (pot-sized) is NOT the user's cost basis — their actual collateral is in Prediction.
+      -- For a resolved prediction, final PnL is deterministic from pk.result + collaterals,
+      -- whether or not the user has redeemed. Predictions that were mutually cancelled via
+      -- Close are excluded (PnL ≈ 0 for mutual cancel, and they're no longer live).
       SELECT p.predictor AS address,
-        CAST(COALESCE(p."predictorClaimable", '0') AS DECIMAL) - CAST(p."predictorCollateral" AS DECIMAL) AS pnl
+        CASE pk.result
+          WHEN 'PREDICTOR_WINS' THEN CAST(p."counterpartyCollateral" AS DECIMAL)
+          WHEN 'COUNTERPARTY_WINS' THEN -CAST(p."predictorCollateral" AS DECIMAL)
+          ELSE 0::DECIMAL
+        END AS pnl
       FROM "Prediction" p
-      LEFT JOIN "Picks" pk ON pk.id = p."pickConfigId"
-      WHERE p.settled = true AND p.result != 'UNRESOLVED'
+      INNER JOIN "Picks" pk ON pk.id = p."pickConfigId"
+      WHERE pk.resolved = true AND pk.result != 'UNRESOLVED'
         AND NOT EXISTS (
-          SELECT 1 FROM "Claim" c
-          WHERE c."positionToken" = pk."predictorToken" AND c.holder = p.predictor
+          SELECT 1 FROM "Close" c
+          WHERE c."pickConfigId" = p."pickConfigId"
+            AND LOWER(c."predictorHolder") = LOWER(p.predictor)
+            AND LOWER(c."counterpartyHolder") = LOWER(p.counterparty)
         )
       UNION ALL
-      -- Unclaimed settled: counterparty side (exclude already-claimed)
+      -- V2 Resolved: counterparty side
       SELECT p.counterparty AS address,
-        CAST(COALESCE(p."counterpartyClaimable", '0') AS DECIMAL) - CAST(p."counterpartyCollateral" AS DECIMAL) AS pnl
+        CASE pk.result
+          WHEN 'COUNTERPARTY_WINS' THEN CAST(p."predictorCollateral" AS DECIMAL)
+          WHEN 'PREDICTOR_WINS' THEN -CAST(p."counterpartyCollateral" AS DECIMAL)
+          ELSE 0::DECIMAL
+        END AS pnl
       FROM "Prediction" p
-      LEFT JOIN "Picks" pk ON pk.id = p."pickConfigId"
-      WHERE p.settled = true AND p.result != 'UNRESOLVED'
+      INNER JOIN "Picks" pk ON pk.id = p."pickConfigId"
+      WHERE pk.resolved = true AND pk.result != 'UNRESOLVED'
         AND NOT EXISTS (
-          SELECT 1 FROM "Claim" c
-          WHERE c."positionToken" = pk."counterpartyToken" AND c.holder = p.counterparty
+          SELECT 1 FROM "Close" c
+          WHERE c."pickConfigId" = p."pickConfigId"
+            AND LOWER(c."predictorHolder") = LOWER(p.predictor)
+            AND LOWER(c."counterpartyHolder") = LOWER(p.counterparty)
         )
     )
     SELECT address, SUM(pnl)::TEXT AS total_pnl, COUNT(*)::BIGINT AS position_count

--- a/packages/app/src/components/leaderboard/Leaderboard.tsx
+++ b/packages/app/src/components/leaderboard/Leaderboard.tsx
@@ -113,7 +113,7 @@ const Leaderboard = () => {
         </div>
         <TabsContent value="pnl">
           <p className="text-xl font-heading font-normal mb-6 text-muted-foreground leading-relaxed">
-            Realized profit ranks{' '}
+            Profit ranks{' '}
             <Link
               href="/markets"
               className="underline decoration-1 decoration-foreground/10 underline-offset-4 hover:decoration-foreground/60"
@@ -162,9 +162,7 @@ const PnLLeaderboard = () => {
       },
       {
         id: 'totalPnL',
-        header: () => (
-          <span className="whitespace-nowrap">Realized Profit</span>
-        ),
+        header: () => <span className="whitespace-nowrap">Profit</span>,
         accessorKey: 'totalPnL',
         cell: ProfitCell,
       },

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -454,12 +454,17 @@ const VaultsPageContent = () => {
     </Tabs>
   );
 
-  const tvlWei = vaultData?.totalLiquidValue ?? 0n;
+  const liquidWei = vaultData?.totalLiquidValue ?? 0n;
 
   const deployedWei = useMemo(() => {
     const lastStat = protocolStats?.[protocolStats.length - 1];
     return lastStat?.vaultDeployed ? BigInt(lastStat.vaultDeployed) : 0n;
   }, [protocolStats]);
+
+  // Vault AUM = liquid USDe in the vault + collateral deployed in open positions.
+  // getTotalLiquidValue() on the contract intentionally excludes position tokens,
+  // so we add the deployed cost basis back here to show true total.
+  const tvlWei = liquidWei + deployedWei;
 
   const utilizationPercent = useMemo(() => {
     if (tvlWei <= 0n) return 0;


### PR DESCRIPTION
## Summary

- Rewrite leaderboard PnL aggregation to use deterministic per-prediction PnL driven by `Picks.result` + actual collateral from `Prediction`, replacing the broken `Claim.collateralPaid − Claim.tokensBurned` formula that evaluated to 0 for most winning redemptions in the parimutuel model.
- Show true vault AUM on `/vaults` by summing `getTotalLiquidValue()` + deployed collateral, since the contract call intentionally excludes position tokens per its docstring.
- Rename the leaderboard column from "Realized Profit" to "Profit" — the metric always included unrealized-from-resolved positions, so the old label was misleading.
- Add `backfillVaultFlows.ts`, a one-shot chain reader for `PendingRequestProcessed` + `EmergencyWithdrawal` events on the current vault. `vault_flow_event` has no active indexer, so any consumer (airdrop-gain calc, flow charts) was reading stale pre-redeployment data.

## Why the leaderboard was wrong

`Claim.tokensBurned` in the parimutuel escrow equals the *full pot share*, not the user's individual stake — per `packages/protocol/CLAUDE.md`, both sides receive position tokens equal to `predictorCollateral + counterpartyCollateral`. So for every winning full redemption the contract correctly emits `collateralPaid == tokensBurned`, and the previous formula collapsed to PnL = 0. The fix keys off `Picks.result` and the actual collateral fields on `Prediction`, which also makes the sum of user PnL reconcile with `-vault_cumulative_pnl` (verified: sum = 0.0000 USDe exactly in prod).

## Why the vault balance was wrong

`getTotalLiquidValue()` returns `(liquidAssets, unconfirmedDeposits)` and intentionally excludes the value of position tokens held by the vault. The UI was rendering only `liquidAssets` while labelling it "VAULT BALANCE" and treating the "deployed" figure as a subset of it. Summing the two yields true AUM.

## Verified against prod (local API pointed at prod DB)

Top of the leaderboard before vs after:

| Address | Before | After |
|---|---|---|
| `0x207745a1…` | −6.09 USDe (rank 35) | **+1,274.91 USDe (rank 1)** |
| `0xFa80D2…` | +1.65 USDe (rank 10) | **+752.45 USDe (rank 2)** |
| Current vault `0x1f5fF6…` | — | +311.04 USDe (matches chart within ~28 USDe) |
| Sum of all user PnL | — | **0.0000 USDe** (perfect zero-sum) |

Dry-run of the backfill script found 1 legitimate deposit event on the current vault (7,923 USDe on 2026-03-26, right after redeployment); combined with ~335 USDe of realized PnL this reconciles with the fixed UI's ~8,258 USDe total AUM.

## Followups (not in this PR)

- Run `backfillVaultFlows.ts` against prod with write credentials (safe: idempotent on `(chainId, tx, logIndex)`).
- Stand up a live vault-flow indexer so `vault_flow_event` stays current.
- Operational recovery: ~586 USDe of winning position tokens are held by legacy vault `0x0f246f…` and never redeemed — the external redemption service appears scoped to the current vault only.

## Test plan

- [ ] Hard-reload `/leaderboard`; confirm `0x207745…` is rank 1 at ~1,275 USDe and the column header reads "Profit" (not "Realized Profit").
- [ ] Hard-reload `/vaults`; confirm "VAULT BALANCE" now reads ~8,258 USDe (liquid 6,122 + deployed 2,136) and the deployed percentage matches.
- [ ] Run `pnpm --filter @sapience/api exec tsx scripts/backfillVaultFlows.ts --dry-run` and verify the printed events look sensible.
- [ ] Smoke-test `accountProfitRank` GraphQL query for `0x207745…` and `0xFa80D2…` return the new numbers.



BY @ukitta555 -> TODO: fix burn SQL exclusion (too aggressive right now); think what to do with burns in general when it comes to PnL