### PR TITLE
chore: migrate Polymarket CLOB URLs to clob-v2

### DIFF
--- a/packages/app/public/SKILL.md
+++ b/packages/app/public/SKILL.md
@@ -200,13 +200,13 @@ Response: `outcomePrices` (YES/NO prices), `outcomes`, `clobTokenIds` (for order
 ### Get Orderbook
 
 ```bash
-curl "https://clob.polymarket.com/book?token_id=<clobTokenId>"
+curl "https://clob-v2.polymarket.com/book?token_id=<clobTokenId>"
 ```
 
 ### Price History
 
 ```bash
-curl "https://clob.polymarket.com/prices-history?market=<clobTokenId>&startTs=<unix_ts>&fidelity=60"
+curl "https://clob-v2.polymarket.com/prices-history?market=<clobTokenId>&startTs=<unix_ts>&fidelity=60"
 ```
 
 No auth required for Polymarket APIs.

--- a/packages/market-keeper/misc/backfill-condition-similar-markets.ts
+++ b/packages/market-keeper/misc/backfill-condition-similar-markets.ts
@@ -102,7 +102,7 @@ async function fetchMarketFromGammaApi(conditionId: string): Promise<PolymarketM
 
 async function fetchMarketFromClobApi(conditionId: string): Promise<PolymarketMarket | null> {
   try {
-    const url = `https://clob.polymarket.com/markets/${conditionId}`;
+    const url = `https://clob-v2.polymarket.com/markets/${conditionId}`;
     const response = await fetchWithRetry(url, {
       headers: { 'Accept': 'application/json' },
     });

--- a/packages/market-keeper/misc/backfill-similar-markets.ts
+++ b/packages/market-keeper/misc/backfill-similar-markets.ts
@@ -110,7 +110,7 @@ async function fetchMarketFromGammaApi(conditionId: string): Promise<PolymarketM
 
 async function fetchMarketFromClobApi(conditionId: string): Promise<PolymarketMarket | null> {
   try {
-    const url = `https://clob.polymarket.com/markets/${conditionId}`;
+    const url = `https://clob-v2.polymarket.com/markets/${conditionId}`;
     const response = await fetchWithRetry(url, {
       headers: { 'Accept': 'application/json' },
     });

--- a/packages/market-keeper/scripts/settle-manual.ts
+++ b/packages/market-keeper/scripts/settle-manual.ts
@@ -101,7 +101,7 @@ const CONDITIONAL_TOKENS_READER_ADDRESS = (process.env
 const DEFAULT_API_URL = 'https://api.sapience.xyz/graphql';
 
 const GAMMA_API_URL = 'https://gamma-api.polymarket.com';
-const CLOB_API_URL = 'https://clob.polymarket.com';
+const CLOB_API_URL = 'https://clob-v2.polymarket.com';
 
 // ============ Chain Definition ============
 

--- a/scripts/polymarket-mcp-server.js
+++ b/scripts/polymarket-mcp-server.js
@@ -11,7 +11,7 @@
  */
 
 const GAMMA_BASE = "https://gamma-api.polymarket.com";
-const CLOB_BASE = "https://clob.polymarket.com";
+const CLOB_BASE = "https://clob-v2.polymarket.com";
 
 // --- Tool definitions --------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Polymarket has migrated their CLOB API to a new host. This sweep replaces every hardcoded `https://clob.polymarket.com` reference in the repo with `https://clob-v2.polymarket.com` so anything that talks to the CLOB keeps working.

Files updated:
- `packages/market-keeper/scripts/settle-manual.ts` — manual settlement path used to reconcile Polymarket conditions
- `packages/market-keeper/misc/backfill-similar-markets.ts` and `backfill-condition-similar-markets.ts` — one-off backfill scripts that fetch CLOB market metadata
- `scripts/polymarket-mcp-server.js` — the local MCP helper used during development
- `packages/app/public/SKILL.md` — agent-facing docs that document the CLOB endpoints (kept in sync so future agents copy the right URL)

No runtime API or client code changes — these are all string constants in scripts and docs. The Polymarket SDK in `packages/sdk` already targets the v2 host through its own configuration.

## Test plan

- [x] `pnpm --filter @sapience/sdk run build:lib`
- [x] `pnpm --filter @sapience/market-keeper run type-check`
- [x] `pnpm --filter @sapience/market-keeper run build`
- [x] `pnpm --filter @sapience/market-keeper run test` (293 tests pass)
- [ ] Smoke a manual settle dry-run after merge to confirm v2 host responds as expected