### PR TITLE
fix(app): show real question text in combined-predictions popover

### DIFF
--- a/packages/app/src/components/markets/pages/QuestionPageContent.tsx
+++ b/packages/app/src/components/markets/pages/QuestionPageContent.tsx
@@ -256,9 +256,6 @@ export default function QuestionPageContent({
               ? otherPicks.map((p) => ({
                   conditionId: p.conditionId,
                   resolverAddress: p.conditionResolver ?? undefined,
-                  // question is hydrated lazily when the popover opens;
-                  // fall back to the conditionId hex until then.
-                  question: p.conditionId,
                   prediction:
                     (p.predictedOutcome as OutcomeSide) === OutcomeSide.YES,
                 }))

--- a/packages/app/src/components/markets/pages/QuestionPageContent.tsx
+++ b/packages/app/src/components/markets/pages/QuestionPageContent.tsx
@@ -255,6 +255,9 @@ export default function QuestionPageContent({
             otherPicks.length > 0
               ? otherPicks.map((p) => ({
                   conditionId: p.conditionId,
+                  resolverAddress: p.conditionResolver ?? undefined,
+                  // question is hydrated lazily when the popover opens;
+                  // fall back to the conditionId hex until then.
                   question: p.conditionId,
                   prediction:
                     (p.predictedOutcome as OutcomeSide) === OutcomeSide.YES,

--- a/packages/app/src/components/markets/question/CombinedPredictionsList.tsx
+++ b/packages/app/src/components/markets/question/CombinedPredictionsList.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import * as React from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
+import { Badge } from '@sapience/ui/components/ui/badge';
+import type { CombinedPrediction } from './types';
+import MarketBadge from '~/components/markets/MarketBadge';
+import ConditionTitleLink from '~/components/markets/ConditionTitleLink';
+import { getCategoryStyle } from '~/lib/utils/categoryStyle';
+
+type CombinedConditionDetail = {
+  id: string;
+  question?: string | null;
+  shortName?: string | null;
+  resolver?: string | null;
+  category?: { slug?: string | null } | null;
+};
+
+const COMBINED_CONDITIONS_QUERY = /* GraphQL */ `
+  query CombinedConditions($where: ConditionWhereInput!) {
+    conditions(where: $where, take: 100) {
+      id
+      question
+      shortName
+      resolver
+      category {
+        slug
+      }
+    }
+  }
+`;
+
+const COMBINED_STALE_MS = 5 * 60 * 1000;
+const COMBINED_GC_MS = 10 * 60 * 1000;
+
+function combinedQueryKey(conditionIds: readonly string[]) {
+  return ['combinedConditionDetails', [...conditionIds].sort().join(',')];
+}
+
+async function fetchCombinedConditionDetails(
+  conditionIds: readonly string[]
+): Promise<CombinedConditionDetail[]> {
+  if (conditionIds.length === 0) return [];
+  const resp = await graphqlRequest<{
+    conditions: CombinedConditionDetail[];
+  }>(COMBINED_CONDITIONS_QUERY, {
+    where: { id: { in: [...conditionIds] } },
+  });
+  return resp?.conditions ?? [];
+}
+
+/**
+ * Imperative prefetch — call from event handlers (e.g. onMouseEnter) to
+ * warm the cache before the popover is opened.
+ */
+export function prefetchCombinedConditions(
+  queryClient: ReturnType<typeof useQueryClient>,
+  conditionIds: string[]
+) {
+  if (conditionIds.length === 0) return;
+  void queryClient.prefetchQuery({
+    queryKey: combinedQueryKey(conditionIds),
+    queryFn: () => fetchCombinedConditionDetails(conditionIds),
+    staleTime: COMBINED_STALE_MS,
+    gcTime: COMBINED_GC_MS,
+  });
+}
+
+/**
+ * Warm the react-query cache for a set of combined-pick condition IDs.
+ * Use when the parent UI (tooltip) opens, so the child popover has data
+ * ready by the time the user clicks into it.
+ */
+export function usePrefetchCombinedConditions(conditionIds: string[]) {
+  const queryClient = useQueryClient();
+  const key = React.useMemo(
+    () => [...conditionIds].sort().join(','),
+    [conditionIds]
+  );
+  React.useEffect(() => {
+    prefetchCombinedConditions(queryClient, conditionIds);
+    // conditionIds identity changes on every render; key string drives the effect.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, queryClient]);
+}
+
+interface Props {
+  combinedPredictions: CombinedPrediction[];
+  combinedWithYes: boolean;
+}
+
+export function CombinedPredictionsList({
+  combinedPredictions,
+  combinedWithYes,
+}: Props) {
+  const conditionIds = React.useMemo(
+    () => combinedPredictions.map((p) => p.conditionId),
+    [combinedPredictions]
+  );
+
+  const { data: details, isPending } = useQuery<CombinedConditionDetail[]>({
+    queryKey: combinedQueryKey(conditionIds),
+    enabled: conditionIds.length > 0,
+    staleTime: COMBINED_STALE_MS,
+    gcTime: COMBINED_GC_MS,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    queryFn: () => fetchCombinedConditionDetails(conditionIds),
+  });
+
+  const detailMap = React.useMemo(() => {
+    const map = new Map<string, CombinedConditionDetail>();
+    for (const c of details ?? []) map.set(c.id.toLowerCase(), c);
+    return map;
+  }, [details]);
+
+  return (
+    <div className="flex flex-col divide-y divide-brand-white/20">
+      <div className="flex items-center gap-3 px-3 py-2">
+        <span className="text-sm text-brand-white">Predicted with</span>
+        <Badge
+          variant="outline"
+          className={`shrink-0 w-9 px-0 py-0.5 text-xs font-medium !rounded-md font-mono flex items-center justify-center ${
+            combinedWithYes
+              ? 'border-yes/40 bg-yes/10 text-yes'
+              : 'border-no/40 bg-no/10 text-no'
+          }`}
+        >
+          {combinedWithYes ? 'YES' : 'NO'}
+        </Badge>
+      </div>
+      {combinedPredictions.map((pred, i) => {
+        const detail = detailMap.get(pred.conditionId.toLowerCase());
+        const resolvedQuestion = detail?.question || undefined;
+        const resolverAddress = detail?.resolver ?? pred.resolverAddress;
+        const categorySlug = detail?.category?.slug ?? pred.categorySlug;
+        const isLoading = isPending && conditionIds.length > 0;
+        return (
+          <div
+            key={`combined-${i}`}
+            className="flex items-center gap-3 px-3 py-2"
+          >
+            <MarketBadge
+              label={resolvedQuestion ?? ''}
+              size={32}
+              color={getCategoryStyle(categorySlug).color}
+              categorySlug={categorySlug}
+            />
+            {resolvedQuestion ? (
+              <ConditionTitleLink
+                conditionId={pred.conditionId}
+                resolverAddress={resolverAddress}
+                title={resolvedQuestion}
+                className="text-sm flex-1 min-w-0"
+                clampLines={1}
+              />
+            ) : isLoading ? (
+              <div className="flex-1 min-w-0 h-4 rounded bg-brand-white/10 animate-pulse" />
+            ) : (
+              <span className="text-sm flex-1 min-w-0 truncate text-muted-foreground/60">
+                Unknown question
+              </span>
+            )}
+            <Badge
+              variant="outline"
+              className={`shrink-0 w-9 px-0 py-0.5 text-xs font-medium !rounded-md font-mono flex items-center justify-center ${
+                pred.prediction
+                  ? 'border-yes/40 bg-yes/10 text-yes'
+                  : 'border-no/40 bg-no/10 text-no'
+              }`}
+            >
+              {pred.prediction ? 'YES' : 'NO'}
+            </Badge>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/app/src/components/markets/question/CombinedPredictionsList.tsx
+++ b/packages/app/src/components/markets/question/CombinedPredictionsList.tsx
@@ -2,11 +2,11 @@
 
 import * as React from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
 import { Badge } from '@sapience/ui/components/ui/badge';
 import type { CombinedPrediction } from './types';
 import MarketBadge from '~/components/markets/MarketBadge';
 import ConditionTitleLink from '~/components/markets/ConditionTitleLink';
+import { fetchConditionsByIds } from '~/hooks/graphql/fetchConditionsByIds';
 import { getCategoryStyle } from '~/lib/utils/categoryStyle';
 
 type CombinedConditionDetail = {
@@ -38,16 +38,13 @@ function combinedQueryKey(conditionIds: readonly string[]) {
   return ['combinedConditionDetails', [...conditionIds].sort().join(',')];
 }
 
-async function fetchCombinedConditionDetails(
+function fetchCombinedConditionDetails(
   conditionIds: readonly string[]
 ): Promise<CombinedConditionDetail[]> {
-  if (conditionIds.length === 0) return [];
-  const resp = await graphqlRequest<{
-    conditions: CombinedConditionDetail[];
-  }>(COMBINED_CONDITIONS_QUERY, {
-    where: { id: { in: [...conditionIds] } },
-  });
-  return resp?.conditions ?? [];
+  return fetchConditionsByIds<CombinedConditionDetail>(
+    COMBINED_CONDITIONS_QUERY,
+    [...conditionIds]
+  );
 }
 
 /**
@@ -130,15 +127,15 @@ export function CombinedPredictionsList({
           {combinedWithYes ? 'YES' : 'NO'}
         </Badge>
       </div>
-      {combinedPredictions.map((pred, i) => {
+      {combinedPredictions.map((pred) => {
         const detail = detailMap.get(pred.conditionId.toLowerCase());
-        const resolvedQuestion = detail?.question || undefined;
+        const resolvedQuestion = detail?.question ?? undefined;
         const resolverAddress = detail?.resolver ?? pred.resolverAddress;
         const categorySlug = detail?.category?.slug ?? pred.categorySlug;
         const isLoading = isPending && conditionIds.length > 0;
         return (
           <div
-            key={`combined-${i}`}
+            key={pred.conditionId}
             className="flex items-center gap-3 px-3 py-2"
           >
             <MarketBadge

--- a/packages/app/src/components/markets/question/PredictionScatterChart.tsx
+++ b/packages/app/src/components/markets/question/PredictionScatterChart.tsx
@@ -26,14 +26,15 @@ import {
 import { motion, AnimatePresence } from 'framer-motion';
 import { formatDistanceToNow } from 'date-fns';
 import dynamic from 'next/dynamic';
+import {
+  CombinedPredictionsList,
+  usePrefetchCombinedConditions,
+} from './CombinedPredictionsList';
+import type { PredictionData, ForecastData } from './types';
 import { AddressDisplay } from '~/components/shared/AddressDisplay';
 import EnsAvatar from '~/components/shared/EnsAvatar';
 import SafeMarkdown from '~/components/shared/SafeMarkdown';
-import MarketBadge from '~/components/markets/MarketBadge';
-import ConditionTitleLink from '~/components/markets/ConditionTitleLink';
-import { getCategoryStyle } from '~/lib/utils/categoryStyle';
 import { formatPercentChance } from '~/lib/format/percentChance';
-import type { PredictionData, ForecastData } from './types';
 
 /** Props passed by Recharts to custom scatter shape renderers */
 interface ScatterShapeProps {
@@ -86,6 +87,14 @@ export function PredictionScatterChart({
   } else if (!isTooltipHovered) {
     lastValidPointRef.current = null;
   }
+
+  // Warm the cache for the hovered point's combined picks so the popover has
+  // data ready the moment the user clicks "N predictions".
+  const prefetchIds = React.useMemo(
+    () => hoveredPoint?.combinedPredictions?.map((p) => p.conditionId) ?? [],
+    [hoveredPoint]
+  );
+  usePrefetchCombinedConditions(prefetchIds);
 
   // Comment square hover state - for comment popover
   const [hoveredComment, setHoveredComment] = React.useState<{
@@ -225,8 +234,6 @@ export function PredictionScatterChart({
               } = point as PredictionData;
               const yesAddress = predictorPrediction ? predictor : counterparty;
               const noAddress = predictorPrediction ? counterparty : predictor;
-              const getCategoryColor = (slug?: string) =>
-                getCategoryStyle(slug).color;
 
               return (
                 <div
@@ -403,55 +410,10 @@ export function PredictionScatterChart({
                                 className="w-auto max-w-sm p-0 bg-brand-black border-brand-white/20"
                                 align="start"
                               >
-                                <div className="flex flex-col divide-y divide-brand-white/20">
-                                  <div className="flex items-center gap-3 px-3 py-2">
-                                    <span className="text-sm text-brand-white">
-                                      Predicted with
-                                    </span>
-                                    <Badge
-                                      variant="outline"
-                                      className={`shrink-0 w-9 px-0 py-0.5 text-xs font-medium !rounded-md font-mono flex items-center justify-center ${
-                                        combinedWithYes
-                                          ? 'border-yes/40 bg-yes/10 text-yes'
-                                          : 'border-no/40 bg-no/10 text-no'
-                                      }`}
-                                    >
-                                      {combinedWithYes ? 'YES' : 'NO'}
-                                    </Badge>
-                                  </div>
-                                  {combinedPredictions.map((pred, i) => (
-                                    <div
-                                      key={`scatter-combined-${i}`}
-                                      className="flex items-center gap-3 px-3 py-2"
-                                    >
-                                      <MarketBadge
-                                        label={pred.question}
-                                        size={32}
-                                        color={getCategoryColor(
-                                          pred.categorySlug
-                                        )}
-                                        categorySlug={pred.categorySlug}
-                                      />
-                                      <ConditionTitleLink
-                                        conditionId={pred.conditionId}
-                                        resolverAddress={pred.resolverAddress}
-                                        title={pred.question}
-                                        className="text-sm flex-1 min-w-0"
-                                        clampLines={1}
-                                      />
-                                      <Badge
-                                        variant="outline"
-                                        className={`shrink-0 w-9 px-0 py-0.5 text-xs font-medium !rounded-md font-mono flex items-center justify-center ${
-                                          pred.prediction
-                                            ? 'border-yes/40 bg-yes/10 text-yes'
-                                            : 'border-no/40 bg-no/10 text-no'
-                                        }`}
-                                      >
-                                        {pred.prediction ? 'YES' : 'NO'}
-                                      </Badge>
-                                    </div>
-                                  ))}
-                                </div>
+                                <CombinedPredictionsList
+                                  combinedPredictions={combinedPredictions}
+                                  combinedWithYes={!!combinedWithYes}
+                                />
                               </PopoverContent>
                             </Popover>
                           </div>

--- a/packages/app/src/components/markets/question/PredictionsTable.tsx
+++ b/packages/app/src/components/markets/question/PredictionsTable.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { useMemo } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import type { ColumnDef, SortingState } from '@tanstack/react-table';
 import {
   flexRender,
@@ -32,12 +33,14 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@sapience/ui/components/ui/popover';
+import {
+  CombinedPredictionsList,
+  prefetchCombinedConditions,
+} from './CombinedPredictionsList';
+import type { PredictionData } from './types';
 import { AddressDisplay } from '~/components/shared/AddressDisplay';
 import EnsAvatar from '~/components/shared/EnsAvatar';
-import MarketBadge from '~/components/markets/MarketBadge';
-import { getCategoryStyle } from '~/lib/utils/categoryStyle';
 import PercentChance from '~/components/shared/PercentChance';
-import type { PredictionData } from './types';
 
 interface PredictionsTableProps {
   data: PredictionData[];
@@ -45,6 +48,7 @@ interface PredictionsTableProps {
 }
 
 export function PredictionsTable({ data, isLoading }: PredictionsTableProps) {
+  const queryClient = useQueryClient();
   // Column definitions for predictions table
   const columns: ColumnDef<PredictionData>[] = useMemo(
     () => [
@@ -254,14 +258,19 @@ export function PredictionsTable({ data, isLoading }: PredictionsTableProps) {
           }
 
           const count = combinedPredictions.length;
-          const getCategoryColor = (slug?: string) =>
-            getCategoryStyle(slug).color;
+          const rowConditionIds = combinedPredictions.map((p) => p.conditionId);
 
           return (
             <Popover>
               <PopoverTrigger asChild>
                 <button
                   type="button"
+                  onMouseEnter={() =>
+                    prefetchCombinedConditions(queryClient, rowConditionIds)
+                  }
+                  onFocus={() =>
+                    prefetchCombinedConditions(queryClient, rowConditionIds)
+                  }
                   className="text-sm text-brand-white hover:text-brand-white/80 underline decoration-dotted underline-offset-2 transition-colors whitespace-nowrap"
                 >
                   {count} prediction{count !== 1 ? 's' : ''}
@@ -271,49 +280,10 @@ export function PredictionsTable({ data, isLoading }: PredictionsTableProps) {
                 className="w-auto max-w-sm p-0 bg-brand-black border-brand-white/20"
                 align="start"
               >
-                <div className="flex flex-col divide-y divide-brand-white/20">
-                  <div className="flex items-center gap-2 px-3 py-3">
-                    <span className="text-base font-medium text-brand-white">
-                      Predicted with
-                    </span>
-                    <Badge
-                      variant="outline"
-                      className={`shrink-0 w-9 px-0 py-0.5 text-xs font-medium !rounded-md font-mono flex items-center justify-center ${
-                        combinedWithYes
-                          ? 'border-yes/40 bg-yes/10 text-yes'
-                          : 'border-no/40 bg-no/10 text-no'
-                      }`}
-                    >
-                      {combinedWithYes ? 'YES' : 'NO'}
-                    </Badge>
-                  </div>
-                  {combinedPredictions.map((pred, i) => (
-                    <div
-                      key={`combined-${i}`}
-                      className="flex items-center gap-3 px-3 py-2"
-                    >
-                      <MarketBadge
-                        label={pred.question}
-                        size={32}
-                        color={getCategoryColor(pred.categorySlug)}
-                        categorySlug={pred.categorySlug}
-                      />
-                      <span className="text-sm flex-1 min-w-0 font-mono underline decoration-dotted underline-offset-2 hover:text-brand-white/80 transition-colors cursor-pointer truncate">
-                        {pred.question}
-                      </span>
-                      <Badge
-                        variant="outline"
-                        className={`shrink-0 w-9 px-0 py-0.5 text-xs font-medium !rounded-md font-mono flex items-center justify-center ${
-                          pred.prediction
-                            ? 'border-yes/40 bg-yes/10 text-yes'
-                            : 'border-no/40 bg-no/10 text-no'
-                        }`}
-                      >
-                        {pred.prediction ? 'YES' : 'NO'}
-                      </Badge>
-                    </div>
-                  ))}
-                </div>
+                <CombinedPredictionsList
+                  combinedPredictions={combinedPredictions}
+                  combinedWithYes={!!combinedWithYes}
+                />
               </PopoverContent>
             </Popover>
           );
@@ -321,7 +291,7 @@ export function PredictionsTable({ data, isLoading }: PredictionsTableProps) {
         enableSorting: false,
       },
     ],
-    []
+    [queryClient]
   );
 
   // Table state

--- a/packages/app/src/components/markets/question/index.ts
+++ b/packages/app/src/components/markets/question/index.ts
@@ -5,3 +5,8 @@ export {
   PredictionScatterChart,
   scatterChartStyles,
 } from './PredictionScatterChart';
+export {
+  CombinedPredictionsList,
+  usePrefetchCombinedConditions,
+  prefetchCombinedConditions,
+} from './CombinedPredictionsList';

--- a/packages/app/src/components/markets/question/types.ts
+++ b/packages/app/src/components/markets/question/types.ts
@@ -1,8 +1,9 @@
-// Type for combined prediction in a position
+// Type for combined prediction in a position.
+// Question/resolver/category are hydrated from the server by
+// CombinedPredictionsList when the popover opens.
 export type CombinedPrediction = {
   conditionId: string;
   resolverAddress?: string;
-  question: string;
   prediction: boolean;
   categorySlug?: string;
 };


### PR DESCRIPTION
## Summary
- On the question page, the "N predictions" popover rendered the raw conditionId hex as each row's title. The `ConditionTitleLink` tooltip then re-printed the same 66-char hash wrapped across two lines, overlapping the trigger row (see original bug screenshot).
- Replace the inline popover content in both `PredictionScatterChart` and `PredictionsTable` with a shared `CombinedPredictionsList` that fetches the real `question` / `shortName` / `resolver` / `category` for each combined conditionId via GraphQL. Rendering now shows a readable question, and the tooltip only fires for genuinely truncated text.
- Fetch is lazy (only runs when the popover mounts). To avoid a visible flash, we prefetch on parent-level hover: scatter chart fires `usePrefetchCombinedConditions` whenever a point is hovered; the table's trigger button calls `prefetchCombinedConditions` on `onMouseEnter` / `onFocus`. Both paths share the same query key so the popover opens with hydrated data.
- While loading, the row shows a subtle skeleton bar instead of the conditionId hex. If the condition isn't found, it falls back to "Unknown question".

## Test plan
- [ ] Open a question page with multi-leg predictions (e.g. `/questions/0xc7a489f8b5cef914fca2511a84cdc0221cd9a0f4/0x9517da80b6edfccdc6091d850bd647a75089ff0938c174dddc39e80feb7ac190#positions`).
- [ ] Hover a scatter point that shows "Combined — N predictions"; click the button. Popover should render real question text (no hex hash) with no visible flash on open.
- [ ] Hovering an address/title tooltip in a popover row should NOT overlap the row with a 2-line hex hash.
- [ ] In the Positions table, hover a "N predictions" trigger; when you then click, popover should be hydrated (prefetch warmed the cache).
- [ ] Opening a popover for a condition whose details fail to load shows "Unknown question" (manually break the fetch to verify, optional).