### PR TITLE
fix(app): run global activity feed query on /feed

### DIFF
--- a/packages/app/src/hooks/graphql/__tests__/useAccountActivity.test.ts
+++ b/packages/app/src/hooks/graphql/__tests__/useAccountActivity.test.ts
@@ -1,0 +1,133 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+const mockGraphqlRequest = vi.fn();
+
+vi.mock('@sapience/sdk/queries/client/graphqlClient', () => ({
+  graphqlRequest: (...args: unknown[]) => mockGraphqlRequest(...args),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+    },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children
+    );
+  };
+}
+
+async function getHook() {
+  const mod = await import('../useAccountActivity');
+  return mod.useAccountActivity;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGraphqlRequest.mockResolvedValue({ accountActivity: [] });
+});
+
+describe('useAccountActivity', () => {
+  it('runs the query for the global feed (no account/pickConfigId/conditionId)', async () => {
+    const useAccountActivity = await getHook();
+
+    renderHook(() => useAccountActivity({}), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
+    });
+
+    const [, variables] = mockGraphqlRequest.mock.calls[0];
+    expect(variables).toMatchObject({
+      address: null,
+      pickConfigId: null,
+      conditionId: null,
+      take: 20,
+      skip: 0,
+    });
+  });
+
+  it('returns mapped prediction items from the global feed', async () => {
+    const useAccountActivity = await getHook();
+
+    mockGraphqlRequest.mockResolvedValue({
+      accountActivity: [
+        {
+          type: 'prediction',
+          timestamp: 1700000000,
+          prediction: {
+            id: 'p1',
+            predictionId: '1',
+            predictor: '0xaaa',
+            counterparty: '0xbbb',
+            predictorCollateral: '0',
+            counterpartyCollateral: '0',
+            settled: false,
+            pickConfig: null,
+          },
+          trade: null,
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useAccountActivity({}), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.items.length).toBe(1);
+    });
+
+    expect(result.current.items[0].type).toBe('prediction');
+    expect(result.current.items[0].timestamp).toBe(1700000000 * 1000);
+  });
+
+  it('respects enabled=false override', async () => {
+    const useAccountActivity = await getHook();
+
+    renderHook(() => useAccountActivity({ enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    // Give react-query a tick to potentially schedule a fetch, then assert
+    // it did not run.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(mockGraphqlRequest).not.toHaveBeenCalled();
+  });
+
+  it('passes account + pickConfigId + conditionId through to the query', async () => {
+    const useAccountActivity = await getHook();
+
+    renderHook(
+      () =>
+        useAccountActivity({
+          account: '0xABCDEF0000000000000000000000000000000001',
+          pickConfigId: 'pc1',
+          conditionId: 'c1',
+          activityType: 'trade',
+        }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
+    });
+
+    const [, variables] = mockGraphqlRequest.mock.calls[0];
+    expect(variables).toMatchObject({
+      address: '0xABCDEF0000000000000000000000000000000001',
+      pickConfigId: 'pc1',
+      conditionId: 'c1',
+      type: 'trade',
+    });
+  });
+});

--- a/packages/app/src/hooks/graphql/useAccountActivity.ts
+++ b/packages/app/src/hooks/graphql/useAccountActivity.ts
@@ -164,14 +164,13 @@ export function useAccountActivity({
    */
   conditionId?: string;
   /**
-   * Override enabled state. Defaults to true when account, pickConfigId, or
-   * conditionId is provided; otherwise returns the global feed.
+   * Override enabled state. Defaults to true — the unscoped feed returns
+   * recent global activity. Pass false to skip the query entirely.
    */
   enabled?: boolean;
 }) {
   const [take, setTake] = useState(pageSize);
-  const enabled =
-    enabledOverride ?? Boolean(account || pickConfigId || conditionId);
+  const enabled = enabledOverride ?? true;
 
   const typeFilter =
     activityType && activityType !== 'all' ? activityType : undefined;


### PR DESCRIPTION
## Summary

- `/feed` was returning "No activity found" even though the API's `accountActivity` resolver explicitly supports an unscoped global feed.
- The regression came from #1592, which added an `enabled` gate requiring `account`, `pickConfigId`, or `conditionId` to be set before running the query.
- Default `enabled` to `true` and keep the override as an explicit opt-out. Profile activity tab and dialog-scoped Related Activity continue to work (they pass their own scoping args); the global feed now runs too.
- Added tests covering: the global-feed path runs, items map correctly, `enabled=false` is respected, and scoping variables pass through to the query.

## Test plan
- [ ] `/feed` returns activity and the filters work
- [ ] `/profile/<addr>#activity` still shows that account's activity
- [ ] Position dialog "Related Activity" table still scopes to the pickConfig
- [ ] Condition page activity tab still scopes to the condition
- [x] `pnpm --filter @sapience/app run test` passes (512/512)
- [x] `pnpm --filter @sapience/app run type-check` clean
- [x] `pnpm --filter @sapience/app run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)