### PR TITLE
feat(api): index protocolStats per configured vault

### DIFF
--- a/packages/api/prisma/migrations/20260422000000_add_vault_address_to_vault_flow_event/migration.sql
+++ b/packages/api/prisma/migrations/20260422000000_add_vault_address_to_vault_flow_event/migration.sql
@@ -1,0 +1,15 @@
+-- Per-vault indexing: existing rows predate the vaultAddress column. Rather
+-- than guess which vault wrote each row, clear the table and require the
+-- backfillVaultFlows.ts script to be re-run. The script is idempotent and the
+-- downstream consumer (protocol_stats_snapshot) is rebuilt from these events
+-- plus on-chain reads, so clearing is safe.
+TRUNCATE "vault_flow_event" RESTART IDENTITY;
+
+-- AlterTable
+ALTER TABLE "vault_flow_event" ADD COLUMN "vaultAddress" VARCHAR NOT NULL;
+
+-- DropIndex
+DROP INDEX "vault_flow_event_chainId_timestamp_idx";
+
+-- CreateIndex
+CREATE INDEX "vault_flow_event_chainId_vaultAddress_timestamp_idx" ON "vault_flow_event"("chainId", "vaultAddress", "timestamp");

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -505,6 +505,7 @@ model VaultFlowEvent {
   id              Int      @id @default(autoincrement())
   createdAt       DateTime @default(now()) @db.Timestamp(6)
   chainId         Int
+  vaultAddress    String   @db.VarChar  // lowercased vault contract address
   blockNumber     Int
   transactionHash String   @db.VarChar
   timestamp       Int
@@ -515,7 +516,7 @@ model VaultFlowEvent {
   shares          String   @db.VarChar  // Shares minted/burned
 
   @@unique([chainId, transactionHash, logIndex])
-  @@index([chainId, timestamp])
+  @@index([chainId, vaultAddress, timestamp])
   @@index([eventType])
   @@map("vault_flow_event")
 }

--- a/packages/api/scripts/backfillVaultFlows.ts
+++ b/packages/api/scripts/backfillVaultFlows.ts
@@ -1,23 +1,24 @@
 /**
- * One-shot backfill for vault_flow_event on the current vault deployment.
- * Reads PendingRequestProcessed + EmergencyWithdrawal events from chain.
+ * One-shot backfill for vault_flow_event. Reads PendingRequestProcessed +
+ * EmergencyWithdrawal events from chain for every configured vault (main,
+ * Pyth options, single-leg) and writes rows tagged with the source vault.
  *
- * Why: no indexer writes to this table today. The rows that exist predate the
- * current vault redeployment (2026-03-25, block 3890223). Running this lets
- * analytics queries (airdrop gains, cumulative flows) reflect reality.
+ * Why: no cron writes to this table today; it is regenerated manually after
+ * schema changes or vault redeployments. Downstream consumers
+ * (protocol_stats_snapshot, airdrop gains, cumulative flows) re-derive from
+ * these events.
  *
  * Usage:
  *   pnpm --filter @sapience/api exec tsx scripts/backfillVaultFlows.ts
  *   pnpm --filter @sapience/api exec tsx scripts/backfillVaultFlows.ts --chainId 5064014
  *   pnpm --filter @sapience/api exec tsx scripts/backfillVaultFlows.ts --dry-run
  *
- * --dry-run prints what would be upserted without touching the database. Use it to
- * verify event discovery and data shape before running with write credentials.
+ * --dry-run prints what would be upserted without touching the database.
  */
 import { parseAbiItem } from 'viem';
 import prisma from '../src/db';
 import { getProviderForChain } from '../src/utils/utils';
-import { contracts } from '@sapience/sdk/contracts';
+import { getConfiguredVaults } from '../src/helpers/protocolStats';
 
 const CHAIN_ID = (() => {
   const eq = process.argv.find((a) => a.startsWith('--chainId='));
@@ -38,30 +39,37 @@ const emergencyEvent = parseAbiItem(
   'event EmergencyWithdrawal(address indexed user, uint256 shares, uint256 assets)'
 );
 
-async function main() {
-  const vaultEntry = contracts.predictionMarketVault[CHAIN_ID];
-  if (!vaultEntry) throw new Error(`No vault configured for chain ${CHAIN_ID}`);
+interface PreviewRow {
+  vault: string;
+  block: number;
+  ts: string;
+  type: string;
+  user: string;
+  assets: string;
+  shares: string;
+}
 
-  const vaultAddress = vaultEntry.address as `0x${string}`;
-  const fromBlock = BigInt(vaultEntry.blockCreated);
-  const client = getProviderForChain(CHAIN_ID);
-  const toBlock = await client.getBlockNumber();
+async function backfillVault(
+  chainId: number,
+  kind: string,
+  address: string,
+  fromBlock: bigint,
+  toBlock: bigint,
+  previewRows: PreviewRow[]
+): Promise<number> {
+  const client = getProviderForChain(chainId);
+  const vaultAddress = address as `0x${string}`;
+  const vaultAddressLower = address.toLowerCase();
 
   console.log(
-    `[backfillVaultFlows] chain=${CHAIN_ID} vault=${vaultAddress} blocks=${fromBlock}..${toBlock}${DRY_RUN ? ' [DRY RUN]' : ''}`
+    `\n[backfillVaultFlows] ${kind} vault ${vaultAddress} blocks=${fromBlock}..${toBlock}${DRY_RUN ? ' [DRY RUN]' : ''}`
   );
 
   let upserted = 0;
-  const previewRows: Array<{
-    block: number;
-    ts: string;
-    type: string;
-    user: string;
-    assets: string;
-    shares: string;
-  }> = [];
+
   for (let start = fromBlock; start <= toBlock; start += BATCH_BLOCKS) {
-    const end = start + BATCH_BLOCKS - 1n > toBlock ? toBlock : start + BATCH_BLOCKS - 1n;
+    const end =
+      start + BATCH_BLOCKS - 1n > toBlock ? toBlock : start + BATCH_BLOCKS - 1n;
 
     const [processedLogs, emergencyLogs] = await Promise.all([
       client.getLogs({
@@ -93,7 +101,8 @@ async function main() {
       if (!user || !shares || !assets || log.logIndex == null) continue;
       const ts = blockTimestamps.get(log.blockNumber!)!;
       const row = {
-        chainId: CHAIN_ID,
+        chainId,
+        vaultAddress: vaultAddressLower,
         blockNumber: Number(log.blockNumber!),
         transactionHash: log.transactionHash!,
         timestamp: ts,
@@ -105,6 +114,7 @@ async function main() {
       };
       if (DRY_RUN) {
         previewRows.push({
+          vault: kind,
           block: row.blockNumber,
           ts: new Date(ts * 1000).toISOString(),
           type: row.eventType,
@@ -122,7 +132,7 @@ async function main() {
             },
           },
           create: row,
-          update: {},
+          update: { vaultAddress: vaultAddressLower },
         });
       }
       upserted++;
@@ -133,7 +143,8 @@ async function main() {
       if (!user || !shares || !assets || log.logIndex == null) continue;
       const ts = blockTimestamps.get(log.blockNumber!)!;
       const row = {
-        chainId: CHAIN_ID,
+        chainId,
+        vaultAddress: vaultAddressLower,
         blockNumber: Number(log.blockNumber!),
         transactionHash: log.transactionHash!,
         timestamp: ts,
@@ -145,6 +156,7 @@ async function main() {
       };
       if (DRY_RUN) {
         previewRows.push({
+          vault: kind,
           block: row.blockNumber,
           ts: new Date(ts * 1000).toISOString(),
           type: 'emergency_withdrawal',
@@ -162,7 +174,7 @@ async function main() {
             },
           },
           create: row,
-          update: {},
+          update: { vaultAddress: vaultAddressLower },
         });
       }
       upserted++;
@@ -175,11 +187,37 @@ async function main() {
     }
   }
 
+  return upserted;
+}
+
+async function main() {
+  const vaults = getConfiguredVaults(CHAIN_ID);
+  if (vaults.length === 0) {
+    throw new Error(`No vaults configured for chain ${CHAIN_ID}`);
+  }
+
+  const client = getProviderForChain(CHAIN_ID);
+  const toBlock = await client.getBlockNumber();
+
+  const previewRows: PreviewRow[] = [];
+  let totalUpserted = 0;
+  for (const vault of vaults) {
+    const fromBlock = BigInt(vault.config.blockCreated);
+    totalUpserted += await backfillVault(
+      CHAIN_ID,
+      vault.kind,
+      vault.address,
+      fromBlock,
+      toBlock,
+      previewRows
+    );
+  }
+
   if (DRY_RUN) {
-    console.log(`\n[DRY RUN] Would upsert ${upserted} vault flow rows:`);
+    console.log(`\n[DRY RUN] Would upsert ${totalUpserted} vault flow rows:`);
     console.table(previewRows);
   } else {
-    console.log(`\nDone. Upserted ${upserted} vault flow rows.`);
+    console.log(`\nDone. Upserted ${totalUpserted} vault flow rows.`);
   }
   await prisma.$disconnect();
 }

--- a/packages/api/src/helpers/protocolStats.test.ts
+++ b/packages/api/src/helpers/protocolStats.test.ts
@@ -2,19 +2,22 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
 
-const { mockPrisma, mockReadContract } = vi.hoisted(() => {
-  const mockReadContract = vi.fn().mockResolvedValue(1000000000000000000n);
-  const mockPrisma = {
-    prediction: { findMany: vi.fn() },
-    vaultFlowEvent: { findMany: vi.fn() },
-    protocolStatsSnapshot: {
-      upsert: vi.fn(),
-      findFirst: vi.fn(),
-      findMany: vi.fn(),
-    },
-  };
-  return { mockPrisma, mockReadContract };
-});
+const { mockPrisma, mockReadContract, mockGetBlockByTimestamp } = vi.hoisted(
+  () => {
+    const mockReadContract = vi.fn().mockResolvedValue(1000000000000000000n);
+    const mockGetBlockByTimestamp = vi.fn();
+    const mockPrisma = {
+      prediction: { findMany: vi.fn() },
+      vaultFlowEvent: { findMany: vi.fn() },
+      protocolStatsSnapshot: {
+        upsert: vi.fn(),
+        findFirst: vi.fn(),
+        findMany: vi.fn(),
+      },
+    };
+    return { mockPrisma, mockReadContract, mockGetBlockByTimestamp };
+  }
+);
 
 vi.mock('../db', () => ({ default: mockPrisma }));
 
@@ -31,7 +34,7 @@ vi.mock('../utils/utils', () => ({
   getProviderForChain: vi.fn().mockReturnValue({
     readContract: mockReadContract,
   }),
-  getBlockByTimestamp: vi.fn(),
+  getBlockByTimestamp: mockGetBlockByTimestamp,
 }));
 
 vi.mock('@sapience/sdk/contracts', () => ({
@@ -437,6 +440,118 @@ describe('computeAndStoreProtocolStats — multiple configured vaults', () => {
     );
     expect(flowsCalls).toContain('0xprotocolvault');
     expect(flowsCalls).toContain('0xpythvault');
+  });
+});
+
+// ─── backfillProtocolStats — redeploy boundary ──────────────────────────────
+
+describe('backfillProtocolStats — legacy/current vault boundaries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.prediction.findMany.mockResolvedValue([]);
+    mockPrisma.vaultFlowEvent.findMany.mockResolvedValue([]);
+    mockPrisma.protocolStatsSnapshot.upsert.mockResolvedValue({});
+    mockReadContract.mockResolvedValue(1000000000000000000n);
+    mockGetBlockByTimestamp.mockResolvedValue({ number: 150n });
+  });
+
+  it('uses the historical vault deployment for backfilled DB-derived metrics', async () => {
+    vi.resetModules();
+    vi.doMock('@sapience/sdk/contracts', () => ({
+      contracts: {
+        collateralToken: { 42161: { address: '0xCollateral' } },
+        predictionMarketEscrow: {
+          42161: { address: '0xEscrow', blockCreated: 0 },
+        },
+        predictionMarketVault: {
+          42161: {
+            address: '0xCurrentVault',
+            blockCreated: 200,
+            legacy: [{ address: '0xLegacyVault', blockCreated: 100 }],
+          },
+        },
+        pythPredictionMarketVault: {},
+        singleLegVault: {},
+      },
+      normalizeLegacyEntry: (e: { address: string; blockCreated: number }) => e,
+    }));
+
+    mockPrisma.prediction.findMany
+      .mockResolvedValueOnce([{ counterpartyCollateral: '300' }])
+      .mockResolvedValueOnce([
+        {
+          predictor: '0xuser',
+          counterparty: '0xlegacyvault',
+          predictorCollateral: '25',
+          counterpartyCollateral: '75',
+          pickConfiguration: { result: 'COUNTERPARTY_WINS' },
+        },
+      ]);
+    mockPrisma.vaultFlowEvent.findMany.mockResolvedValue([
+      { assets: '100', eventType: 'deposit' },
+    ]);
+
+    const { backfillProtocolStats: backfill } = await import('./protocolStats');
+    await backfill(42161, 1);
+
+    expect(mockReadContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: '0xCollateral',
+        functionName: 'balanceOf',
+        args: ['0xLegacyVault'],
+        blockNumber: 150n,
+      })
+    );
+    expect(mockReadContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: '0xLegacyVault',
+        functionName: 'availableAssets',
+        blockNumber: 150n,
+      })
+    );
+
+    expect(mockPrisma.prediction.findMany).toHaveBeenNthCalledWith(1, {
+      where: {
+        chainId: 42161,
+        counterparty: '0xlegacyvault',
+        onChainCreatedAt: expect.any(Object),
+        OR: [
+          { pickConfigId: null },
+          { pickConfiguration: { resolved: false } },
+          {
+            pickConfiguration: {
+              resolved: true,
+              resolvedAt: expect.any(Object),
+            },
+          },
+        ],
+      },
+      select: { counterpartyCollateral: true },
+    });
+    expect(mockPrisma.prediction.findMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [
+            { predictor: '0xlegacyvault' },
+            { counterparty: '0xlegacyvault' },
+          ],
+        }),
+      })
+    );
+    expect(mockPrisma.vaultFlowEvent.findMany).toHaveBeenCalledWith({
+      where: {
+        chainId: 42161,
+        vaultAddress: '0xlegacyvault',
+        timestamp: expect.any(Object),
+      },
+    });
+
+    const upsertCall = mockPrisma.protocolStatsSnapshot.upsert.mock.calls[0][0];
+    expect(upsertCall.create.vaultAddress).toBe('0xcurrentvault');
+    expect(upsertCall.create.vaultDeployed).toBe('300');
+    expect(upsertCall.create.vaultRealizedPnL).toBe('25');
+    expect(upsertCall.create.vaultDeposits).toBe('100');
   });
 });
 

--- a/packages/api/src/helpers/protocolStats.test.ts
+++ b/packages/api/src/helpers/protocolStats.test.ts
@@ -43,9 +43,13 @@ vi.mock('@sapience/sdk/contracts', () => ({
       42161: { address: '0xEscrow' },
     },
     predictionMarketVault: {
-      42161: { address: '0xVault' },
+      42161: { address: '0xVault', blockCreated: 0 },
     },
+    pythPredictionMarketVault: {},
+    singleLegVault: {},
   },
+  normalizeLegacyEntry: (entry: { address: string; blockCreated: number }) =>
+    entry,
 }));
 
 vi.mock('@sapience/sdk/abis', () => ({
@@ -360,6 +364,79 @@ describe('vault PnL calculation', () => {
     expect(upsertCall.create.vaultRealizedPnL).toBe('0');
     expect(upsertCall.create.vaultPositionsWon).toBe(0);
     expect(upsertCall.create.vaultPositionsLost).toBe(0);
+  });
+});
+
+// ─── multi-vault fan-out ────────────────────────────────────────────────────
+
+describe('computeAndStoreProtocolStats — multiple configured vaults', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.prediction.findMany.mockResolvedValue([]);
+    mockPrisma.vaultFlowEvent.findMany.mockResolvedValue([]);
+    mockPrisma.protocolStatsSnapshot.upsert.mockResolvedValue({});
+    mockReadContract.mockResolvedValue(1000000000000000000n);
+  });
+
+  it('writes one snapshot row per configured vault', async () => {
+    vi.resetModules();
+    vi.doMock('@sapience/sdk/contracts', () => ({
+      contracts: {
+        collateralToken: { 42161: { address: '0xCollateral' } },
+        predictionMarketEscrow: { 42161: { address: '0xEscrow' } },
+        predictionMarketVault: {
+          42161: { address: '0xProtocolVault', blockCreated: 0 },
+        },
+        pythPredictionMarketVault: {
+          42161: { address: '0xPythVault', blockCreated: 0 },
+        },
+        singleLegVault: {},
+      },
+      normalizeLegacyEntry: (e: { address: string; blockCreated: number }) => e,
+    }));
+
+    const { computeAndStoreProtocolStats: compute } = await import(
+      './protocolStats'
+    );
+    await compute(42161);
+
+    expect(mockPrisma.protocolStatsSnapshot.upsert).toHaveBeenCalledTimes(2);
+    const vaultAddresses = mockPrisma.protocolStatsSnapshot.upsert.mock.calls
+      .map(
+        (c) =>
+          (c[0] as { create: { vaultAddress: string } }).create.vaultAddress
+      )
+      .sort();
+    expect(vaultAddresses).toEqual(['0xprotocolvault', '0xpythvault']);
+  });
+
+  it('filters vault flow events by vaultAddress', async () => {
+    vi.resetModules();
+    vi.doMock('@sapience/sdk/contracts', () => ({
+      contracts: {
+        collateralToken: { 42161: { address: '0xCollateral' } },
+        predictionMarketEscrow: { 42161: { address: '0xEscrow' } },
+        predictionMarketVault: {
+          42161: { address: '0xProtocolVault', blockCreated: 0 },
+        },
+        pythPredictionMarketVault: {
+          42161: { address: '0xPythVault', blockCreated: 0 },
+        },
+        singleLegVault: {},
+      },
+      normalizeLegacyEntry: (e: { address: string; blockCreated: number }) => e,
+    }));
+
+    const { computeAndStoreProtocolStats: compute } = await import(
+      './protocolStats'
+    );
+    await compute(42161);
+
+    const flowsCalls = mockPrisma.vaultFlowEvent.findMany.mock.calls.map(
+      (c) => (c[0] as { where: { vaultAddress: string } }).where.vaultAddress
+    );
+    expect(flowsCalls).toContain('0xprotocolvault');
+    expect(flowsCalls).toContain('0xpythvault');
   });
 });
 

--- a/packages/api/src/helpers/protocolStats.ts
+++ b/packages/api/src/helpers/protocolStats.ts
@@ -785,23 +785,29 @@ async function backfillVaultStats(
       });
     }
 
-    const vaultDeployed = await fetchVaultDeployedAtBlock(
-      chainId,
-      blockNumber,
-      timestamp,
-      vault.address
-    );
+    const historicalVaultAddress = vaultAddrAtBlock?.toLowerCase();
 
-    const pnlResult = await calculateVaultPnL(
-      chainId,
-      timestamp,
-      vault.address
-    );
-    const flowsResult = await calculateVaultFlows(
-      chainId,
-      timestamp,
-      vault.address
-    );
+    const vaultDeployed = historicalVaultAddress
+      ? await fetchVaultDeployedAtBlock(
+          chainId,
+          blockNumber,
+          timestamp,
+          historicalVaultAddress
+        )
+      : 0n;
+
+    const pnlResult = historicalVaultAddress
+      ? await calculateVaultPnL(chainId, timestamp, historicalVaultAddress)
+      : {
+          realizedPnL: 0n,
+          positionsWon: 0,
+          positionsLost: 0,
+          totalCollateralWon: 0n,
+          totalCollateralLost: 0n,
+        };
+    const flowsResult = historicalVaultAddress
+      ? await calculateVaultFlows(chainId, timestamp, historicalVaultAddress)
+      : { totalDeposits: 0n, totalWithdrawals: 0n };
 
     const actualTotalAssets = vaultBalance + vaultDeployed;
     const expectedTotalAssets =

--- a/packages/api/src/helpers/protocolStats.ts
+++ b/packages/api/src/helpers/protocolStats.ts
@@ -34,15 +34,65 @@ interface ProtocolStatsData {
   vaultCollateralLost: bigint;
 }
 
+type VaultConfig = (typeof contracts.predictionMarketVault)[number];
+
+export interface ConfiguredVault {
+  kind: 'protocol' | 'pyth' | 'single-leg';
+  config: VaultConfig;
+  address: string;
+}
+
+/**
+ * Return all vault contracts deployed on the given chain. Used to fan-out
+ * per-vault snapshot computation.
+ */
+export function getConfiguredVaults(chainId: number): ConfiguredVault[] {
+  const list: ConfiguredVault[] = [];
+  const main = contracts.predictionMarketVault[chainId];
+  if (main) {
+    list.push({
+      kind: 'protocol',
+      config: main,
+      address: main.address.toLowerCase(),
+    });
+  }
+  const pyth = contracts.pythPredictionMarketVault[chainId];
+  if (pyth) {
+    list.push({
+      kind: 'pyth',
+      config: pyth,
+      address: pyth.address.toLowerCase(),
+    });
+  }
+  const single = contracts.singleLegVault[chainId];
+  if (single) {
+    list.push({
+      kind: 'single-leg',
+      config: single,
+      address: single.address.toLowerCase(),
+    });
+  }
+  return list;
+}
+
+function resolveVaultAddress(
+  chainId: number,
+  vaultAddressArg?: string
+): string | undefined {
+  return (
+    vaultAddressArg ?? contracts.predictionMarketVault[chainId]?.address
+  )?.toLowerCase();
+}
+
 /**
  * Fetch Vault balance: collateral.balanceOf(vault)
  */
 export async function fetchVaultTVL(
-  chainId: number = DEFAULT_CHAIN_ID
+  chainId: number = DEFAULT_CHAIN_ID,
+  vaultAddressArg?: string
 ): Promise<bigint> {
   const client = getProviderForChain(chainId);
-
-  const vaultAddress = contracts.predictionMarketVault[chainId]?.address;
+  const vaultAddress = resolveVaultAddress(chainId, vaultAddressArg);
   const collateralAddress = contracts.collateralToken[chainId]?.address;
 
   if (!vaultAddress || !collateralAddress) {
@@ -55,7 +105,7 @@ export async function fetchVaultTVL(
     address: collateralAddress,
     abi: erc20Abi,
     functionName: 'balanceOf',
-    args: [vaultAddress],
+    args: [vaultAddress as `0x${string}`],
   });
 
   return balance;
@@ -71,15 +121,16 @@ export async function fetchVaultTVL(
  */
 export async function fetchVaultDeployed(
   chainId: number = DEFAULT_CHAIN_ID,
-  atTimestamp?: number
+  atTimestamp?: number,
+  vaultAddressArg?: string
 ): Promise<bigint> {
-  const vaultAddress = contracts.predictionMarketVault[chainId]?.address;
+  const vaultAddress = resolveVaultAddress(chainId, vaultAddressArg);
   if (!vaultAddress) return 0n;
 
   const predictions = await prisma.prediction.findMany({
     where: {
       chainId,
-      counterparty: vaultAddress.toLowerCase(),
+      counterparty: vaultAddress,
       ...(atTimestamp
         ? {
             onChainCreatedAt: { lte: atTimestamp },
@@ -120,26 +171,28 @@ export async function fetchVaultDeployed(
 export async function fetchVaultDeployedAtBlock(
   chainId: number,
   _blockNumber: bigint,
-  atTimestamp?: number
+  atTimestamp?: number,
+  vaultAddressArg?: string
 ): Promise<bigint> {
-  return fetchVaultDeployed(chainId, atTimestamp);
+  return fetchVaultDeployed(chainId, atTimestamp, vaultAddressArg);
 }
 
 /**
  * Fetch Vault available assets: vault.availableAssets()
  */
 export async function fetchVaultAvailableAssets(
-  chainId: number = DEFAULT_CHAIN_ID
+  chainId: number = DEFAULT_CHAIN_ID,
+  vaultAddressArg?: string
 ): Promise<bigint> {
   const client = getProviderForChain(chainId);
-  const vaultAddress = contracts.predictionMarketVault[chainId]?.address;
+  const vaultAddress = resolveVaultAddress(chainId, vaultAddressArg);
 
   if (!vaultAddress) {
     throw new Error(`Vault not configured for chain ${chainId}`);
   }
 
   const availableAssets = (await client.readContract({
-    address: vaultAddress,
+    address: vaultAddress as `0x${string}`,
     abi: predictionMarketVaultAbi,
     functionName: 'availableAssets',
     args: [],
@@ -153,17 +206,18 @@ export async function fetchVaultAvailableAssets(
  */
 export async function fetchVaultAvailableAssetsAtBlock(
   chainId: number,
-  blockNumber: bigint
+  blockNumber: bigint,
+  vaultAddressArg?: string
 ): Promise<bigint> {
   const client = getProviderForChain(chainId);
-  const vaultAddress = contracts.predictionMarketVault[chainId]?.address;
+  const vaultAddress = resolveVaultAddress(chainId, vaultAddressArg);
 
   if (!vaultAddress) {
     throw new Error(`Vault not configured for chain ${chainId}`);
   }
 
   const availableAssets = (await client.readContract({
-    address: vaultAddress,
+    address: vaultAddress as `0x${string}`,
     abi: predictionMarketVaultAbi,
     functionName: 'availableAssets',
     args: [],
@@ -207,11 +261,11 @@ export async function fetchPredictionMarketEscrowTVL(
  */
 export async function fetchVaultTVLAtBlock(
   chainId: number,
-  blockNumber: bigint
+  blockNumber: bigint,
+  vaultAddressArg?: string
 ): Promise<bigint> {
   const client = getProviderForChain(chainId);
-
-  const vaultAddress = contracts.predictionMarketVault[chainId]?.address;
+  const vaultAddress = resolveVaultAddress(chainId, vaultAddressArg);
   const collateralAddress = contracts.collateralToken[chainId]?.address;
 
   if (!vaultAddress || !collateralAddress) {
@@ -224,7 +278,7 @@ export async function fetchVaultTVLAtBlock(
     address: collateralAddress,
     abi: erc20Abi,
     functionName: 'balanceOf',
-    args: [vaultAddress],
+    args: [vaultAddress as `0x${string}`],
     blockNumber,
   });
 
@@ -297,9 +351,10 @@ function getContractForBlock(
  */
 export async function calculateVaultPnL(
   chainId: number,
-  beforeTimestamp?: number
+  beforeTimestamp?: number,
+  vaultAddressArg?: string
 ): Promise<VaultPnLResult> {
-  const vaultAddress = contracts.predictionMarketVault[chainId]?.address;
+  const vaultAddress = resolveVaultAddress(chainId, vaultAddressArg);
   if (!vaultAddress) {
     return {
       realizedPnL: 0n,
@@ -309,7 +364,6 @@ export async function calculateVaultPnL(
       totalCollateralLost: 0n,
     };
   }
-  const vaultAddressLower = vaultAddress.toLowerCase();
 
   const predictions = await prisma.prediction.findMany({
     where: {
@@ -320,10 +374,7 @@ export async function calculateVaultPnL(
         result: { not: SettlementResult.UNRESOLVED },
         ...(beforeTimestamp ? { resolvedAt: { lte: beforeTimestamp } } : {}),
       },
-      OR: [
-        { predictor: vaultAddressLower },
-        { counterparty: vaultAddressLower },
-      ],
+      OR: [{ predictor: vaultAddress }, { counterparty: vaultAddress }],
     },
     include: {
       pickConfiguration: { select: { result: true } },
@@ -344,7 +395,7 @@ export async function calculateVaultPnL(
     const counterpartyCollateral = BigInt(prediction.counterpartyCollateral);
 
     const isVaultPredictor =
-      prediction.predictor.toLowerCase() === vaultAddressLower;
+      prediction.predictor.toLowerCase() === vaultAddress;
 
     const vaultWon =
       (isVaultPredictor && picksResult === SettlementResult.PREDICTOR_WINS) ||
@@ -377,15 +428,22 @@ export async function calculateVaultPnL(
 }
 
 /**
- * Calculate vault's cumulative deposits and withdrawals from indexed flow events.
+ * Calculate a vault's cumulative deposits and withdrawals from indexed flow
+ * events. Events are keyed by vaultAddress so each deployment is isolated.
  */
 export async function calculateVaultFlows(
   chainId: number,
-  beforeTimestamp?: number
+  beforeTimestamp?: number,
+  vaultAddressArg?: string
 ): Promise<VaultFlowsResult> {
-  const whereClause: { chainId: number; timestamp?: { lte: number } } = {
-    chainId,
-  };
+  const vaultAddress = resolveVaultAddress(chainId, vaultAddressArg);
+  if (!vaultAddress) return { totalDeposits: 0n, totalWithdrawals: 0n };
+
+  const whereClause: {
+    chainId: number;
+    vaultAddress: string;
+    timestamp?: { lte: number };
+  } = { chainId, vaultAddress };
 
   if (beforeTimestamp) {
     whereClause.timestamp = { lte: beforeTimestamp };
@@ -466,62 +524,47 @@ async function upsertProtocolStatsSnapshot(
 }
 
 /**
- * Main function to compute and store daily protocol stats snapshot.
+ * Compute and store a snapshot for a single vault.
  */
-export async function computeAndStoreProtocolStats(
-  chainId: number = DEFAULT_CHAIN_ID
+async function computeAndStoreVaultStats(
+  chainId: number,
+  vault: ConfiguredVault,
+  escrowBalance: bigint,
+  timestamp: number
 ): Promise<void> {
-  const vaultAddress = (
-    contracts.predictionMarketVault[chainId]?.address ?? ''
-  ).toLowerCase();
-
   console.log(
-    `[ProtocolStats] Starting stats computation for chain ${chainId}, vault ${vaultAddress}`
+    `[ProtocolStats] Computing ${vault.kind} vault ${vault.address} on chain ${chainId}`
   );
 
-  // Use UTC midnight for consistent daily snapshots (matches backfillProtocolStats)
-  const timestamp = getUtcMidnightTimestamp(new Date());
-
-  // Fetch balances
-  const vaultBalance = await fetchVaultTVL(chainId);
-  const vaultAvailableAssets = await fetchVaultAvailableAssets(chainId);
-  const vaultDeployed = await fetchVaultDeployed(chainId);
-
-  // Sum escrow balance across current + legacy escrow contracts
-  const escrowConfig = contracts.predictionMarketEscrow[chainId];
-  let escrowBalance = await fetchPredictionMarketEscrowTVL(chainId);
-  for (const legEntry of escrowConfig?.legacy ?? []) {
-    const { address } = normalizeLegacyEntry(legEntry);
-    try {
-      escrowBalance += await fetchPredictionMarketEscrowTVL(chainId, address);
-    } catch {
-      // Legacy escrow may no longer exist
-    }
-  }
-
-  console.log(
-    `[ProtocolStats] Vault: ${formatUnits(vaultBalance, 18)} balance, ${formatUnits(vaultAvailableAssets, 18)} available, ${formatUnits(vaultDeployed, 18)} deployed`
+  const vaultBalance = await fetchVaultTVL(chainId, vault.address);
+  const vaultAvailableAssets = await fetchVaultAvailableAssets(
+    chainId,
+    vault.address
   );
-  console.log(
-    `[ProtocolStats] Escrow: ${formatUnits(escrowBalance, 18)} USDe (all contracts)`
+  const vaultDeployed = await fetchVaultDeployed(
+    chainId,
+    undefined,
+    vault.address
   );
 
-  // Calculate vault PnL
-  const pnlResult = await calculateVaultPnL(chainId);
   console.log(
-    `[ProtocolStats] Vault PnL: ${formatUnits(pnlResult.realizedPnL, 18)} USDe (won: ${pnlResult.positionsWon}, lost: ${pnlResult.positionsLost})`
+    `[ProtocolStats]   ${formatUnits(vaultBalance, 18)} balance, ${formatUnits(vaultAvailableAssets, 18)} available, ${formatUnits(vaultDeployed, 18)} deployed`
   );
 
-  // Calculate vault flows
-  const flowsResult = await calculateVaultFlows(chainId);
+  const pnlResult = await calculateVaultPnL(chainId, undefined, vault.address);
   console.log(
-    `[ProtocolStats] Deposits: ${formatUnits(flowsResult.totalDeposits, 18)}, Withdrawals: ${formatUnits(flowsResult.totalWithdrawals, 18)}`
+    `[ProtocolStats]   PnL: ${formatUnits(pnlResult.realizedPnL, 18)} USDe (won: ${pnlResult.positionsWon}, lost: ${pnlResult.positionsLost})`
   );
 
-  // Calculate airdrop gains: unexplained balance increases
-  // Actual total assets = vaultBalance + vaultDeployed
-  // Expected total assets = deposits - withdrawals + realizedPnL
-  // Airdrop gains = actual - expected
+  const flowsResult = await calculateVaultFlows(
+    chainId,
+    undefined,
+    vault.address
+  );
+  console.log(
+    `[ProtocolStats]   Deposits: ${formatUnits(flowsResult.totalDeposits, 18)}, Withdrawals: ${formatUnits(flowsResult.totalWithdrawals, 18)}`
+  );
+
   const actualTotalAssets = vaultBalance + vaultDeployed;
   const expectedTotalAssets =
     flowsResult.totalDeposits -
@@ -532,11 +575,7 @@ export async function computeAndStoreProtocolStats(
       ? actualTotalAssets - expectedTotalAssets
       : 0n;
 
-  console.log(
-    `[ProtocolStats] Airdrop gains: ${formatUnits(airdropGains, 18)} USDe`
-  );
-
-  await upsertProtocolStatsSnapshot(timestamp, chainId, vaultAddress, {
+  await upsertProtocolStatsSnapshot(timestamp, chainId, vault.address, {
     vaultBalance,
     vaultAvailableAssets,
     vaultDeployed,
@@ -550,8 +589,48 @@ export async function computeAndStoreProtocolStats(
     vaultCollateralWon: pnlResult.totalCollateralWon,
     vaultCollateralLost: pnlResult.totalCollateralLost,
   });
+}
 
-  console.log(`[ProtocolStats] Snapshot stored successfully`);
+/**
+ * Main function to compute and store daily protocol stats snapshots, one per
+ * configured vault on the chain.
+ */
+export async function computeAndStoreProtocolStats(
+  chainId: number = DEFAULT_CHAIN_ID
+): Promise<void> {
+  const vaults = getConfiguredVaults(chainId);
+  if (vaults.length === 0) {
+    console.log(`[ProtocolStats] No vaults configured for chain ${chainId}`);
+    return;
+  }
+
+  console.log(
+    `[ProtocolStats] Starting stats computation for chain ${chainId}, ${vaults.length} vault(s): ${vaults.map((v) => `${v.kind}@${v.address}`).join(', ')}`
+  );
+
+  const timestamp = getUtcMidnightTimestamp(new Date());
+
+  // Escrow is shared across all vaults on the chain — compute once and attach
+  // the same value to each per-vault snapshot.
+  const escrowConfig = contracts.predictionMarketEscrow[chainId];
+  let escrowBalance = await fetchPredictionMarketEscrowTVL(chainId);
+  for (const legEntry of escrowConfig?.legacy ?? []) {
+    const { address } = normalizeLegacyEntry(legEntry);
+    try {
+      escrowBalance += await fetchPredictionMarketEscrowTVL(chainId, address);
+    } catch {
+      // Legacy escrow may no longer exist
+    }
+  }
+  console.log(
+    `[ProtocolStats] Escrow: ${formatUnits(escrowBalance, 18)} USDe (all contracts)`
+  );
+
+  for (const vault of vaults) {
+    await computeAndStoreVaultStats(chainId, vault, escrowBalance, timestamp);
+  }
+
+  console.log(`[ProtocolStats] Snapshots stored successfully`);
 }
 
 /**
@@ -592,20 +671,38 @@ export async function getProtocolStatsTimeSeries(
   });
 }
 
-/**
- * Backfill historical protocol stats by querying on-chain state at past blocks.
- */
-export async function backfillProtocolStats(
-  chainId: number = DEFAULT_CHAIN_ID,
-  days: number = 90
+// Ethereal mainnet launched ~October 20, 2025. Before this date, no contracts
+// existed on-chain, so we create zero-valued snapshots as time-axis placeholders.
+const ETHEREAL_MAINNET_LAUNCH = Math.floor(Date.UTC(2025, 9, 20) / 1000);
+
+const ZERO_SNAPSHOT: ProtocolStatsData = {
+  vaultBalance: 0n,
+  vaultAvailableAssets: 0n,
+  vaultDeployed: 0n,
+  escrowBalance: 0n,
+  vaultRealizedPnL: 0n,
+  vaultAirdropGains: 0n,
+  vaultDeposits: 0n,
+  vaultWithdrawals: 0n,
+  vaultPositionsWon: 0,
+  vaultPositionsLost: 0,
+  vaultCollateralWon: 0n,
+  vaultCollateralLost: 0n,
+};
+
+async function backfillVaultStats(
+  chainId: number,
+  vault: ConfiguredVault,
+  days: number
 ): Promise<void> {
   const client = getProviderForChain(chainId);
-  const vaultAddress = (
-    contracts.predictionMarketVault[chainId]?.address ?? ''
-  ).toLowerCase();
+  const collateralAddress = contracts.collateralToken[chainId]?.address as
+    | `0x${string}`
+    | undefined;
+  const escrowConfig = contracts.predictionMarketEscrow[chainId];
 
   console.log(
-    `[ProtocolStats] Starting backfill for ${days} days on chain ${chainId}, vault ${vaultAddress}`
+    `[ProtocolStats] Backfilling ${days} days for ${vault.kind} vault ${vault.address}`
   );
 
   const todayMidnight = getUtcMidnightTimestamp(new Date());
@@ -617,10 +714,6 @@ export async function backfillProtocolStats(
   let successCount = 0;
   let skipCount = 0;
 
-  // Ethereal mainnet launched ~October 20, 2025. Before this date, no contracts
-  // existed on-chain, so we create zero-valued snapshots as time-axis placeholders.
-  const ETHEREAL_MAINNET_LAUNCH = Math.floor(Date.UTC(2025, 9, 20) / 1000); // 2025-10-20 UTC
-
   for (let idx = 0; idx < timestamps.length; idx++) {
     const timestamp = timestamps[idx];
     const dateStr = new Date(timestamp * 1000).toISOString().split('T')[0];
@@ -629,20 +722,12 @@ export async function backfillProtocolStats(
       console.log(
         `[ProtocolStats] ${dateStr} - before Ethereal mainnet launch, creating zero-valued snapshot`
       );
-      await upsertProtocolStatsSnapshot(timestamp, chainId, vaultAddress, {
-        vaultBalance: 0n,
-        vaultAvailableAssets: 0n,
-        vaultDeployed: 0n,
-        escrowBalance: 0n,
-        vaultRealizedPnL: 0n,
-        vaultAirdropGains: 0n,
-        vaultDeposits: 0n,
-        vaultWithdrawals: 0n,
-        vaultPositionsWon: 0,
-        vaultPositionsLost: 0,
-        vaultCollateralWon: 0n,
-        vaultCollateralLost: 0n,
-      });
+      await upsertProtocolStatsSnapshot(
+        timestamp,
+        chainId,
+        vault.address,
+        ZERO_SNAPSHOT
+      );
       skipCount++;
       continue;
     }
@@ -660,33 +745,24 @@ export async function backfillProtocolStats(
       `[ProtocolStats] Processing ${dateStr} (block ${blockNumber}) [${idx + 1}/${timestamps.length}]`
     );
 
-    // Query historical balances using blockCreated to pick the right contract.
-    const vaultConfig = contracts.predictionMarketVault[chainId];
-    const escrowConfig = contracts.predictionMarketEscrow[chainId];
-    const collateralAddress = contracts.collateralToken[chainId]?.address as
-      | `0x${string}`
-      | undefined;
-
-    const vaultAddr = vaultConfig
-      ? getContractForBlock(vaultConfig, blockNumber)
-      : null;
+    const vaultAddrAtBlock = getContractForBlock(vault.config, blockNumber);
     const escrowAddr = escrowConfig
       ? getContractForBlock(escrowConfig, blockNumber)
       : null;
 
     let vaultBalance = 0n;
     let vaultAvailableAssets = 0n;
-    if (vaultAddr && collateralAddress) {
+    if (vaultAddrAtBlock && collateralAddress) {
       vaultBalance = await client.readContract({
         address: collateralAddress,
         abi: erc20Abi,
         functionName: 'balanceOf',
-        args: [vaultAddr],
+        args: [vaultAddrAtBlock],
         blockNumber,
       });
       try {
         vaultAvailableAssets = (await client.readContract({
-          address: vaultAddr,
+          address: vaultAddrAtBlock,
           abi: predictionMarketVaultAbi,
           functionName: 'availableAssets',
           args: [],
@@ -712,14 +788,21 @@ export async function backfillProtocolStats(
     const vaultDeployed = await fetchVaultDeployedAtBlock(
       chainId,
       blockNumber,
-      timestamp
+      timestamp,
+      vault.address
     );
 
-    // Calculate PnL up to this timestamp
-    const pnlResult = await calculateVaultPnL(chainId, timestamp);
-    const flowsResult = await calculateVaultFlows(chainId, timestamp);
+    const pnlResult = await calculateVaultPnL(
+      chainId,
+      timestamp,
+      vault.address
+    );
+    const flowsResult = await calculateVaultFlows(
+      chainId,
+      timestamp,
+      vault.address
+    );
 
-    // Calculate airdrop gains
     const actualTotalAssets = vaultBalance + vaultDeployed;
     const expectedTotalAssets =
       flowsResult.totalDeposits -
@@ -730,7 +813,7 @@ export async function backfillProtocolStats(
         ? actualTotalAssets - expectedTotalAssets
         : 0n;
 
-    await upsertProtocolStatsSnapshot(timestamp, chainId, vaultAddress, {
+    await upsertProtocolStatsSnapshot(timestamp, chainId, vault.address, {
       vaultBalance,
       vaultAvailableAssets,
       vaultDeployed,
@@ -754,6 +837,29 @@ export async function backfillProtocolStats(
   }
 
   console.log(
-    `[ProtocolStats] Backfill complete: ${successCount} days processed, ${skipCount} skipped`
+    `[ProtocolStats] Backfill for ${vault.kind} complete: ${successCount} processed, ${skipCount} skipped`
   );
+}
+
+/**
+ * Backfill historical protocol stats by querying on-chain state at past blocks,
+ * iterating over every configured vault on the chain.
+ */
+export async function backfillProtocolStats(
+  chainId: number = DEFAULT_CHAIN_ID,
+  days: number = 90
+): Promise<void> {
+  const vaults = getConfiguredVaults(chainId);
+  if (vaults.length === 0) {
+    console.log(`[ProtocolStats] No vaults configured for chain ${chainId}`);
+    return;
+  }
+
+  console.log(
+    `[ProtocolStats] Starting backfill for chain ${chainId}, ${vaults.length} vault(s): ${vaults.map((v) => `${v.kind}@${v.address}`).join(', ')}`
+  );
+
+  for (const vault of vaults) {
+    await backfillVaultStats(chainId, vault, days);
+  }
 }


### PR DESCRIPTION
## Summary

- Fan out the daily `protocolStats` cron + backfill over every configured vault on the chain (main protocol vault, Pyth options vault, single-leg vault) instead of hardcoding `predictionMarketVault`.
- Thread an optional `vaultAddress` through all read helpers (`fetchVaultTVL`, `fetchVaultAvailableAssets`, `fetchVaultDeployed`, `calculateVaultPnL`, `calculateVaultFlows`, and their at-block variants). Defaults to the main vault so existing callers are unaffected.
- Add `vaultAddress` to `VaultFlowEvent` so `calculateVaultFlows` can scope deposits/withdrawals per vault rather than summing every event on the chain. The migration truncates the table — existing rows predate the column and `backfillVaultFlows.ts` is idempotent.
- `backfillVaultFlows.ts` now loops over every configured vault on the target chain and writes the new column.
- Fix the historical backfill path so pre-redeploy snapshots use the vault deployment that was actually live at that block for deployed/PnL/flow calculations, while still writing into the current vault's time series row.

## Why

PR #1601 added a tab switcher between the Protocol and Options vaults on `/vaults` and plumbed an optional `vaultAddress` through the GraphQL `protocolStats` query — but the underlying `protocol_stats_snapshot` table only had rows for the main vault, so the Options tab on testnet rendered with zero TVL / zero deployed / flat PnL.

This PR closes that gap on the write side. After merging and running the backfills, the Options tab will reflect real on-chain state.

While reviewing the multi-vault write path, we also found a redeploy-boundary bug in the historical backfill: on-chain balance reads already switched to the legacy vault for old blocks, but deployed/PnL/flow queries still filtered by the current vault address. That produced mixed snapshots around vault redeploys. This patch fixes that mismatch and adds a regression test.

## Post-deploy steps

1. Run the Prisma migration (`add_vault_address_to_vault_flow_event`). It truncates `vault_flow_event`.
2. Re-run the vault-flows backfill per env:
   ```
   pnpm --filter @sapience/api exec tsx scripts/backfillVaultFlows.ts --chainId 5064014  # mainnet
   pnpm --filter @sapience/api exec tsx scripts/backfillVaultFlows.ts --chainId 13374202 # testnet (main + Pyth)
   ```
3. Trigger the `backfillProtocolStats` route to rebuild the 90-day snapshot history for every configured vault.

## Test plan

- [x] `pnpm --filter @sapience/sdk run build:lib && pnpm --filter @sapience/api run prisma:generate`
- [x] `pnpm --filter @sapience/api run test` — 434 pass before this patch; targeted `src/helpers/protocolStats.test.ts` now covers both multi-vault fan-out and the redeploy-boundary regression
- [x] `pnpm --filter @sapience/api run type-check`
- [x] `pnpm --filter @sapience/api run lint`
- [ ] Run migration + backfill scripts on staging and confirm Options tab shows non-zero balance/deployed/PnL
- [ ] Sanity-check the Protocol tab numbers are unchanged before/after migration (same vault, same helper defaults)
- [ ] Sanity-check a vault with a redeploy history to confirm the backfilled series stays continuous across the old/new deployment boundary
