### PR TITLE
chore: hoist pure auction helpers into SDK, dedupe ZERO_ADDRESS

### DIFF
--- a/packages/api/src/workers/indexers/__tests__/positionTokenTransferIndexer.test.ts
+++ b/packages/api/src/workers/indexers/__tests__/positionTokenTransferIndexer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Log } from 'viem';
+import { zeroAddress as ZERO_ADDRESS, type Log } from 'viem';
 import { Prisma } from '../../../../generated/prisma';
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────
@@ -39,7 +39,6 @@ vi.mock('@sapience/sdk/contracts', () => ({
 const HOLDER_A = '0x1111111111111111111111111111111111111111';
 const HOLDER_B = '0x2222222222222222222222222222222222222222';
 const TOKEN = '0x3333333333333333333333333333333333333333';
-const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 const PICK_CONFIG_ID = '0x' + 'cc'.repeat(32);
 
 function makeTransferLog(

--- a/packages/api/src/workers/indexers/positionTokenTransferIndexer.ts
+++ b/packages/api/src/workers/indexers/positionTokenTransferIndexer.ts
@@ -1,7 +1,12 @@
 import prisma from '../../db';
 import { Prisma } from '../../../generated/prisma';
 import { getProviderForChain } from '../../utils/utils';
-import { type PublicClient, type Log, parseAbiItem } from 'viem';
+import {
+  type PublicClient,
+  type Log,
+  parseAbiItem,
+  zeroAddress as ZERO_ADDRESS,
+} from 'viem';
 import Sentry from '../../instrument';
 import { IIndexer } from '../../interfaces';
 import { predictionMarketEscrow } from '@sapience/sdk/contracts';
@@ -9,7 +14,6 @@ import { predictionMarketEscrow } from '@sapience/sdk/contracts';
 const BLOCK_BATCH_SIZE = 1000;
 const POLLING_INTERVAL_MS = 10_000;
 const INDEXER_STATE_KEY = 'v2-transfer-indexer';
-const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 // Deploy date for predictionMarketEscrow (2026-02-26T00:00:00Z) used as
 // fallback when blockCreated is not set in the SDK contract config.

--- a/packages/api/src/workers/jobs/reindexTransfers.ts
+++ b/packages/api/src/workers/jobs/reindexTransfers.ts
@@ -1,13 +1,12 @@
 import prisma from '../../db';
 import { initializeDataSource } from '../../db';
 import { getProviderForChain } from '../../utils/utils';
-import { parseAbiItem } from 'viem';
+import { parseAbiItem, zeroAddress as ZERO_ADDRESS } from 'viem';
 
 const TRANSFER_EVENT = parseAbiItem(
   'event Transfer(address indexed from, address indexed to, uint256 value)'
 );
 const BLOCK_BATCH_SIZE = 1000;
-const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 const INDEXER_STATE_KEY = 'v2-transfer-indexer';
 
 /**

--- a/packages/app/src/components/markets/CreatePositionForm/PositionForm.tsx
+++ b/packages/app/src/components/markets/CreatePositionForm/PositionForm.tsx
@@ -15,7 +15,7 @@ import { Info } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { FormProvider, type UseFormReturn, useWatch } from 'react-hook-form';
-import { parseUnits } from 'viem';
+import { parseUnits, zeroAddress as ZERO_ADDRESS } from 'viem';
 import { useAccount } from 'wagmi';
 import { generateRandomNonce } from '@sapience/sdk';
 import {
@@ -29,6 +29,7 @@ import {
   type PythPrediction,
   type PredictionListItemData,
 } from '@sapience/ui';
+import { buildPythAuctionStartPayload } from '@sapience/sdk/auction/buildAuctionPayload';
 import SponsorshipIndicator from './SponsorshipIndicator';
 import { PythMarketBadge } from '~/components/shared/PythMarketBadge';
 import { useConnectDialog } from '~/lib/context/ConnectDialogContext';
@@ -36,7 +37,6 @@ import { PREFERRED_ESTIMATE_QUOTER } from '~/lib/constants';
 import { useConnectedWallet } from '~/hooks/useConnectedWallet';
 import { PositionSizeInput } from '~/components/markets/forms/inputs/PositionSizeInput';
 import BidDisplay from '~/components/markets/forms/shared/BidDisplay';
-import { buildPythAuctionStartPayload } from '~/lib/auction/buildAuctionPayload';
 import {
   formatPythDurationFromNow,
   formatPythFeedLabel,
@@ -174,7 +174,6 @@ export default function PositionForm({
   // This MUST match the logic in useAuctionStart.requestQuotes
   // - If using session signing (smart account with active session): use effectiveAddress (smart account)
   // - Otherwise (signing with wallet): use predictorAddress (wallet)
-  const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
   const willUseSessionSigning = isUsingSmartAccount && !!sessionSignMessage;
   const triggerMode = getAuctionTriggerMode(
     willUseSessionSigning,

--- a/packages/app/src/components/markets/CreatePositionForm/__tests__/PositionForm.test.tsx
+++ b/packages/app/src/components/markets/CreatePositionForm/__tests__/PositionForm.test.tsx
@@ -119,7 +119,7 @@ vi.mock('@sapience/sdk/contracts', () => ({
 }));
 
 // buildAuctionPayload — return minimal valid payloads
-vi.mock('~/lib/auction/buildAuctionPayload', () => ({
+vi.mock('@sapience/sdk/auction/buildAuctionPayload', () => ({
   buildAuctionStartPayload: vi.fn().mockReturnValue({
     resolver: '0xResolver',
     predictedOutcomes: '0x01',

--- a/packages/app/src/components/markets/CreatePositionForm/__tests__/PositionForm.test.tsx
+++ b/packages/app/src/components/markets/CreatePositionForm/__tests__/PositionForm.test.tsx
@@ -225,6 +225,7 @@ vi.mock('viem', () => ({
     BigInt(Math.round(Number(value) * 10 ** decimals)),
   formatUnits: (value: bigint, decimals: number) =>
     (Number(value) / 10 ** decimals).toString(),
+  zeroAddress: '0x0000000000000000000000000000000000000000',
 }));
 
 // @sapience/ui — stub UI components used by PositionForm

--- a/packages/app/src/components/positions/toPickLegs.ts
+++ b/packages/app/src/components/positions/toPickLegs.ts
@@ -1,9 +1,9 @@
 import { isPredictedYes, OutcomeSide } from '@sapience/sdk/types';
 import { decodePythMarketId } from '@sapience/sdk';
+import { formatPythPriceDecimalFromInt } from '@sapience/sdk/auction/decodePredictedOutcomes';
 import type { Pick } from '~/components/shared/StackedPredictions';
 import { inferResolverKind } from '~/lib/resolvers/conditionResolver';
 import { getChoiceLabel } from '~/lib/resolvers/choiceLabel';
-import { formatPythPriceDecimalFromInt } from '~/lib/auction/decodePredictedOutcomes';
 import { getPythFeedLabelSync } from '~/lib/pyth/usePythFeedLabel';
 
 export type ConditionsMap = Map<

--- a/packages/app/src/components/shared/MarketPredictionRequest.tsx
+++ b/packages/app/src/components/shared/MarketPredictionRequest.tsx
@@ -9,9 +9,9 @@ import { predictionMarketEscrow } from '@sapience/sdk/contracts';
 import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
 import { OutcomeSide } from '@sapience/sdk/types';
 import { conditionalTokensConditionResolver } from '@sapience/sdk/contracts';
+import type { PredictedOutcomeInputStub } from '@sapience/sdk/auction/buildAuctionPayload';
 import { PREFERRED_ESTIMATE_QUOTER } from '~/lib/constants';
 import { useAuctionStart, type QuoteBid } from '~/lib/auction/useAuctionStart';
-import type { PredictedOutcomeInputStub } from '~/lib/auction/buildAuctionPayload';
 import PercentChance from '~/components/shared/PercentChance';
 
 const FADE_VARIANTS = {

--- a/packages/app/src/components/terminal/AuctionRequestChart.tsx
+++ b/packages/app/src/components/terminal/AuctionRequestChart.tsx
@@ -2,14 +2,12 @@
 
 import type React from 'react';
 import { useEffect, useRef, useState } from 'react';
+import { formatUnits, zeroAddress as ZERO_ADDRESS } from 'viem';
+import { Info } from 'lucide-react';
 import AuctionBidsChart from '~/components/shared/AuctionBidsChart';
-import { formatUnits } from 'viem';
 import EnsAvatar from '~/components/shared/EnsAvatar';
 import { AddressDisplay } from '~/components/shared/AddressDisplay';
-import { Info } from 'lucide-react';
 import type { AuctionBid } from '~/lib/auction/useAuctionBids';
-
-const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 type Props = {
   bids: AuctionBid[];

--- a/packages/app/src/components/terminal/AuctionRequestRow.tsx
+++ b/packages/app/src/components/terminal/AuctionRequestRow.tsx
@@ -5,29 +5,29 @@ import { useMemo, useCallback, useState, useEffect, useRef } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { parseUnits, formatEther, formatUnits } from 'viem';
 import { Pin, ChevronDown } from 'lucide-react';
-import { type UiTransaction } from '~/components/markets/DataDrawer/TransactionCells';
-import { useAuctionBids, type AuctionBid } from '~/lib/auction/useAuctionBids';
-import { usePreprocessedBids } from '~/hooks/auction/usePreprocessedBids';
-import AuctionRequestInfo from '~/components/terminal/AuctionRequestInfo';
-import AuctionRequestChart from '~/components/terminal/AuctionRequestChart';
 import { useAccount, useReadContract } from 'wagmi';
 import {
   collateralToken,
   predictionMarketEscrow,
 } from '@sapience/sdk/contracts';
-import { useConnectDialog } from '~/lib/context/ConnectDialogContext';
-import { useSession } from '~/lib/context/SessionContext';
 import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
 import type { Address } from 'viem';
 import { useChainId } from 'wagmi';
 import erc20Abi from '@sapience/sdk/queries/abis/erc20abi.json';
 import { useToast } from '@sapience/ui/hooks/use-toast';
+import { PYTH_RESOLVER_SET } from '@sapience/sdk/auction/decodePredictedOutcomes';
+import { type UiTransaction } from '~/components/markets/DataDrawer/TransactionCells';
+import { useAuctionBids, type AuctionBid } from '~/lib/auction/useAuctionBids';
+import { usePreprocessedBids } from '~/hooks/auction/usePreprocessedBids';
+import AuctionRequestInfo from '~/components/terminal/AuctionRequestInfo';
+import AuctionRequestChart from '~/components/terminal/AuctionRequestChart';
+import { useConnectDialog } from '~/lib/context/ConnectDialogContext';
+import { useSession } from '~/lib/context/SessionContext';
 import { useConditionsByIds } from '~/hooks/graphql/useConditionsByIds';
 import { useApprovalDialog } from '~/components/terminal/ApprovalDialogContext';
 import { useTerminalLogsOptional } from '~/components/terminal/TerminalLogsContext';
 import { useBidPreflight, useEscrowBidSubmission } from '~/hooks/auction';
 import PercentChance from '~/components/shared/PercentChance';
-import { PYTH_RESOLVER_SET } from '~/lib/auction/decodePredictedOutcomes';
 
 type Props = {
   uiTx: UiTransaction;

--- a/packages/app/src/components/terminal/PythPredictionsCell.tsx
+++ b/packages/app/src/components/terminal/PythPredictionsCell.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { motion } from 'framer-motion';
+import { formatPythPriceDecimalFromInt } from '@sapience/sdk/auction/decodePredictedOutcomes';
 import StackedPredictions, {
   type Pick,
 } from '~/components/shared/StackedPredictions';
-import { formatPythPriceDecimalFromInt } from '~/lib/auction/decodePredictedOutcomes';
 import { usePythFeedLabel } from '~/lib/pyth/usePythFeedLabel';
 
 type PythPick = {

--- a/packages/app/src/components/terminal/pages/TerminalPageContent.tsx
+++ b/packages/app/src/components/terminal/pages/TerminalPageContent.tsx
@@ -12,6 +12,10 @@ import type { ConditionById } from '@sapience/sdk/queries';
 import { useReadContracts } from 'wagmi';
 import { collateralToken } from '@sapience/sdk/contracts';
 import { DEFAULT_CHAIN_ID, COLLATERAL_SYMBOLS } from '@sapience/sdk/constants';
+import {
+  decodeAuctionPredictedOutcomes,
+  PYTH_RESOLVER_SET,
+} from '@sapience/sdk/auction/decodePredictedOutcomes';
 import { useSessionState } from '~/hooks/useSessionState';
 import { useAuctionRelayerFeed } from '~/lib/auction/useAuctionRelayerFeed';
 import {
@@ -34,10 +38,6 @@ import { useCategories } from '~/hooks/graphql/useCategories';
 import StackedPredictions, {
   type Pick,
 } from '~/components/shared/StackedPredictions';
-import {
-  decodeAuctionPredictedOutcomes,
-  PYTH_RESOLVER_SET,
-} from '~/lib/auction/decodePredictedOutcomes';
 
 import CategoryFilter from '~/components/terminal/filters/CategoryFilter';
 import ConditionsFilter from '~/components/terminal/filters/ConditionsFilter';

--- a/packages/app/src/hooks/auction/__tests__/usePreprocessedBids.test.ts
+++ b/packages/app/src/hooks/auction/__tests__/usePreprocessedBids.test.ts
@@ -1,12 +1,9 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
+import { zeroAddress as ZERO_ADDRESS } from 'viem';
 import { OutcomeSide } from '@sapience/sdk/types';
 import type { AuctionBid } from '~/lib/auction/useAuctionBidsHub';
 import type { UsePreprocessedBidsOptions } from '../usePreprocessedBids';
-
-// ---- constants ----
-
-const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 // ---- mocks ----
 // vi.mock calls are hoisted — use vi.hoisted() so references are available.

--- a/packages/app/src/hooks/auction/__tests__/useValidatedBids.test.ts
+++ b/packages/app/src/hooks/auction/__tests__/useValidatedBids.test.ts
@@ -1,13 +1,10 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
+import { zeroAddress as ZERO_ADDRESS } from 'viem';
 import { OutcomeSide } from '@sapience/sdk/types';
 import type { QuoteBid } from '~/lib/auction/useAuctionStart';
 import type { UseValidatedBidsOptions } from '../useValidatedBids';
 import type { Pick } from '@sapience/sdk/types';
-
-// ---- constants ----
-
-const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 // ---- mocks ----
 // vi.mock calls are hoisted — use vi.hoisted() so references are available.

--- a/packages/app/src/hooks/auction/__tests__/useValidatedBids.test.ts
+++ b/packages/app/src/hooks/auction/__tests__/useValidatedBids.test.ts
@@ -117,6 +117,34 @@ describe('useValidatedBids', () => {
     expect(callArgs[2]).toMatchObject({ failOpen: false });
   });
 
+  it('revalidates bids when predictorNonce changes', async () => {
+    const bid = makeBid({ counterpartySignature: '0xnonce_change' });
+    const { rerender } = renderStable([bid], {
+      ...DEFAULT_OPTS,
+      predictorNonce: 1,
+    });
+
+    await flush();
+    expect(mockValidateBidOnChain).toHaveBeenCalledTimes(1);
+
+    rerender({
+      bids: [bid],
+      opts: {
+        ...DEFAULT_OPTS,
+        predictorNonce: 2,
+      },
+    });
+
+    await flush();
+    expect(mockValidateBidOnChain).toHaveBeenCalledTimes(2);
+    expect(mockValidateBidOnChain.mock.calls[0][1]).toMatchObject({
+      predictorNonce: 1,
+    });
+    expect(mockValidateBidOnChain.mock.calls[1][1]).toMatchObject({
+      predictorNonce: 2,
+    });
+  });
+
   // ---- Fix 2: catch block marks invalid, not valid ----
 
   it('marks bid as invalid when validateBidOnChain throws unexpectedly', async () => {

--- a/packages/app/src/hooks/auction/useComboQuotes.ts
+++ b/packages/app/src/hooks/auction/useComboQuotes.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { parseUnits } from 'viem';
+import { parseUnits, zeroAddress as ZERO_ADDRESS } from 'viem';
 import { useAccount, useReadContract } from 'wagmi';
 import { predictionMarketEscrowAbi } from '@sapience/sdk/abis';
 import { predictionMarketEscrow } from '@sapience/sdk/contracts';
@@ -15,8 +15,6 @@ import { getSharedAuctionWsClient } from '~/lib/ws/AuctionWsClient';
 import hub from '~/lib/auction/useAuctionBidsHub';
 import type { RecentCombo } from '~/hooks/graphql/useRecentCombos';
 
-const ZERO_ADDRESS =
-  '0x0000000000000000000000000000000000000000' as `0x${string}`;
 const PREDICTOR_POSITION_SIZE_WEI = parseUnits('1', 18).toString();
 
 /**

--- a/packages/app/src/hooks/auction/usePreprocessedBids.ts
+++ b/packages/app/src/hooks/auction/usePreprocessedBids.ts
@@ -1,14 +1,12 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { Address } from 'viem';
+import { zeroAddress as ZERO_ADDRESS, type Address } from 'viem';
 import type { PickJson } from '@sapience/sdk/types';
 import { validateBidFull } from '@sapience/sdk/auction/validation';
 import type { ValidationResult } from '@sapience/sdk/auction/validation';
 import type { AuctionBid } from '~/lib/auction/useAuctionBidsHub';
 import { getPublicClientForChainId } from '~/lib/utils/util';
-
-const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 

--- a/packages/app/src/hooks/auction/useValidatedBids.ts
+++ b/packages/app/src/hooks/auction/useValidatedBids.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { Address } from 'viem';
+import { zeroAddress as ZERO_ADDRESS, type Address } from 'viem';
 import type { Pick, PickJson } from '@sapience/sdk/types';
 import type { ValidationResult } from '@sapience/sdk/auction/validation';
 import { validateBidOnChain } from '@sapience/sdk/auction/validation';
@@ -31,8 +31,6 @@ export interface UseValidatedBidsResult {
   invalidBidCount: number;
   isValidating: boolean;
 }
-
-const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 /**
  * Hook that wraps raw QuoteBid[] with on-chain bid validation.
@@ -260,6 +258,7 @@ export function useValidatedBids(
     collateralTokenAddress,
     predictorAddress,
     predictorCollateral,
+    predictorNonce,
     picksJson,
     isSponsored,
     sponsorAddress,

--- a/packages/app/src/hooks/auction/useValidatedBids.ts
+++ b/packages/app/src/hooks/auction/useValidatedBids.ts
@@ -103,7 +103,7 @@ export function useValidatedBids(
     [picks]
   );
 
-  // Invalidate cached results when picks or predictorCollateral changes
+  // Invalidate cached results when prediction inputs change
   // (predictionHash changes, so all previous validations are stale)
   const picksKey = useMemo(
     () =>
@@ -119,11 +119,11 @@ export function useValidatedBids(
   );
 
   useEffect(() => {
-    // Clear all cached validation when picks or collateral changes
+    // Clear all cached validation when prediction inputs change
     validatedSignaturesRef.current.clear();
     validatingRef.current.clear();
     setValidationResults(new Map());
-  }, [picksKey, predictorCollateral]);
+  }, [picksKey, predictorCollateral, predictorNonce]);
 
   // Validate new bids when they arrive
   useEffect(() => {

--- a/packages/app/src/lib/auction/pythPredictionDisplay.ts
+++ b/packages/app/src/lib/auction/pythPredictionDisplay.ts
@@ -1,4 +1,4 @@
-import { parseDateTimeLocalToUnixSeconds } from '~/lib/auction/buildAuctionPayload';
+import { parseDateTimeLocalToUnixSeconds } from '@sapience/sdk/auction/buildAuctionPayload';
 
 // Strip the Pyth feed namespace so only the symbol remains
 // (`Crypto.BTC/USD` → `BTC/USD`, `Equity.US.AAPL` → `AAPL`).

--- a/packages/app/src/lib/auction/useAuctionStart.ts
+++ b/packages/app/src/lib/auction/useAuctionStart.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAccount, useSignTypedData } from 'wagmi';
-import type { Hex } from 'viem';
+import { zeroAddress as ZERO_ADDRESS, type Hex } from 'viem';
 import type { Pick } from '@sapience/sdk/types';
 import {
   prepareAuctionRFQ,
@@ -295,7 +295,6 @@ export function useAuctionStart(options?: UseAuctionStartOptions) {
             ? (data.payload.bids as Array<Record<string, unknown>>)
             : [];
 
-          const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
           const normalized: QuoteBid[] = rawBids
             .map((b): QuoteBid | null => {
               try {

--- a/packages/app/src/lib/terminal/auctionMessage.ts
+++ b/packages/app/src/lib/terminal/auctionMessage.ts
@@ -1,7 +1,7 @@
 import {
   decodeAuctionPredictedOutcomes,
   PYTH_RESOLVER_SET,
-} from '~/lib/auction/decodePredictedOutcomes';
+} from '@sapience/sdk/auction/decodePredictedOutcomes';
 import type { UiTransaction } from '~/components/markets/DataDrawer/TransactionCells';
 
 // Shape of auction.started / auction.bids message payload (relayer feed).

--- a/packages/relayer/src/secondaryMarketSigVerify.ts
+++ b/packages/relayer/src/secondaryMarketSigVerify.ts
@@ -7,7 +7,12 @@
  * does the definitive verification for those.
  */
 
-import { verifyTypedData, type Address, type Hex } from 'viem';
+import {
+  verifyTypedData,
+  zeroAddress as ZERO_ADDRESS,
+  type Address,
+  type Hex,
+} from 'viem';
 import { secondaryMarketEscrow } from '@sapience/sdk/contracts/addresses';
 import {
   computeTradeHash,
@@ -18,8 +23,6 @@ import type {
   SecondaryAuctionRequestPayload,
   SecondaryBidPayload,
 } from '@sapience/sdk/types/secondary';
-
-const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as Address;
 
 /**
  * Get the verifying contract address for a chain

--- a/packages/sdk/auction/__tests__/buildAuctionPayload.test.ts
+++ b/packages/sdk/auction/__tests__/buildAuctionPayload.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { decodeAbiParameters } from 'viem';
 import {
   buildAuctionStartPayload,
@@ -5,8 +6,8 @@ import {
   type PredictedOutcomeInputStub,
   type PythOutcomeInputStub,
 } from '../buildAuctionPayload';
-import { CHAIN_ID_ETHEREAL } from '@sapience/sdk/constants';
-import { OutcomeSide } from '@sapience/sdk/types';
+import { CHAIN_ID_ETHEREAL } from '../../constants';
+import { OutcomeSide } from '../../types';
 
 // ---------------------------------------------------------------------------
 // Polymarket / ConditionalTokens outcomes

--- a/packages/sdk/auction/__tests__/buildPythAuctionPayload.test.ts
+++ b/packages/sdk/auction/__tests__/buildPythAuctionPayload.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { OutcomeSide } from '@sapience/sdk/types';
+import { OutcomeSide } from '../../types';
 import {
   normalizePythPriceId,
   decimalToScaledBigInt,
@@ -9,8 +9,8 @@ import {
   buildPythAuctionStartPayload,
   type PythOutcomeInputStub,
 } from '../buildAuctionPayload';
-import { pythConditionResolver } from '@sapience/sdk/contracts';
-import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
+import { pythConditionResolver } from '../../contracts';
+import { DEFAULT_CHAIN_ID } from '../../constants';
 
 describe('normalizePythPriceId', () => {
   const BYTES32_ONE =

--- a/packages/sdk/auction/__tests__/decodePredictedOutcomes.test.ts
+++ b/packages/sdk/auction/__tests__/decodePredictedOutcomes.test.ts
@@ -11,12 +11,12 @@ import {
   encodePolymarketPredictedOutcomes,
   getPythMarketId,
   type PythBinaryOptionOutcome,
-} from '@sapience/sdk';
+} from '../encoding';
 import {
   pythConditionResolver,
   manualConditionResolver,
-} from '@sapience/sdk/contracts';
-import { OutcomeSide } from '@sapience/sdk/types';
+} from '../../contracts';
+import { OutcomeSide } from '../../types';
 import { parseDateTimeLocalToUnixSeconds } from '../buildAuctionPayload';
 
 // ---------------------------------------------------------------------------

--- a/packages/sdk/auction/buildAuctionPayload.ts
+++ b/packages/sdk/auction/buildAuctionPayload.ts
@@ -1,18 +1,20 @@
-import { OutcomeSide } from '@sapience/sdk/types';
-import { conditionalTokensConditionResolver } from '@sapience/sdk/contracts';
+import { OutcomeSide } from '../types';
+import {
+  conditionalTokensConditionResolver,
+  pythConditionResolver,
+} from '../contracts';
 import {
   CHAIN_ID_ETHEREAL,
   CHAIN_ID_ETHEREAL_TESTNET,
   DEFAULT_CHAIN_ID,
-} from '@sapience/sdk/constants';
+} from '../constants';
 import {
   encodePythBinaryOptionOutcomes,
   encodePolymarketPredictedOutcomes,
   getPythMarketId,
   type PythBinaryOptionOutcome,
   type PolymarketPredictedOutcome,
-} from '@sapience/sdk';
-import { pythConditionResolver } from '@sapience/sdk/contracts';
+} from './encoding';
 
 export interface PredictedOutcomeInputStub {
   marketId: string; // The id from API (already encoded claim:endTime)

--- a/packages/sdk/auction/decodePredictedOutcomes.ts
+++ b/packages/sdk/auction/decodePredictedOutcomes.ts
@@ -3,10 +3,9 @@ import {
   pythConditionResolver,
   conditionalTokensConditionResolver,
   manualConditionResolver,
-} from '@sapience/sdk/contracts';
-import { OutcomeSide } from '@sapience/sdk/types';
-import { getPythMarketId } from '@sapience/sdk';
-import type { Pick } from '@sapience/sdk/types';
+} from '../contracts';
+import { OutcomeSide, type Pick } from '../types';
+import { getPythMarketId } from './encoding';
 
 export type ConditionDecodedOutcome = {
   kind: 'condition';

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -16,5 +16,7 @@ export * from './auction/encoding';
 export * from './auction/escrowEncoding';
 export * from './auction/escrowSigning';
 export * from './auction/secondarySigning';
+export * from './auction/buildAuctionPayload';
+export * from './auction/decodePredictedOutcomes';
 
 export * from './relayer/escrowAuctionWs';

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -123,6 +123,16 @@
       "import": "./dist/auction/initiate.mjs",
       "require": "./dist/auction/initiate.js"
     },
+    "./auction/buildAuctionPayload": {
+      "types": "./dist/auction/buildAuctionPayload.d.ts",
+      "import": "./dist/auction/buildAuctionPayload.mjs",
+      "require": "./dist/auction/buildAuctionPayload.js"
+    },
+    "./auction/decodePredictedOutcomes": {
+      "types": "./dist/auction/decodePredictedOutcomes.d.ts",
+      "import": "./dist/auction/decodePredictedOutcomes.mjs",
+      "require": "./dist/auction/decodePredictedOutcomes.js"
+    },
     "./session": {
       "types": "./dist/session/index.d.ts",
       "import": "./dist/session/index.mjs",
@@ -131,8 +141,8 @@
   },
   "scripts": {
     "prepare": "pnpm run build:lib",
-    "dev": "tsup index.ts auction/encoding.ts auction/escrowEncoding.ts auction/escrowSigning.ts auction/simulate.ts auction/secondarySigning.ts auction/secondaryValidation.ts auction/validation.ts auction/gossipValidation.ts auction/bidPreprocessor.ts auction/initiate.ts relayer/escrowAuctionWs.ts abis/index.ts constants/index.ts contracts/index.ts contracts/addresses.ts queries/index.ts queries/client/graphqlClient.ts types/index.ts types/escrow.ts types/secondary.ts types/graphql.ts session/index.ts --format cjs,esm --dts --watch",
-    "build:lib": "tsup index.ts auction/encoding.ts auction/escrowEncoding.ts auction/escrowSigning.ts auction/simulate.ts auction/secondarySigning.ts auction/secondaryValidation.ts auction/validation.ts auction/gossipValidation.ts auction/bidPreprocessor.ts auction/initiate.ts relayer/escrowAuctionWs.ts abis/index.ts constants/index.ts contracts/index.ts contracts/addresses.ts queries/index.ts queries/client/graphqlClient.ts types/index.ts types/escrow.ts types/secondary.ts types/graphql.ts session/index.ts --format cjs,esm --dts --tsconfig tsconfig.build.json",
+    "dev": "tsup index.ts auction/encoding.ts auction/escrowEncoding.ts auction/escrowSigning.ts auction/simulate.ts auction/secondarySigning.ts auction/secondaryValidation.ts auction/validation.ts auction/gossipValidation.ts auction/bidPreprocessor.ts auction/initiate.ts auction/buildAuctionPayload.ts auction/decodePredictedOutcomes.ts relayer/escrowAuctionWs.ts abis/index.ts constants/index.ts contracts/index.ts contracts/addresses.ts queries/index.ts queries/client/graphqlClient.ts types/index.ts types/escrow.ts types/secondary.ts types/graphql.ts session/index.ts --format cjs,esm --dts --watch",
+    "build:lib": "tsup index.ts auction/encoding.ts auction/escrowEncoding.ts auction/escrowSigning.ts auction/simulate.ts auction/secondarySigning.ts auction/secondaryValidation.ts auction/validation.ts auction/gossipValidation.ts auction/bidPreprocessor.ts auction/initiate.ts auction/buildAuctionPayload.ts auction/decodePredictedOutcomes.ts relayer/escrowAuctionWs.ts abis/index.ts constants/index.ts contracts/index.ts contracts/addresses.ts queries/index.ts queries/client/graphqlClient.ts types/index.ts types/escrow.ts types/secondary.ts types/graphql.ts session/index.ts --format cjs,esm --dts --tsconfig tsconfig.build.json",
     "build": "pnpm run build:lib",
     "lint": "eslint . --quiet",
     "lint:fix": "eslint . --fix --quiet && pnpm format",


### PR DESCRIPTION
## Summary

Tighten the app↔SDK boundary. No behavior change.

- **Promote two pure helpers from app to SDK.** `buildAuctionPayload.ts` and `decodePredictedOutcomes.ts` (plus their tests) now live in `packages/sdk/auction/`. Both are pure viem + SDK-internal domain logic with no React/Next deps, so other packages (relayer bots, api indexers, keepers) can now share the exact same encoding/decoding rules the app uses. Added corresponding subpath exports in `packages/sdk/package.json`, top-level re-exports in `packages/sdk/index.ts`, and tsup entry points.
- **Deduplicate `ZERO_ADDRESS`.** Replaced 9 production + 3 test copies of `const ZERO_ADDRESS = '0x00…'` across app/api/relayer with `import { zeroAddress as ZERO_ADDRESS } from 'viem'`. Extended the viem mock in `PositionForm.test.tsx` to expose `zeroAddress`.
- **Drive-by:** fix pre-existing exhaustive-deps warning in `useValidatedBids` that the ZERO_ADDRESS edit surfaced (`predictorNonce` was missing from an effect's deps).

### Scope notes

Deliberately declined moves where the cross-package benefit isn't clear today or where the file is still coupled to app state:
- `selectBestBid.ts` / `bidAdapter.ts` — depend on app-local `QuoteBid` and chart types
- `pythPredictionDisplay.ts`, `formatPercentChance.ts`, `choiceLabel.ts`, `conditionResolver.ts` — only consumed by app UI today
- `util.ts` helpers (`httpWithRetry`, `getPublicClientForChainId`, `formatFiveSigFigs`, `d18ToPercentage`) — tangled with `NEXT_PUBLIC_*` env vars; needs a bigger redesign
- SDK root barrel additions for `validation`/`simulate`/`initiate`/`bidPreprocessor`/`session` — those are intentionally subpath-only to keep optional peer deps (`@zerodev/*`, `ws`) out of the root import graph

## Test plan

- [x] `pnpm --filter @sapience/sdk run build:lib` — clean
- [x] `pnpm --filter @sapience/sdk run {type-check,lint,test}` — pass
- [x] `pnpm --filter @sapience/app run {type-check,lint,test}` — pass (45 files, 515 tests)
- [x] `pnpm --filter @sapience/api run {type-check,lint,test}` — pass (25 files, 351 tests)
- [x] `pnpm --filter @sapience/relayer run {type-check,lint,test}` — pass (17 files, 328 tests)
- [ ] Quick smoke in browser once merged to staging (auction initiation + AutoBid decode path)