### PR TITLE
fix(activity): scope Related Activity by pickConfigId and conditionId

### DIFF
--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -1443,7 +1443,7 @@ type Query {
   """
   Unified activity feed — predictions and trades merged by timestamp. When address is provided, scopes to that account; otherwise returns recent global activity.
   """
-  accountActivity(address: String, skip: Int! = 0, take: Int! = 20, type: String): [ActivityItem!]!
+  accountActivity(address: String, conditionId: String, pickConfigId: String, skip: Int! = 0, take: Int! = 20, type: String): [ActivityItem!]!
 
   """
   Time-bucketed balance snapshots for a single address showing deployed and claimable collateral

--- a/packages/api/src/graphql/resolvers/ActivityResolver.ts
+++ b/packages/api/src/graphql/resolvers/ActivityResolver.ts
@@ -89,11 +89,17 @@ export class ActivityResolver {
     @Arg('address', () => String, { nullable: true }) address?: string,
     @Arg('take', () => Int, { defaultValue: 20 }) take?: number,
     @Arg('skip', () => Int, { defaultValue: 0 }) skip?: number,
-    @Arg('type', () => String, { nullable: true }) type?: string
+    @Arg('type', () => String, { nullable: true }) type?: string,
+    @Arg('pickConfigId', () => String, { nullable: true })
+    pickConfigId?: string,
+    @Arg('conditionId', () => String, { nullable: true })
+    conditionId?: string
   ): Promise<ActivityItemType[]> {
     const cappedTake = Math.max(1, Math.min(take ?? 20, 100));
     const cappedSkip = Math.max(0, Math.min(skip ?? 0, MAX_SKIP));
     const addr = address?.toLowerCase();
+    const pickConfigIdLower = pickConfigId?.toLowerCase();
+    const conditionIdLower = conditionId?.toLowerCase();
 
     const includePredictions = !type || type === 'prediction';
     const includeTrades = !type || type === 'trade';
@@ -102,10 +108,92 @@ export class ActivityResolver {
     // for any interleaving of the two timestamp-sorted streams.
     const fetchSize = cappedSkip + cappedTake;
 
-    const predictionWhere = addr
+    // Resolve the set of pick configurations in scope. Predictions filter on
+    // pickConfigId; trades filter on the corresponding token set (trades carry
+    // no pickConfigId FK — the linkage is via the token address).
+    //
+    // - pickConfigId alone → single-element set
+    // - conditionId alone → every pickConfig whose picks reference the condition
+    // - both → intersection
+    let scopedPickConfigIds: string[] | null = null; // null = no scoping
+    if (conditionIdLower) {
+      const matchingPicks = await prisma.pick.findMany({
+        where: {
+          conditionId: { equals: conditionIdLower, mode: 'insensitive' },
+        },
+        select: { pickConfigId: true },
+        distinct: ['pickConfigId'],
+      });
+      scopedPickConfigIds = matchingPicks.map((p) => p.pickConfigId);
+      if (pickConfigIdLower) {
+        scopedPickConfigIds = scopedPickConfigIds.filter(
+          (id) => id === pickConfigIdLower
+        );
+      }
+    } else if (pickConfigIdLower) {
+      scopedPickConfigIds = [pickConfigIdLower];
+    }
+
+    // Nothing can match — short-circuit before any further queries.
+    if (scopedPickConfigIds !== null && scopedPickConfigIds.length === 0) {
+      return [];
+    }
+
+    // Load tokens for every in-scope pick configuration (for trade filtering).
+    const scopedTokens: string[] = [];
+    if (scopedPickConfigIds !== null) {
+      const configs = await prisma.picks.findMany({
+        where: { id: { in: scopedPickConfigIds } },
+        select: { predictorToken: true, counterpartyToken: true },
+      });
+      const seen = new Set<string>();
+      for (const c of configs) {
+        for (const raw of [c.predictorToken, c.counterpartyToken]) {
+          if (!raw) continue;
+          const t = raw.toLowerCase();
+          if (!seen.has(t)) {
+            seen.add(t);
+            scopedTokens.push(t);
+          }
+        }
+      }
+    }
+
+    const addressPredictionClause = addr
       ? { OR: [{ predictor: addr }, { counterparty: addr }] }
-      : {};
-    const tradeWhere = addr ? { OR: [{ seller: addr }, { buyer: addr }] } : {};
+      : null;
+    const addressTradeClause = addr
+      ? { OR: [{ seller: addr }, { buyer: addr }] }
+      : null;
+
+    // A single pickConfigId scope can be expressed as a flat equality to keep
+    // the query plan simple; any broader scope uses `IN`.
+    const pickConfigIdClause =
+      scopedPickConfigIds !== null
+        ? scopedPickConfigIds.length === 1
+          ? { pickConfigId: scopedPickConfigIds[0] }
+          : { pickConfigId: { in: scopedPickConfigIds } }
+        : null;
+
+    const tokenClause =
+      scopedPickConfigIds !== null ? { token: { in: scopedTokens } } : null;
+
+    const predictionWhere = pickConfigIdClause
+      ? addressPredictionClause
+        ? { AND: [addressPredictionClause, pickConfigIdClause] }
+        : pickConfigIdClause
+      : (addressPredictionClause ?? {});
+
+    const tradeWhere = tokenClause
+      ? addressTradeClause
+        ? { AND: [addressTradeClause, tokenClause] }
+        : tokenClause
+      : (addressTradeClause ?? {});
+
+    // If the scope has no matching tokens, trades cannot match — skip the query.
+    const shouldFetchTrades =
+      includeTrades &&
+      (scopedPickConfigIds === null || scopedTokens.length > 0);
 
     const [predictions, trades] = await Promise.all([
       includePredictions
@@ -116,7 +204,7 @@ export class ActivityResolver {
             include: { pickConfiguration: { include: { picks: true } } },
           })
         : Promise.resolve([]),
-      includeTrades
+      shouldFetchTrades
         ? prisma.secondaryTrade.findMany({
             where: tradeWhere,
             orderBy: { executedAt: 'desc' },

--- a/packages/api/src/graphql/resolvers/ActivityResolver.ts
+++ b/packages/api/src/graphql/resolvers/ActivityResolver.ts
@@ -118,9 +118,7 @@ export class ActivityResolver {
     let scopedPickConfigIds: string[] | null = null; // null = no scoping
     if (conditionIdLower) {
       const matchingPicks = await prisma.pick.findMany({
-        where: {
-          conditionId: { equals: conditionIdLower, mode: 'insensitive' },
-        },
+        where: { conditionId: conditionIdLower },
         select: { pickConfigId: true },
         distinct: ['pickConfigId'],
       });

--- a/packages/api/src/graphql/resolvers/__tests__/ActivityResolver.test.ts
+++ b/packages/api/src/graphql/resolvers/__tests__/ActivityResolver.test.ts
@@ -421,11 +421,7 @@ describe('ActivityResolver', () => {
     // conditionId → distinct pickConfigIds lookup
     expect(mockPrisma.pick.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({
-          conditionId: expect.objectContaining({
-            equals: '0xcondition-abc',
-          }),
-        }),
+        where: { conditionId: '0xcondition-abc' },
         select: { pickConfigId: true },
         distinct: ['pickConfigId'],
       })

--- a/packages/api/src/graphql/resolvers/__tests__/ActivityResolver.test.ts
+++ b/packages/api/src/graphql/resolvers/__tests__/ActivityResolver.test.ts
@@ -10,6 +10,10 @@ const mockPrisma = vi.hoisted(() => ({
   },
   picks: {
     findMany: vi.fn(),
+    findUnique: vi.fn(),
+  },
+  pick: {
+    findMany: vi.fn(),
   },
 }));
 
@@ -109,6 +113,8 @@ describe('ActivityResolver', () => {
     vi.clearAllMocks();
     resolver = new ActivityResolver();
     mockPrisma.picks.findMany.mockResolvedValue([]);
+    mockPrisma.picks.findUnique.mockResolvedValue(null);
+    mockPrisma.pick.findMany.mockResolvedValue([]);
   });
 
   it('merges predictions and trades sorted by timestamp descending', async () => {
@@ -277,6 +283,230 @@ describe('ActivityResolver', () => {
     const result = await resolver.accountActivity('0xalice', 20, 0);
 
     expect(result).toEqual([]);
+  });
+
+  it('lowercases pickConfigId before querying', async () => {
+    mockPrisma.prediction.findMany.mockResolvedValue([]);
+    mockPrisma.secondaryTrade.findMany.mockResolvedValue([]);
+    mockPrisma.picks.findMany.mockResolvedValue([
+      {
+        id: '0xpc-mixedcase',
+        predictorToken: '0xtoken-pred',
+        counterpartyToken: '0xtoken-cp',
+      },
+    ]);
+
+    await resolver.accountActivity(
+      '0xalice',
+      20,
+      0,
+      undefined,
+      '0xPC-MixedCase'
+    );
+
+    expect(mockPrisma.picks.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: { in: ['0xpc-mixedcase'] } },
+      })
+    );
+    expect(mockPrisma.prediction.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          AND: expect.arrayContaining([
+            expect.objectContaining({ pickConfigId: '0xpc-mixedcase' }),
+          ]),
+        }),
+      })
+    );
+  });
+
+  it('filters predictions by pickConfigId when provided', async () => {
+    mockPrisma.prediction.findMany.mockResolvedValue([]);
+    mockPrisma.secondaryTrade.findMany.mockResolvedValue([]);
+    mockPrisma.picks.findMany.mockResolvedValue([
+      {
+        id: 'pc-1',
+        predictorToken: '0xtoken-pred',
+        counterpartyToken: '0xtoken-cp',
+      },
+    ]);
+
+    await resolver.accountActivity('0xalice', 20, 0, undefined, 'pc-1');
+
+    expect(mockPrisma.prediction.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          AND: [
+            { OR: [{ predictor: '0xalice' }, { counterparty: '0xalice' }] },
+            { pickConfigId: 'pc-1' },
+          ],
+        }),
+      })
+    );
+  });
+
+  it('filters trades by the pickConfig tokens when pickConfigId is provided', async () => {
+    mockPrisma.prediction.findMany.mockResolvedValue([]);
+    mockPrisma.secondaryTrade.findMany.mockResolvedValue([]);
+    mockPrisma.picks.findMany.mockResolvedValue([
+      {
+        id: 'pc-1',
+        predictorToken: '0xTOKEN-PRED',
+        counterpartyToken: '0xTOKEN-CP',
+      },
+    ]);
+
+    await resolver.accountActivity('0xalice', 20, 0, undefined, 'pc-1');
+
+    expect(mockPrisma.secondaryTrade.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          AND: [
+            { OR: [{ seller: '0xalice' }, { buyer: '0xalice' }] },
+            { token: { in: ['0xtoken-pred', '0xtoken-cp'] } },
+          ],
+        }),
+      })
+    );
+  });
+
+  it('returns no trades when pickConfigId does not resolve to any pick configuration', async () => {
+    mockPrisma.prediction.findMany.mockResolvedValue([]);
+    mockPrisma.secondaryTrade.findMany.mockResolvedValue([]);
+    // No rows come back for this id → no tokens → trades short-circuited
+    mockPrisma.picks.findMany.mockResolvedValue([]);
+
+    const result = await resolver.accountActivity(
+      '0xalice',
+      20,
+      0,
+      undefined,
+      'pc-missing'
+    );
+
+    expect(result).toEqual([]);
+    expect(mockPrisma.secondaryTrade.findMany).not.toHaveBeenCalled();
+  });
+
+  it('filters predictions and trades by conditionId via matched pickConfigs', async () => {
+    mockPrisma.prediction.findMany.mockResolvedValue([]);
+    mockPrisma.secondaryTrade.findMany.mockResolvedValue([]);
+    // Two pick configs contain the condition
+    mockPrisma.pick.findMany.mockResolvedValue([
+      { pickConfigId: 'pc-a' },
+      { pickConfigId: 'pc-b' },
+    ]);
+    mockPrisma.picks.findMany.mockResolvedValue([
+      {
+        id: 'pc-a',
+        predictorToken: '0xa-pred',
+        counterpartyToken: '0xa-cp',
+      },
+      {
+        id: 'pc-b',
+        predictorToken: '0xb-pred',
+        counterpartyToken: null,
+      },
+    ]);
+
+    await resolver.accountActivity(
+      undefined,
+      20,
+      0,
+      undefined,
+      undefined,
+      '0xCONDITION-Abc'
+    );
+
+    // conditionId → distinct pickConfigIds lookup
+    expect(mockPrisma.pick.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          conditionId: expect.objectContaining({
+            equals: '0xcondition-abc',
+          }),
+        }),
+        select: { pickConfigId: true },
+        distinct: ['pickConfigId'],
+      })
+    );
+
+    // Predictions filtered by pickConfigId IN
+    expect(mockPrisma.prediction.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          pickConfigId: { in: ['pc-a', 'pc-b'] },
+        }),
+      })
+    );
+
+    // Trades filtered by the derived tokens (deduped, lowercased, nulls dropped)
+    expect(mockPrisma.secondaryTrade.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          token: { in: ['0xa-pred', '0xa-cp', '0xb-pred'] },
+        }),
+      })
+    );
+  });
+
+  it('short-circuits when conditionId matches no pickConfigs', async () => {
+    mockPrisma.prediction.findMany.mockResolvedValue([]);
+    mockPrisma.secondaryTrade.findMany.mockResolvedValue([]);
+    mockPrisma.pick.findMany.mockResolvedValue([]);
+
+    const result = await resolver.accountActivity(
+      undefined,
+      20,
+      0,
+      undefined,
+      undefined,
+      '0xnoop'
+    );
+
+    expect(result).toEqual([]);
+    expect(mockPrisma.prediction.findMany).not.toHaveBeenCalled();
+    expect(mockPrisma.secondaryTrade.findMany).not.toHaveBeenCalled();
+  });
+
+  it('combines account and conditionId filters', async () => {
+    mockPrisma.prediction.findMany.mockResolvedValue([]);
+    mockPrisma.secondaryTrade.findMany.mockResolvedValue([]);
+    mockPrisma.pick.findMany.mockResolvedValue([{ pickConfigId: 'pc-x' }]);
+    mockPrisma.picks.findMany.mockResolvedValue([
+      { id: 'pc-x', predictorToken: '0xtok-p', counterpartyToken: '0xtok-c' },
+    ]);
+
+    await resolver.accountActivity(
+      '0xAlice',
+      20,
+      0,
+      undefined,
+      undefined,
+      '0xcond'
+    );
+
+    // Single-element scope collapses to a flat equality (not `{ in: [...] }`).
+    expect(mockPrisma.prediction.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          AND: [
+            { OR: [{ predictor: '0xalice' }, { counterparty: '0xalice' }] },
+            { pickConfigId: 'pc-x' },
+          ],
+        }),
+      })
+    );
+    expect(mockPrisma.secondaryTrade.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          AND: [
+            { OR: [{ seller: '0xalice' }, { buyer: '0xalice' }] },
+            { token: { in: ['0xtok-p', '0xtok-c'] } },
+          ],
+        }),
+      })
+    );
   });
 
   it('returns global activity when address is omitted', async () => {

--- a/packages/app/src/components/positions/ActivityTable.tsx
+++ b/packages/app/src/components/positions/ActivityTable.tsx
@@ -22,15 +22,12 @@ import CounterpartyBadge from '~/components/shared/CounterpartyBadge';
 import EnsAvatar from '~/components/shared/EnsAvatar';
 import { AddressDisplay } from '~/components/shared/AddressDisplay';
 import {
-  usePredictionsByConditionId,
-  usePositionBalances,
   type Prediction,
   type PickConfigData,
 } from '~/hooks/graphql/usePositions';
 import { useConditionsByIds } from '~/hooks/graphql/useConditionsByIds';
 import {
   useAccountActivity,
-  type ActivityItem,
   type PredictionActivity,
   type TradeActivity,
 } from '~/hooks/graphql/useAccountActivity';
@@ -592,8 +589,9 @@ export default function ActivityTable({
    */
   hiddenColumns?: ReadonlyArray<ActivityColumn>;
   /**
-   * Client-side filter limiting items to those on a specific pick
-   * configuration. Applied after the normal account/condition fetch.
+   * Scope the feed to a single pick configuration. Forwarded to the server
+   * query so the result contains every matching item, not just those present
+   * in the first page of the unscoped feed.
    */
   filterPickConfigId?: string;
   /** Hide the filter toolbar (search/status/value-range/date-range). */
@@ -609,11 +607,14 @@ export default function ActivityTable({
     getDefaultActivityFilterState
   );
 
-  // ── Unified activity (account + recent modes) ───────────────────────────
-  const isConditionMode = !account && !!conditionId;
+  // ── Unified activity feed ────────────────────────────────────────────────
+  // One server query handles account, condition, pickConfig, and global scopes.
+  // The resolver combines predictions and secondary trades, so condition-scoped
+  // views include both types and we no longer fetch per-holder positions just
+  // to attach pickConfigs client-side.
   const {
-    items: activityItems,
-    isLoading: activityLoading,
+    items,
+    isLoading,
     isFetchingMore: activityFetchingMore,
     hasMore: activityHasMore,
     fetchMore: activityFetchMore,
@@ -621,67 +622,11 @@ export default function ActivityTable({
     account,
     pageSize: effectivePageSize,
     activityType: filters.activityType,
-    enabled: !isConditionMode,
+    pickConfigId: filterPickConfigId,
+    conditionId: !account ? conditionId : undefined,
   });
 
-  // ── Condition-only mode (no account) ─────────────────────────────────────
-  const [condTake, setCondTake] = useState(effectivePageSize);
-
-  const { data: conditionPredictions, isLoading: conditionLoading } =
-    usePredictionsByConditionId({
-      conditionId: !account ? conditionId : undefined,
-      take: condTake,
-      skip: 0,
-    });
-
-  // Positions for non-account enrichment
-  const { data: positions } = usePositionBalances({
-    holder: account,
-  });
-
-  // Decide which mode we're in
   const isAccountMode = !!account;
-
-  const isLoading = isConditionMode ? conditionLoading : activityLoading;
-
-  // For condition mode, build items from predictions only
-  const tokenMap = React.useMemo(() => {
-    const map = new Map<
-      string,
-      { pickConfig: PickConfigData; isPredictorToken: boolean }
-    >();
-    for (const pos of positions) {
-      if (pos.pickConfig) {
-        map.set(pos.tokenAddress.toLowerCase(), {
-          pickConfig: pos.pickConfig,
-          isPredictorToken: pos.isPredictorToken,
-        });
-      }
-    }
-    return map;
-  }, [positions]);
-
-  const conditionItems: ActivityItem[] = React.useMemo(() => {
-    return conditionPredictions.map((pred) => {
-      const byPredictor = tokenMap.get(pred.predictorToken.toLowerCase());
-      const byCounterparty = tokenMap.get(pred.counterpartyToken.toLowerCase());
-      const match = byPredictor ?? byCounterparty;
-      const timestamp = pred.collateralDepositedAt
-        ? pred.collateralDepositedAt * 1000
-        : new Date(pred.createdAt).getTime();
-      return {
-        type: 'prediction' as const,
-        timestamp,
-        prediction: pred,
-        pickConfig: pred.pickConfig ?? match?.pickConfig ?? null,
-        isPredictorSide: account
-          ? pred.predictor.toLowerCase() === account.toLowerCase()
-          : true,
-      };
-    });
-  }, [conditionPredictions, tokenMap, account]);
-
-  const items = isConditionMode ? conditionItems : activityItems;
 
   // ── Condition enrichment for all prediction items ────────────────────────
   const conditionIds = React.useMemo(() => {
@@ -700,16 +645,7 @@ export default function ActivityTable({
   const filteredItems = React.useMemo(() => {
     let result = items;
 
-    // Scope to a specific pick configuration when requested (used by the
-    // PositionDialog embed so the table mirrors that aggregated position).
-    if (filterPickConfigId) {
-      const pcId = filterPickConfigId.toLowerCase();
-      result = result.filter(
-        (item) => (item.pickConfig?.id ?? '').toLowerCase() === pcId
-      );
-    }
-
-    // Activity type filtering is handled server-side via the hook
+    // pickConfigId scoping and activity type filtering are handled server-side
 
     // Filter by search term
     if (filters.searchTerm.trim()) {
@@ -772,7 +708,7 @@ export default function ActivityTable({
     }
 
     return result;
-  }, [items, filters, conditionsMap, filterPickConfigId]);
+  }, [items, filters, conditionsMap]);
 
   // ── Share / detail dialog state ──────────────────────────────────────────
   const [sharePrediction, setSharePrediction] = useState<{
@@ -788,21 +724,11 @@ export default function ActivityTable({
   } | null>(null);
 
   // ── Infinite scroll ──────────────────────────────────────────────────────
-  const hasMore = isConditionMode
-    ? conditionPredictions.length >= condTake
-    : activityHasMore;
-
   const { loadMoreRef } = useInfiniteScroll({
-    hasMore,
+    hasMore: activityHasMore,
     isLoading,
-    isFetchingMore: isConditionMode ? false : activityFetchingMore,
-    onFetchMore: () => {
-      if (isConditionMode) {
-        setCondTake((t) => t + effectivePageSize);
-      } else {
-        activityFetchMore();
-      }
-    },
+    isFetchingMore: activityFetchingMore,
+    onFetchMore: activityFetchMore,
   });
 
   // ── Render ───────────────────────────────────────────────────────────────
@@ -815,7 +741,7 @@ export default function ActivityTable({
             <ActivityTableFilters
               filters={filters}
               onFiltersChange={setFilters}
-              showTypeFilter={!isConditionMode}
+              showTypeFilter
             />
           </div>
         )}

--- a/packages/app/src/hooks/graphql/useAccountActivity.ts
+++ b/packages/app/src/hooks/graphql/useAccountActivity.ts
@@ -31,8 +31,17 @@ const ACCOUNT_ACTIVITY_QUERY = /* GraphQL */ `
     $take: Int
     $skip: Int
     $type: String
+    $pickConfigId: String
+    $conditionId: String
   ) {
-    accountActivity(address: $address, take: $take, skip: $skip, type: $type) {
+    accountActivity(
+      address: $address
+      take: $take
+      skip: $skip
+      type: $type
+      pickConfigId: $pickConfigId
+      conditionId: $conditionId
+    ) {
       type
       timestamp
       prediction {
@@ -137,16 +146,32 @@ export function useAccountActivity({
   account,
   pageSize = DEFAULT_PAGE_SIZE,
   activityType,
+  pickConfigId,
+  conditionId,
   enabled: enabledOverride,
 }: {
   account?: Address;
   pageSize?: number;
   activityType?: string;
-  /** Override enabled state. Defaults to true when account is provided. */
+  /**
+   * Scope the feed to a single pick configuration. Filters predictions by
+   * pickConfigId and trades by the pickConfig's predictor/counterparty tokens.
+   */
+  pickConfigId?: string;
+  /**
+   * Scope the feed to a condition. Matches every pick configuration whose
+   * picks reference this conditionId.
+   */
+  conditionId?: string;
+  /**
+   * Override enabled state. Defaults to true when account, pickConfigId, or
+   * conditionId is provided; otherwise returns the global feed.
+   */
   enabled?: boolean;
 }) {
   const [take, setTake] = useState(pageSize);
-  const enabled = enabledOverride ?? Boolean(account);
+  const enabled =
+    enabledOverride ?? Boolean(account || pickConfigId || conditionId);
 
   const typeFilter =
     activityType && activityType !== 'all' ? activityType : undefined;
@@ -156,7 +181,14 @@ export function useAccountActivity({
     isLoading: initialLoading,
     isFetching,
   } = useQuery({
-    queryKey: ['accountActivity', account ?? 'global', take, typeFilter],
+    queryKey: [
+      'accountActivity',
+      account ?? 'global',
+      take,
+      typeFilter,
+      pickConfigId ?? null,
+      conditionId ?? null,
+    ],
     enabled,
     staleTime: 30_000,
     gcTime: 5 * 60 * 1000,
@@ -172,6 +204,8 @@ export function useAccountActivity({
         take,
         skip: 0,
         type: typeFilter ?? null,
+        pickConfigId: pickConfigId ?? null,
+        conditionId: conditionId ?? null,
       });
       return resp ?? { accountActivity: [] };
     },

--- a/packages/sdk/types/graphql.ts
+++ b/packages/sdk/types/graphql.ts
@@ -1642,6 +1642,8 @@ export type QueryAccountAccuracyRankArgs = {
 
 export type QueryAccountActivityArgs = {
   address?: InputMaybe<Scalars['String']['input']>;
+  conditionId?: InputMaybe<Scalars['String']['input']>;
+  pickConfigId?: InputMaybe<Scalars['String']['input']>;
   skip?: Scalars['Int']['input'];
   take?: Scalars['Int']['input'];
   type?: InputMaybe<Scalars['String']['input']>;


### PR DESCRIPTION
## Summary
- Position dialog's *Related Activity* was filtering a 20-item account feed client-side, so it often showed nothing even when relevant activity existed. Condition pages (`QuestionPageContent`) also never showed secondary trades.
- Move both scopes into the `accountActivity` resolver: new optional `pickConfigId` and `conditionId` args filter predictions on the FK / Pick relation and filter trades on the pickConfig's predictor/counterparty token set.
- Collapse the parallel `usePredictionsByConditionId` + `usePositionBalances` branch inside `ActivityTable` — one `useAccountActivity` hook now serves profile, condition, global, and dialog-scoped modes.

## Test plan
- [x] `pnpm --filter @sapience/api run test` — 460/460 pass (7 new `ActivityResolver` tests)
- [x] `pnpm --filter @sapience/app run test` — 508/508 pass
- [x] `pnpm --filter @sapience/api run lint`, `pnpm --filter @sapience/app run lint`
- [x] `pnpm --filter @sapience/app run type-check`
- [ ] After deploy: open a profile with positions, confirm *Related Activity* fills in for any picked position (not just the ones with recent top-20 activity)
- [ ] After deploy: open a question page with secondary-market trades, confirm both predictions and trades appear in the Predictions tab's feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)