### PR TITLE
fix(app): stop feed category icons from flashing to unknown

### DIFF
--- a/packages/app/src/app/predictions/[predictionId]/PredictionPageClient.tsx
+++ b/packages/app/src/app/predictions/[predictionId]/PredictionPageClient.tsx
@@ -1,24 +1,10 @@
 'use client';
 
-import { formatEther } from 'viem';
 import { useQuery } from '@tanstack/react-query';
-import { OutcomeSide } from '@sapience/sdk/types';
-import { PicksContent } from '~/components/shared/PicksSummary';
-import PositionSummary from '~/components/positions/PositionSummary';
+import PredictionDetails from '~/components/positions/PredictionDetails';
+import type { ConditionsMap } from '~/components/positions/toPickLegs';
 import type { PredictionData, ConditionData } from '~/lib/data/predictions';
 import { fetchPredictionWithConditions } from '~/lib/data/predictions';
-import type { Pick } from '~/components/shared/StackedPredictions';
-import { computeResultFromConditions } from '~/components/positions/toPickLegs';
-import { inferResolverKind } from '~/lib/resolvers/conditionResolver';
-
-function formatCollateral(wei?: string): number {
-  if (!wei) return 0;
-  try {
-    return Number(formatEther(BigInt(wei)));
-  } catch {
-    return 0;
-  }
-}
 
 export default function PredictionPageClient({
   predictionId,
@@ -71,96 +57,15 @@ export default function PredictionPageClient({
     );
   }
 
-  const conditionsMap = new Map(conditions.map((c) => [c.id, c]));
-  const picks = prediction.pickConfig?.picks ?? [];
-
-  // Build picks from predictor's perspective
-  const displayPicks: Pick[] = picks.map((pick) => {
-    const condition = conditionsMap.get(pick.conditionId);
-    const resolverAddr = pick.conditionResolver ?? condition?.resolver ?? null;
-    const resolverKind = inferResolverKind(resolverAddr);
-    return {
-      question: condition?.question || condition?.shortName || pick.conditionId,
-      choice:
-        (pick.predictedOutcome as OutcomeSide) === OutcomeSide.YES
-          ? 'YES'
-          : 'NO',
-      conditionId: pick.conditionId,
-      categorySlug: condition?.category?.slug ?? null,
-      endTime: condition?.endTime ?? null,
-      settled: condition?.settled ?? false,
-      resolvedToYes: condition?.resolvedToYes ?? false,
-      nonDecisive: condition?.nonDecisive,
-      resolverAddress: resolverAddr,
-      ...(resolverKind === 'pyth' && { source: 'pyth' as const }),
-    };
-  });
-
-  const predictorStake = formatCollateral(prediction.predictorCollateral);
-  const counterpartyStake = formatCollateral(prediction.counterpartyCollateral);
-  const totalPayout = predictorStake + counterpartyStake;
-  const createdAt = prediction.createdAt
-    ? new Date(prediction.createdAt)
-    : null;
-
-  // Compute the maximum endTime from conditions
-  const endsAtMs =
-    picks.reduce((max, pick) => {
-      const endTime = conditionsMap.get(pick.conditionId)?.endTime;
-      return endTime ? Math.max(max, endTime * 1000) : max;
-    }, 0) || null;
-
-  // Compute result from individual conditions when prediction not yet settled on-chain
-  const computed = !prediction.settled
-    ? computeResultFromConditions(
-        picks,
-        conditionsMap as Parameters<typeof computeResultFromConditions>[1]
-      )
-    : null;
-  const isSettled = prediction.settled || computed?.result !== 'UNRESOLVED';
-  const result = prediction.settled
-    ? prediction.result
-    : (computed?.result ?? 'UNRESOLVED');
-  const predictorWon = result === 'PREDICTOR_WINS';
-  // NON_DECISIVE resolves to the counterparty on-chain.
-  const counterpartyWon =
-    result === 'COUNTERPARTY_WINS' || result === 'NON_DECISIVE';
+  const conditionsMap: ConditionsMap = new Map(
+    conditions.map((c) => [c.id, c])
+  );
 
   return (
-    <>
-      <div className="mb-6">
-        <PositionSummary
-          positionId={predictionId}
-          createdAt={createdAt}
-          endsAtMs={endsAtMs}
-          positionSize={0}
-          payout={totalPayout}
-          pnl={null}
-          roi={null}
-          isSettled={isSettled}
-          predictorAddress={prediction.predictor}
-          counterpartyAddress={prediction.counterparty}
-          predictorStake={predictorStake}
-          counterpartyStake={counterpartyStake}
-          predictorWon={predictorWon}
-          counterpartyWon={counterpartyWon}
-        />
-      </div>
-
-      <PicksContent
-        picks={displayPicks}
-        positionId={predictionId}
-        hideHeader
-        positionStatus={
-          isSettled
-            ? predictorWon
-              ? 'won'
-              : 'lost'
-            : endsAtMs && endsAtMs <= Date.now()
-              ? 'pending'
-              : 'active'
-        }
-      />
-    </>
+    <PredictionDetails
+      prediction={prediction}
+      picks={prediction.pickConfig?.picks ?? []}
+      conditionsMap={conditionsMap}
+    />
   );
 }

--- a/packages/app/src/app/predictions/[predictionId]/PredictionPageClient.tsx
+++ b/packages/app/src/app/predictions/[predictionId]/PredictionPageClient.tsx
@@ -96,10 +96,9 @@ export default function PredictionPageClient({
     };
   });
 
-  const positionSize = formatCollateral(prediction.predictorCollateral);
-  const totalPayout =
-    formatCollateral(prediction.predictorCollateral) +
-    formatCollateral(prediction.counterpartyCollateral);
+  const predictorStake = formatCollateral(prediction.predictorCollateral);
+  const counterpartyStake = formatCollateral(prediction.counterpartyCollateral);
+  const totalPayout = predictorStake + counterpartyStake;
   const createdAt = prediction.createdAt
     ? new Date(prediction.createdAt)
     : null;
@@ -123,17 +122,9 @@ export default function PredictionPageClient({
     ? prediction.result
     : (computed?.result ?? 'UNRESOLVED');
   const predictorWon = result === 'PREDICTOR_WINS';
-  // This page shows the predictor's side; NON_DECISIVE resolves to the counterparty.
-  const positionWon = isSettled && predictorWon;
-
-  // PnL
-  const pnl = isSettled
-    ? positionWon
-      ? totalPayout - positionSize
-      : -positionSize
-    : null;
-  const roi =
-    pnl !== null && positionSize > 0 ? (pnl / positionSize) * 100 : null;
+  // NON_DECISIVE resolves to the counterparty on-chain.
+  const counterpartyWon =
+    result === 'COUNTERPARTY_WINS' || result === 'NON_DECISIVE';
 
   return (
     <>
@@ -142,14 +133,17 @@ export default function PredictionPageClient({
           positionId={predictionId}
           createdAt={createdAt}
           endsAtMs={endsAtMs}
-          positionSize={positionSize}
+          positionSize={0}
           payout={totalPayout}
-          pnl={pnl}
-          roi={roi}
+          pnl={null}
+          roi={null}
           isSettled={isSettled}
-          positionWon={positionWon}
           predictorAddress={prediction.predictor}
           counterpartyAddress={prediction.counterparty}
+          predictorStake={predictorStake}
+          counterpartyStake={counterpartyStake}
+          predictorWon={predictorWon}
+          counterpartyWon={counterpartyWon}
         />
       </div>
 
@@ -159,7 +153,7 @@ export default function PredictionPageClient({
         hideHeader
         positionStatus={
           isSettled
-            ? positionWon
+            ? predictorWon
               ? 'won'
               : 'lost'
             : endsAtMs && endsAtMs <= Date.now()

--- a/packages/app/src/components/positions/ActivityTable.tsx
+++ b/packages/app/src/components/positions/ActivityTable.tsx
@@ -815,9 +815,10 @@ export default function ActivityTable({
                 </th>
               )}
               {!isHidden('share') && (
-                <th className="px-4 py-3 text-left align-middle font-medium">
-                  Share
-                </th>
+                <th
+                  className="px-4 py-3 text-left align-middle font-medium"
+                  aria-label="Share"
+                />
               )}
             </tr>
           </thead>

--- a/packages/app/src/components/positions/PositionDialog.tsx
+++ b/packages/app/src/components/positions/PositionDialog.tsx
@@ -130,7 +130,7 @@ export default function PositionDialog({
             />
           </button>
           {activityOpen && (
-            <div className="border-t border-border/60 max-h-56 overflow-y-auto">
+            <div className="border-t border-border/60">
               <ActivityTable
                 account={position.holder as Address}
                 filterPickConfigId={position.pickConfigId}

--- a/packages/app/src/components/positions/PositionDialog.tsx
+++ b/packages/app/src/components/positions/PositionDialog.tsx
@@ -130,7 +130,7 @@ export default function PositionDialog({
             />
           </button>
           {activityOpen && (
-            <div className="border-t border-border/60">
+            <div className="border-t border-border/60 max-h-56 overflow-y-auto">
               <ActivityTable
                 account={position.holder as Address}
                 filterPickConfigId={position.pickConfigId}

--- a/packages/app/src/components/positions/PositionSummary.tsx
+++ b/packages/app/src/components/positions/PositionSummary.tsx
@@ -180,15 +180,25 @@ export default function PositionSummary({
 
   const renderStatusCell = () => {
     let value: string;
-    if (isSettled && predictorWon) value = 'PREDICTOR';
-    else if (isSettled && counterpartyWon) value = 'COUNTERPARTY';
-    else value = 'PENDING';
+    let valueClass: string;
+    if (isSettled && predictorWon) {
+      value = 'PREDICTOR';
+      valueClass = 'text-brand-white';
+    } else if (isSettled && counterpartyWon) {
+      value = 'COUNTERPARTY';
+      valueClass = 'text-brand-white';
+    } else {
+      value = 'PENDING';
+      valueClass = 'text-muted-foreground';
+    }
     return (
       <div className="flex flex-col gap-1 min-w-0">
         <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
           Winner
         </div>
-        <span className="text-sm md:text-base font-medium font-mono text-foreground">
+        <span
+          className={`text-sm md:text-base font-medium font-mono ${valueClass}`}
+        >
           {value}
         </span>
       </div>

--- a/packages/app/src/components/positions/PositionSummary.tsx
+++ b/packages/app/src/components/positions/PositionSummary.tsx
@@ -193,7 +193,7 @@ export default function PositionSummary({
         'border-muted-foreground/40 bg-muted-foreground/10 text-muted-foreground';
     }
     return (
-      <div className="flex flex-col gap-1.5 min-w-0 items-start">
+      <div className="flex flex-col gap-1 min-w-0 items-start">
         <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
           Winner
         </div>

--- a/packages/app/src/components/positions/PositionSummary.tsx
+++ b/packages/app/src/components/positions/PositionSummary.tsx
@@ -237,18 +237,21 @@ export default function PositionSummary({
         {label}
       </div>
       {address ? (
-        <Link
-          href={`/profile/${address}`}
-          className="inline-flex items-center gap-1.5 text-sm md:text-base font-medium tabular-nums text-foreground hover:text-accent-gold transition-colors min-w-0 max-w-full overflow-hidden"
-        >
-          <EnsAvatar
-            address={address}
-            className="shrink-0 rounded-sm ring-1 ring-border/50"
-            width={16}
-            height={16}
-          />
+        <div className="inline-flex items-center gap-1.5 text-sm md:text-base font-medium tabular-nums text-foreground min-w-0 max-w-full overflow-hidden">
+          <Link
+            href={`/profile/${address}`}
+            aria-label={`View profile for ${address}`}
+            className="shrink-0 hover:opacity-80 transition-opacity"
+          >
+            <EnsAvatar
+              address={address}
+              className="shrink-0 rounded-sm ring-1 ring-border/50"
+              width={16}
+              height={16}
+            />
+          </Link>
           <AddressDisplay address={address} />
-        </Link>
+        </div>
       ) : (
         <span className="text-sm md:text-base font-medium tabular-nums text-muted-foreground">
           —

--- a/packages/app/src/components/positions/PositionSummary.tsx
+++ b/packages/app/src/components/positions/PositionSummary.tsx
@@ -193,7 +193,7 @@ export default function PositionSummary({
         'border-muted-foreground/40 bg-muted-foreground/10 text-muted-foreground';
     }
     return (
-      <div className="flex flex-col gap-1 min-w-0 items-start">
+      <div className="flex flex-col gap-[5px] min-w-0 items-start">
         <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
           Winner
         </div>

--- a/packages/app/src/components/positions/PositionSummary.tsx
+++ b/packages/app/src/components/positions/PositionSummary.tsx
@@ -179,28 +179,23 @@ export default function PositionSummary({
   );
 
   const renderStatusCell = () => {
-    const label = isSettled ? 'Winner' : 'Status';
     let value: string;
     let badgeClass: string;
-    if (!isSettled) {
-      const isLive = endsAtMs != null && endsAtMs > Date.now();
-      value = isLive ? 'ACTIVE' : 'PENDING';
-      badgeClass = 'border-foreground/40 bg-foreground/10 text-foreground';
-    } else if (predictorWon) {
+    if (isSettled && predictorWon) {
       value = 'PREDICTOR';
       badgeClass = 'border-yes/40 bg-yes/10 text-yes';
-    } else if (counterpartyWon) {
+    } else if (isSettled && counterpartyWon) {
       value = 'COUNTERPARTY';
       badgeClass = 'border-yes/40 bg-yes/10 text-yes';
     } else {
-      value = 'SETTLED';
+      value = 'PENDING';
       badgeClass =
         'border-muted-foreground/40 bg-muted-foreground/10 text-muted-foreground';
     }
     return (
       <div className="flex flex-col gap-1.5 min-w-0 items-start">
         <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
-          {label}
+          Winner
         </div>
         <span
           className={`inline-block px-1.5 py-0.5 text-xs font-medium rounded-md font-mono border ${badgeClass}`}
@@ -392,18 +387,21 @@ export default function PositionSummary({
                   <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
                     Holder
                   </div>
-                  <Link
-                    href={`/profile/${holderAddress}`}
-                    className="inline-flex items-center gap-1.5 text-sm md:text-base font-medium tabular-nums text-foreground hover:text-accent-gold transition-colors"
-                  >
-                    <EnsAvatar
-                      address={holderAddress}
-                      className="shrink-0 rounded-sm ring-1 ring-border/50"
-                      width={16}
-                      height={16}
-                    />
+                  <div className="inline-flex items-center gap-1.5 text-sm md:text-base font-medium tabular-nums text-foreground">
+                    <Link
+                      href={`/profile/${holderAddress}`}
+                      aria-label={`View profile for ${holderAddress}`}
+                      className="shrink-0 hover:opacity-80 transition-opacity"
+                    >
+                      <EnsAvatar
+                        address={holderAddress}
+                        className="shrink-0 rounded-sm ring-1 ring-border/50"
+                        width={16}
+                        height={16}
+                      />
+                    </Link>
                     <AddressDisplay address={holderAddress} />
-                  </Link>
+                  </div>
                 </div>
               )}
 
@@ -417,18 +415,21 @@ export default function PositionSummary({
                       <Loader className="w-3.5 h-3.5" />
                     </div>
                   ) : currentOwner ? (
-                    <Link
-                      href={`/profile/${currentOwner}`}
-                      className="inline-flex items-center gap-1.5 text-sm md:text-base font-medium tabular-nums text-foreground hover:text-accent-gold transition-colors"
-                    >
-                      <EnsAvatar
-                        address={currentOwner}
-                        className="shrink-0 rounded-sm ring-1 ring-border/50"
-                        width={16}
-                        height={16}
-                      />
+                    <div className="inline-flex items-center gap-1.5 text-sm md:text-base font-medium tabular-nums text-foreground">
+                      <Link
+                        href={`/profile/${currentOwner}`}
+                        aria-label={`View profile for ${currentOwner}`}
+                        className="shrink-0 hover:opacity-80 transition-opacity"
+                      >
+                        <EnsAvatar
+                          address={currentOwner}
+                          className="shrink-0 rounded-sm ring-1 ring-border/50"
+                          width={16}
+                          height={16}
+                        />
+                      </Link>
                       <AddressDisplay address={currentOwner} />
-                    </Link>
+                    </div>
                   ) : (
                     <span className="text-sm md:text-base font-medium tabular-nums text-muted-foreground">
                       —

--- a/packages/app/src/components/positions/PositionSummary.tsx
+++ b/packages/app/src/components/positions/PositionSummary.tsx
@@ -180,26 +180,15 @@ export default function PositionSummary({
 
   const renderStatusCell = () => {
     let value: string;
-    let badgeClass: string;
-    if (isSettled && predictorWon) {
-      value = 'PREDICTOR';
-      badgeClass = 'border-yes/40 bg-yes/10 text-yes';
-    } else if (isSettled && counterpartyWon) {
-      value = 'COUNTERPARTY';
-      badgeClass = 'border-yes/40 bg-yes/10 text-yes';
-    } else {
-      value = 'PENDING';
-      badgeClass =
-        'border-muted-foreground/40 bg-muted-foreground/10 text-muted-foreground';
-    }
+    if (isSettled && predictorWon) value = 'PREDICTOR';
+    else if (isSettled && counterpartyWon) value = 'COUNTERPARTY';
+    else value = 'PENDING';
     return (
-      <div className="flex flex-col gap-[5px] min-w-0 items-start">
+      <div className="flex flex-col gap-1 min-w-0">
         <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
           Winner
         </div>
-        <span
-          className={`inline-block px-1.5 py-0.5 text-xs font-medium rounded-md font-mono border ${badgeClass}`}
-        >
+        <span className="text-sm md:text-base font-medium font-mono text-foreground">
           {value}
         </span>
       </div>

--- a/packages/app/src/components/positions/PredictionDetails.tsx
+++ b/packages/app/src/components/positions/PredictionDetails.tsx
@@ -87,36 +87,31 @@ export default function PredictionDetails({
       : 'active';
 
   return (
-    <>
-      <div className="min-w-0">
-        <PositionSummary
-          positionId={prediction.predictionId}
-          createdAt={createdAt}
-          endsAtMs={endsAtMs}
-          positionSize={0}
-          payout={totalPayout}
-          pnl={null}
-          roi={null}
-          isSettled={isSettled}
-          collateralSymbol={collateralSymbol}
-          positionUrl={positionUrl}
-          predictorAddress={prediction.predictor}
-          counterpartyAddress={prediction.counterparty}
-          predictorStake={predictorStake}
-          counterpartyStake={counterpartyStake}
-          predictorWon={predictorWon}
-          counterpartyWon={counterpartyWon}
-        />
-      </div>
-
-      <div className="min-w-0">
-        <PicksContent
-          picks={displayPicks}
-          positionId={prediction.predictionId}
-          hideHeader
-          positionStatus={positionStatus}
-        />
-      </div>
-    </>
+    <div className="min-w-0 space-y-4">
+      <PositionSummary
+        positionId={prediction.predictionId}
+        createdAt={createdAt}
+        endsAtMs={endsAtMs}
+        positionSize={0}
+        payout={totalPayout}
+        pnl={null}
+        roi={null}
+        isSettled={isSettled}
+        collateralSymbol={collateralSymbol}
+        positionUrl={positionUrl}
+        predictorAddress={prediction.predictor}
+        counterpartyAddress={prediction.counterparty}
+        predictorStake={predictorStake}
+        counterpartyStake={counterpartyStake}
+        predictorWon={predictorWon}
+        counterpartyWon={counterpartyWon}
+      />
+      <PicksContent
+        picks={displayPicks}
+        positionId={prediction.predictionId}
+        hideHeader
+        positionStatus={positionStatus}
+      />
+    </div>
   );
 }

--- a/packages/app/src/components/positions/PredictionDetails.tsx
+++ b/packages/app/src/components/positions/PredictionDetails.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { formatEther } from 'viem';
+import PositionSummary from './PositionSummary';
+import {
+  toPicks,
+  computeResultFromConditions,
+  type ConditionsMap,
+  type PickInput,
+} from './toPickLegs';
+import { PicksContent } from '~/components/shared/PicksSummary';
+
+/** Minimum prediction fields this block needs. Both the client `Prediction`
+ *  (from usePositions) and the SSR `PredictionData` (from lib/data/predictions)
+ *  satisfy it. */
+export interface PredictionInput {
+  predictionId: string;
+  predictor: string;
+  counterparty: string;
+  predictorCollateral: string;
+  counterpartyCollateral: string;
+  settled: boolean;
+  result: string;
+  createdAt: string;
+}
+
+export interface PredictionDetailsProps {
+  prediction: PredictionInput;
+  picks: readonly PickInput[];
+  conditionsMap: ConditionsMap;
+  collateralSymbol?: string;
+  /** If set, PositionSummary shows an external-link icon to this URL next to
+   *  the prediction id (used by the dialog to deep-link into the full page). */
+  positionUrl?: string;
+}
+
+/**
+ * Symmetric prediction detail block: summary of both parties + the list of
+ * picks. Shared by `PredictionDialog` and `/predictions/[id]` so the two
+ * surfaces render identically and derive stake/winner/end data in one place.
+ */
+export default function PredictionDetails({
+  prediction,
+  picks,
+  conditionsMap,
+  collateralSymbol = 'USDe',
+  positionUrl,
+}: PredictionDetailsProps) {
+  // Side-agnostic: render from the predictor's canonical perspective.
+  const displayPicks = toPicks(picks, true, conditionsMap);
+
+  const predictorStake = Number(
+    formatEther(BigInt(prediction.predictorCollateral))
+  );
+  const counterpartyStake = Number(
+    formatEther(BigInt(prediction.counterpartyCollateral))
+  );
+  const totalPayout = predictorStake + counterpartyStake;
+
+  const computed = !prediction.settled
+    ? computeResultFromConditions(picks, conditionsMap)
+    : null;
+  const isSettled = prediction.settled || computed?.result !== 'UNRESOLVED';
+  const result = prediction.settled
+    ? prediction.result
+    : (computed?.result ?? 'UNRESOLVED');
+  const predictorWon = result === 'PREDICTOR_WINS';
+  // NON_DECISIVE resolves to the counterparty on-chain.
+  const counterpartyWon =
+    result === 'COUNTERPARTY_WINS' || result === 'NON_DECISIVE';
+
+  const createdAt = prediction.createdAt
+    ? new Date(prediction.createdAt)
+    : null;
+  const endsAtMs =
+    picks.reduce((max, pick) => {
+      const endTime = conditionsMap.get(pick.conditionId)?.endTime;
+      return endTime ? Math.max(max, endTime * 1000) : max;
+    }, 0) || null;
+
+  const positionStatus: 'won' | 'lost' | 'pending' | 'active' = isSettled
+    ? predictorWon
+      ? 'won'
+      : 'lost'
+    : endsAtMs && endsAtMs <= Date.now()
+      ? 'pending'
+      : 'active';
+
+  return (
+    <>
+      <div className="min-w-0 mb-6">
+        <PositionSummary
+          positionId={prediction.predictionId}
+          createdAt={createdAt}
+          endsAtMs={endsAtMs}
+          positionSize={0}
+          payout={totalPayout}
+          pnl={null}
+          roi={null}
+          isSettled={isSettled}
+          collateralSymbol={collateralSymbol}
+          positionUrl={positionUrl}
+          predictorAddress={prediction.predictor}
+          counterpartyAddress={prediction.counterparty}
+          predictorStake={predictorStake}
+          counterpartyStake={counterpartyStake}
+          predictorWon={predictorWon}
+          counterpartyWon={counterpartyWon}
+        />
+      </div>
+
+      <div className="min-w-0">
+        <PicksContent
+          picks={displayPicks}
+          positionId={prediction.predictionId}
+          hideHeader
+          positionStatus={positionStatus}
+        />
+      </div>
+    </>
+  );
+}

--- a/packages/app/src/components/positions/PredictionDetails.tsx
+++ b/packages/app/src/components/positions/PredictionDetails.tsx
@@ -88,7 +88,7 @@ export default function PredictionDetails({
 
   return (
     <>
-      <div className="min-w-0 mb-6">
+      <div className="min-w-0">
         <PositionSummary
           positionId={prediction.predictionId}
           createdAt={createdAt}

--- a/packages/app/src/components/positions/PredictionDialog.tsx
+++ b/packages/app/src/components/positions/PredictionDialog.tsx
@@ -1,15 +1,9 @@
 'use client';
 
 import { Dialog, DialogContent } from '@sapience/ui/components/ui/dialog';
-import { formatEther } from 'viem';
-import PositionSummary from './PositionSummary';
-import { PicksContent } from '~/components/shared/PicksSummary';
+import PredictionDetails from './PredictionDetails';
 import type { Prediction, PickConfigData } from '~/hooks/graphql/usePositions';
-import {
-  toPicks,
-  computeResultFromConditions,
-  type ConditionsMap,
-} from '~/components/positions/toPickLegs';
+import type { ConditionsMap } from '~/components/positions/toPickLegs';
 
 interface PredictionDialogProps {
   open: boolean;
@@ -30,73 +24,16 @@ export default function PredictionDialog({
 }: PredictionDialogProps) {
   if (!prediction) return null;
 
-  const rawPicks = pickConfig?.picks ?? [];
-  // Side-agnostic dialog: picks always render from the predictor's canonical
-  // perspective; viewer identity does not flip YES/NO on display.
-  const picks = toPicks(rawPicks, true, conditionsMap);
-
-  const predictorStake = Number(
-    formatEther(BigInt(prediction.predictorCollateral))
-  );
-  const counterpartyStake = Number(
-    formatEther(BigInt(prediction.counterpartyCollateral))
-  );
-
-  const computed = !prediction.settled
-    ? computeResultFromConditions(rawPicks, conditionsMap)
-    : null;
-  const isSettled = prediction.settled || computed?.result !== 'UNRESOLVED';
-  const result = prediction.settled
-    ? prediction.result
-    : (computed?.result ?? 'UNRESOLVED');
-  const predictorWon = result === 'PREDICTOR_WINS';
-  // NON_DECISIVE resolves to the counterparty on-chain.
-  const counterpartyWon =
-    result === 'COUNTERPARTY_WINS' || result === 'NON_DECISIVE';
-
-  const createdAt = prediction.createdAt
-    ? new Date(prediction.createdAt)
-    : null;
-
-  const endsAtMs =
-    rawPicks.reduce((max, pick) => {
-      const endTime = conditionsMap.get(pick.conditionId)?.endTime;
-      return endTime ? Math.max(max, endTime * 1000) : max;
-    }, 0) || null;
-
-  const predictionUrl = `/predictions/${prediction.predictionId}`;
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-4xl pt-8 overflow-x-hidden">
-        <div className="min-w-0">
-          <PositionSummary
-            positionId={prediction.predictionId}
-            createdAt={createdAt}
-            endsAtMs={endsAtMs}
-            positionSize={0}
-            payout={0}
-            pnl={null}
-            roi={null}
-            isSettled={isSettled}
-            collateralSymbol={collateralSymbol}
-            positionUrl={predictionUrl}
-            predictorAddress={prediction.predictor}
-            counterpartyAddress={prediction.counterparty}
-            predictorStake={predictorStake}
-            counterpartyStake={counterpartyStake}
-            predictorWon={predictorWon}
-            counterpartyWon={counterpartyWon}
-          />
-        </div>
-
-        <div className="min-w-0">
-          <PicksContent
-            picks={picks}
-            positionId={prediction.predictionId}
-            hideHeader
-          />
-        </div>
+        <PredictionDetails
+          prediction={prediction}
+          picks={pickConfig?.picks ?? []}
+          conditionsMap={conditionsMap}
+          collateralSymbol={collateralSymbol}
+          positionUrl={`/predictions/${prediction.predictionId}`}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/packages/app/src/components/positions/toPickLegs.ts
+++ b/packages/app/src/components/positions/toPickLegs.ts
@@ -1,6 +1,5 @@
 import { isPredictedYes, OutcomeSide } from '@sapience/sdk/types';
 import { decodePythMarketId } from '@sapience/sdk';
-import type { PickData } from '~/hooks/graphql/usePositions';
 import type { Pick } from '~/components/shared/StackedPredictions';
 import { inferResolverKind } from '~/lib/resolvers/conditionResolver';
 import { getChoiceLabel } from '~/lib/resolvers/choiceLabel';
@@ -21,9 +20,18 @@ export type ConditionsMap = Map<
   }
 >;
 
+/** Minimum pick shape consumed by `toPicks` — read-only access to
+ *  conditionId, conditionResolver, and predictedOutcome. Accepts either
+ *  escrow `PickData` (usePositions) or the SSR `PredictionPick` shape. */
+export type PickInput = {
+  conditionId: string;
+  conditionResolver: string;
+  predictedOutcome: number;
+};
+
 /** Map escrow PickData to the Pick interface used by PicksSummary / PicksContent */
 export function toPicks(
-  picks: PickData[],
+  picks: readonly PickInput[],
   isPredictorSide: boolean,
   conditionsMap: ConditionsMap
 ): Pick[] {

--- a/packages/app/src/components/shared/PicksSummary.tsx
+++ b/packages/app/src/components/shared/PicksSummary.tsx
@@ -108,7 +108,7 @@ export function PicksContent({
   positionStatus,
 }: PicksContentProps) {
   return (
-    <div className="pt-2">
+    <div>
       {!hideHeader && (
         <div className="flex items-baseline gap-2 text-lg font-semibold mb-4">
           Prediction #{positionId}

--- a/packages/app/src/components/shared/PicksSummary.tsx
+++ b/packages/app/src/components/shared/PicksSummary.tsx
@@ -108,7 +108,7 @@ export function PicksContent({
   positionStatus,
 }: PicksContentProps) {
   return (
-    <div className="pt-4">
+    <div className="pt-2">
       {!hideHeader && (
         <div className="flex items-baseline gap-2 text-lg font-semibold mb-4">
           Prediction #{positionId}

--- a/packages/app/src/components/shared/StackedPredictions.tsx
+++ b/packages/app/src/components/shared/StackedPredictions.tsx
@@ -72,36 +72,49 @@ export function StackedIcons({
     getCategoryColor(pick.categorySlug)
   );
 
+  // Subtle left-to-right fade-in once each pick's category resolves. Cached
+  // loads render ready on the first paint (no transition fires); loads that
+  // arrive later transition from opacity 0 to their target opacity.
+  const STAGGER_MS = 40;
+
   return (
-    <div
-      className={`flex items-center -space-x-2 animate-in fade-in duration-300 ${className ?? ''}`}
-    >
+    <div className={`flex items-center -space-x-2 ${className ?? ''}`}>
       {visiblePicks.map((pick, i) => {
         const isPyth = pick.source === 'pyth';
+        const hasCategory = !!pick.categorySlug;
         const CategoryIcon = getCategoryIcon(pick.categorySlug);
         const color = colors[i] || 'hsl(var(--muted-foreground))';
         // Fade the trailing icons when there are more picks hidden behind them:
         // last icon fades most, second-to-last a little, to hint at the stack.
-        let opacity: number | undefined;
+        let truncationOpacity: number | undefined;
         if (truncated) {
-          if (i === visiblePicks.length - 1) opacity = 0.4;
-          else if (i === visiblePicks.length - 2) opacity = 0.7;
+          if (i === visiblePicks.length - 1) truncationOpacity = 0.4;
+          else if (i === visiblePicks.length - 2) truncationOpacity = 0.7;
         }
-        return isPyth ? (
-          <PythMarketBadge
-            key={`icon-${pick.conditionId || i}-${i}`}
-            className="ring-2 ring-background"
-            style={{ zIndex: picks.length - i, opacity }}
-          />
-        ) : (
+        const ready = isPyth || hasCategory;
+        const opacity = ready ? (truncationOpacity ?? 1) : 0;
+        const transitionDelay = ready ? `${i * STAGGER_MS}ms` : '0ms';
+
+        if (isPyth) {
+          return (
+            <PythMarketBadge
+              key={`icon-${pick.conditionId || i}-${i}`}
+              className="ring-2 ring-background transition-opacity duration-300 ease-out"
+              style={{ zIndex: picks.length - i, opacity, transitionDelay }}
+            />
+          );
+        }
+        return (
           <div
             key={`icon-${pick.conditionId || i}-${i}`}
-            className="w-6 h-6 rounded-full shrink-0 flex items-center justify-center ring-2 ring-background transition-colors duration-300"
+            className="w-6 h-6 rounded-full shrink-0 flex items-center justify-center ring-2 ring-background transition-opacity duration-300 ease-out"
             style={{
               backgroundColor: color,
               zIndex: picks.length - i,
               opacity,
+              transitionDelay,
             }}
+            aria-hidden={!ready || undefined}
           >
             <CategoryIcon className="h-3 w-3 text-white/80" />
           </div>

--- a/packages/app/src/hooks/graphql/useConditionsByIds.ts
+++ b/packages/app/src/hooks/graphql/useConditionsByIds.ts
@@ -19,6 +19,11 @@ export function useConditionsByIds(ids: string[]) {
     staleTime: 60_000,
     gcTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
+    // Keep previously fetched conditions while a new query (e.g. after
+    // scrolling loads more activity and expands the id set) is in flight.
+    // Without this, the map empties between key changes and every row's
+    // category icon flashes to the "unknown" fallback.
+    placeholderData: (prev) => prev,
     queryFn: async () => {
       const conditions = await fetchConditionsByIdsQuery(sorted);
       return { conditions };


### PR DESCRIPTION
## Summary
- Fix the activity-feed category icons fading through the muted "unknown" (TagIcon) style while scrolling. The main cause was `useConditionsByIds` dropping its data to `undefined` every time the condition-id set grew (new activity page → new query key), emptying `conditionsMap` for the entire feed. Added `placeholderData: (prev) => prev` so the previously fetched conditions stay in place during refetch — matches what `useAccountActivity` and `useForecasts` already do.
- Replace the always-on `animate-in fade-in` and per-icon `transition-colors` in `StackedIcons` with an opacity transition gated on `pick.categorySlug` being known. When condition data isn't resolved yet, the wrapper sits at opacity 0 (space reserved, no unknown flash); once the slug is known it fades to its target opacity. Added a subtle 40ms left-to-right stagger so rows whose conditions arrive post-mount fade in cleanly instead of popping. Cached loads render ready on first paint with no transition.

## Test plan
- [ ] Load `/feed` cold and confirm category icons appear without any grey "unknown" flash and with a subtle left-to-right fade.
- [ ] Scroll the feed to trigger pagination and confirm previously-visible rows no longer revert to the unknown icon during refetch.
- [ ] Navigate into a prediction from the feed and confirm `StackedIcons` still render correctly in other contexts (e.g. positions table, share dialogs).
- [ ] Verify Pyth picks still render the Pyth badge (not gated on `categorySlug`).