### PR TITLE
fix(app): anchor Vault PnL chart y-axis at zero when non-negative

### DIFF
--- a/packages/app/src/components/vaults/VaultPnlChart.tsx
+++ b/packages/app/src/components/vaults/VaultPnlChart.tsx
@@ -16,6 +16,7 @@ import { Button } from '@sapience/ui/components/ui/button';
 import {
   buildVaultPnlChartData,
   calculateVaultPnlHeadlineApy,
+  computeVaultPnlYDomain,
 } from './vaultPnlChartUtils';
 import {
   useProtocolStats,
@@ -234,18 +235,14 @@ export default function VaultPnlChart({
     [chartData, displayMode]
   );
 
-  const yDomain = useMemo(() => {
-    if (displayData.length === 0) return [-1, 1];
-
-    const values = displayData.map((d) => d.value);
-    const minVal = Math.min(...values);
-    const maxVal = Math.max(...values);
-
-    const range = maxVal - minVal;
-    const padding = range * 0.1 || (displayMode === 'pct' ? 0.01 : 0.1);
-
-    return [minVal - padding, maxVal + padding];
-  }, [displayData, displayMode]);
+  const yDomain = useMemo(
+    () =>
+      computeVaultPnlYDomain(
+        displayData.map((d) => d.value),
+        displayMode
+      ),
+    [displayData, displayMode]
+  );
 
   const currentValue =
     displayData.length > 0 ? displayData[displayData.length - 1].value : 0;

--- a/packages/app/src/components/vaults/__tests__/VaultPnlChart.test.ts
+++ b/packages/app/src/components/vaults/__tests__/VaultPnlChart.test.ts
@@ -3,6 +3,7 @@ import type { ProtocolStat } from '~/hooks/graphql/useAnalytics';
 import {
   buildVaultPnlChartData,
   calculateVaultPnlHeadlineApy,
+  computeVaultPnlYDomain,
 } from '../vaultPnlChartUtils';
 
 const ONE_DAY = 24 * 60 * 60;
@@ -138,6 +139,35 @@ describe('vaultPnlChartUtils', () => {
     );
 
     expect(chartData).toEqual([]);
+  });
+
+  describe('computeVaultPnlYDomain', () => {
+    it('anchors the baseline at zero when all values are non-negative', () => {
+      const [bottom, top] = computeVaultPnlYDomain([2.26, 5.1, 8.18], 'pct');
+      expect(bottom).toBe(0);
+      expect(top).toBeCloseTo(8.18 + (8.18 - 2.26) * 0.1, 10);
+    });
+
+    it('pads below the minimum when any value is negative', () => {
+      const [bottom, top] = computeVaultPnlYDomain([-3, 0, 5], 'pct');
+      const padding = (5 - -3) * 0.1;
+      expect(bottom).toBeCloseTo(-3 - padding, 10);
+      expect(top).toBeCloseTo(5 + padding, 10);
+    });
+
+    it('uses a fallback pad when all values collapse to a single point', () => {
+      const [bottomPct, topPct] = computeVaultPnlYDomain([4, 4], 'pct');
+      expect(bottomPct).toBe(0);
+      expect(topPct).toBeCloseTo(4 + 0.01, 10);
+
+      const [bottomAbs, topAbs] = computeVaultPnlYDomain([-2, -2], 'abs');
+      expect(bottomAbs).toBeCloseTo(-2 - 0.1, 10);
+      expect(topAbs).toBeCloseTo(-2 + 0.1, 10);
+    });
+
+    it('returns a neutral range for an empty series', () => {
+      expect(computeVaultPnlYDomain([], 'pct')).toEqual([-1, 1]);
+    });
   });
 
   it('preserves the zero-TVL leading-point trim when no anchorSec is supplied', () => {

--- a/packages/app/src/components/vaults/vaultPnlChartUtils.ts
+++ b/packages/app/src/components/vaults/vaultPnlChartUtils.ts
@@ -87,6 +87,23 @@ export function buildVaultPnlChartData(
   });
 }
 
+export function computeVaultPnlYDomain(
+  values: number[],
+  displayMode: 'pct' | 'abs'
+): [number, number] {
+  if (values.length === 0) return [-1, 1];
+
+  const minVal = Math.min(...values);
+  const maxVal = Math.max(...values);
+  const range = maxVal - minVal;
+  const padding = range * 0.1 || (displayMode === 'pct' ? 0.01 : 0.1);
+
+  // Anchor the baseline at zero when the series never goes negative so gains
+  // read against a stable floor instead of a floating one that hides scale.
+  const bottom = minVal >= 0 ? 0 : minVal - padding;
+  return [bottom, maxVal + padding];
+}
+
 export function calculateVaultPnlHeadlineApy(
   chartData: VaultPnlChartPoint[],
   nowSec = Math.floor(Date.now() / 1000)


### PR DESCRIPTION
## Summary
- Clamp the Vault PnL chart y-axis bottom to 0 when the visible series has no negative values, so a strong month (e.g. Core Vault 1M reading 2.26% → 8.18%) no longer floats on an arbitrary non-zero baseline.
- Preserve the existing padded-below behavior when the series contains losses, so negative shapes stay readable.
- Extract the domain math into `computeVaultPnlYDomain` in `vaultPnlChartUtils.ts` and cover the rule with unit tests.

Addresses #real feedback ("small nit - can you make it so zero is the bottom of the y-axis").

## Test plan
- [x] `pnpm --filter @sapience/app exec vitest run src/components/vaults/__tests__/VaultPnlChart.test.ts` — 10/10 pass
- [x] `pnpm --filter @sapience/app run lint`
- [x] `pnpm --filter @sapience/app run type-check`
- [ ] Visual check on staging: Core Vault 1W/1M/3M/ALL views show 0% at the chart floor; verify loss periods (synthetic if needed) still render with pad-below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)