### PR TITLE
fix(app): default vault tab without query param

### DIFF
--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -88,6 +88,7 @@ const VaultsPageContent = () => {
   }, [VAULT_CHAIN_ID]);
 
   const queryVault = normalizeAddress(searchParams.get(VAULT_QUERY_PARAM));
+  const hasVaultQueryParam = queryVault !== '';
   const selectedVault = useMemo(() => {
     const match = vaultOptions.find(
       (v) => normalizeAddress(v.address) === queryVault
@@ -96,7 +97,7 @@ const VaultsPageContent = () => {
   }, [queryVault, vaultOptions]);
 
   useEffect(() => {
-    if (!selectedVault) return;
+    if (!selectedVault || !hasVaultQueryParam) return;
     const params = new URLSearchParams(searchParams.toString());
     if (
       normalizeAddress(params.get(VAULT_QUERY_PARAM)) ===
@@ -106,7 +107,7 @@ const VaultsPageContent = () => {
     }
     params.set(VAULT_QUERY_PARAM, selectedVault.address.toLowerCase());
     router.replace(`${pathname}?${params.toString()}`, { scroll: false });
-  }, [selectedVault, searchParams, router, pathname]);
+  }, [selectedVault, hasVaultQueryParam, searchParams, router, pathname]);
 
   const handleVaultChange = (value: string) => {
     const params = new URLSearchParams(searchParams.toString());

--- a/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
+++ b/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
@@ -10,11 +10,15 @@ const {
   mockUsePassiveLiquidityVault,
   mockUseCurrentAddress,
   mockUseProtocolStats,
+  mockRouterReplace,
+  mockSearchParamsToString,
 } = vi.hoisted(() => ({
   mockUseRestrictedJurisdiction: vi.fn(),
   mockUsePassiveLiquidityVault: vi.fn(),
   mockUseCurrentAddress: vi.fn(),
   mockUseProtocolStats: vi.fn(),
+  mockRouterReplace: vi.fn(),
+  mockSearchParamsToString: vi.fn(() => ''),
 }));
 
 // ---------------------------------------------------------------------------
@@ -172,9 +176,13 @@ vi.mock('date-fns', () => ({
 }));
 
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+  useRouter: () => ({ replace: mockRouterReplace, push: vi.fn() }),
   usePathname: () => '/vaults',
-  useSearchParams: () => new URLSearchParams(''),
+  useSearchParams: () => ({
+    get: (key: string) =>
+      new URLSearchParams(mockSearchParamsToString()).get(key),
+    toString: () => mockSearchParamsToString(),
+  }),
 }));
 
 vi.mock('next/link', () => {
@@ -280,6 +288,7 @@ function setDefaults() {
 describe('VaultsPageContent geofence', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSearchParamsToString.mockReturnValue('');
     setDefaults();
   });
 
@@ -328,5 +337,18 @@ describe('VaultsPageContent geofence', () => {
     // Deposit button should be enabled (all other conditions satisfied by mocks)
     const depositBtn = screen.getByRole('button', { name: /Submit Deposit/ });
     expect(depositBtn).not.toBeDisabled();
+  });
+
+  it('defaults to the first vault tab without rewriting the URL when no address query param is present', () => {
+    mockUseRestrictedJurisdiction.mockReturnValue({
+      isRestricted: false,
+      isPermitLoading: false,
+      permitData: { permitted: true },
+      permitError: null,
+    });
+
+    render(<VaultsPageContent />);
+
+    expect(mockRouterReplace).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Why

The vault page was rewriting `/vaults` to include `?address=<first-vault>` on initial load when no query param was present. We want the page to behave as if the first tab is selected without mutating the URL.

This is the app-side follow-up for the staging -> main rollout review on #1613.

## What

- only normalize the address query param when one already exists
- leave a bare `/vaults` URL alone and default to the first vault tab in-memory
- add a regression test covering the no-query-param case

## Testing

- `pnpm exec vitest run src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx --pool=forks --poolOptions.forks.singleFork`
- `pnpm exec eslint src/components/vaults/pages/VaultsPageContent.tsx src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx --no-warn-ignored`
- `pnpm exec prettier --check src/components/vaults/pages/VaultsPageContent.tsx src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx`

## Notes

- I did not claim a clean local `tsc --noEmit` because the worktree hit pre-existing/unrelated app+ui typecheck noise unrelated to this change.