### PR TITLE
chore(sdk): drop BOT_PRIVATE_KEY fallback from settlePythMarkets script

### DIFF
--- a/packages/sdk/scripts/settlePythMarkets.ts
+++ b/packages/sdk/scripts/settlePythMarkets.ts
@@ -47,7 +47,7 @@ import { getPythMarketHash, decodePythMarketId } from '../auction/encoding';
  *
  * Env var equivalents:
  * - RPC_URL (or BOT_RPC_URL)
- * - PRIVATE_KEY (or BOT_PRIVATE_KEY)
+ * - PRIVATE_KEY
  * - PYTH_CONSUMER_TOKEN (or PYTH_API_KEY)
  * - GRAPHQL_URL
  */
@@ -111,10 +111,7 @@ function parseArgs(argv: string[]): Args {
     process.env.GRAPHQL_URL ??
     'http://localhost:3001/graphql';
 
-  const privateKey =
-    get('private-key') ??
-    process.env.BOT_PRIVATE_KEY ??
-    process.env.PRIVATE_KEY;
+  const privateKey = get('private-key') ?? process.env.PRIVATE_KEY;
 
   const pythToken =
     get('pyth-token') ??


### PR DESCRIPTION
## Summary
- `packages/sdk/scripts/settlePythMarkets.ts` was reading `BOT_PRIVATE_KEY` only as a fallback alias for `PRIVATE_KEY`. Removed it so the script accepts only the canonical `--private-key` flag or `PRIVATE_KEY` env var.
- Updated the docstring "Env var equivalents" block to match.

## Context
Audit of `BOT_PRIVATE_KEY` usage across the org showed only two consumers in this repo: this script (alias only) and `packages/relayer/src/botExample.ts` (optional approval helper in a demo whose bid uses dummy maker/signature, so the env var has no functional role there either). After this change, the SDK script no longer references `BOT_PRIVATE_KEY`. Security inventory in `sapience-docs` will be updated separately.

## Operational note
If anyone runs `pnpm --filter @sapience/sdk run settle:pyth` in an environment where only `BOT_PRIVATE_KEY` is set (e.g. Railway), they need to switch to `PRIVATE_KEY` or pass `--private-key`. No CI/cron invokes this script, so no automated job is affected.

## Test plan
- [x] `pnpm exec tsc --noEmit` in `packages/sdk` passes
- [ ] Reviewer confirms no other consumer of `BOT_PRIVATE_KEY` was missed