### PR TITLE
Always show Predict Prices and make feed dropdown instant

### DIFF
--- a/packages/app/src/components/markets/MarketsPage.tsx
+++ b/packages/app/src/components/markets/MarketsPage.tsx
@@ -29,7 +29,6 @@ import {
   type VolumeWindow,
 } from '~/hooks/graphql/useInfiniteQuestions';
 import { useDebouncedValue } from '~/hooks/useDebouncedValue';
-import { useFeatureFlag } from '~/hooks/useFeatureFlag';
 import { useSessionState } from '~/hooks/useSessionState';
 import { useCreatePositionContext } from '~/lib/context/CreatePositionContext';
 
@@ -54,11 +53,6 @@ const MarketsPage = () => {
 
   // Get compact status (needed by callbacks below)
   const isCompact = useIsBelow(1024);
-
-  const showPredictPrices = useFeatureFlag(
-    'markets.predictPrices',
-    'predictPrices'
-  );
 
   const { openPopover } = useCreatePositionContext();
 
@@ -381,21 +375,19 @@ const MarketsPage = () => {
           {!useCardGrid && <ExampleCombos className="mt-4 md:mt-0" />}
 
           {/* Predict Prices (shared) */}
-          {showPredictPrices && (
-            <div className={`w-full mt-4 mb-2 ${useCardGrid ? 'px-4' : ''}`}>
-              <div className="flex items-center justify-between mb-2 px-1">
-                <h2
-                  className={`sc-heading ${useCardGrid ? 'text-white/80' : 'text-foreground'}`}
-                >
-                  Predict Prices
-                </h2>
-              </div>
-              <CreatePythPredictionForm
-                featuredFeeds={PYTH_FEEDS}
-                onPick={handlePythPick}
-              />
+          <div className={`w-full mt-4 mb-2 ${useCardGrid ? 'px-4' : ''}`}>
+            <div className="flex items-center justify-between mb-2 px-1">
+              <h2
+                className={`sc-heading ${useCardGrid ? 'text-white/80' : 'text-foreground'}`}
+              >
+                Predict Prices
+              </h2>
             </div>
-          )}
+            <CreatePythPredictionForm
+              featuredFeeds={PYTH_FEEDS}
+              onPick={handlePythPick}
+            />
+          </div>
 
           {/* Results area */}
           <div className="relative w-full max-w-full overflow-x-hidden flex-1 flex flex-col min-h-0">

--- a/packages/ui/components/CreatePythPredictionForm.tsx
+++ b/packages/ui/components/CreatePythPredictionForm.tsx
@@ -119,15 +119,64 @@ async function fetchPythProFeeds(
 let cachedLazerFeeds: PythProFeedRow[] | null = null;
 let inflightLazerFeeds: Promise<PythProFeedRow[]> | null = null;
 
+const LAZER_FEEDS_STORAGE_KEY = 'sapience.pyth.lazerFeeds.v1';
+const LAZER_FEEDS_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+
+type LazerFeedsEnvelope = {
+  cachedAt: number;
+  feeds: PythProFeedRow[];
+};
+
+function readLazerFeedsFromStorage(): PythProFeedRow[] | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(LAZER_FEEDS_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as LazerFeedsEnvelope;
+    if (
+      !parsed ||
+      typeof parsed.cachedAt !== 'number' ||
+      !Array.isArray(parsed.feeds)
+    ) {
+      return null;
+    }
+    if (Date.now() - parsed.cachedAt > LAZER_FEEDS_TTL_MS) return null;
+    return parsed.feeds;
+  } catch {
+    return null;
+  }
+}
+
+function writeLazerFeedsToStorage(feeds: PythProFeedRow[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const envelope: LazerFeedsEnvelope = { cachedAt: Date.now(), feeds };
+    window.localStorage.setItem(
+      LAZER_FEEDS_STORAGE_KEY,
+      JSON.stringify(envelope)
+    );
+  } catch {
+    // Storage unavailable or quota exceeded — ignore.
+  }
+}
+
 async function loadPythProFeedsCached(
   signal: AbortSignal
 ): Promise<PythProFeedRow[]> {
   if (cachedLazerFeeds && cachedLazerFeeds.length > 0) return cachedLazerFeeds;
+
+  const fromStorage = readLazerFeedsFromStorage();
+  if (fromStorage && fromStorage.length > 0) {
+    cachedLazerFeeds = fromStorage;
+    return fromStorage;
+  }
+
   if (inflightLazerFeeds) return await inflightLazerFeeds;
   inflightLazerFeeds = (async () => {
     try {
       const rows = await fetchPythProFeeds(signal);
       cachedLazerFeeds = rows;
+      writeLazerFeedsToStorage(rows);
       return rows;
     } finally {
       inflightLazerFeeds = null;
@@ -864,6 +913,12 @@ export function CreatePythPredictionForm({
       setLazerFeeds(cachedLazerFeeds);
       return () => {};
     }
+    const fromStorage = readLazerFeedsFromStorage();
+    if (fromStorage && fromStorage.length > 0) {
+      cachedLazerFeeds = fromStorage;
+      setLazerFeeds(fromStorage);
+      return () => {};
+    }
 
     const ac = new AbortController();
     setIsLoadingLazerFeeds(true);
@@ -1093,11 +1148,11 @@ export function CreatePythPredictionForm({
               >
                 <Command>
                   <CommandList>
-                    {isLoadingLazerFeeds ? (
+                    {filteredLazerFeeds.length === 0 && isLoadingLazerFeeds ? (
                       <div className="py-3 px-3 text-sm opacity-75">
                         Loading…
                       </div>
-                    ) : lazerFeedsError ? (
+                    ) : filteredLazerFeeds.length === 0 && lazerFeedsError ? (
                       <div className="py-3 px-3 text-sm text-red-400">
                         {lazerFeedsError}
                       </div>


### PR DESCRIPTION
## Summary
- Remove the `predictPrices` feature flag so the Predict Prices section is always rendered on `/markets`.
- Render featured Pyth feeds (BTC, ETH, ENA, …) immediately on dropdown open instead of gating them behind a "Loading…" state.
- Persist the full Pyth Lazer feed list to `localStorage` with a 24h TTL so subsequent visits skip the network fetch entirely.

## Test plan
- [ ] Visit `/markets` — the Predict Prices section is visible without `?predictPrices=true`.
- [ ] Click "Select Price Feed" on a fresh browser profile — featured feeds (BTC, ETH, ENA, OIL, GOLD, SPY, TSLA) show instantly; search still works once the full list finishes loading in the background.
- [ ] Reload the page and reopen the dropdown — no "Loading…" state; full list is available from localStorage.
- [ ] Clear `sapience.pyth.lazerFeeds.v1` from localStorage and confirm the first-visit behavior (featured rows instant, background fetch repopulates cache).