### PR TITLE
fix(market-keeper): submit groupMetadataUpdates from add-events script

### DIFF
--- a/packages/market-keeper/scripts/add-events.ts
+++ b/packages/market-keeper/scripts/add-events.ts
@@ -22,7 +22,12 @@ import type { PolymarketMarket } from '../src/types';
 import { DEFAULT_SAPIENCE_API_URL } from '../src/constants';
 import { fetchWithRetry, validatePrivateKey } from '../src/utils';
 import { groupMarkets } from '../src/generate/grouping';
-import { printDryRun, submitToAPI, submitMetadataUpdates } from '../src/generate/api';
+import {
+  printDryRun,
+  submitToAPI,
+  submitMetadataUpdates,
+  submitGroupMetadataUpdates,
+} from '../src/generate/api';
 
 async function fetchEventBySlug(slug: string): Promise<PolymarketMarket[]> {
   const url = `https://gamma-api.polymarket.com/events?slug=${encodeURIComponent(slug)}`;
@@ -128,6 +133,14 @@ async function main() {
 
   if (sapienceData.metadataUpdates.length > 0) {
     await submitMetadataUpdates(apiUrl, privateKey, sapienceData.metadataUpdates);
+  }
+
+  if (sapienceData.groupMetadataUpdates.length > 0) {
+    await submitGroupMetadataUpdates(
+      apiUrl,
+      privateKey,
+      sapienceData.groupMetadataUpdates
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

Addresses the blocker from the `nostradamus-agent` review on #1595:

> `packages/market-keeper/scripts/add-events.ts` runs the same grouping pipeline as `generate`, but it only submits `metadataUpdates` and never submits `groupMetadataUpdates`. That means manual event backfills can leave existing condition-group metadata stale even though the normal generate path updates it.

The `add-events` one-off backfill now mirrors `generate/index.ts`: after `submitMetadataUpdates`, it also calls `submitGroupMetadataUpdates` (already exported from `generate/api.ts`) when `sapienceData.groupMetadataUpdates` is non-empty.

## Test plan

- [x] `pnpm --filter @sapience/market-keeper exec tsc --noEmit` — clean
- [x] `pnpm --filter @sapience/market-keeper exec eslint scripts/add-events.ts --quiet` — clean
- [x] `pnpm --filter @sapience/market-keeper exec vitest run src/__tests__/metadata-updates.test.ts` — 26/26 passed

Targets `staging` so it folds into PR #1595 on the next `Staging → main` promotion. Non-blocking prod-confirmation suggestion from the same review is left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)