### PR TITLE
Toggle between Protocol and Options vaults on /vaults

### DIFF
--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -1533,7 +1533,7 @@ type Query {
   """
   Daily protocol statistics time series (last 90 days) — vault balance, volume, PnL, and open interest
   """
-  protocolStats: [ProtocolStat!]!
+  protocolStats(vaultAddress: String): [ProtocolStat!]!
 
   """Time-bucketed total protocol trading volume across all users"""
   protocolVolume(from: DateTimeISO, interval: TimeInterval!, to: DateTimeISO): [VolumeDataPoint!]!

--- a/packages/api/src/graphql/resolvers/AnalyticsResolver.ts
+++ b/packages/api/src/graphql/resolvers/AnalyticsResolver.ts
@@ -1,4 +1,5 @@
 import {
+  Arg,
   Directive,
   Field,
   Int,
@@ -103,10 +104,15 @@ export class AnalyticsResolver {
       'Daily protocol statistics time series (last 90 days) — vault balance, volume, PnL, and open interest',
   })
   @Directive('@cacheControl(maxAge: 60)')
-  async protocolStats(): Promise<ProtocolStat[]> {
+  async protocolStats(
+    @Arg('vaultAddress', () => String, { nullable: true })
+    vaultAddressArg?: string
+  ): Promise<ProtocolStat[]> {
     const chainId = DEFAULT_CHAIN_ID;
     const vaultAddress = (
-      contracts.predictionMarketVault[chainId]?.address ?? ''
+      vaultAddressArg ??
+      contracts.predictionMarketVault[chainId]?.address ??
+      ''
     ).toLowerCase();
 
     // Fetch all available snapshots

--- a/packages/app/src/components/shared/AddressDisplay.tsx
+++ b/packages/app/src/components/shared/AddressDisplay.tsx
@@ -15,7 +15,11 @@ import { useQuery } from '@tanstack/react-query';
 import { Copy, ExternalLink, User, Vault } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { predictionMarketVault } from '@sapience/sdk/contracts';
+import {
+  predictionMarketVault,
+  pythPredictionMarketVault,
+  singleLegVault,
+} from '@sapience/sdk/contracts';
 import { getAddress } from 'viem';
 import { getExplorerUrl } from '~/lib/utils/util';
 import { mainnetClient } from '~/lib/utils/util';
@@ -116,9 +120,12 @@ const AddressDisplay = ({
       : '';
 
   // Check if address matches any vault address across all chains
-  const isVaultAddress = Object.values(predictionMarketVault).some(
-    (vault) => vault.address.toLowerCase() === address.toLowerCase()
-  );
+  const lowerAddress = address.toLowerCase();
+  const isVaultAddress = [
+    ...Object.values(predictionMarketVault),
+    ...Object.values(pythPredictionMarketVault),
+    ...Object.values(singleLegVault),
+  ].some((vault) => vault.address.toLowerCase() === lowerAddress);
 
   return (
     <div

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -601,7 +601,7 @@ const VaultsPageContent = () => {
   return (
     <div className="relative">
       <div className="container max-w-[600px] lg:max-w-[1200px] mx-auto px-4 pt-10 md:pt-14 lg:pt-10 pb-12 relative z-10">
-        <div className="mb-4 md:mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 sm:gap-4">
+        <div className="mb-4 md:mb-6 flex flex-row items-center justify-between gap-4">
           <h1 className="text-3xl md:text-5xl font-sans font-normal text-foreground">
             Vaults
           </h1>

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import { predictionMarketVault } from '@sapience/sdk/contracts';
+import {
+  predictionMarketVault,
+  pythPredictionMarketVault,
+} from '@sapience/sdk/contracts';
 import { Button } from '@sapience/ui/components/ui/button';
 import { Card, CardContent } from '@sapience/ui/components/ui/card';
 import { Input } from '@sapience/ui/components/ui/input';
@@ -46,11 +49,49 @@ const DEPOSIT_WHITELIST: `0x${string}`[] = [
 
 const DEPOSIT_CAP = 10000;
 
+type VaultKind = 'protocol' | 'options';
+
 const VaultsPageContent = () => {
   const { currentAddress, isConnected } = useCurrentAddress();
   const { openConnectDialog } = useConnectDialog();
   const VAULT_CHAIN_ID = DEFAULT_CHAIN_ID;
-  const VAULT_ADDRESS = predictionMarketVault[VAULT_CHAIN_ID]?.address;
+  const protocolVaultAddress = predictionMarketVault[VAULT_CHAIN_ID]?.address;
+  const optionsVaultAddress =
+    pythPredictionMarketVault[VAULT_CHAIN_ID]?.address;
+  const optionsVaultAvailable = Boolean(optionsVaultAddress);
+
+  const [selectedVault, setSelectedVault] = useState<VaultKind>('protocol');
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const syncFromHash = () => {
+      const hash = window.location.hash.replace('#', '').toLowerCase();
+      if (hash === 'options' || hash === 'protocol') {
+        setSelectedVault(hash);
+      }
+    };
+    syncFromHash();
+    window.addEventListener('hashchange', syncFromHash);
+    return () => window.removeEventListener('hashchange', syncFromHash);
+  }, []);
+
+  const handleVaultChange = (value: string) => {
+    const next = value === 'options' ? 'options' : 'protocol';
+    setSelectedVault(next);
+    if (typeof window !== 'undefined') {
+      const url = `${window.location.pathname}${window.location.search}#${next}`;
+      window.history.replaceState(null, '', url);
+    }
+  };
+
+  const activeVault: VaultKind =
+    selectedVault === 'options' && !optionsVaultAvailable
+      ? 'protocol'
+      : selectedVault;
+  const VAULT_ADDRESS =
+    activeVault === 'options' ? optionsVaultAddress : protocolVaultAddress;
+  const vaultTitle =
+    activeVault === 'options' ? 'Options Vault' : 'Protocol Vault';
   const collateralSymbol = COLLATERAL_SYMBOLS[VAULT_CHAIN_ID] || 'testUSDe';
 
   const {
@@ -80,7 +121,7 @@ const VaultsPageContent = () => {
 
   const { isRestricted, isPermitLoading } = useRestrictedJurisdiction();
   const { data: protocolStats, isLoading: isAnalyticsLoading } =
-    useProtocolStats();
+    useProtocolStats(VAULT_ADDRESS);
 
   const [depositAmount, setDepositAmount] = useState('');
   const [withdrawAmount, setWithdrawAmount] = useState('');
@@ -564,7 +605,42 @@ const VaultsPageContent = () => {
           <h1 className="text-3xl md:text-5xl font-sans font-normal text-foreground">
             Vaults
           </h1>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-4">
+            <Tabs value={activeVault} onValueChange={handleVaultChange}>
+              <TabsList className="h-auto p-1">
+                <TabsTrigger
+                  value="protocol"
+                  className="text-sm px-3 py-1.5 data-[state=active]:text-brand-white"
+                >
+                  Protocol Vault
+                </TabsTrigger>
+                {optionsVaultAvailable ? (
+                  <TabsTrigger
+                    value="options"
+                    className="text-sm px-3 py-1.5 data-[state=active]:text-brand-white"
+                  >
+                    Options Vault
+                  </TabsTrigger>
+                ) : (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="inline-flex cursor-not-allowed">
+                        <TabsTrigger
+                          value="options"
+                          disabled
+                          className="text-sm px-3 py-1.5 opacity-50"
+                        >
+                          Options Vault
+                        </TabsTrigger>
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Not yet deployed on this network</p>
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+              </TabsList>
+            </Tabs>
             <Tooltip>
               <TooltipTrigger asChild>
                 <span className="inline-flex cursor-not-allowed">
@@ -597,7 +673,7 @@ const VaultsPageContent = () => {
               <CardContent className="p-6">
                 <div className="space-y-6">
                   <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-                    <h3 className="text-2xl font-medium">Protocol Vault</h3>
+                    <h3 className="text-2xl font-medium">{vaultTitle}</h3>
                     <div className="flex items-center gap-2">
                       <EnsAvatar
                         address={VAULT_ADDRESS}

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -60,23 +60,37 @@ const VaultsPageContent = () => {
     pythPredictionMarketVault[VAULT_CHAIN_ID]?.address;
   const optionsVaultAvailable = Boolean(optionsVaultAddress);
 
-  const [selectedVault, setSelectedVault] = useState<VaultKind>('protocol');
+  const [selectedVault, setSelectedVault] = useState<VaultKind>(() => {
+    if (typeof window === 'undefined') return 'protocol';
+    const hash = window.location.hash.replace('#', '').toLowerCase();
+    return hash === 'options' && optionsVaultAvailable ? 'options' : 'protocol';
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!optionsVaultAvailable && window.location.hash === '#options') {
+      const url = `${window.location.pathname}${window.location.search}#protocol`;
+      window.history.replaceState(null, '', url);
+    }
+  }, [optionsVaultAvailable]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const syncFromHash = () => {
       const hash = window.location.hash.replace('#', '').toLowerCase();
-      if (hash === 'options' || hash === 'protocol') {
-        setSelectedVault(hash);
+      if (hash === 'options' && optionsVaultAvailable) {
+        setSelectedVault('options');
+      } else if (hash === 'options' || hash === 'protocol') {
+        setSelectedVault('protocol');
       }
     };
-    syncFromHash();
     window.addEventListener('hashchange', syncFromHash);
     return () => window.removeEventListener('hashchange', syncFromHash);
-  }, []);
+  }, [optionsVaultAvailable]);
 
   const handleVaultChange = (value: string) => {
-    const next = value === 'options' ? 'options' : 'protocol';
+    const next =
+      value === 'options' && optionsVaultAvailable ? 'options' : 'protocol';
     setSelectedVault(next);
     if (typeof window !== 'undefined') {
       const url = `${window.location.pathname}${window.location.search}#${next}`;
@@ -84,14 +98,10 @@ const VaultsPageContent = () => {
     }
   };
 
-  const activeVault: VaultKind =
-    selectedVault === 'options' && !optionsVaultAvailable
-      ? 'protocol'
-      : selectedVault;
   const VAULT_ADDRESS =
-    activeVault === 'options' ? optionsVaultAddress : protocolVaultAddress;
+    selectedVault === 'options' ? optionsVaultAddress : protocolVaultAddress;
   const vaultTitle =
-    activeVault === 'options' ? 'Options Vault' : 'Protocol Vault';
+    selectedVault === 'options' ? 'Options Vault' : 'Protocol Vault';
   const collateralSymbol = COLLATERAL_SYMBOLS[VAULT_CHAIN_ID] || 'testUSDe';
 
   const {
@@ -605,7 +615,7 @@ const VaultsPageContent = () => {
           <h1 className="text-3xl md:text-5xl font-sans font-normal text-foreground">
             Vaults
           </h1>
-          <Tabs value={activeVault} onValueChange={handleVaultChange}>
+          <Tabs value={selectedVault} onValueChange={handleVaultChange}>
             <TabsList className="h-auto p-1">
               <TabsTrigger
                 value="protocol"

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -18,7 +18,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@sapience/ui/components/ui/tooltip';
-import { Vault, Clock } from 'lucide-react';
+import { Clock } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { parseUnits } from 'viem';
 import { formatDuration, intervalToDuration } from 'date-fns';
@@ -601,66 +601,45 @@ const VaultsPageContent = () => {
   return (
     <div className="relative">
       <div className="container max-w-[600px] lg:max-w-[1200px] mx-auto px-4 pt-10 md:pt-14 lg:pt-10 pb-12 relative z-10">
-        <div className="mb-4 md:mb-6 flex flex-row items-center justify-between">
+        <div className="mb-4 md:mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 sm:gap-4">
           <h1 className="text-3xl md:text-5xl font-sans font-normal text-foreground">
             Vaults
           </h1>
-          <div className="flex items-center gap-4">
-            <Tabs value={activeVault} onValueChange={handleVaultChange}>
-              <TabsList className="h-auto p-1">
+          <Tabs value={activeVault} onValueChange={handleVaultChange}>
+            <TabsList className="h-auto p-1">
+              <TabsTrigger
+                value="protocol"
+                className="text-sm px-3 py-1.5 data-[state=active]:text-brand-white"
+              >
+                Protocol Vault
+              </TabsTrigger>
+              {optionsVaultAvailable ? (
                 <TabsTrigger
-                  value="protocol"
+                  value="options"
                   className="text-sm px-3 py-1.5 data-[state=active]:text-brand-white"
                 >
-                  Protocol Vault
+                  Options Vault
                 </TabsTrigger>
-                {optionsVaultAvailable ? (
-                  <TabsTrigger
-                    value="options"
-                    className="text-sm px-3 py-1.5 data-[state=active]:text-brand-white"
-                  >
-                    Options Vault
-                  </TabsTrigger>
-                ) : (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span className="inline-flex cursor-not-allowed">
-                        <TabsTrigger
-                          value="options"
-                          disabled
-                          className="text-sm px-3 py-1.5 opacity-50"
-                        >
-                          Options Vault
-                        </TabsTrigger>
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Not yet deployed on this network</p>
-                    </TooltipContent>
-                  </Tooltip>
-                )}
-              </TabsList>
-            </Tabs>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="inline-flex cursor-not-allowed">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled
-                    className="inline-flex items-center gap-2"
-                    onClick={(e) => e.preventDefault()}
-                  >
-                    <Vault className="h-4 w-4" />
-                    Deploy Vault
-                  </Button>
-                </span>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>Coming soon</p>
-              </TooltipContent>
-            </Tooltip>
-          </div>
+              ) : (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex cursor-not-allowed">
+                      <TabsTrigger
+                        value="options"
+                        disabled
+                        className="text-sm px-3 py-1.5 opacity-50"
+                      >
+                        Options Vault
+                      </TabsTrigger>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Not yet deployed on this network</p>
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </TabsList>
+          </Tabs>
         </div>
 
         <div className="grid grid-cols-1 gap-8">

--- a/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
+++ b/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
@@ -59,6 +59,8 @@ vi.mock('~/components/shared/RestrictedJurisdictionBanner', () => {
 // SDK mocks
 vi.mock('@sapience/sdk/contracts', () => ({
   predictionMarketVault: { 42161: { address: '0xVault' } },
+  pythPredictionMarketVault: { 42161: { address: '0xOptionsVault' } },
+  singleLegVault: {},
 }));
 
 vi.mock('@sapience/sdk/constants', () => ({

--- a/packages/app/src/hooks/graphql/useAnalytics.ts
+++ b/packages/app/src/hooks/graphql/useAnalytics.ts
@@ -3,10 +3,10 @@ import { fetchProtocolStats, type ProtocolStat } from '@sapience/sdk/queries';
 
 const CACHE_TIME_MS = 60 * 1000;
 
-export function useProtocolStats() {
+export function useProtocolStats(vaultAddress?: string) {
   return useQuery<ProtocolStat[]>({
-    queryKey: ['protocolStats'],
-    queryFn: fetchProtocolStats,
+    queryKey: ['protocolStats', vaultAddress?.toLowerCase() ?? null],
+    queryFn: () => fetchProtocolStats(vaultAddress),
     staleTime: CACHE_TIME_MS,
     refetchInterval: CACHE_TIME_MS,
   });

--- a/packages/sdk/queries/analytics.ts
+++ b/packages/sdk/queries/analytics.ts
@@ -19,8 +19,8 @@ export interface ProtocolStat {
 }
 
 const GET_PROTOCOL_STATS = /* GraphQL */ `
-  query ProtocolStats {
-    protocolStats {
+  query ProtocolStats($vaultAddress: String) {
+    protocolStats(vaultAddress: $vaultAddress) {
       timestamp
       cumulativeVolume
       openInterest
@@ -40,9 +40,11 @@ const GET_PROTOCOL_STATS = /* GraphQL */ `
   }
 `;
 
-export async function fetchProtocolStats(): Promise<ProtocolStat[]> {
+export async function fetchProtocolStats(
+  vaultAddress?: string
+): Promise<ProtocolStat[]> {
   const data = await graphqlRequest<{
     protocolStats: ProtocolStat[];
-  }>(GET_PROTOCOL_STATS);
+  }>(GET_PROTOCOL_STATS, { vaultAddress });
   return data?.protocolStats ?? [];
 }

--- a/packages/sdk/types/graphql.ts
+++ b/packages/sdk/types/graphql.ts
@@ -1859,6 +1859,11 @@ export type QueryProfitLeaderboardArgs = {
 };
 
 
+export type QueryProtocolStatsArgs = {
+  vaultAddress?: InputMaybe<Scalars['String']['input']>;
+};
+
+
 export type QueryProtocolVolumeArgs = {
   from?: InputMaybe<Scalars['DateTimeISO']['input']>;
   interval: TimeInterval;


### PR DESCRIPTION
## Summary

- Adds a tab switcher beside the Deploy Vault button on `/vaults` that lets users view the Protocol Vault or the Pyth-backed Options Vault (`pythPredictionMarketVault`) on the same page.
- Tabs sync with the URL hash: `/vaults#protocol` and `/vaults#options`.
- The Options tab is disabled with a tooltip on networks where the Pyth vault isn't deployed (e.g. Ethereal mainnet today).
- `protocolStats` GraphQL query now accepts an optional `vaultAddress` so TVL, deployed amount, and the PnL chart update per-vault.
- `AddressDisplay` renders the vault icon for `pythPredictionMarketVault` and `singleLegVault` addresses too, not just the main protocol vault.

## Test plan
- [ ] Visit `/vaults` — tabs appear left of the Deploy Vault button.
- [ ] On mainnet the Options tab is disabled and tooltip explains it's not yet deployed on this network.
- [ ] Set `NEXT_PUBLIC_DEFAULT_CHAIN_ID=13374202` (Ethereal testnet) — Options tab becomes enabled.
- [ ] Switching tabs updates title, address display, profile link, Vault Balance, deployed amount, and the PnL chart.
- [ ] Landing on `/vaults#options` opens the Options tab; changing tabs updates the hash.
- [ ] `AddressDisplay` on any Pyth or single-leg vault address shows the gold vault icon.