### PR TITLE
fix(app): anchor Core Vault PnL chart history to 2026-04-17

### DIFF
--- a/packages/app/src/components/vaults/VaultPnlChart.tsx
+++ b/packages/app/src/components/vaults/VaultPnlChart.tsx
@@ -170,6 +170,8 @@ type VaultPnlChartProps = {
   externalPeriod?: Period;
   /** Hide entire internal header (title, APY, tabs). Defaults to true. */
   showHeader?: boolean;
+  /** Optional lower bound on visible history (Unix seconds). Snapshots before this are dropped. */
+  chartAnchorSec?: number;
 };
 
 export default function VaultPnlChart({
@@ -179,6 +181,7 @@ export default function VaultPnlChart({
   className,
   externalPeriod,
   showHeader = true,
+  chartAnchorSec,
 }: VaultPnlChartProps) {
   const collateralSymbol = COLLATERAL_SYMBOLS[DEFAULT_CHAIN_ID] || 'USDe';
   const [internalPeriod, setInternalPeriod] = useState<Period>('1W');
@@ -195,10 +198,18 @@ export default function VaultPnlChart({
 
   // Trim pre-activity snapshots for every period so % mode and APY anchor off
   // the first funded point, while keeping a visible zero baseline immediately
-  // before activity when a prior snapshot exists.
+  // before activity when a prior snapshot exists. `chartAnchorSec` adds a hard
+  // lower bound on visible history for vaults where the caller wants to hide
+  // a pre-activity tail (see `vaultAnchors.ts`).
   const chartData = useMemo(
-    () => buildVaultPnlChartData(protocolStats, period),
-    [protocolStats, period]
+    () =>
+      buildVaultPnlChartData(
+        protocolStats,
+        period,
+        Math.floor(Date.now() / 1000),
+        chartAnchorSec
+      ),
+    [protocolStats, period, chartAnchorSec]
   );
 
   // Headline APY uses wall-clock now for elapsed-days so it doesn't snap to

--- a/packages/app/src/components/vaults/__tests__/VaultPnlChart.test.ts
+++ b/packages/app/src/components/vaults/__tests__/VaultPnlChart.test.ts
@@ -73,4 +73,88 @@ describe('vaultPnlChartUtils', () => {
       10
     );
   });
+
+  it('clamps visible history to anchorSec when the period window extends before it', () => {
+    const anchorSec = NOW_SEC - 7 * ONE_DAY;
+    const protocolStats = [
+      makeStat({ timestamp: NOW_SEC - 30 * ONE_DAY, tvl: 100, pnl: 1 }),
+      makeStat({ timestamp: NOW_SEC - 14 * ONE_DAY, tvl: 100, pnl: 2 }),
+      makeStat({ timestamp: NOW_SEC - 8 * ONE_DAY, tvl: 100, pnl: 3 }),
+      makeStat({ timestamp: anchorSec, tvl: 100, pnl: 10 }),
+      makeStat({ timestamp: NOW_SEC - 3 * ONE_DAY, tvl: 100, pnl: 20 }),
+      makeStat({ timestamp: NOW_SEC - ONE_DAY, tvl: 100, pnl: 30 }),
+    ];
+
+    const chartData = buildVaultPnlChartData(
+      protocolStats,
+      'ALL',
+      NOW_SEC,
+      anchorSec
+    );
+
+    expect(chartData.map((point) => point.timestamp)).toEqual([
+      anchorSec,
+      NOW_SEC - 3 * ONE_DAY,
+      NOW_SEC - ONE_DAY,
+    ]);
+    // pnlDelta rebases off the first post-anchor point (pnl=10).
+    expect(chartData.map((point) => point.pnlDelta)).toEqual([0, 10, 20]);
+    expect(chartData[0].isReturnAnchor).toBe(true);
+  });
+
+  it('computes APY from the post-anchor snapshot, not an earlier funded one', () => {
+    const anchorSec = NOW_SEC - 7 * ONE_DAY;
+    const protocolStats = [
+      makeStat({ timestamp: NOW_SEC - 30 * ONE_DAY, tvl: 100, pnl: 1 }),
+      makeStat({ timestamp: anchorSec, tvl: 100, pnl: 10 }),
+      makeStat({ timestamp: NOW_SEC - ONE_DAY, tvl: 100, pnl: 20 }),
+    ];
+
+    const chartData = buildVaultPnlChartData(
+      protocolStats,
+      'ALL',
+      NOW_SEC,
+      anchorSec
+    );
+    const apy = calculateVaultPnlHeadlineApy(chartData, NOW_SEC);
+
+    // periodReturn = (20 - 10) / 100 = 0.1 over 7 days
+    const expectedApy = (Math.pow(1.1, 365 / 7) - 1) * 100;
+    expect(apy).toBeCloseTo(expectedApy, 10);
+  });
+
+  it('returns an empty series when anchorSec is in the future', () => {
+    const anchorSec = NOW_SEC + ONE_DAY;
+    const protocolStats = [
+      makeStat({ timestamp: NOW_SEC - 5 * ONE_DAY, tvl: 100, pnl: 1 }),
+      makeStat({ timestamp: NOW_SEC - ONE_DAY, tvl: 100, pnl: 2 }),
+    ];
+
+    const chartData = buildVaultPnlChartData(
+      protocolStats,
+      'ALL',
+      NOW_SEC,
+      anchorSec
+    );
+
+    expect(chartData).toEqual([]);
+  });
+
+  it('preserves the zero-TVL leading-point trim when no anchorSec is supplied', () => {
+    const protocolStats = [
+      makeStat({ timestamp: NOW_SEC - 4 * ONE_DAY, tvl: 0, pnl: 0 }),
+      makeStat({ timestamp: NOW_SEC - 3 * ONE_DAY, tvl: 0, pnl: 0 }),
+      makeStat({ timestamp: NOW_SEC - 2 * ONE_DAY, tvl: 100, pnl: 5 }),
+      makeStat({ timestamp: NOW_SEC - ONE_DAY, tvl: 100, pnl: 10 }),
+    ];
+
+    const chartData = buildVaultPnlChartData(protocolStats, '1W', NOW_SEC);
+
+    expect(chartData.map((point) => point.timestamp)).toEqual([
+      NOW_SEC - 3 * ONE_DAY,
+      NOW_SEC - 2 * ONE_DAY,
+      NOW_SEC - ONE_DAY,
+    ]);
+    expect(chartData.map((point) => point.pnlDelta)).toEqual([0, 0, 5]);
+  });
 });

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -34,6 +34,7 @@ import { useProtocolStats } from '~/hooks/graphql/useAnalytics';
 import RiskDisclaimer from '~/components/markets/forms/shared/RiskDisclaimer';
 import Loader from '~/components/shared/Loader';
 import VaultPnlChart from '~/components/vaults/VaultPnlChart';
+import { getVaultPnlAnchorSec } from '~/components/vaults/vaultAnchors';
 import { ETHENA_BASE_APY } from '~/components/layout/StatusIndicators';
 
 const DEPOSIT_WHITELIST: `0x${string}`[] = [
@@ -815,6 +816,7 @@ const VaultsPageContent = () => {
                         <VaultPnlChart
                           protocolStats={protocolStats ?? undefined}
                           isLoading={isAnalyticsLoading}
+                          chartAnchorSec={getVaultPnlAnchorSec(VAULT_ADDRESS)}
                           className="flex-1"
                         />
                       </div>

--- a/packages/app/src/components/vaults/vaultAnchors.ts
+++ b/packages/app/src/components/vaults/vaultAnchors.ts
@@ -1,0 +1,22 @@
+import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
+import { predictionMarketVault } from '@sapience/sdk/contracts';
+
+// Per-vault "start of visible history" for the Vault PnL chart. A vault may
+// have had TVL (and near-zero PnL accrual) for some time before the team
+// considers it meaningfully "live"; clamping the chart to an explicit anchor
+// date hides that pre-activity tail so the %/APY read off the real curve.
+// Requested by fifa for the Core Vault (Discord, 2026-04-24).
+const CORE_VAULT_ADDRESS = predictionMarketVault[DEFAULT_CHAIN_ID]?.address;
+
+export const VAULT_PNL_ANCHORS_SEC: Record<string, number> = CORE_VAULT_ADDRESS
+  ? {
+      [CORE_VAULT_ADDRESS.toLowerCase()]: Math.floor(
+        Date.UTC(2026, 3, 17) / 1000
+      ),
+    }
+  : {};
+
+export function getVaultPnlAnchorSec(address?: string): number | undefined {
+  if (!address) return undefined;
+  return VAULT_PNL_ANCHORS_SEC[address.toLowerCase()];
+}

--- a/packages/app/src/components/vaults/vaultPnlChartUtils.ts
+++ b/packages/app/src/components/vaults/vaultPnlChartUtils.ts
@@ -32,13 +32,16 @@ function findFirstActivePointIndex(points: BasePoint[]): number {
 export function buildVaultPnlChartData(
   protocolStats: ProtocolStat[] | undefined,
   period: Period,
-  nowSec = Math.floor(Date.now() / 1000)
+  nowSec = Math.floor(Date.now() / 1000),
+  anchorSec?: number
 ): VaultPnlChartPoint[] {
   if (!protocolStats || protocolStats.length === 0) return [];
 
   const periodDays = PERIOD_DAYS[period];
-  const cutoffTimestamp =
+  const periodCutoff =
     periodDays === Infinity ? 0 : nowSec - periodDays * ONE_DAY_IN_SECONDS;
+  const cutoffTimestamp =
+    anchorSec !== undefined ? Math.max(periodCutoff, anchorSec) : periodCutoff;
 
   const filteredPoints = protocolStats
     .filter((stat) => stat.timestamp >= cutoffTimestamp)


### PR DESCRIPTION
## Summary

Requested by fifa (Discord, 9:42 AM): *"can we truncate vault history shown in the app so it just starts on 4/17?"*

The Core Vault had TVL starting ~3/27 with near-zero PnL accrual until 4/17, producing an ugly flat leading baseline in every chart view. The existing `tvl > 0` leading-point trim (PR #1617, in staging) doesn't help because TVL was non-zero the whole pre-activity stretch. This PR adds an explicit per-vault start-date anchor.

### Before / after (Core Vault, `ALL` view)
- **Before:** flat line from 3/27 → 4/17, then real curve.
- **After:** chart starts at 4/17; `1W` is unchanged (already within anchor); `1M` / `3M` / `ALL` all clip to 4/17; APY annualizes from 4/17 → now.
- **Edge / Options vaults:** unchanged — no anchor configured.

## Design

`buildVaultPnlChartData` stays vault-agnostic — gets an optional 4th `anchorSec` param and clamps the period cutoff via `max(periodCutoff, anchorSec)`. Per-vault anchor map lives in a new `vaultAnchors.ts` so it's discoverable and easy to extend; fifa asked for the anchor to be editable in one place.

```ts
// vaultPnlChartUtils.ts — only new logic
const cutoffTimestamp =
  anchorSec !== undefined ? Math.max(periodCutoff, anchorSec) : periodCutoff;
```

```ts
// vaultAnchors.ts — per-vault anchors, lowercased-address → Unix seconds
VAULT_PNL_ANCHORS_SEC = {
  [coreVault.toLowerCase()]: Math.floor(Date.UTC(2026, 3, 17) / 1000),
};
```

## Files changed

| File | Change |
|---|---|
| `packages/app/src/components/vaults/vaultAnchors.ts` **(new)** | Per-vault anchor map + `getVaultPnlAnchorSec(address?)` helper. |
| `packages/app/src/components/vaults/vaultPnlChartUtils.ts` | Add optional `anchorSec?: number` param; clamp cutoff. |
| `packages/app/src/components/vaults/VaultPnlChart.tsx` | Add optional `chartAnchorSec?: number` prop; thread through. |
| `packages/app/src/components/vaults/pages/VaultsPageContent.tsx` | Look up anchor from selected vault, pass to `VaultPnlChart`. |
| `packages/app/src/components/vaults/__tests__/VaultPnlChart.test.ts` | +4 tests: anchor mid-window clamps, APY anchors post-anchor, future anchor → empty, un-anchored path preserves the staging `tvl > 0` trim. |

## Why APY is unchanged-safe
Post-clamp the first chart point is at-or-after the anchor and has `tvl > 0` (Core Vault was already funded), so `findFirstActivePointIndex` returns 0, `isReturnAnchor` lands on the first post-anchor point, and APY annualizes from there. Pinned by the new APY test.

## Test plan
- [x] `pnpm --filter @sapience/sdk run build:lib`
- [x] `pnpm --filter @sapience/app run test --run` — 576/576 pass (48 files), including 4 new cases in `VaultPnlChart.test.ts`.
- [x] `pnpm --filter @sapience/app run type-check`, `lint` — clean.
- [x] Manual on Vercel preview: `/vaults` → Core Vault → confirm `ALL`/`1M`/`3M` all start at 4/17 with no flat pre-4/17 segment; toggle to Edge + Options → behavior unchanged.

## Future-facing

To bump the anchor later (per fifa: *"if i want to just do all time from 4/17 at any point in the future"*), edit the single date in `vaultAnchors.ts`. To add an anchor for Edge or Options, drop another entry in the same map.
