### PR TITLE
fix(app): remove 4px gap under Activity table

### DIFF
--- a/packages/app/src/components/positions/ActivityTable.tsx
+++ b/packages/app/src/components/positions/ActivityTable.tsx
@@ -852,7 +852,7 @@ export default function ActivityTable({
           </tbody>
         </table>
       </div>
-      <div ref={loadMoreRef} className="h-1" />
+      <div ref={loadMoreRef} className="h-0" />
       {sharePrediction && (
         <SharePredictionDialog
           sharePrediction={sharePrediction}


### PR DESCRIPTION
## Summary
- The infinite-scroll sentinel below `ActivityTable` was `h-1` (4px), rendering as a visible empty strip inside the bordered card on the profile page and on the question page's Activity tab. `PositionsTable` has no sentinel, so it already sat flush.
- Dropped the sentinel to `h-0`. The `useInfiniteScroll` hook only reads `getBoundingClientRect` y-position, so height is irrelevant for detection.

## Test plan
- [ ] Profile page → Activity tab: last row sits flush with the card's bottom border
- [ ] Question/condition page → Activity tab: same
- [ ] Positions tab on both pages is unchanged
- [ ] Infinite scroll on Activity still loads additional pages when scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)