### PR TITLE
ui(app): side-agnostic PredictionDialog + polish

### DIFF
--- a/packages/app/src/components/markets/pages/QuestionPageContent.tsx
+++ b/packages/app/src/components/markets/pages/QuestionPageContent.tsx
@@ -414,16 +414,14 @@ export default function QuestionPageContent({
     return (TAB_VALUES as string[]).includes(raw) ? (raw as PrimaryTab) : null;
   };
 
-  // Keep primary tab controlled so we can default to Positions when available
-  const [primaryTab, setPrimaryTab] = React.useState<PrimaryTab>('forecasts');
-  const hashOverrideRef = React.useRef(false);
+  // Activity is the default landing tab; empty-state falls through naturally.
+  const [primaryTab, setPrimaryTab] = React.useState<PrimaryTab>('predictions');
 
   // Read hash on mount
   React.useEffect(() => {
     const fromHash = getTabFromHash();
     if (fromHash) {
       setPrimaryTab(fromHash);
-      hashOverrideRef.current = true;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -451,27 +449,13 @@ export default function QuestionPageContent({
     }
   };
 
+  // Positions tab is hidden until the condition has predictions; if routed
+  // there without any, fall back to Activity (the default).
   const primaryTabValue = useMemo(() => {
-    if (
-      !hasPositions &&
-      (primaryTab === 'predictions' || primaryTab === 'positions')
-    ) {
-      return 'forecasts';
+    if (!hasPositions && primaryTab === 'positions') {
+      return 'predictions';
     }
     return primaryTab;
-  }, [hasPositions, primaryTab]);
-
-  // Default to Positions once when they first become available; thereafter respect user choice
-  const hasEverHadPositionsRef = React.useRef(hasPositions);
-  React.useEffect(() => {
-    if (hasPositions) {
-      if (!hasEverHadPositionsRef.current && !hashOverrideRef.current) {
-        setPrimaryTab('predictions');
-      }
-      hasEverHadPositionsRef.current = true;
-    } else if (primaryTab === 'predictions') {
-      setPrimaryTab('forecasts');
-    }
   }, [hasPositions, primaryTab]);
 
   // Calculate X axis domain and ticks based on all chart data
@@ -628,23 +612,21 @@ export default function QuestionPageContent({
         {/* Header with all tabs */}
         <div className="flex items-center gap-4 px-2 py-2.5 border-b border-border/60 bg-muted/10 overflow-x-auto">
           <TabsList className="h-auto p-0 bg-transparent gap-2 flex-nowrap">
+            <TabsTrigger
+              value="predictions"
+              className="px-3 py-1.5 text-sm rounded-md bg-brand-white/[0.08] data-[state=active]:bg-brand-white/15 data-[state=active]:text-brand-white text-muted-foreground hover:text-brand-white/80 hover:bg-brand-white/[0.12] transition-colors inline-flex items-center gap-1.5 whitespace-nowrap"
+            >
+              <Activity className="h-3.5 w-3.5" />
+              Activity
+            </TabsTrigger>
             {hasPositions && (
-              <>
-                <TabsTrigger
-                  value="predictions"
-                  className="px-3 py-1.5 text-sm rounded-md bg-brand-white/[0.08] data-[state=active]:bg-brand-white/15 data-[state=active]:text-brand-white text-muted-foreground hover:text-brand-white/80 hover:bg-brand-white/[0.12] transition-colors inline-flex items-center gap-1.5 whitespace-nowrap"
-                >
-                  <Activity className="h-3.5 w-3.5" />
-                  Activity
-                </TabsTrigger>
-                <TabsTrigger
-                  value="positions"
-                  className="px-3 py-1.5 text-sm rounded-md bg-brand-white/[0.08] data-[state=active]:bg-brand-white/15 data-[state=active]:text-brand-white text-muted-foreground hover:text-brand-white/80 hover:bg-brand-white/[0.12] transition-colors inline-flex items-center gap-1.5 whitespace-nowrap"
-                >
-                  <ArrowLeftRight className="h-3.5 w-3.5" />
-                  Positions
-                </TabsTrigger>
-              </>
+              <TabsTrigger
+                value="positions"
+                className="px-3 py-1.5 text-sm rounded-md bg-brand-white/[0.08] data-[state=active]:bg-brand-white/15 data-[state=active]:text-brand-white text-muted-foreground hover:text-brand-white/80 hover:bg-brand-white/[0.12] transition-colors inline-flex items-center gap-1.5 whitespace-nowrap"
+              >
+                <ArrowLeftRight className="h-3.5 w-3.5" />
+                Positions
+              </TabsTrigger>
             )}
             <TabsTrigger
               value="forecasts"
@@ -791,23 +773,21 @@ export default function QuestionPageContent({
         {/* Header with integrated tabs */}
         <div className="flex items-center gap-4 px-2 py-2.5 border-b border-border/60 bg-muted/10">
           <TabsList className="h-auto p-0 bg-transparent gap-2">
+            <TabsTrigger
+              value="predictions"
+              className="px-3 py-1.5 text-sm rounded-md bg-brand-white/[0.08] data-[state=active]:bg-brand-white/15 data-[state=active]:text-brand-white text-muted-foreground hover:text-brand-white/80 hover:bg-brand-white/[0.12] transition-colors inline-flex items-center gap-1.5"
+            >
+              <Activity className="h-3.5 w-3.5" />
+              Activity
+            </TabsTrigger>
             {hasPositions && (
-              <>
-                <TabsTrigger
-                  value="predictions"
-                  className="px-3 py-1.5 text-sm rounded-md bg-brand-white/[0.08] data-[state=active]:bg-brand-white/15 data-[state=active]:text-brand-white text-muted-foreground hover:text-brand-white/80 hover:bg-brand-white/[0.12] transition-colors inline-flex items-center gap-1.5"
-                >
-                  <Activity className="h-3.5 w-3.5" />
-                  Activity
-                </TabsTrigger>
-                <TabsTrigger
-                  value="positions"
-                  className="px-3 py-1.5 text-sm rounded-md bg-brand-white/[0.08] data-[state=active]:bg-brand-white/15 data-[state=active]:text-brand-white text-muted-foreground hover:text-brand-white/80 hover:bg-brand-white/[0.12] transition-colors inline-flex items-center gap-1.5"
-                >
-                  <ArrowLeftRight className="h-3.5 w-3.5" />
-                  Positions
-                </TabsTrigger>
-              </>
+              <TabsTrigger
+                value="positions"
+                className="px-3 py-1.5 text-sm rounded-md bg-brand-white/[0.08] data-[state=active]:bg-brand-white/15 data-[state=active]:text-brand-white text-muted-foreground hover:text-brand-white/80 hover:bg-brand-white/[0.12] transition-colors inline-flex items-center gap-1.5"
+              >
+                <ArrowLeftRight className="h-3.5 w-3.5" />
+                Positions
+              </TabsTrigger>
             )}
             <TabsTrigger
               value="forecasts"

--- a/packages/app/src/components/positions/ActivityTable.tsx
+++ b/packages/app/src/components/positions/ActivityTable.tsx
@@ -183,7 +183,7 @@ function PredictionActivityRow({
       {!isHidden('type') && (
         <td className="px-4 py-3 whitespace-nowrap">
           <div className="text-sm">
-            <div className="xl:hidden text-xs text-muted-foreground mb-1">
+            <div className="xl:hidden text-xs text-muted-foreground mb-2">
               Type
             </div>
             <TypeBadge type="prediction" />
@@ -200,7 +200,6 @@ function PredictionActivityRow({
             {pickLegs.length > 0 ? (
               <PicksSummary
                 picks={pickLegs}
-                isCounterparty={!isPredictorSide}
                 predictionId={prediction.predictionId}
                 onClick={onOpenDialog}
               />
@@ -381,7 +380,7 @@ function TradeActivityRow({
       {!isHidden('type') && (
         <td className="px-4 py-3 whitespace-nowrap">
           <div className="text-sm">
-            <div className="xl:hidden text-xs text-muted-foreground mb-1">
+            <div className="xl:hidden text-xs text-muted-foreground mb-2">
               Type
             </div>
             <TypeBadge type="trade" />
@@ -720,7 +719,6 @@ export default function ActivityTable({
   const [dialogPrediction, setDialogPrediction] = useState<{
     prediction: Prediction;
     pickConfig: PickConfigData | null;
-    isPredictorSide: boolean;
   } | null>(null);
 
   // ── Infinite scroll ──────────────────────────────────────────────────────
@@ -836,7 +834,6 @@ export default function ActivityTable({
                     setDialogPrediction({
                       prediction: item.prediction,
                       pickConfig: item.pickConfig,
-                      isPredictorSide: item.isPredictorSide,
                     })
                   }
                   isHidden={isHidden}
@@ -871,7 +868,6 @@ export default function ActivityTable({
         }}
         prediction={dialogPrediction?.prediction ?? null}
         pickConfig={dialogPrediction?.pickConfig ?? null}
-        isPredictorSide={dialogPrediction?.isPredictorSide ?? true}
         conditionsMap={conditionsMap}
         collateralSymbol={collateralSymbol}
       />

--- a/packages/app/src/components/positions/PositionDialog.tsx
+++ b/packages/app/src/components/positions/PositionDialog.tsx
@@ -95,7 +95,6 @@ export default function PositionDialog({
           kind="position"
           positionId={position.id}
           pickCount={rawPicks.length}
-          isCounterpartyPosition={!isPredictorSide}
           createdAt={createdAt}
           endsAtMs={endsAtMs}
           positionSize={positionSize}
@@ -111,7 +110,6 @@ export default function PositionDialog({
         <PicksContent
           picks={picks}
           positionId={String(position.id)}
-          isCounterparty={!isPredictorSide}
           hideHeader
           positionStatus={getPositionStatus()}
         />

--- a/packages/app/src/components/positions/PositionSummary.tsx
+++ b/packages/app/src/components/positions/PositionSummary.tsx
@@ -183,7 +183,8 @@ export default function PositionSummary({
     let value: string;
     let badgeClass: string;
     if (!isSettled) {
-      value = 'PENDING';
+      const isLive = endsAtMs != null && endsAtMs > Date.now();
+      value = isLive ? 'ACTIVE' : 'PENDING';
       badgeClass = 'border-foreground/40 bg-foreground/10 text-foreground';
     } else if (predictorWon) {
       value = 'PREDICTOR';

--- a/packages/app/src/components/positions/PositionSummary.tsx
+++ b/packages/app/src/components/positions/PositionSummary.tsx
@@ -9,7 +9,6 @@ import {
 import { ExternalLink } from 'lucide-react';
 import Link from 'next/link';
 import { formatDistanceToNow } from 'date-fns';
-import CounterpartyBadge from '~/components/shared/CounterpartyBadge';
 import NumberDisplay from '~/components/shared/NumberDisplay';
 import CountdownCell from '~/components/shared/CountdownCell';
 import { AddressDisplay } from '~/components/shared/AddressDisplay';
@@ -18,8 +17,6 @@ import Loader from '~/components/shared/Loader';
 
 export interface PositionSummaryProps {
   positionId: string | number;
-  /** Whether this is a counterparty position (as opposed to predictor position) */
-  isCounterpartyPosition?: boolean;
   createdAt: Date | null;
   endsAtMs: number | null;
   positionSize: number;
@@ -44,7 +41,7 @@ export interface PositionSummaryProps {
   holderAddress?: string | null;
   /**
    * Entity kind the summary represents. Controls the header label: a single
-   * on-chain prediction renders "Prediction #<id>", while an aggregated
+   * on-chain prediction renders "Prediction <0xhash>", while an aggregated
    * holder position across multiple predictions renders "Position".
    */
   kind?: 'prediction' | 'position';
@@ -53,11 +50,21 @@ export interface PositionSummaryProps {
    * kind="position", the header becomes "{n} Pick Position".
    */
   pickCount?: number;
+  /**
+   * When both stakes are provided, the summary switches to a side-agnostic
+   * 3-row layout (Predictor / Counterparty / Ends+Payout) and suppresses
+   * viewer-specific fields like P/L. Omit for the legacy aggregate layout.
+   */
+  predictorStake?: number;
+  counterpartyStake?: number;
+  /** Whether the predictor side won (for winner highlight in symmetric layout). */
+  predictorWon?: boolean;
+  /** Whether the counterparty side won (for winner highlight in symmetric layout). */
+  counterpartyWon?: boolean;
 }
 
 export default function PositionSummary({
   positionId,
-  isCounterpartyPosition,
   createdAt,
   endsAtMs,
   positionSize,
@@ -75,11 +82,18 @@ export default function PositionSummary({
   holderAddress,
   kind = 'prediction',
   pickCount,
+  predictorStake,
+  counterpartyStake,
+  predictorWon,
+  counterpartyWon,
 }: PositionSummaryProps) {
+  const useSymmetricStats =
+    predictorStake !== undefined && counterpartyStake !== undefined;
   const showOwner = isOwnerLoading || !!currentOwner;
   const showHolder = !!holderAddress;
   const showAddressesRow =
-    showOwner || showHolder || predictorAddress || counterpartyAddress;
+    !useSymmetricStats &&
+    (showOwner || showHolder || predictorAddress || counterpartyAddress);
   const addressCellCount =
     (showOwner ? 1 : 0) + (showHolder ? 1 : 0) + (kind === 'position' ? 0 : 2);
   const addressGridCols =
@@ -89,45 +103,223 @@ export default function PositionSummary({
         ? 'sm:grid-cols-2'
         : 'sm:grid-cols-1';
 
+  const renderEndsCell = () => (
+    <div className="flex flex-col gap-1 min-w-0">
+      <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
+        {endsAtMs && endsAtMs > Date.now()
+          ? 'Ends'
+          : kind === 'position'
+            ? 'Ended'
+            : 'Created'}
+      </div>
+      <span className="text-sm md:text-base font-medium tabular-nums text-foreground">
+        {endsAtMs && endsAtMs > Date.now() ? (
+          <CountdownCell endTime={Math.floor(endsAtMs / 1000)} />
+        ) : kind === 'position' ? (
+          endsAtMs ? (
+            <span title={new Date(endsAtMs).toLocaleString()}>
+              {new Date(endsAtMs).toLocaleDateString(undefined, {
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric',
+              })}
+            </span>
+          ) : (
+            '—'
+          )
+        ) : createdAt ? (
+          <span title={createdAt.toLocaleString()}>
+            {createdAt.toLocaleDateString(undefined, {
+              month: 'short',
+              day: 'numeric',
+              year: 'numeric',
+            })}
+          </span>
+        ) : (
+          '—'
+        )}
+      </span>
+    </div>
+  );
+
+  const renderCreatedCell = () => (
+    <div className="flex flex-col gap-1 min-w-0">
+      <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
+        Created
+      </div>
+      <span className="text-sm md:text-base font-medium tabular-nums text-foreground">
+        {createdAt ? (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="cursor-default whitespace-nowrap">
+                  {formatDistanceToNow(createdAt, { addSuffix: false })} ago
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                <span>
+                  {createdAt.toLocaleString(undefined, {
+                    year: 'numeric',
+                    month: 'short',
+                    day: '2-digit',
+                    hour: 'numeric',
+                    minute: '2-digit',
+                    second: '2-digit',
+                    timeZoneName: 'short',
+                  })}
+                </span>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : (
+          '—'
+        )}
+      </span>
+    </div>
+  );
+
+  const renderStatusCell = () => {
+    const label = isSettled ? 'Winner' : 'Status';
+    let value: string;
+    let badgeClass: string;
+    if (!isSettled) {
+      value = 'PENDING';
+      badgeClass = 'border-foreground/40 bg-foreground/10 text-foreground';
+    } else if (predictorWon) {
+      value = 'PREDICTOR';
+      badgeClass = 'border-yes/40 bg-yes/10 text-yes';
+    } else if (counterpartyWon) {
+      value = 'COUNTERPARTY';
+      badgeClass = 'border-yes/40 bg-yes/10 text-yes';
+    } else {
+      value = 'SETTLED';
+      badgeClass =
+        'border-muted-foreground/40 bg-muted-foreground/10 text-muted-foreground';
+    }
+    return (
+      <div className="flex flex-col gap-1.5 min-w-0 items-start">
+        <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
+          {label}
+        </div>
+        <span
+          className={`inline-block px-1.5 py-0.5 text-xs font-medium rounded-md font-mono border ${badgeClass}`}
+        >
+          {value}
+        </span>
+      </div>
+    );
+  };
+
+  const renderPayoutCell = () => (
+    <div className="flex flex-col gap-1 min-w-0">
+      <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
+        Payout
+      </div>
+      <span className="text-sm md:text-base font-medium tabular-nums text-foreground">
+        <NumberDisplay
+          value={(predictorStake ?? 0) + (counterpartyStake ?? 0)}
+          className="tabular-nums"
+        />
+        <span className="ml-1 text-xs font-normal text-muted-foreground">
+          {collateralSymbol}
+        </span>
+      </span>
+    </div>
+  );
+
+  const renderPartyCell = (
+    label: 'Predictor' | 'Counterparty',
+    address: string | null | undefined
+  ) => (
+    <div className="flex flex-col gap-1 min-w-0">
+      <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
+        {label}
+      </div>
+      {address ? (
+        <Link
+          href={`/profile/${address}`}
+          className="inline-flex items-center gap-1.5 text-sm md:text-base font-medium tabular-nums text-foreground hover:text-accent-gold transition-colors min-w-0 max-w-full overflow-hidden"
+        >
+          <EnsAvatar
+            address={address}
+            className="shrink-0 rounded-sm ring-1 ring-border/50"
+            width={16}
+            height={16}
+          />
+          <AddressDisplay address={address} />
+        </Link>
+      ) : (
+        <span className="text-sm md:text-base font-medium tabular-nums text-muted-foreground">
+          —
+        </span>
+      )}
+    </div>
+  );
+
+  const renderStakeCell = (stake: number, sideWon: boolean | undefined) => (
+    <div className="flex flex-col gap-1 min-w-0">
+      <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
+        Position Size
+      </div>
+      <span
+        className={`text-sm md:text-base font-medium tabular-nums ${
+          isSettled && sideWon ? 'text-green-600' : 'text-foreground'
+        }`}
+      >
+        <NumberDisplay value={stake} className="tabular-nums" />
+        <span className="ml-1 text-xs font-normal text-muted-foreground">
+          {collateralSymbol}
+        </span>
+      </span>
+    </div>
+  );
+
   return (
     <div className="space-y-4 pt-2">
       {/* Header row */}
       <div className="flex items-center gap-2 pb-2">
-        {/* Left group: Position ID, external link, counterparty badge */}
+        {/* Left group: Position ID, external link */}
         <div className="flex items-center gap-2">
           <h2 className="eyebrow text-foreground">
-            {kind === 'position'
-              ? typeof pickCount === 'number'
-                ? `${pickCount} Pick Position`
-                : 'Position'
-              : (() => {
-                  const idSuffix =
-                    typeof positionId === 'string' &&
-                    positionId.startsWith('0x') &&
-                    positionId.length > 12
-                      ? `${positionId.slice(0, 6)}...${positionId.slice(-4)}`
-                      : `#${positionId}`;
-                  return `Prediction ${idSuffix}`;
-                })()}
+            {(() => {
+              if (kind === 'position') {
+                return typeof pickCount === 'number'
+                  ? `${pickCount} Pick Position`
+                  : 'Position';
+              }
+              const idStr = String(positionId);
+              if (idStr.startsWith('0x')) {
+                const truncated =
+                  idStr.length > 12
+                    ? `${idStr.slice(0, 6)}...${idStr.slice(-4)}`
+                    : idStr;
+                return (
+                  <>
+                    Prediction <span className="font-mono">{truncated}</span>
+                  </>
+                );
+              }
+              return `Prediction #${idStr}`;
+            })()}
           </h2>
-          {isCounterpartyPosition && <CounterpartyBadge />}
         </div>
-        {/* Status badge + external link */}
-        {isSettled ? (
-          positionWon ? (
-            <span className="px-1.5 py-0.5 text-xs font-medium rounded-md font-mono border border-yes/40 bg-yes/10 text-yes">
-              WON
-            </span>
+        {/* Status badge (legacy mode only — symmetric mode surfaces it in the grid below) */}
+        {!useSymmetricStats &&
+          (isSettled ? (
+            positionWon ? (
+              <span className="px-1.5 py-0.5 text-xs font-medium rounded-md font-mono border border-yes/40 bg-yes/10 text-yes">
+                WON
+              </span>
+            ) : (
+              <span className="px-1.5 py-0.5 text-xs font-medium rounded-md font-mono border border-no/40 bg-no/10 text-no">
+                LOST
+              </span>
+            )
           ) : (
-            <span className="px-1.5 py-0.5 text-xs font-medium rounded-md font-mono border border-no/40 bg-no/10 text-no">
-              LOST
+            <span className="px-1.5 py-0.5 text-xs font-medium rounded-md font-mono border border-foreground/40 bg-foreground/10 text-foreground">
+              ACTIVE
             </span>
-          )
-        ) : (
-          <span className="px-1.5 py-0.5 text-xs font-medium rounded-md font-mono border border-foreground/40 bg-foreground/10 text-foreground">
-            ACTIVE
-          </span>
-        )}
+          ))}
         {positionUrl && (
           <Link
             href={positionUrl}
@@ -139,10 +331,12 @@ export default function PositionSummary({
             <ExternalLink className="h-4 w-4" />
           </Link>
         )}
-        {/* Created time - pushed right. Omitted for aggregate positions since
-            a holder's token balance has no single creation event. */}
+        {/* Created time - pushed right. Symmetric mode renders this inside
+            the grid; legacy mode keeps it in the header. Omitted for
+            aggregate positions since a holder's token balance has no single
+            creation event. */}
         <div className="flex items-center gap-2 ml-auto">
-          {kind !== 'position' && createdAt && (
+          {!useSymmetricStats && kind !== 'position' && createdAt && (
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -170,214 +364,177 @@ export default function PositionSummary({
         </div>
       </div>
 
-      {/* Addresses row */}
-      {showAddressesRow && (
-        <div className={`grid grid-cols-1 gap-4 ${addressGridCols}`}>
-          {/* Holder - shown for aggregate position views */}
-          {showHolder && (
-            <div className="space-y-1">
-              <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
-                Holder
-              </div>
-              <Link
-                href={`/profile/${holderAddress}`}
-                className="inline-flex items-center gap-1.5 text-sm md:text-base font-medium tabular-nums text-foreground hover:text-accent-gold transition-colors"
-              >
-                <EnsAvatar
-                  address={holderAddress}
-                  className="shrink-0 rounded-sm ring-1 ring-border/50"
-                  width={16}
-                  height={16}
-                />
-                <AddressDisplay address={holderAddress} />
-              </Link>
-            </div>
-          )}
+      {useSymmetricStats ? (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-x-4 gap-y-6">
+          {/* Row 1: parties with stakes */}
+          {renderPartyCell('Predictor', predictorAddress)}
+          {renderStakeCell(predictorStake, predictorWon)}
+          {renderPartyCell('Counterparty', counterpartyAddress)}
+          {renderStakeCell(counterpartyStake, counterpartyWon)}
 
-          {/* Current Owner - only shown for NFT-based positions */}
-          {showOwner && (
-            <div className="space-y-1">
-              <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
-                Current Owner
-              </div>
-              {isOwnerLoading ? (
-                <div className="flex items-center h-[24px]">
-                  <Loader className="w-3.5 h-3.5" />
+          {/* Row 2: lifecycle */}
+          {renderCreatedCell()}
+          {renderEndsCell()}
+          {renderStatusCell()}
+          {renderPayoutCell()}
+        </div>
+      ) : (
+        <>
+          {/* Addresses row */}
+          {showAddressesRow && (
+            <div className={`grid grid-cols-1 gap-4 ${addressGridCols}`}>
+              {showHolder && (
+                <div className="space-y-1">
+                  <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
+                    Holder
+                  </div>
+                  <Link
+                    href={`/profile/${holderAddress}`}
+                    className="inline-flex items-center gap-1.5 text-sm md:text-base font-medium tabular-nums text-foreground hover:text-accent-gold transition-colors"
+                  >
+                    <EnsAvatar
+                      address={holderAddress}
+                      className="shrink-0 rounded-sm ring-1 ring-border/50"
+                      width={16}
+                      height={16}
+                    />
+                    <AddressDisplay address={holderAddress} />
+                  </Link>
                 </div>
-              ) : currentOwner ? (
-                <Link
-                  href={`/profile/${currentOwner}`}
-                  className="inline-flex items-center gap-1.5 text-sm md:text-base font-medium tabular-nums text-foreground hover:text-accent-gold transition-colors"
-                >
-                  <EnsAvatar
-                    address={currentOwner}
-                    className="shrink-0 rounded-sm ring-1 ring-border/50"
-                    width={16}
-                    height={16}
-                  />
-                  <AddressDisplay address={currentOwner} />
-                </Link>
-              ) : (
-                <span className="text-sm md:text-base font-medium tabular-nums text-muted-foreground">
-                  —
-                </span>
               )}
+
+              {showOwner && (
+                <div className="space-y-1">
+                  <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
+                    Current Owner
+                  </div>
+                  {isOwnerLoading ? (
+                    <div className="flex items-center h-[24px]">
+                      <Loader className="w-3.5 h-3.5" />
+                    </div>
+                  ) : currentOwner ? (
+                    <Link
+                      href={`/profile/${currentOwner}`}
+                      className="inline-flex items-center gap-1.5 text-sm md:text-base font-medium tabular-nums text-foreground hover:text-accent-gold transition-colors"
+                    >
+                      <EnsAvatar
+                        address={currentOwner}
+                        className="shrink-0 rounded-sm ring-1 ring-border/50"
+                        width={16}
+                        height={16}
+                      />
+                      <AddressDisplay address={currentOwner} />
+                    </Link>
+                  ) : (
+                    <span className="text-sm md:text-base font-medium tabular-nums text-muted-foreground">
+                      —
+                    </span>
+                  )}
+                </div>
+              )}
+
+              {kind !== 'position' &&
+                renderPartyCell('Predictor', predictorAddress)}
+              {kind !== 'position' &&
+                renderPartyCell('Counterparty', counterpartyAddress)}
             </div>
           )}
 
-          {/* Predictor — prediction-level view only */}
-          {kind !== 'position' && (
-            <div className="space-y-1">
+          {/* Legacy stats row */}
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            <div className="flex flex-col gap-1 min-w-0">
               <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
-                Predictor
+                {endsAtMs && endsAtMs > Date.now()
+                  ? 'Ends'
+                  : kind === 'position'
+                    ? 'Ended'
+                    : 'Created'}
               </div>
-              {predictorAddress ? (
-                <Link
-                  href={`/profile/${predictorAddress}`}
-                  className="inline-flex items-center gap-1.5 text-sm md:text-base font-medium tabular-nums text-foreground hover:text-accent-gold transition-colors"
-                >
-                  <EnsAvatar
-                    address={predictorAddress}
-                    className="shrink-0 rounded-sm ring-1 ring-border/50"
-                    width={16}
-                    height={16}
-                  />
-                  <AddressDisplay address={predictorAddress} />
-                </Link>
-              ) : (
-                <span className="text-sm md:text-base font-medium tabular-nums text-muted-foreground">
-                  —
-                </span>
-              )}
+              <span className="text-sm md:text-base font-medium tabular-nums text-foreground">
+                {endsAtMs && endsAtMs > Date.now() ? (
+                  <CountdownCell endTime={Math.floor(endsAtMs / 1000)} />
+                ) : kind === 'position' ? (
+                  endsAtMs ? (
+                    <span title={new Date(endsAtMs).toLocaleString()}>
+                      {new Date(endsAtMs).toLocaleDateString(undefined, {
+                        month: 'short',
+                        day: 'numeric',
+                        year: 'numeric',
+                      })}
+                    </span>
+                  ) : (
+                    '—'
+                  )
+                ) : createdAt ? (
+                  <span title={createdAt.toLocaleString()}>
+                    {createdAt.toLocaleDateString(undefined, {
+                      month: 'short',
+                      day: 'numeric',
+                      year: 'numeric',
+                    })}
+                  </span>
+                ) : (
+                  '—'
+                )}
+              </span>
             </div>
-          )}
 
-          {/* Counterparty — prediction-level view only */}
-          {kind !== 'position' && (
-            <div className="space-y-1">
+            <div className="flex flex-col gap-1 min-w-0">
               <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
-                Counterparty
+                Position Size
               </div>
-              {counterpartyAddress ? (
-                <Link
-                  href={`/profile/${counterpartyAddress}`}
-                  className="inline-flex items-center gap-1.5 text-sm md:text-base font-medium tabular-nums text-foreground hover:text-accent-gold transition-colors"
-                >
-                  <EnsAvatar
-                    address={counterpartyAddress}
-                    className="shrink-0 rounded-sm ring-1 ring-border/50"
-                    width={16}
-                    height={16}
-                  />
-                  <AddressDisplay address={counterpartyAddress} />
-                </Link>
-              ) : (
-                <span className="text-sm md:text-base font-medium tabular-nums text-muted-foreground">
-                  —
+              <span className="text-sm md:text-base font-medium tabular-nums text-foreground">
+                <NumberDisplay value={positionSize} className="tabular-nums" />
+                <span className="ml-1 text-xs font-normal text-muted-foreground">
+                  {collateralSymbol}
                 </span>
-              )}
+              </span>
             </div>
-          )}
-        </div>
-      )}
 
-      {/* Stats row */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-        {/* Ends / Created */}
-        <div className="space-y-1">
-          <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
-            {endsAtMs && endsAtMs > Date.now()
-              ? 'Ends'
-              : kind === 'position'
-                ? 'Ended'
-                : 'Created'}
-          </div>
-          <span className="text-sm md:text-base font-medium tabular-nums text-foreground">
-            {endsAtMs && endsAtMs > Date.now() ? (
-              <CountdownCell endTime={Math.floor(endsAtMs / 1000)} />
-            ) : kind === 'position' ? (
-              endsAtMs ? (
-                <span title={new Date(endsAtMs).toLocaleString()}>
-                  {new Date(endsAtMs).toLocaleDateString(undefined, {
-                    month: 'short',
-                    day: 'numeric',
-                    year: 'numeric',
-                  })}
+            <div className="flex flex-col gap-1 min-w-0">
+              <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
+                Payout
+              </div>
+              <span className="text-sm md:text-base font-medium tabular-nums text-foreground">
+                <NumberDisplay value={payout} className="tabular-nums" />
+                <span className="ml-1 text-xs font-normal text-muted-foreground">
+                  {collateralSymbol}
                 </span>
-              ) : (
-                '—'
-              )
-            ) : createdAt ? (
-              <span title={createdAt.toLocaleString()}>
-                {createdAt.toLocaleDateString(undefined, {
-                  month: 'short',
-                  day: 'numeric',
-                  year: 'numeric',
-                })}
               </span>
-            ) : (
-              '—'
-            )}
-          </span>
-        </div>
+            </div>
 
-        {/* Position Size */}
-        <div className="space-y-1">
-          <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
-            Position Size
-          </div>
-          <span className="text-sm md:text-base font-medium tabular-nums text-foreground">
-            <NumberDisplay value={positionSize} className="tabular-nums" />
-            <span className="ml-1 text-xs font-normal text-muted-foreground">
-              {collateralSymbol}
-            </span>
-          </span>
-        </div>
-
-        {/* Payout */}
-        <div className="space-y-1">
-          <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
-            Payout
-          </div>
-          <span className="text-sm md:text-base font-medium tabular-nums text-foreground">
-            <NumberDisplay value={payout} className="tabular-nums" />
-            <span className="ml-1 text-xs font-normal text-muted-foreground">
-              {collateralSymbol}
-            </span>
-          </span>
-        </div>
-
-        {/* Profit/Loss */}
-        <div className="space-y-1">
-          <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
-            Profit/Loss
-          </div>
-          {pnl !== null ? (
-            <span
-              className={`text-sm md:text-base font-medium tabular-nums items-baseline ${pnl >= 0 ? 'text-green-600' : 'text-red-600'}`}
-            >
-              <NumberDisplay value={pnl} className="tabular-nums" />
-              <span
-                className={`ml-1 text-xs font-normal ${pnl >= 0 ? 'text-green-600' : 'text-red-600'}`}
-              >
-                {collateralSymbol}
-              </span>
-              {roi !== null && positionSize > 0 && (
+            <div className="flex flex-col gap-1 min-w-0">
+              <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
+                Profit/Loss
+              </div>
+              {pnl !== null ? (
                 <span
-                  className={`ml-1 text-[10px] tabular-nums font-mono ${pnl >= 0 ? 'text-green-600' : 'text-red-600'}`}
+                  className={`text-sm md:text-base font-medium tabular-nums items-baseline ${pnl >= 0 ? 'text-green-600' : 'text-red-600'}`}
                 >
-                  {roi >= 0 ? '+' : ''}
-                  {Math.round(roi).toLocaleString()}%
+                  <NumberDisplay value={pnl} className="tabular-nums" />
+                  <span
+                    className={`ml-1 text-xs font-normal ${pnl >= 0 ? 'text-green-600' : 'text-red-600'}`}
+                  >
+                    {collateralSymbol}
+                  </span>
+                  {roi !== null && positionSize > 0 && (
+                    <span
+                      className={`ml-1 text-[10px] tabular-nums font-mono ${pnl >= 0 ? 'text-green-600' : 'text-red-600'}`}
+                    >
+                      {roi >= 0 ? '+' : ''}
+                      {Math.round(roi).toLocaleString()}%
+                    </span>
+                  )}
+                </span>
+              ) : (
+                <span className="text-sm md:text-base font-medium tabular-nums text-muted-foreground">
+                  —
                 </span>
               )}
-            </span>
-          ) : (
-            <span className="text-sm md:text-base font-medium tabular-nums text-muted-foreground">
-              —
-            </span>
-          )}
-        </div>
-      </div>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/packages/app/src/components/positions/PositionsTable.tsx
+++ b/packages/app/src/components/positions/PositionsTable.tsx
@@ -277,7 +277,6 @@ function PositionRow({
       <TableCell>
         <PicksSummary
           picks={picks}
-          isCounterparty={!isPredictorToken}
           predictionId={pickConfig?.predictionId}
           onClick={onOpenDialog}
         />

--- a/packages/app/src/components/positions/PredictionDialog.tsx
+++ b/packages/app/src/components/positions/PredictionDialog.tsx
@@ -16,7 +16,6 @@ interface PredictionDialogProps {
   onOpenChange: (open: boolean) => void;
   prediction: Prediction | null;
   pickConfig: PickConfigData | null;
-  isPredictorSide: boolean;
   conditionsMap: ConditionsMap;
   collateralSymbol?: string;
 }
@@ -26,23 +25,23 @@ export default function PredictionDialog({
   onOpenChange,
   prediction,
   pickConfig,
-  isPredictorSide,
   conditionsMap,
   collateralSymbol = 'USDe',
 }: PredictionDialogProps) {
   if (!prediction) return null;
 
   const rawPicks = pickConfig?.picks ?? [];
-  const picks = toPicks(rawPicks, isPredictorSide, conditionsMap);
+  // Side-agnostic dialog: picks always render from the predictor's canonical
+  // perspective; viewer identity does not flip YES/NO on display.
+  const picks = toPicks(rawPicks, true, conditionsMap);
 
-  const positionSize = Number(
+  const predictorStake = Number(
     formatEther(BigInt(prediction.predictorCollateral))
   );
-  const totalPayout =
-    Number(formatEther(BigInt(prediction.predictorCollateral))) +
-    Number(formatEther(BigInt(prediction.counterpartyCollateral)));
+  const counterpartyStake = Number(
+    formatEther(BigInt(prediction.counterpartyCollateral))
+  );
 
-  // Use on-chain result if settled, otherwise compute from individual conditions
   const computed = !prediction.settled
     ? computeResultFromConditions(rawPicks, conditionsMap)
     : null;
@@ -54,21 +53,6 @@ export default function PredictionDialog({
   // NON_DECISIVE resolves to the counterparty on-chain.
   const counterpartyWon =
     result === 'COUNTERPARTY_WINS' || result === 'NON_DECISIVE';
-  const positionWon =
-    isSettled &&
-    ((isPredictorSide && predictorWon) ||
-      (!isPredictorSide && counterpartyWon));
-
-  const viewerSize = isPredictorSide
-    ? positionSize
-    : Number(formatEther(BigInt(prediction.counterpartyCollateral)));
-
-  const pnl = isSettled
-    ? positionWon
-      ? totalPayout - viewerSize
-      : -viewerSize
-    : null;
-  const roi = pnl !== null && viewerSize > 0 ? (pnl / viewerSize) * 100 : null;
 
   const createdAt = prediction.createdAt
     ? new Date(prediction.createdAt)
@@ -82,40 +66,37 @@ export default function PredictionDialog({
 
   const predictionUrl = `/predictions/${prediction.predictionId}`;
 
-  const getPositionStatus = (): 'won' | 'lost' | 'pending' | 'active' => {
-    if (isSettled && positionWon) return 'won';
-    if (isSettled && !positionWon) return 'lost';
-    if (endsAtMs && endsAtMs <= Date.now()) return 'pending';
-    return 'active';
-  };
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-4xl pt-8">
-        <PositionSummary
-          positionId={prediction.predictionId.slice(0, 8)}
-          isCounterpartyPosition={!isPredictorSide}
-          createdAt={createdAt}
-          endsAtMs={endsAtMs}
-          positionSize={viewerSize}
-          payout={totalPayout}
-          pnl={pnl}
-          roi={roi}
-          isSettled={isSettled}
-          positionWon={positionWon}
-          collateralSymbol={collateralSymbol}
-          positionUrl={predictionUrl}
-          predictorAddress={prediction.predictor}
-          counterpartyAddress={prediction.counterparty}
-        />
+      <DialogContent className="sm:max-w-4xl pt-8 overflow-x-hidden">
+        <div className="min-w-0">
+          <PositionSummary
+            positionId={prediction.predictionId}
+            createdAt={createdAt}
+            endsAtMs={endsAtMs}
+            positionSize={0}
+            payout={0}
+            pnl={null}
+            roi={null}
+            isSettled={isSettled}
+            collateralSymbol={collateralSymbol}
+            positionUrl={predictionUrl}
+            predictorAddress={prediction.predictor}
+            counterpartyAddress={prediction.counterparty}
+            predictorStake={predictorStake}
+            counterpartyStake={counterpartyStake}
+            predictorWon={predictorWon}
+            counterpartyWon={counterpartyWon}
+          />
+        </div>
 
-        <PicksContent
-          picks={picks}
-          positionId={prediction.predictionId.slice(0, 8)}
-          isCounterparty={!isPredictorSide}
-          hideHeader
-          positionStatus={getPositionStatus()}
-        />
+        <div className="min-w-0">
+          <PicksContent
+            picks={picks}
+            positionId={prediction.predictionId}
+            hideHeader
+          />
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/packages/app/src/components/shared/PicksPopover.tsx
+++ b/packages/app/src/components/shared/PicksPopover.tsx
@@ -42,7 +42,7 @@ export default function PicksPopover({
 
   return (
     <div className="flex items-center gap-2">
-      <StackedIcons picks={picks} />
+      <StackedIcons picks={picks} max={4} />
       <Popover>
         <PopoverTrigger asChild>
           <button

--- a/packages/app/src/components/shared/PicksSummary.tsx
+++ b/packages/app/src/components/shared/PicksSummary.tsx
@@ -13,7 +13,6 @@ import {
   StackedIcons,
   type Pick,
 } from '~/components/shared/StackedPredictions';
-import CounterpartyBadge from '~/components/shared/CounterpartyBadge';
 import { PythMarketBadge } from '~/components/shared/PythMarketBadge';
 import ResolutionBadge from '~/components/shared/ResolutionBadge';
 import ConditionStatus from '~/components/shared/ConditionStatus';
@@ -24,7 +23,6 @@ import MarketPredictionRequest from '~/components/shared/MarketPredictionRequest
 
 interface PicksSummaryProps {
   picks: Pick[];
-  isCounterparty?: boolean;
   predictionId?: string | null;
   onClick?: () => void;
 }
@@ -32,7 +30,6 @@ interface PicksSummaryProps {
 export interface PicksContentProps {
   picks: Pick[];
   positionId: string | number;
-  isCounterparty?: boolean;
   createdAt?: string | number;
   hideHeader?: boolean;
   /** Position-level status: controls what the "Ends" column shows for settled picks */
@@ -106,7 +103,6 @@ function PickEndsCell({
 export function PicksContent({
   picks,
   positionId,
-  isCounterparty,
   createdAt,
   hideHeader,
   positionStatus,
@@ -116,7 +112,6 @@ export function PicksContent({
       {!hideHeader && (
         <div className="flex items-baseline gap-2 text-lg font-semibold mb-4">
           Prediction #{positionId}
-          {isCounterparty && <CounterpartyBadge />}
           {createdAt && (
             <span className="text-sm font-normal text-muted-foreground">
               created{' '}
@@ -217,7 +212,6 @@ export function PicksContent({
 
 export default function PicksSummary({
   picks,
-  isCounterparty,
   predictionId,
   onClick,
 }: PicksSummaryProps) {
@@ -227,7 +221,7 @@ export default function PicksSummary({
 
   return (
     <div className="flex items-center gap-2">
-      <StackedIcons picks={picks} />
+      <StackedIcons picks={picks} max={4} />
       {href ? (
         onClick ? (
           <button
@@ -250,7 +244,6 @@ export default function PicksSummary({
           {picks.length} {picks.length === 1 ? 'PICK' : 'PICKS'}
         </span>
       )}
-      {isCounterparty && <CounterpartyBadge />}
     </div>
   );
 }

--- a/packages/app/src/components/shared/StackedPredictions.tsx
+++ b/packages/app/src/components/shared/StackedPredictions.tsx
@@ -67,6 +67,7 @@ export function StackedIcons({
   }
 
   const visiblePicks = max != null ? picks.slice(0, max) : picks;
+  const truncated = max != null && picks.length > max;
   const colors = visiblePicks.map((pick) =>
     getCategoryColor(pick.categorySlug)
   );
@@ -79,11 +80,18 @@ export function StackedIcons({
         const isPyth = pick.source === 'pyth';
         const CategoryIcon = getCategoryIcon(pick.categorySlug);
         const color = colors[i] || 'hsl(var(--muted-foreground))';
+        // Fade the trailing icons when there are more picks hidden behind them:
+        // last icon fades most, second-to-last a little, to hint at the stack.
+        let opacity: number | undefined;
+        if (truncated) {
+          if (i === visiblePicks.length - 1) opacity = 0.4;
+          else if (i === visiblePicks.length - 2) opacity = 0.7;
+        }
         return isPyth ? (
           <PythMarketBadge
             key={`icon-${pick.conditionId || i}-${i}`}
             className="ring-2 ring-background"
-            style={{ zIndex: picks.length - i }}
+            style={{ zIndex: picks.length - i, opacity }}
           />
         ) : (
           <div
@@ -92,6 +100,7 @@ export function StackedIcons({
             style={{
               backgroundColor: color,
               zIndex: picks.length - i,
+              opacity,
             }}
           >
             <CategoryIcon className="h-3 w-3 text-white/80" />


### PR DESCRIPTION
## Summary

- **PredictionDialog** becomes side-agnostic: summary is a 4×2 grid (Predictor / Position Size / Counterparty / Position Size; Created / Ends / Status / Payout) — no "Your Stake", no P/L, no WON/LOST framing. Status cell shows `PENDING` while active, `Winner: PREDICTOR` or `Winner: COUNTERPARTY` once settled. Header renders the prediction hash in mono (no `#`), and `Created`/`Status` moved out of the header into the grid. `PositionDialog` (aggregate) keeps the legacy Position Size / Payout / P/L layout.
- **Counterparty badge** removed from the activity row's Position column and from the dialog headers — those surfaces stay agnostic to viewer side.
- **Stacked pick icons** cap at 4 with a trailing fade (4th, and slightly 3rd, reduced opacity) to hint at overflow.
- **Mobile overflow** fix: `min-w-0` wrappers + `overflow-x-hidden` on the dialog so long picks scroll inside the inner table instead of bleeding past the viewport.
- **Question page** (`/questions/...`) defaults to the Activity tab (was Forecasts); Activity is always visible, Positions stays gated on `hasPositions`.
- **Mobile polish**: `ActivityTable`'s "Type" label gets a touch more bottom margin. Legacy Position Dialog stats get real 4px label-to-value gaps (the former `space-y-1` was a no-op on inline values, replaced with `flex flex-col gap-1`).

## Test plan

- [ ] `/profile/<addr>` → open a prediction activity row. Summary is 4×2, addresses + stakes on top, Created/Ends/Status/Payout below. No "Your Stake" or P/L. Predictor/Counterparty-addresses make sense even if viewer isn't either.
- [ ] `/questions/<resolver>/<conditionId>#predictions` loads directly on the Activity tab. Also loads on Activity with an empty-activity condition instead of silently redirecting to Forecasts.
- [ ] Activity row with >4 picks shows 4 stacked icons; 4th is faded, 3rd slightly faded; badge text reflects total count.
- [ ] Mobile viewport: prediction dialog fits the viewport; long question text in the picks table scrolls horizontally inside the dialog.
- [ ] `PositionDialog` (aggregate holder position) still shows **Position Size / Payout / Profit/Loss**; stats row labels now have real 4px label-to-value breathing room.
- [ ] `SecondaryListingsTable` / `SecondaryTradesTable` / `BidOnListingDialog` activity rows: icon cap of 4 with fade renders correctly.
- [ ] Condition page dialog (no viewer) opens in observer mode — numbers come from on-chain, no P/L anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)