### PR TITLE
feat(app): redesign position dialog header

### DIFF
--- a/packages/app/src/components/positions/PositionDialog.tsx
+++ b/packages/app/src/components/positions/PositionDialog.tsx
@@ -90,55 +90,58 @@ export default function PositionDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-4xl pt-8">
-        <PositionSummary
-          kind="position"
-          positionId={position.id}
-          pickCount={rawPicks.length}
-          createdAt={createdAt}
-          endsAtMs={endsAtMs}
-          positionSize={positionSize}
-          payout={totalPayout}
-          pnl={pnl}
-          roi={roi}
-          isSettled={isSettled}
-          positionWon={positionWon}
-          collateralSymbol={collateralSymbol}
-          holderAddress={position.holder}
-        />
+      <DialogContent className="sm:max-w-4xl pt-8 overflow-x-hidden">
+        <div className="min-w-0 space-y-4">
+          <PositionSummary
+            kind="position"
+            positionId={position.id}
+            pickCount={rawPicks.length}
+            createdAt={createdAt}
+            endsAtMs={endsAtMs}
+            positionSize={positionSize}
+            payout={totalPayout}
+            pnl={pnl}
+            roi={roi}
+            isSettled={isSettled}
+            positionWon={positionWon}
+            collateralSymbol={collateralSymbol}
+            holderAddress={position.holder}
+            isPredictorSide={isPredictorSide}
+          />
 
-        <PicksContent
-          picks={picks}
-          positionId={String(position.id)}
-          hideHeader
-          positionStatus={getPositionStatus()}
-        />
+          <PicksContent
+            picks={picks}
+            positionId={String(position.id)}
+            hideHeader
+            positionStatus={getPositionStatus()}
+          />
 
-        <div className="mt-2 rounded-md border border-border/60 overflow-hidden">
-          <button
-            type="button"
-            onClick={() => setActivityOpen((v) => !v)}
-            aria-expanded={activityOpen}
-            className="w-full flex items-center justify-between px-4 py-3 bg-white/[0.03] hover:bg-white/[0.06] transition-colors"
-          >
-            <span className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
-              Related Activity
-            </span>
-            <ChevronDown
-              className={`h-4 w-4 text-muted-foreground transition-transform ${activityOpen ? 'rotate-180' : ''}`}
-              aria-hidden="true"
-            />
-          </button>
-          {activityOpen && (
-            <div className="border-t border-border/60 max-h-56 overflow-y-auto">
-              <ActivityTable
-                account={position.holder as Address}
-                filterPickConfigId={position.pickConfigId}
-                hiddenColumns={['position', 'status', 'share']}
-                hideFilters
+          <div className="mt-2 rounded-md border border-border/60 overflow-hidden">
+            <button
+              type="button"
+              onClick={() => setActivityOpen((v) => !v)}
+              aria-expanded={activityOpen}
+              className="w-full flex items-center justify-between px-4 py-3 bg-white/[0.03] hover:bg-white/[0.06] transition-colors"
+            >
+              <span className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
+                Related Activity
+              </span>
+              <ChevronDown
+                className={`h-4 w-4 text-muted-foreground transition-transform ${activityOpen ? 'rotate-180' : ''}`}
+                aria-hidden="true"
               />
-            </div>
-          )}
+            </button>
+            {activityOpen && (
+              <div className="border-t border-border/60 max-h-56 overflow-y-auto">
+                <ActivityTable
+                  account={position.holder as Address}
+                  filterPickConfigId={position.pickConfigId}
+                  hiddenColumns={['position', 'status', 'share']}
+                  hideFilters
+                />
+              </div>
+            )}
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/packages/app/src/components/positions/PositionSummary.tsx
+++ b/packages/app/src/components/positions/PositionSummary.tsx
@@ -61,6 +61,11 @@ export interface PositionSummaryProps {
   predictorWon?: boolean;
   /** Whether the counterparty side won (for winner highlight in symmetric layout). */
   counterpartyWon?: boolean;
+  /**
+   * Which side the holder is on. When provided with kind="position", renders a
+   * "Side" cell (PREDICTOR / COUNTERPARTY) next to the Holder cell.
+   */
+  isPredictorSide?: boolean;
 }
 
 export default function PositionSummary({
@@ -86,22 +91,38 @@ export default function PositionSummary({
   counterpartyStake,
   predictorWon,
   counterpartyWon,
+  isPredictorSide,
 }: PositionSummaryProps) {
   const useSymmetricStats =
     predictorStake !== undefined && counterpartyStake !== undefined;
   const showOwner = isOwnerLoading || !!currentOwner;
   const showHolder = !!holderAddress;
+  const showSide = kind === 'position' && isPredictorSide !== undefined;
+  const showPicks = kind === 'position' && typeof pickCount === 'number';
+  const showPositionStatus = kind === 'position' && !useSymmetricStats;
   const showAddressesRow =
     !useSymmetricStats &&
-    (showOwner || showHolder || predictorAddress || counterpartyAddress);
+    (showOwner ||
+      showHolder ||
+      showSide ||
+      showPositionStatus ||
+      predictorAddress ||
+      counterpartyAddress);
   const addressCellCount =
-    (showOwner ? 1 : 0) + (showHolder ? 1 : 0) + (kind === 'position' ? 0 : 2);
+    (showOwner ? 1 : 0) +
+    (showHolder ? 1 : 0) +
+    (showSide ? 1 : 0) +
+    (showPicks ? 1 : 0) +
+    (showPositionStatus ? 1 : 0) +
+    (kind === 'position' ? 0 : 2);
   const addressGridCols =
-    addressCellCount >= 3
-      ? 'sm:grid-cols-3'
-      : addressCellCount === 2
-        ? 'sm:grid-cols-2'
-        : 'sm:grid-cols-1';
+    addressCellCount >= 4
+      ? 'sm:grid-cols-4'
+      : addressCellCount === 3
+        ? 'sm:grid-cols-3'
+        : addressCellCount === 2
+          ? 'sm:grid-cols-2'
+          : 'sm:grid-cols-1';
 
   const renderEndsCell = () => (
     <div className="flex flex-col gap-1 min-w-0">
@@ -281,9 +302,7 @@ export default function PositionSummary({
           <h2 className="eyebrow text-foreground">
             {(() => {
               if (kind === 'position') {
-                return typeof pickCount === 'number'
-                  ? `${pickCount} Pick Position`
-                  : 'Position';
+                return 'Position';
               }
               const idStr = String(positionId);
               if (idStr.startsWith('0x')) {
@@ -301,8 +320,10 @@ export default function PositionSummary({
             })()}
           </h2>
         </div>
-        {/* Status badge (legacy mode only — symmetric mode surfaces it in the grid below) */}
+        {/* Status badge (legacy prediction mode only — symmetric mode and
+            position kind both surface it in the grid below) */}
         {!useSymmetricStats &&
+          kind !== 'position' &&
           (isSettled ? (
             positionWon ? (
               <span className="px-1.5 py-0.5 text-xs font-medium rounded-md font-mono border border-yes/40 bg-yes/10 text-yes">
@@ -380,7 +401,9 @@ export default function PositionSummary({
         <>
           {/* Addresses row */}
           {showAddressesRow && (
-            <div className={`grid grid-cols-1 gap-4 ${addressGridCols}`}>
+            <div
+              className={`grid ${addressCellCount > 1 ? 'grid-cols-2' : 'grid-cols-1'} gap-4 ${addressGridCols}`}
+            >
               {showHolder && (
                 <div className="space-y-1">
                   <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
@@ -434,6 +457,53 @@ export default function PositionSummary({
                       —
                     </span>
                   )}
+                </div>
+              )}
+
+              {showSide && (
+                <div className="space-y-1">
+                  <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
+                    Side
+                  </div>
+                  <div className="flex items-center h-[24px] text-sm md:text-base font-medium font-mono text-foreground">
+                    {isPredictorSide ? 'PREDICTOR' : 'COUNTERPARTY'}
+                  </div>
+                </div>
+              )}
+
+              {showPicks && (
+                <div className="space-y-1">
+                  <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
+                    Picks
+                  </div>
+                  <div className="flex items-center h-[24px] text-sm md:text-base font-medium tabular-nums text-foreground">
+                    {pickCount}
+                  </div>
+                </div>
+              )}
+
+              {showPositionStatus && (
+                <div className="space-y-1">
+                  <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
+                    Status
+                  </div>
+                  <div className="flex items-center h-[24px]">
+                    {isSettled ? (
+                      positionWon ? (
+                        <span className="px-1.5 py-0.5 text-xs font-medium rounded-md font-mono border border-yes/40 bg-yes/10 text-yes">
+                          WON
+                        </span>
+                      ) : (
+                        <span className="px-1.5 py-0.5 text-xs font-medium rounded-md font-mono border border-no/40 bg-no/10 text-no">
+                          LOST
+                        </span>
+                      )
+                    ) : (
+                      <span className="px-1.5 py-0.5 text-xs font-medium rounded-md font-mono border border-foreground/40 bg-foreground/10 text-foreground">
+                        ACTIVE
+                      </span>
+                    )}
+                  </div>
                 </div>
               )}
 

--- a/packages/app/src/components/positions/PositionSummary.tsx
+++ b/packages/app/src/components/positions/PositionSummary.tsx
@@ -47,7 +47,7 @@ export interface PositionSummaryProps {
   kind?: 'prediction' | 'position';
   /**
    * Number of picks backing this aggregate position. When provided with
-   * kind="position", the header becomes "{n} Pick Position".
+   * kind="position", renders a "Picks" cell in the addresses row.
    */
   pickCount?: number;
   /**

--- a/packages/app/src/components/positions/__tests__/PositionDialog.test.tsx
+++ b/packages/app/src/components/positions/__tests__/PositionDialog.test.tsx
@@ -19,10 +19,15 @@ vi.mock('next/link', () => ({
   default: ({
     children,
     href,
+    ...rest
   }: {
     children: React.ReactNode;
     href: string;
-  }) => <a href={href}>{children}</a>,
+  } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
 }));
 
 // EnsAvatar / AddressDisplay both reach for react-query (ENS lookups); render
@@ -122,11 +127,36 @@ describe('PositionDialog', () => {
       />
     );
 
-    // Header reads "{picks} Pick Position" and must NOT surface the
-    // predictionId, since a position can aggregate many predictions with
-    // distinct ids. Picks for the test fixture are empty (0).
-    expect(screen.getByText('0 Pick Position')).toBeInTheDocument();
+    // Header reads "Position" and must NOT surface the predictionId, since a
+    // position can aggregate many predictions with distinct ids. Pick count
+    // moved to a dedicated "Picks" cell in the grid below.
+    expect(
+      screen.getByRole('heading', { name: 'Position' })
+    ).toBeInTheDocument();
     expect(screen.queryByText(/Prediction\s+0xb8c5/i)).not.toBeInTheDocument();
+  });
+
+  it('renders Side, Picks, and Status cells in the addresses row', () => {
+    render(
+      <PositionDialog
+        open
+        onOpenChange={() => {}}
+        position={counterpartyPosition}
+        conditionsMap={new Map()}
+        collateralSymbol="USDe"
+      />
+    );
+
+    // Labels for the new cells
+    expect(screen.getByText('Side')).toBeInTheDocument();
+    expect(screen.getByText('Picks')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+
+    // Counterparty-side holder → Side shows COUNTERPARTY.
+    expect(screen.getByText('COUNTERPARTY')).toBeInTheDocument();
+
+    // Unresolved pickConfig with no picks → Status shows ACTIVE.
+    expect(screen.getByText('ACTIVE')).toBeInTheDocument();
   });
 
   it('renders the aggregate size and payout from the PositionBalance', () => {


### PR DESCRIPTION
## Summary
- Header now reads just **Position** (no more \"N Pick Position\") and no longer renders the inline ACTIVE/WON/LOST badge.
- Adds a labeled row of cells: **Holder | Side | Picks | Status**. Side shows PREDICTOR or COUNTERPARTY; Picks shows the pick count; Status surfaces the ACTIVE / WON / LOST pill that used to live in the header.
- Values are wrapped in fixed-height flex containers so their baselines line up with the Holder avatar + address.
- Addresses row stacks to 2 columns on mobile (instead of 1).
- Dialog now wraps content in \`min-w-0\` + \`overflow-x-hidden\` so the picks table scrolls horizontally inside the dialog (matching the prediction dialog).

Scoped to \`kind=\"position\"\` — the prediction-detail view (symmetric-stakes layout) is untouched.

## Test plan
- [ ] Open a position dialog on desktop: header reads \"Position\", Holder / Side / Picks / Status cells are in one row with matching baselines.
- [ ] Settled position: Status cell shows WON or LOST pill instead of ACTIVE.
- [ ] Mobile width: addresses row stacks to 2 columns; picks table scrolls horizontally within the dialog instead of overflowing the viewport.
- [ ] Prediction dialog still renders with the symmetric Predictor/Counterparty layout unchanged.