### PR TITLE
fix(app): rebase vault pnl percent chart after first funded point

### DIFF
--- a/packages/app/src/components/vaults/VaultPnlChart.tsx
+++ b/packages/app/src/components/vaults/VaultPnlChart.tsx
@@ -14,12 +14,16 @@ import {
 import { Tabs, TabsTrigger } from '@sapience/ui/components/ui/tabs';
 import { Button } from '@sapience/ui/components/ui/button';
 import {
+  buildVaultPnlChartData,
+  calculateVaultPnlHeadlineApy,
+} from './vaultPnlChartUtils';
+import {
   useProtocolStats,
   type ProtocolStat,
 } from '~/hooks/graphql/useAnalytics';
 import Loader from '~/components/shared/Loader';
 import SegmentedTabsList from '~/components/shared/SegmentedTabsList';
-import { type Period, PERIOD_DAYS } from '~/components/shared/PeriodFilter';
+import { type Period } from '~/components/shared/PeriodFilter';
 
 function formatLargeNumber(value: number): string {
   const abs = Math.abs(value);
@@ -189,83 +193,21 @@ export default function VaultPnlChart({
   const protocolStats = externalStats ?? internalStats;
   const isLoading = externalLoading ?? internalLoading;
 
-  // Transform protocol stats into PnL chart data using real vaultCumulativePnL
-  const chartData = useMemo(() => {
-    if (!protocolStats || protocolStats.length === 0) return [];
-
-    // Filter based on selected period
-    const periodDays = PERIOD_DAYS[period];
-    const cutoffTimestamp =
-      periodDays === Infinity
-        ? 0
-        : Math.floor(Date.now() / 1000) - periodDays * 24 * 60 * 60;
-
-    let filteredStats = protocolStats.filter(
-      (stat) => stat.timestamp >= cutoffTimestamp
-    );
-
-    // For the ALL view, drop leading entries where PnL hasn't started accruing
-    // yet (new vault, no activity). Keep the last zero so the chart visually
-    // starts at 0 before the first non-zero move.
-    if (period === 'ALL') {
-      const firstActiveIdx = filteredStats.findIndex(
-        (s) => s.vaultCumulativePnL && parseFloat(s.vaultCumulativePnL) !== 0
-      );
-      if (firstActiveIdx > 0) {
-        filteredStats = filteredStats.slice(firstActiveIdx - 1);
-      }
-    }
-
-    if (filteredStats.length === 0) return [];
-
-    const points = filteredStats.map((point) => {
-      const currentTvl =
-        (parseFloat(point.vaultBalance) + parseFloat(point.escrowBalance)) /
-        1e18;
-
-      const pnl = point.vaultCumulativePnL
-        ? parseFloat(point.vaultCumulativePnL) / 1e18
-        : 0;
-
-      return {
-        timestamp: point.timestamp,
-        pnl,
-        tvl: currentTvl,
-      };
-    });
-
-    // Both charts rebase to zero at the window start:
-    //   pnlDelta = cumulative PnL accrued since the window start
-    //   apy      = compound-annualized return on starting TVL to date
-    // Concretely apy_t = ((1 + pnlDelta_t / startTvl)^(365/daysElapsed_t) - 1)
-    const startPnl = points[0].pnl;
-    const startTvl = points[0].tvl;
-
-    return points.map((p) => {
-      const pnlDelta = p.pnl - startPnl;
-      const periodReturn = startTvl > 0 ? pnlDelta / startTvl : 0;
-      // `pct` is just the $ chart scaled by 1/startTvl, so the % curve has
-      // exactly the same shape — only the axis scale differs.
-      const pct = periodReturn * 100;
-      return { ...p, pnlDelta, pct };
-    });
-  }, [protocolStats, period]);
+  // Trim pre-activity snapshots for every period so % mode and APY anchor off
+  // the first funded point, while keeping a visible zero baseline immediately
+  // before activity when a prior snapshot exists.
+  const chartData = useMemo(
+    () => buildVaultPnlChartData(protocolStats, period),
+    [protocolStats, period]
+  );
 
   // Headline APY uses wall-clock now for elapsed-days so it doesn't snap to
   // whatever the last snapshot's timestamp is (midnight UTC). Chart points
   // stay on daily granularity; only this annualization sees "now".
-  const apy = useMemo(() => {
-    if (chartData.length < 2) return null;
-    const first = chartData[0];
-    const last = chartData[chartData.length - 1];
-    if (first.tvl <= 0) return null;
-    const periodReturn = last.pnlDelta / first.tvl;
-    if (1 + periodReturn <= 0) return null;
-    const nowSec = Math.floor(Date.now() / 1000);
-    const daysElapsed = (nowSec - first.timestamp) / (24 * 60 * 60);
-    if (daysElapsed < 0.5) return null;
-    return (Math.pow(1 + periodReturn, 365 / daysElapsed) - 1) * 100;
-  }, [chartData]);
+  const apy = useMemo(
+    () => calculateVaultPnlHeadlineApy(chartData),
+    [chartData]
+  );
 
   // Recharts animates only when the dataKey and point count stay stable, so
   // project both modes onto a single `value` field. Swapping source makes the

--- a/packages/app/src/components/vaults/__tests__/VaultPnlChart.test.ts
+++ b/packages/app/src/components/vaults/__tests__/VaultPnlChart.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import type { ProtocolStat } from '~/hooks/graphql/useAnalytics';
+import {
+  buildVaultPnlChartData,
+  calculateVaultPnlHeadlineApy,
+} from '../vaultPnlChartUtils';
+
+const ONE_DAY = 24 * 60 * 60;
+const ONE_ETH = 10n ** 18n;
+const NOW_SEC = Date.UTC(2026, 3, 24, 0, 0, 0) / 1000;
+
+function makeStat({
+  timestamp,
+  tvl,
+  pnl,
+}: {
+  timestamp: number;
+  tvl: number;
+  pnl: number;
+}): ProtocolStat {
+  const tvlWei = BigInt(tvl) * ONE_ETH;
+
+  return {
+    timestamp,
+    vaultBalance: tvlWei.toString(),
+    escrowBalance: '0',
+    vaultCumulativePnL: (BigInt(pnl) * ONE_ETH).toString(),
+  } as ProtocolStat;
+}
+
+describe('vaultPnlChartUtils', () => {
+  it('trims leading zero-TVL 3M snapshots but preserves a zero baseline before the first active point', () => {
+    const protocolStats = [
+      ...Array.from({ length: 38 }, (_, index) =>
+        makeStat({
+          timestamp: NOW_SEC - (80 - index) * ONE_DAY,
+          tvl: 0,
+          pnl: 0,
+        })
+      ),
+      makeStat({ timestamp: NOW_SEC - 42 * ONE_DAY, tvl: 100, pnl: 10 }),
+      makeStat({ timestamp: NOW_SEC - 20 * ONE_DAY, tvl: 100, pnl: 20 }),
+      makeStat({ timestamp: NOW_SEC - ONE_DAY, tvl: 100, pnl: 30 }),
+    ];
+
+    const chartData = buildVaultPnlChartData(protocolStats, '3M', NOW_SEC);
+
+    expect(chartData).toHaveLength(4);
+    expect(chartData.map((point) => point.timestamp)).toEqual([
+      NOW_SEC - 43 * ONE_DAY,
+      NOW_SEC - 42 * ONE_DAY,
+      NOW_SEC - 20 * ONE_DAY,
+      NOW_SEC - ONE_DAY,
+    ]);
+    expect(chartData.map((point) => point.pnlDelta)).toEqual([0, 0, 10, 20]);
+    expect(chartData.map((point) => point.pct)).toEqual([0, 0, 10, 20]);
+  });
+
+  it('calculates headline APY from the first active 3M snapshot instead of the preserved zero-TVL baseline', () => {
+    const protocolStats = [
+      makeStat({ timestamp: NOW_SEC - 43 * ONE_DAY, tvl: 0, pnl: 0 }),
+      makeStat({ timestamp: NOW_SEC - 42 * ONE_DAY, tvl: 100, pnl: 10 }),
+      makeStat({ timestamp: NOW_SEC - 20 * ONE_DAY, tvl: 100, pnl: 20 }),
+      makeStat({ timestamp: NOW_SEC - ONE_DAY, tvl: 100, pnl: 30 }),
+    ];
+
+    const chartData = buildVaultPnlChartData(protocolStats, '3M', NOW_SEC);
+
+    const expectedApy = (Math.pow(1.2, 365 / 42) - 1) * 100;
+
+    expect(calculateVaultPnlHeadlineApy(chartData, NOW_SEC)).toBeCloseTo(
+      expectedApy,
+      10
+    );
+  });
+});

--- a/packages/app/src/components/vaults/vaultPnlChartUtils.ts
+++ b/packages/app/src/components/vaults/vaultPnlChartUtils.ts
@@ -1,0 +1,106 @@
+import type { ProtocolStat } from '~/hooks/graphql/useAnalytics';
+import { PERIOD_DAYS, type Period } from '~/components/shared/PeriodFilter';
+
+const ONE_DAY_IN_SECONDS = 24 * 60 * 60;
+
+export type VaultPnlChartPoint = {
+  timestamp: number;
+  pnl: number;
+  tvl: number;
+  pnlDelta: number;
+  pct: number;
+  isReturnAnchor: boolean;
+};
+
+type BasePoint = Pick<VaultPnlChartPoint, 'timestamp' | 'pnl' | 'tvl'>;
+
+function mapProtocolStatToPoint(point: ProtocolStat): BasePoint {
+  return {
+    timestamp: point.timestamp,
+    pnl: point.vaultCumulativePnL
+      ? parseFloat(point.vaultCumulativePnL) / 1e18
+      : 0,
+    tvl:
+      (parseFloat(point.vaultBalance) + parseFloat(point.escrowBalance)) / 1e18,
+  };
+}
+
+function findFirstActivePointIndex(points: BasePoint[]): number {
+  return points.findIndex((point) => point.tvl > 0);
+}
+
+export function buildVaultPnlChartData(
+  protocolStats: ProtocolStat[] | undefined,
+  period: Period,
+  nowSec = Math.floor(Date.now() / 1000)
+): VaultPnlChartPoint[] {
+  if (!protocolStats || protocolStats.length === 0) return [];
+
+  const periodDays = PERIOD_DAYS[period];
+  const cutoffTimestamp =
+    periodDays === Infinity ? 0 : nowSec - periodDays * ONE_DAY_IN_SECONDS;
+
+  const filteredPoints = protocolStats
+    .filter((stat) => stat.timestamp >= cutoffTimestamp)
+    .map(mapProtocolStatToPoint);
+
+  if (filteredPoints.length === 0) return [];
+
+  const firstActivePointIndex = findFirstActivePointIndex(filteredPoints);
+
+  if (firstActivePointIndex === -1) {
+    return filteredPoints.map((point) => ({
+      ...point,
+      pnlDelta: 0,
+      pct: 0,
+      isReturnAnchor: false,
+    }));
+  }
+
+  const sliceStart = Math.max(0, firstActivePointIndex - 1);
+  const returnAnchorIndex = firstActivePointIndex - sliceStart;
+  const visiblePoints = filteredPoints.slice(sliceStart);
+  const returnAnchor = visiblePoints[returnAnchorIndex];
+
+  return visiblePoints.map((point, index) => {
+    if (index < returnAnchorIndex) {
+      return {
+        ...point,
+        pnlDelta: 0,
+        pct: 0,
+        isReturnAnchor: false,
+      };
+    }
+
+    const pnlDelta = point.pnl - returnAnchor.pnl;
+    const pct = returnAnchor.tvl > 0 ? (pnlDelta / returnAnchor.tvl) * 100 : 0;
+
+    return {
+      ...point,
+      pnlDelta,
+      pct,
+      isReturnAnchor: index === returnAnchorIndex,
+    };
+  });
+}
+
+export function calculateVaultPnlHeadlineApy(
+  chartData: VaultPnlChartPoint[],
+  nowSec = Math.floor(Date.now() / 1000)
+): number | null {
+  if (chartData.length < 2) return null;
+
+  const returnAnchor =
+    chartData.find((point) => point.isReturnAnchor) ?? chartData[0];
+  const lastPoint = chartData[chartData.length - 1];
+
+  if (returnAnchor.tvl <= 0) return null;
+
+  const periodReturn = lastPoint.pnlDelta / returnAnchor.tvl;
+  if (1 + periodReturn <= 0) return null;
+
+  const daysElapsed = (nowSec - returnAnchor.timestamp) / ONE_DAY_IN_SECONDS;
+  if (daysElapsed < 0.5) return null;
+
+  return (Math.pow(1 + periodReturn, 365 / daysElapsed) - 1) * 100;
+}


### PR DESCRIPTION
## Summary
- trim leading zero-TVL / pre-activity vault PnL snapshots for every period, not just `ALL`
- keep a zero baseline point right before the first funded snapshot when available
- add regression tests for the 3M `%` chart and headline APY

## Why
On `/vaults`, the Core vault 3M `%` chart could go flat and the headline APY disappeared when the selected window started with pre-launch zero-TVL snapshots. `$` mode still rendered because it used raw PnL deltas, but `%` mode and APY were anchoring off a zero-denominator start point.

## Verification
- `pnpm --filter @sapience/app exec vitest run src/components/vaults/__tests__/VaultPnlChart.test.ts`
- `pnpm --filter @sapience/app run type-check`
- `pnpm --filter @sapience/app run lint`
- `pnpm --filter @sapience/app run test -- --pool=forks --poolOptions.forks.singleFork`