### PR TITLE
feat(app): tighten bid-estimate hints and Pyth prediction line UI

### DIFF
--- a/packages/app/src/components/markets/CreatePositionForm/PositionForm.tsx
+++ b/packages/app/src/components/markets/CreatePositionForm/PositionForm.tsx
@@ -101,8 +101,11 @@ function parsePythEndDate(dateTimeLocal: string): Date | null {
 
 // Floor at each boundary so we never round up into the next unit
 // (e.g. 59m50s shows as `59M`, not `60M`; 23h59m stays `23H`, not `1D`).
+// Sub-minute remaining time renders as `<1M` so the row never shows `0M`.
 function formatPythDurationFromNow(endMs: number, nowMs: number): string {
-  const mins = Math.max(0, Math.floor((endMs - nowMs) / 60000));
+  const ms = Math.max(0, endMs - nowMs);
+  const mins = Math.floor(ms / 60000);
+  if (mins < 1) return `<1M`;
   if (mins < 60) return `${mins}M`;
   const hours = Math.floor(mins / 60);
   if (hours < 24) return `${hours}H`;
@@ -271,20 +274,16 @@ export default function PositionForm({
     return !Number.isNaN(sizeNum) && sizeNum > 1000;
   }, [positionSizeValue]);
 
-  // Combos that mix Polymarket conditions and Pyth price feeds attract fewer
-  // bids — surface this in the estimate UI.
-  const hasMixedResolvers = useMemo(() => {
+  // Pick-composition flags drive which bid-estimate hint we surface:
+  // mixed combos attract fewer bids; all-Pyth combos get the shorter-duration
+  // nudge (Polymarket conditions have fixed end times the user doesn't control).
+  const { hasMixedResolvers, isAllPyth } = useMemo(() => {
     const hasPolymarket = selections.length > 0;
     const hasPyth = (pythPredictions?.length ?? 0) > 0;
-    return hasPolymarket && hasPyth;
-  }, [selections, pythPredictions]);
-
-  // All picks are Pyth price feeds — "shorter durations" nudge only makes sense here
-  // (Polymarket conditions have fixed end times the user doesn't control).
-  const isAllPyth = useMemo(() => {
-    const hasPolymarket = selections.length > 0;
-    const hasPyth = (pythPredictions?.length ?? 0) > 0;
-    return hasPyth && !hasPolymarket;
+    return {
+      hasMixedResolvers: hasPolymarket && hasPyth,
+      isAllPyth: hasPyth && !hasPolymarket,
+    };
   }, [selections, pythPredictions]);
 
   // Calculate predictor position size in wei for auction chart
@@ -930,6 +929,11 @@ export default function PositionForm({
                           className="max-w-xs text-xs whitespace-normal break-words font-mono"
                         >
                           <div>{p.priceFeedLabel ?? 'Crypto'}</div>
+                          {priceDisplay && (
+                            <div className="mt-1">
+                              {directionSymbol} ${priceDisplay}
+                            </div>
+                          )}
                           {exactTimestamp && (
                             <div className="mt-1 text-muted-foreground">
                               {exactTimestamp}

--- a/packages/app/src/components/markets/CreatePositionForm/PositionForm.tsx
+++ b/packages/app/src/components/markets/CreatePositionForm/PositionForm.tsx
@@ -6,6 +6,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@sapience/ui/components/ui/dialog';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@sapience/ui/components/ui/tooltip';
 import { Info } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -210,6 +215,27 @@ export default function PositionForm({
     const sizeNum = Number(positionSizeValue);
     return !Number.isNaN(sizeNum) && sizeNum > 1000;
   }, [positionSizeValue]);
+
+  // Combos that mix oracle types (e.g. Pyth feeds + Polymarket/UMA conditions)
+  // or multiple UMA resolvers attract fewer bids — surface this in the estimate UI.
+  const hasMixedResolvers = useMemo(() => {
+    const umaResolvers = new Set(
+      selections
+        .map((s) => s.resolverAddress?.toLowerCase())
+        .filter((a): a is string => Boolean(a))
+    );
+    const hasUma = selections.length > 0;
+    const hasPyth = (pythPredictions?.length ?? 0) > 0;
+    return (hasUma && hasPyth) || umaResolvers.size > 1;
+  }, [selections, pythPredictions]);
+
+  // All picks are Pyth price feeds — "shorter durations" nudge only makes sense here
+  // (UMA/Polymarket conditions have fixed end times the user doesn't control).
+  const isAllPyth = useMemo(() => {
+    const hasUma = selections.length > 0;
+    const hasPyth = (pythPredictions?.length ?? 0) > 0;
+    return hasPyth && !hasUma;
+  }, [selections, pythPredictions]);
 
   // Calculate predictor position size in wei for auction chart
   const predictorPositionSizeWei = useMemo(() => {
@@ -722,7 +748,7 @@ export default function PositionForm({
   // Since automatic auction trigger is disabled, show button immediately when no bids
   const showNoBidsHint = !bestBid && !recentlyRequested;
 
-  // Show "Some combinations may not receive bids" hint after 3 seconds of no bids
+  // Show "Some predictions may not receive bids" hint after 3 seconds of no bids
   // This replaces the disclaimer after waiting for bids without success
   const HINT_DELAY_MS = 3000;
   const showNoBidsWarning =
@@ -807,21 +833,96 @@ export default function PositionForm({
           ].map((item, index) => {
             if (item.kind === 'pyth') {
               const p = item.p;
-              const predictionData: PredictionListItemData = {
-                id: p.id,
-                question: `${p.priceFeedLabel ?? 'Crypto'} OVER $${p.targetPrice.toLocaleString()}`,
-                prediction: p.direction === 'over',
-              };
+              const feedLabel = (p.priceFeedLabel ?? 'Crypto').replace(
+                /^[^.]+\./,
+                ''
+              );
+              const directionSymbol = p.direction === 'over' ? '>' : '<';
+              const priceStr = p.targetPrice.toLocaleString(undefined, {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+              });
+              const endDate = (() => {
+                const m = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/.exec(
+                  p.dateTimeLocal
+                );
+                if (!m) return null;
+                return new Date(
+                  Number(m[1]),
+                  Number(m[2]) - 1,
+                  Number(m[3]),
+                  Number(m[4]),
+                  Number(m[5])
+                );
+              })();
+              const durationStr = (() => {
+                if (!endDate) return null;
+                const mins = Math.max(
+                  0,
+                  Math.round((endDate.getTime() - Date.now()) / 60000)
+                );
+                if (mins < 60) return `${mins}M`;
+                const hours = Math.round(mins / 60);
+                if (hours < 24) return `${hours}H`;
+                return `${Math.round(hours / 24)}D`;
+              })();
+              const exactPrice = (() => {
+                const raw = p.targetPriceRaw ?? String(p.targetPrice);
+                const n = Number(raw);
+                if (!Number.isFinite(n)) return raw;
+                return n.toLocaleString(undefined, {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 20,
+                });
+              })();
+              const exactTimestamp = endDate
+                ? new Intl.DateTimeFormat(undefined, {
+                    year: 'numeric',
+                    month: 'short',
+                    day: 'numeric',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    second: '2-digit',
+                    timeZoneName: 'short',
+                  }).format(endDate)
+                : null;
+              const pythTitle = `${feedLabel} ${directionSymbol}$${priceStr}${durationStr ? ` IN ${durationStr}` : ''}`;
               return (
                 <div
                   key={p.id}
                   className={`-mx-4 px-4 py-2.5 border-b border-brand-white/10 ${index === 0 ? 'border-t' : ''}`}
                 >
-                  <PredictionListItem
-                    prediction={predictionData}
-                    leading={<PythMarketBadge className="w-5 h-5" />}
-                    onRemove={onRemovePythPrediction}
-                  />
+                  <div className="flex items-center gap-2">
+                    <PythMarketBadge className="w-5 h-5" />
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <div className="truncate text-brand-white font-mono text-sm flex-1 min-w-0 cursor-default">
+                          {pythTitle}
+                        </div>
+                      </TooltipTrigger>
+                      <TooltipContent
+                        side="top"
+                        className="max-w-xs text-xs whitespace-normal break-words font-mono"
+                      >
+                        <div>
+                          {feedLabel} {directionSymbol}${exactPrice}
+                        </div>
+                        {exactTimestamp && (
+                          <div className="mt-1 text-muted-foreground">
+                            {exactTimestamp}
+                          </div>
+                        )}
+                      </TooltipContent>
+                    </Tooltip>
+                    <button
+                      onClick={() => onRemovePythPrediction?.(p.id)}
+                      className="text-[22px] leading-none text-muted-foreground hover:text-foreground shrink-0"
+                      type="button"
+                      aria-label="Remove"
+                    >
+                      ×
+                    </button>
+                  </div>
                 </div>
               );
             }
@@ -922,6 +1023,8 @@ export default function PositionForm({
               }
               enableRainbowHover={isRainbowHoverEnabled}
               hintMounted={hintMounted}
+              hasMixedResolvers={hasMixedResolvers}
+              isAllPyth={isAllPyth}
               disclaimerMounted={disclaimerMounted}
               allBids={validBids}
               predictorPositionSizeWei={predictorPositionSizeWei}

--- a/packages/app/src/components/markets/CreatePositionForm/PositionForm.tsx
+++ b/packages/app/src/components/markets/CreatePositionForm/PositionForm.tsx
@@ -99,12 +99,14 @@ function parsePythEndDate(dateTimeLocal: string): Date | null {
   }
 }
 
+// Floor at each boundary so we never round up into the next unit
+// (e.g. 59m50s shows as `59M`, not `60M`; 23h59m stays `23H`, not `1D`).
 function formatPythDurationFromNow(endMs: number, nowMs: number): string {
-  const mins = Math.max(0, Math.round((endMs - nowMs) / 60000));
+  const mins = Math.max(0, Math.floor((endMs - nowMs) / 60000));
   if (mins < 60) return `${mins}M`;
-  const hours = Math.round(mins / 60);
+  const hours = Math.floor(mins / 60);
   if (hours < 24) return `${hours}H`;
-  return `${Math.round(hours / 24)}D`;
+  return `${Math.floor(hours / 24)}D`;
 }
 
 interface PositionFormProps {

--- a/packages/app/src/components/markets/CreatePositionForm/PositionForm.tsx
+++ b/packages/app/src/components/markets/CreatePositionForm/PositionForm.tsx
@@ -36,7 +36,10 @@ import { PREFERRED_ESTIMATE_QUOTER } from '~/lib/constants';
 import { useConnectedWallet } from '~/hooks/useConnectedWallet';
 import { PositionSizeInput } from '~/components/markets/forms';
 import BidDisplay from '~/components/markets/forms/shared/BidDisplay';
-import { buildPythAuctionStartPayload } from '~/lib/auction/buildAuctionPayload';
+import {
+  buildPythAuctionStartPayload,
+  parseDateTimeLocalToUnixSeconds,
+} from '~/lib/auction/buildAuctionPayload';
 import type { AuctionParams, QuoteBid } from '~/lib/auction/useAuctionStart';
 import { useCreatePositionContext } from '~/lib/context/CreatePositionContext';
 import ConditionTitleLink from '~/components/markets/ConditionTitleLink';
@@ -53,6 +56,56 @@ import { useSponsorStatus } from '~/hooks/sponsorship/useSponsorStatus';
 import { useSponsorshipActivation } from '~/hooks/sponsorship/useSponsorshipActivation';
 
 const EMPTY_BIDS: QuoteBid[] = [];
+
+// Strip the Pyth feed namespace so only the symbol remains
+// (`Crypto.BTC/USD` → `BTC/USD`, `Equity.US.AAPL` → `AAPL`).
+function formatPythFeedLabel(label: string | undefined): string {
+  const raw = label ?? 'Crypto';
+  const lastDot = raw.lastIndexOf('.');
+  return lastDot >= 0 ? raw.slice(lastDot + 1) : raw;
+}
+
+// Display the strike price at the same precision that's actually submitted on-chain.
+// `targetPriceRaw` is the user-entered decimal string; we only add thousand separators
+// to the integer part and preserve the fractional part verbatim. Falls back to
+// `targetPrice` (number) when raw is missing.
+function formatPythTargetPriceDisplay(
+  targetPriceRaw: string | undefined,
+  targetPrice: number
+): string {
+  const raw =
+    targetPriceRaw && targetPriceRaw.trim().length > 0
+      ? targetPriceRaw.trim()
+      : Number.isFinite(targetPrice)
+        ? String(targetPrice)
+        : '';
+  if (!raw) return '';
+  const [intPart, fracPart] = raw.split('.');
+  const intNum = Number(intPart);
+  const formattedInt = Number.isFinite(intNum)
+    ? intNum.toLocaleString(undefined, { maximumFractionDigits: 0 })
+    : intPart;
+  return fracPart !== undefined ? `${formattedInt}.${fracPart}` : formattedInt;
+}
+
+// Same parse rules as the on-chain endTime encoding — ensures the displayed
+// duration is computed from the same instant we submit. Returns null on invalid input.
+function parsePythEndDate(dateTimeLocal: string): Date | null {
+  try {
+    const unixSec = parseDateTimeLocalToUnixSeconds(dateTimeLocal);
+    return new Date(Number(unixSec) * 1000);
+  } catch {
+    return null;
+  }
+}
+
+function formatPythDurationFromNow(endMs: number, nowMs: number): string {
+  const mins = Math.max(0, Math.round((endMs - nowMs) / 60000));
+  if (mins < 60) return `${mins}M`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours}H`;
+  return `${Math.round(hours / 24)}D`;
+}
 
 interface PositionFormProps {
   methods: UseFormReturn<{
@@ -216,25 +269,20 @@ export default function PositionForm({
     return !Number.isNaN(sizeNum) && sizeNum > 1000;
   }, [positionSizeValue]);
 
-  // Combos that mix oracle types (e.g. Pyth feeds + Polymarket/UMA conditions)
-  // or multiple UMA resolvers attract fewer bids — surface this in the estimate UI.
+  // Combos that mix Polymarket conditions and Pyth price feeds attract fewer
+  // bids — surface this in the estimate UI.
   const hasMixedResolvers = useMemo(() => {
-    const umaResolvers = new Set(
-      selections
-        .map((s) => s.resolverAddress?.toLowerCase())
-        .filter((a): a is string => Boolean(a))
-    );
-    const hasUma = selections.length > 0;
+    const hasPolymarket = selections.length > 0;
     const hasPyth = (pythPredictions?.length ?? 0) > 0;
-    return (hasUma && hasPyth) || umaResolvers.size > 1;
+    return hasPolymarket && hasPyth;
   }, [selections, pythPredictions]);
 
   // All picks are Pyth price feeds — "shorter durations" nudge only makes sense here
-  // (UMA/Polymarket conditions have fixed end times the user doesn't control).
+  // (Polymarket conditions have fixed end times the user doesn't control).
   const isAllPyth = useMemo(() => {
-    const hasUma = selections.length > 0;
+    const hasPolymarket = selections.length > 0;
     const hasPyth = (pythPredictions?.length ?? 0) > 0;
-    return hasPyth && !hasUma;
+    return hasPyth && !hasPolymarket;
   }, [selections, pythPredictions]);
 
   // Calculate predictor position size in wei for auction chart
@@ -247,10 +295,10 @@ export default function PositionForm({
     }
   }, [positionSizeValue, collateralDecimals]);
 
-  // Create a stable key from all prediction legs (UMA + Pyth) to detect changes
+  // Create a stable key from all prediction legs (Polymarket + Pyth) to detect changes
   // and ensure we clear/re-key bids correctly when *either* leg set changes.
   const predictionsKey = useMemo(() => {
-    const umaKey = selections
+    const polymarketKey = selections
       .map((s) => `${s.conditionId}:${s.prediction}`)
       .sort()
       .join('|');
@@ -261,7 +309,7 @@ export default function PositionForm({
       )
       .sort()
       .join('|');
-    return [umaKey, pythKey].filter(Boolean).join('||');
+    return [polymarketKey, pythKey].filter(Boolean).join('||');
   }, [selections, pythPredictions]);
   const prevPredictionsKeyRef = useRef<string>(predictionsKey);
 
@@ -530,10 +578,10 @@ export default function PositionForm({
         return;
       }
 
-      const hasUma = selections.length > 0;
+      const hasPolymarket = selections.length > 0;
       const hasPyth = pythPredictions.length > 0;
 
-      if (!hasUma && !hasPyth) {
+      if (!hasPolymarket && !hasPyth) {
         return;
       }
       if (hasFormErrors) {
@@ -592,7 +640,7 @@ export default function PositionForm({
         let picks: AuctionParams['picks'] = [];
         if (hasPyth && pythEscrowPicks) {
           picks = pythEscrowPicks;
-        } else if (hasUma) {
+        } else if (hasPolymarket) {
           const conditionPicks = getPolymarketPicks();
           if (conditionPicks.length > 0) {
             picks = conditionPicks;
@@ -700,7 +748,7 @@ export default function PositionForm({
     // Don't auto-trigger if there are form errors (auto mode only)
     if (triggerMode === 'auto' && hasFormErrors) return;
 
-    // Must have at least one UMA prediction or at least one Pyth prediction
+    // Must have at least one Polymarket prediction or at least one Pyth prediction
     const hasPredictions = selections.length >= 1 || pythPredictions.length > 0;
     if (!hasPredictions) return;
 
@@ -833,48 +881,16 @@ export default function PositionForm({
           ].map((item, index) => {
             if (item.kind === 'pyth') {
               const p = item.p;
-              const feedLabel = (p.priceFeedLabel ?? 'Crypto').replace(
-                /^[^.]+\./,
-                ''
-              );
+              const feedLabel = formatPythFeedLabel(p.priceFeedLabel);
               const directionSymbol = p.direction === 'over' ? '>' : '<';
-              const priceStr = p.targetPrice.toLocaleString(undefined, {
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2,
-              });
-              const endDate = (() => {
-                const m = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/.exec(
-                  p.dateTimeLocal
-                );
-                if (!m) return null;
-                return new Date(
-                  Number(m[1]),
-                  Number(m[2]) - 1,
-                  Number(m[3]),
-                  Number(m[4]),
-                  Number(m[5])
-                );
-              })();
-              const durationStr = (() => {
-                if (!endDate) return null;
-                const mins = Math.max(
-                  0,
-                  Math.round((endDate.getTime() - Date.now()) / 60000)
-                );
-                if (mins < 60) return `${mins}M`;
-                const hours = Math.round(mins / 60);
-                if (hours < 24) return `${hours}H`;
-                return `${Math.round(hours / 24)}D`;
-              })();
-              const exactPrice = (() => {
-                const raw = p.targetPriceRaw ?? String(p.targetPrice);
-                const n = Number(raw);
-                if (!Number.isFinite(n)) return raw;
-                return n.toLocaleString(undefined, {
-                  minimumFractionDigits: 2,
-                  maximumFractionDigits: 20,
-                });
-              })();
+              const priceDisplay = formatPythTargetPriceDisplay(
+                p.targetPriceRaw,
+                p.targetPrice
+              );
+              const endDate = parsePythEndDate(p.dateTimeLocal);
+              const durationStr = endDate
+                ? formatPythDurationFromNow(endDate.getTime(), nowMs)
+                : null;
               const exactTimestamp = endDate
                 ? new Intl.DateTimeFormat(undefined, {
                     year: 'numeric',
@@ -886,43 +902,42 @@ export default function PositionForm({
                     timeZoneName: 'short',
                   }).format(endDate)
                 : null;
-              const pythTitle = `${feedLabel} ${directionSymbol}$${priceStr}${durationStr ? ` IN ${durationStr}` : ''}`;
+              const pythTitle = `${feedLabel} ${directionSymbol}$${priceDisplay}${durationStr ? ` IN ${durationStr}` : ''}`;
               return (
                 <div
                   key={p.id}
                   className={`-mx-4 px-4 py-2.5 border-b border-brand-white/10 ${index === 0 ? 'border-t' : ''}`}
                 >
-                  <div className="flex items-center gap-2">
-                    <PythMarketBadge className="w-5 h-5" />
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <div className="truncate text-brand-white font-mono text-sm flex-1 min-w-0 cursor-default">
-                          {pythTitle}
-                        </div>
-                      </TooltipTrigger>
-                      <TooltipContent
-                        side="top"
-                        className="max-w-xs text-xs whitespace-normal break-words font-mono"
-                      >
-                        <div>
-                          {feedLabel} {directionSymbol}${exactPrice}
-                        </div>
-                        {exactTimestamp && (
-                          <div className="mt-1 text-muted-foreground">
-                            {exactTimestamp}
+                  <PredictionListItem
+                    prediction={{
+                      id: p.id,
+                      question: pythTitle,
+                      prediction: p.direction === 'over',
+                    }}
+                    leading={<PythMarketBadge className="w-5 h-5" />}
+                    showChoice={false}
+                    title={
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <div className="truncate text-brand-white font-mono text-sm cursor-default">
+                            {pythTitle}
                           </div>
-                        )}
-                      </TooltipContent>
-                    </Tooltip>
-                    <button
-                      onClick={() => onRemovePythPrediction?.(p.id)}
-                      className="text-[22px] leading-none text-muted-foreground hover:text-foreground shrink-0"
-                      type="button"
-                      aria-label="Remove"
-                    >
-                      ×
-                    </button>
-                  </div>
+                        </TooltipTrigger>
+                        <TooltipContent
+                          side="top"
+                          className="max-w-xs text-xs whitespace-normal break-words font-mono"
+                        >
+                          <div>{p.priceFeedLabel ?? 'Crypto'}</div>
+                          {exactTimestamp && (
+                            <div className="mt-1 text-muted-foreground">
+                              {exactTimestamp}
+                            </div>
+                          )}
+                        </TooltipContent>
+                      </Tooltip>
+                    }
+                    onRemove={onRemovePythPrediction}
+                  />
                 </div>
               );
             }

--- a/packages/app/src/components/markets/forms/shared/BidDisplay.tsx
+++ b/packages/app/src/components/markets/forms/shared/BidDisplay.tsx
@@ -102,10 +102,10 @@ export default function BidDisplay({
 
   // Helper function to calculate payout amount
   const calculatePayoutAmount = useCallback(
-    (bid: QuoteBid, sizeStr: string): string => {
+    (bid: QuoteBid, size: string): string => {
       let userPositionSizeWei: bigint = 0n;
       try {
-        userPositionSizeWei = parseUnits(sizeStr || '0', collateralDecimals);
+        userPositionSizeWei = parseUnits(size || '0', collateralDecimals);
       } catch {
         userPositionSizeWei = 0n;
       }

--- a/packages/app/src/components/markets/forms/shared/BidDisplay.tsx
+++ b/packages/app/src/components/markets/forms/shared/BidDisplay.tsx
@@ -40,6 +40,10 @@ interface BidDisplayProps {
   disclaimerMounted?: boolean;
   /** Whether hint is mounted */
   hintMounted?: boolean;
+  /** Combo mixes oracle types / resolvers — surface a specific reason bids may be scarce */
+  hasMixedResolvers?: boolean;
+  /** Every pick is a Pyth price prediction — show the "shorter durations" nudge */
+  isAllPyth?: boolean;
   /** Optional className for the container */
   className?: string;
   /** All bids for auction chart display */
@@ -81,6 +85,8 @@ export default function BidDisplay({
   enableRainbowHover = false,
   disclaimerMounted = true,
   hintMounted = false,
+  hasMixedResolvers = false,
+  isAllPyth = false,
   className,
   allBids = [],
   predictorPositionSizeWei,
@@ -96,13 +102,10 @@ export default function BidDisplay({
 
   // Helper function to calculate payout amount
   const calculatePayoutAmount = useCallback(
-    (bid: QuoteBid, positionSize: string): string => {
+    (bid: QuoteBid, sizeStr: string): string => {
       let userPositionSizeWei: bigint = 0n;
       try {
-        userPositionSizeWei = parseUnits(
-          positionSize || '0',
-          collateralDecimals
-        );
+        userPositionSizeWei = parseUnits(sizeStr || '0', collateralDecimals);
       } catch {
         userPositionSizeWei = 0n;
       }
@@ -527,12 +530,21 @@ export default function BidDisplay({
         )}
       </Button>
 
-      {/* Position-specific hint for combinations that may not receive bids */}
+      {/* Position-specific hint for combos that may not receive bids.
+          Surfaces a targeted hint for mixed-resolver combos or a
+          shorter-duration nudge for Pyth-only combos; falls back to a generic
+          message otherwise. */}
       {hintMounted && (
-        <div className="text-xs text-foreground font-medium mt-3">
-          <span className="text-accent-gold">
-            Some combinations may not receive bids
-          </span>
+        <div className="text-xs text-foreground font-medium mt-3 space-y-1">
+          <div>
+            <span className="text-accent-gold">
+              {hasMixedResolvers
+                ? 'Predictions that mix oracle types may attract fewer bids.'
+                : isAllPyth
+                  ? 'Shorter price prediction durations attract more bids.'
+                  : 'Some predictions may not receive bids.'}
+            </span>
+          </div>
         </div>
       )}
 

--- a/packages/app/src/lib/auction/__tests__/buildPythAuctionPayload.test.ts
+++ b/packages/app/src/lib/auction/__tests__/buildPythAuctionPayload.test.ts
@@ -120,6 +120,27 @@ describe('parseDateTimeLocalToUnixSeconds', () => {
     const d = new Date(2024, 0, 1, 0, 0);
     expect(result).toBe(BigInt(Math.floor(d.getTime() / 1000)));
   });
+
+  it('parses datetime string with seconds', () => {
+    const result = parseDateTimeLocalToUnixSeconds('2024-01-15T10:30:45');
+    const d = new Date(2024, 0, 15, 10, 30, 45);
+    expect(result).toBe(BigInt(Math.floor(d.getTime() / 1000)));
+  });
+
+  it('treats HH:MM as HH:MM:00 (no seconds = zero seconds)', () => {
+    const withoutSec = parseDateTimeLocalToUnixSeconds('2024-01-15T10:30');
+    const withZeroSec = parseDateTimeLocalToUnixSeconds('2024-01-15T10:30:00');
+    expect(withoutSec).toBe(withZeroSec);
+  });
+
+  it('throws for malformed seconds segment', () => {
+    expect(() => parseDateTimeLocalToUnixSeconds('2024-01-15T10:30:5')).toThrow(
+      'invalid_datetime_local'
+    );
+    expect(() => parseDateTimeLocalToUnixSeconds('2024-01-15T10:30:')).toThrow(
+      'invalid_datetime_local'
+    );
+  });
 });
 
 describe('pow10', () => {

--- a/packages/app/src/lib/auction/buildAuctionPayload.ts
+++ b/packages/app/src/lib/auction/buildAuctionPayload.ts
@@ -51,14 +51,18 @@ function normalizePolymarketOutcomes(
 }
 
 export function parseDateTimeLocalToUnixSeconds(value: string): bigint {
-  const m = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/.exec(value);
+  // Accept both YYYY-MM-DDTHH:MM and YYYY-MM-DDTHH:MM:SS.
+  const m = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?$/.exec(
+    value
+  );
   if (!m) throw new Error('invalid_datetime_local');
   const yyyy = Number(m[1]);
   const mm = Number(m[2]);
   const dd = Number(m[3]);
   const hh = Number(m[4]);
   const min = Number(m[5]);
-  const d = new Date(yyyy, mm - 1, dd, hh, min);
+  const sec = m[6] !== undefined ? Number(m[6]) : 0;
+  const d = new Date(yyyy, mm - 1, dd, hh, min, sec);
   const ms = d.getTime();
   if (Number.isNaN(ms)) throw new Error('invalid_datetime_local');
   return BigInt(Math.floor(ms / 1000));

--- a/packages/ui/components/CreatePythPredictionForm.tsx
+++ b/packages/ui/components/CreatePythPredictionForm.tsx
@@ -143,7 +143,8 @@ function formatDateTimeLocalInputValue(date: Date): string {
   const dd = pad(date.getDate());
   const hh = pad(date.getHours());
   const min = pad(date.getMinutes());
-  return `${yyyy}-${mm}-${dd}T${hh}:${min}`;
+  const sec = pad(date.getSeconds());
+  return `${yyyy}-${mm}-${dd}T${hh}:${min}:${sec}`;
 }
 
 function addMinutes(date: Date, minutes: number): Date {
@@ -158,17 +159,21 @@ function parseDateTimeLocalInputValue(value: string): {
   date: Date | undefined;
   time: string;
 } {
-  // Expected: YYYY-MM-DDTHH:MM
-  const m = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/.exec(value);
-  if (!m) return { date: undefined, time: '12:00' };
+  // Accept YYYY-MM-DDTHH:MM or YYYY-MM-DDTHH:MM:SS.
+  const m = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?$/.exec(
+    value
+  );
+  if (!m) return { date: undefined, time: '12:00:00' };
   const yyyy = Number(m[1]);
   const mm = Number(m[2]);
   const dd = Number(m[3]);
   const hh = Number(m[4]);
   const min = Number(m[5]);
-  const d = new Date(yyyy, mm - 1, dd, hh, min);
-  if (Number.isNaN(d.getTime())) return { date: undefined, time: '12:00' };
-  return { date: d, time: `${m[4]}:${m[5]}` };
+  const sec = m[6] !== undefined ? Number(m[6]) : 0;
+  const d = new Date(yyyy, mm - 1, dd, hh, min, sec);
+  if (Number.isNaN(d.getTime())) return { date: undefined, time: '12:00:00' };
+  const secStr = m[6] ?? '00';
+  return { date: d, time: `${m[4]}:${m[5]}:${secStr}` };
 }
 
 function getLocalTimeZoneLabel(): string {
@@ -451,13 +456,16 @@ function DateTimeSelector({
                       selected={selectedDate}
                       onSelect={(d) => {
                         if (!d) return;
-                        const [hh, min] = selectedTime.split(':').map(Number);
+                        const [hh, min, sec] = selectedTime
+                          .split(':')
+                          .map(Number);
                         const next = new Date(
                           d.getFullYear(),
                           d.getMonth(),
                           d.getDate(),
                           Number.isFinite(hh) ? hh : 12,
-                          Number.isFinite(min) ? min : 0
+                          Number.isFinite(min) ? min : 0,
+                          Number.isFinite(sec) ? sec : 0
                         );
                         const nextValue = formatDateTimeLocalInputValue(next);
                         setCustomValue(nextValue);
@@ -472,17 +480,21 @@ function DateTimeSelector({
                       <div className="relative flex-1">
                         <Input
                           type="time"
+                          step={1}
                           value={selectedTime}
                           onChange={(e) => {
                             const nextTime = e.target.value;
                             const base = selectedDate ?? new Date();
-                            const [hh, min] = nextTime.split(':').map(Number);
+                            const [hh, min, sec] = nextTime
+                              .split(':')
+                              .map(Number);
                             const next = new Date(
                               base.getFullYear(),
                               base.getMonth(),
                               base.getDate(),
                               Number.isFinite(hh) ? hh : 12,
-                              Number.isFinite(min) ? min : 0
+                              Number.isFinite(min) ? min : 0,
+                              Number.isFinite(sec) ? sec : 0
                             );
                             const nextValue =
                               formatDateTimeLocalInputValue(next);

--- a/packages/ui/components/CreatePythPredictionForm.tsx
+++ b/packages/ui/components/CreatePythPredictionForm.tsx
@@ -65,7 +65,7 @@ export type CreatePythPredictionFormValues = {
   dateTimeLocal: string;
 };
 
-type DateTimePreset = '' | '5m' | '1h' | '1w' | 'custom' | 'relative';
+type DateTimePreset = '' | '5m' | '10m' | '15m' | 'custom' | 'relative';
 
 type RelativeUnit = 'minutes' | 'hours' | 'days';
 
@@ -277,9 +277,9 @@ function DateTimeSelector({
       const next =
         nextPreset === '5m'
           ? formatDateTimeLocalInputValue(addMinutes(now, 5))
-          : nextPreset === '1h'
-            ? formatDateTimeLocalInputValue(addMinutes(now, 60))
-            : formatDateTimeLocalInputValue(addDays(now, 7));
+          : nextPreset === '10m'
+            ? formatDateTimeLocalInputValue(addMinutes(now, 10))
+            : formatDateTimeLocalInputValue(addMinutes(now, 15));
 
       onChange(next);
     },
@@ -300,8 +300,8 @@ function DateTimeSelector({
         {(
           [
             { id: '5m', label: '5m', aria: 'In 5 minutes' },
-            { id: '1h', label: '1h', aria: 'In 1 hour' },
-            { id: '1w', label: '1w', aria: 'In a week' },
+            { id: '10m', label: '10m', aria: 'In 10 minutes' },
+            { id: '15m', label: '15m', aria: 'In 15 minutes' },
             { id: 'relative', label: 'relative', aria: 'Relative time' },
             { id: 'custom', label: 'custom', aria: 'Custom time' },
           ] as const
@@ -957,10 +957,10 @@ export function CreatePythPredictionForm({
     const computedDateTimeLocal =
       dateTimePreset === '5m'
         ? formatDateTimeLocalInputValue(addMinutes(new Date(), 5))
-        : dateTimePreset === '1h'
-          ? formatDateTimeLocalInputValue(addMinutes(new Date(), 60))
-          : dateTimePreset === '1w'
-            ? formatDateTimeLocalInputValue(addDays(new Date(), 7))
+        : dateTimePreset === '10m'
+          ? formatDateTimeLocalInputValue(addMinutes(new Date(), 10))
+          : dateTimePreset === '15m'
+            ? formatDateTimeLocalInputValue(addMinutes(new Date(), 15))
             : dateTimePreset === 'relative'
               ? (() => {
                   const amt = Number(parentRelativeAmount);

--- a/packages/ui/components/PredictionListItem.tsx
+++ b/packages/ui/components/PredictionListItem.tsx
@@ -27,6 +27,8 @@ export type PredictionListItemProps = {
   onRemove?: (id: string) => void;
   yesLabel?: string;
   noLabel?: string;
+  /** Hide the YES/NO badge. For rows where the title already encodes the choice. */
+  showChoice?: boolean;
 };
 
 export function PredictionListItem({
@@ -36,6 +38,7 @@ export function PredictionListItem({
   onRemove,
   yesLabel = 'YES',
   noLabel = 'NO',
+  showChoice = true,
 }: PredictionListItemProps) {
   return (
     <div className="flex items-center gap-2">
@@ -55,11 +58,13 @@ export function PredictionListItem({
                 </div>
               )}
             </div>
-            <span className="shrink-0">
-              <PredictionChoiceBadge
-                choice={prediction.prediction ? yesLabel : noLabel}
-              />
-            </span>
+            {showChoice && (
+              <span className="shrink-0">
+                <PredictionChoiceBadge
+                  choice={prediction.prediction ? yesLabel : noLabel}
+                />
+              </span>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Replace the single "Some combinations may not receive bids" message with targeted hints: mixed-resolver warning, Pyth-only shorter-duration nudge, or a generic fallback.
- Rewrite the Pyth prediction row in the create-position list: strip `Crypto.`-style prefix, use `<`/`>` with 2dp price and compact duration (e.g. `BTC/USD <$75,343.50 IN 15M`), tooltip reveals full-precision price and exact end timestamp.
- Swap Pyth date presets from `5m / 1h / 1w` to `5m / 10m / 15m` to match the shorter-duration nudge.

## Test plan
- [ ] Create a Pyth BTC/USD "over" prediction → row reads `BTC/USD >$X,XXX.XX IN NM`, tooltip shows full-precision price + exact timestamp.
- [ ] Create a Pyth "under" prediction → shows `<` symbol (not a YES/NO badge).
- [ ] Mix a Pyth pick with a Polymarket pick → mixed-resolver hint appears.
- [ ] Pyth-only picks → shorter-duration nudge appears.
- [ ] Neither condition → generic fallback hint.
- [ ] Date preset buttons (5m / 10m / 15m) all produce correct end times.