### PR TITLE
feat(app): analytics OI distribution charts (donut + time-to-resolution)

### DIFF
--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -279,6 +279,18 @@ input CategoryNullableRelationFilter {
   isNot: CategoryWhereInput
 }
 
+"""
+Protocol-wide statistics snapshot including vault metrics, volume, and PnL.
+Cadence is controlled by the snapshot cron; periodPnL and periodVolume are
+deltas over that interval.
+"""
+type CategoryOpenInterest {
+  category: Category!
+
+  """Open interest in wei (decimal string)"""
+  openInterest: String!
+}
+
 input CategoryOrderByWithRelationInput {
   conditionGroups: ConditionGroupOrderByRelationAggregateInput
   conditions: ConditionOrderByRelationAggregateInput
@@ -1401,11 +1413,6 @@ type ProfitRank {
   totalPnL: String!
 }
 
-"""
-Protocol-wide statistics snapshot including vault metrics, volume, and PnL.
-Cadence is controlled by the snapshot cron; periodPnL and periodVolume are
-deltas over that interval.
-"""
 type ProtocolStat {
   cumulativeVolume: String!
   escrowBalance: String!
@@ -1497,6 +1504,16 @@ type Query {
   conditionGroup(where: ConditionGroupWhereUniqueInput!): ConditionGroup
   conditionGroups(cursor: ConditionGroupWhereUniqueInput, distinct: [ConditionGroupScalarFieldEnum!], orderBy: [ConditionGroupOrderByWithRelationInput!], skip: Int, take: Int, where: ConditionGroupWhereInput): [ConditionGroup!]!
   conditions(cursor: ConditionWhereUniqueInput, distinct: [ConditionScalarFieldEnum!], orderBy: [ConditionOrderByWithRelationInput!], skip: Int, take: Int, where: ConditionWhereInput): [Condition!]!
+
+  """
+  Open interest aggregated per category — protocol-wide. Sums each ConditionGroup's pre-computed totalOpenInterest plus each ungrouped public condition's openInterest, returning categories with non-zero OI sorted descending.
+  """
+  openInterestByCategory: [CategoryOpenInterest!]!
+
+  """
+  Open interest bucketed by time-to-resolution — protocol-wide. Each unsettled prediction's collateral falls into the bucket of its latest condition endTime; expired-but-pending predictions roll into the soonest bucket.
+  """
+  openInterestByTimeToResolution: [TimeToResolutionBucket!]!
 
   """Look up a single pick configuration by ID"""
   pickConfiguration(id: String!): PickConfiguration
@@ -1715,6 +1732,26 @@ enum TimeInterval {
   HOUR
   MONTH
   WEEK
+}
+
+"""
+Open-interest aggregated by time-to-resolution bucket. Each unsettled
+prediction's collateral is bucketed by the latest endTime among the conditions
+it touches (the moment its OI can finally be claimed). One row per non-empty
+bucket, ordered from soonest (bucket = 1) to furthest out.
+"""
+type TimeToResolutionBucket {
+  """Sort order: 1 = soonest, increasing for further-out buckets"""
+  bucket: Int!
+
+  """Display label, e.g. "≤1d", "2-7d", "1-2mo" """
+  label: String!
+
+  """Open interest in wei (decimal string)"""
+  openInterest: String!
+
+  """Number of predictions contributing to this bucket"""
+  predictionCount: Int!
 }
 
 """

--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -279,11 +279,7 @@ input CategoryNullableRelationFilter {
   isNot: CategoryWhereInput
 }
 
-"""
-Protocol-wide statistics snapshot including vault metrics, volume, and PnL.
-Cadence is controlled by the snapshot cron; periodPnL and periodVolume are
-deltas over that interval.
-"""
+"""Open-interest aggregated for a single category."""
 type CategoryOpenInterest {
   category: Category!
 
@@ -1413,6 +1409,11 @@ type ProfitRank {
   totalPnL: String!
 }
 
+"""
+Protocol-wide statistics snapshot including vault metrics, volume, and PnL.
+Cadence is controlled by the snapshot cron; periodPnL and periodVolume are
+deltas over that interval.
+"""
 type ProtocolStat {
   cumulativeVolume: String!
   escrowBalance: String!

--- a/packages/api/src/graphql/sdl/resolvers/index.ts
+++ b/packages/api/src/graphql/sdl/resolvers/index.ts
@@ -32,7 +32,11 @@ import { ReferralCode } from './ReferralCode';
 import { User } from './User';
 
 import { accountActivity } from './queries/activity';
-import { protocolStats } from './queries/analytics';
+import {
+  openInterestByCategory,
+  openInterestByTimeToResolution,
+  protocolStats,
+} from './queries/analytics';
 import {
   collateralBalance,
   collateralBalanceHistory,
@@ -95,6 +99,8 @@ export const resolvers: Resolvers = {
     // Activity + unified feeds
     accountActivity,
     // Analytics
+    openInterestByCategory,
+    openInterestByTimeToResolution,
     protocolStats,
     // Collateral
     accountTotalVolume,

--- a/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
@@ -286,56 +286,85 @@ interface CategoryOpenInterestRow {
 }
 
 /**
- * Query.openInterestByCategory — protocol-wide open interest aggregated by category.
- *
- * Mirrors the canonical "what's a market" filter from the questions resolver:
- * sums each ConditionGroup's pre-computed totalOpenInterest plus each ungrouped
- * public condition's openInterest. Returns only categories with non-zero OI,
- * sorted descending so the donut chart renders largest slice first.
+ * Tiny TTL memo for argument-less resolvers. Single-flight on cache miss so
+ * a thundering herd collapses to one DB hit.
  */
-export const openInterestByCategory: NonNullable<
-  QueryResolvers['openInterestByCategory']
-> = async (): Promise<CategoryOpenInterest[]> => {
-  const rows = await prisma.$queryRaw<CategoryOpenInterestRow[]>`
-    WITH combined AS (
-      SELECT cg."categoryId" AS category_id, cg."totalOpenInterest"::numeric AS oi
-      FROM condition_group cg
-      WHERE cg."publicConditionCount" > 0 AND cg."categoryId" IS NOT NULL
+const memoTtl = <T>(
+  fn: () => Promise<T>,
+  ttlMs: number
+): (() => Promise<T>) => {
+  let cached: { value: T; expiresAt: number } | null = null;
+  let inflight: Promise<T> | null = null;
+  return async () => {
+    const now = Date.now();
+    if (cached && cached.expiresAt > now) return cached.value;
+    if (inflight) return inflight;
+    inflight = (async () => {
+      try {
+        const value = await fn();
+        cached = { value, expiresAt: Date.now() + ttlMs };
+        return value;
+      } finally {
+        inflight = null;
+      }
+    })();
+    return inflight;
+  };
+};
 
-      UNION ALL
+const ANALYTICS_CACHE_TTL_MS = 60_000;
 
-      SELECT c."categoryId" AS category_id, c."openInterest"::numeric AS oi
-      FROM condition c
-      WHERE c.public = true
-        AND c."conditionGroupId" IS NULL
-        AND c."categoryId" IS NOT NULL
-    )
+/**
+ * Query.openInterestByCategory — protocol-wide open interest aggregated by
+ * category for the configured chain.
+ *
+ * Aggregates per-condition `openInterest` directly (rather than reading
+ * `condition_group.totalOpenInterest`) so the chainId filter applies cleanly.
+ * Math is equivalent: the denormalized group total is a sum of its
+ * conditions' OI, so summing condition rows produces the same per-category
+ * total. Uses `IDX_condition_market_filter (public, chainId, ...)`.
+ *
+ * Cached in-process for 60s — single-flighted, so concurrent requests
+ * collapse to one DB hit and the result feeds the public CDN as well.
+ */
+const fetchOpenInterestByCategory = memoTtl(
+  async (): Promise<CategoryOpenInterest[]> => {
+    const chainId = DEFAULT_CHAIN_ID;
+    const rows = await prisma.$queryRaw<CategoryOpenInterestRow[]>`
     SELECT
       cat.id AS category_id,
       cat.name AS category_name,
       cat.slug AS category_slug,
       cat."createdAt" AS category_created_at,
-      SUM(combined.oi)::text AS total_oi
-    FROM combined
-    INNER JOIN category cat ON cat.id = combined.category_id
+      SUM(c."openInterest"::numeric)::text AS total_oi
+    FROM condition c
+    INNER JOIN category cat ON cat.id = c."categoryId"
+    WHERE c.public = true
+      AND c.settled = false
+      AND c."chainId" = ${chainId}
     GROUP BY cat.id, cat.name, cat.slug, cat."createdAt"
-    HAVING SUM(combined.oi) > 0
-    ORDER BY SUM(combined.oi) DESC
+    HAVING SUM(c."openInterest"::numeric) > 0
+    ORDER BY SUM(c."openInterest"::numeric) DESC
   `;
 
-  return rows.map((row) => ({
-    // Relation fields (conditions / conditionGroups) resolve lazily through
-    // their own field resolvers if the client requests them; the cast keeps
-    // codegen happy without forcing us to load them eagerly here.
-    category: {
-      id: row.category_id,
-      name: row.category_name,
-      slug: row.category_slug,
-      createdAt: row.category_created_at,
-    } as unknown as Category,
-    openInterest: row.total_oi,
-  }));
-};
+    return rows.map((row) => ({
+      // Category field resolvers (conditions/conditionGroups) only read parent.id,
+      // so a partial row satisfies them — no need to load relations eagerly.
+      category: {
+        id: row.category_id,
+        name: row.category_name,
+        slug: row.category_slug,
+        createdAt: row.category_created_at,
+      } as unknown as Category,
+      openInterest: row.total_oi,
+    }));
+  },
+  ANALYTICS_CACHE_TTL_MS
+);
+
+export const openInterestByCategory: NonNullable<
+  QueryResolvers['openInterestByCategory']
+> = () => fetchOpenInterestByCategory();
 
 interface TimeToResolutionRow {
   bucket: number;
@@ -355,65 +384,68 @@ const TTR_BUCKET_LABELS: Record<number, string> = {
 
 /**
  * Query.openInterestByTimeToResolution — protocol-wide OI bucketed by how soon
- * each prediction's collateral can finally be claimed. For each unsettled
- * prediction we take the MAX endTime across the conditions it touches (combo
- * predictions resolve only when *all* legs settle), then bucket the prediction's
- * total collateral by that horizon. Predictions whose latest endTime is in the
+ * each prediction's collateral can finally be claimed. Pre-aggregates each
+ * pickConfig once (max endTime across legs, all-public flag), then joins
+ * predictions in a single pass — avoiding the Pick × condition fan-out that
+ * the obvious join would create. Predictions whose latest endTime is in the
  * past but haven't been resolved roll into bucket 1 (imminent / overdue).
  *
  * Mirrors the privacy filter used by the OI time-series resolver: drops any
  * prediction that touches a non-public condition, so the totals reconcile with
- * what's shown elsewhere.
+ * what's shown elsewhere. The CTE pre-filters Pick rows by condition.chainId
+ * so the per-pickConfig aggregation only walks rows for the target chain
+ * (Pick legs are co-chain with their pickConfig in practice). Cached
+ * in-process for 60s with single-flight.
  */
-export const openInterestByTimeToResolution: NonNullable<
-  QueryResolvers['openInterestByTimeToResolution']
-> = async (): Promise<TimeToResolutionBucket[]> => {
-  const rows = await prisma.$queryRaw<TimeToResolutionRow[]>`
-    WITH per_prediction AS (
+const fetchOpenInterestByTimeToResolution = memoTtl(
+  async (): Promise<TimeToResolutionBucket[]> => {
+    const chainId = DEFAULT_CHAIN_ID;
+    const rows = await prisma.$queryRaw<TimeToResolutionRow[]>`
+    WITH per_pick_config AS (
       SELECT
-        p.id,
-        (CAST(p."predictorCollateral" AS numeric) +
-         CAST(p."counterpartyCollateral" AS numeric)) AS oi,
-        MAX(c."endTime") AS max_end_time
-      FROM "Prediction" p
-      JOIN "Picks" pk ON pk.id = p."pickConfigId"
-      JOIN "Pick" pi ON pi."pickConfigId" = pk.id
+        pi."pickConfigId" AS pick_config_id,
+        MAX(c."endTime")  AS max_end_time,
+        BOOL_AND(c.public) AS all_public
+      FROM "Pick" pi
       JOIN "condition" c ON c.id = pi."conditionId"
-      WHERE pk."resolvedAt" IS NULL
-        AND NOT EXISTS (
-          SELECT 1 FROM "Pick" pi2
-          JOIN "condition" c2 ON c2.id = pi2."conditionId"
-          WHERE pi2."pickConfigId" = pk.id AND c2.public = false
-        )
-      GROUP BY p.id, p."predictorCollateral", p."counterpartyCollateral"
-    ),
-    bucketed AS (
-      SELECT
-        CASE
-          WHEN (max_end_time - EXTRACT(EPOCH FROM NOW()))::numeric <= 86400 THEN 1
-          WHEN (max_end_time - EXTRACT(EPOCH FROM NOW()))::numeric <= 7 * 86400 THEN 2
-          WHEN (max_end_time - EXTRACT(EPOCH FROM NOW()))::numeric <= 30 * 86400 THEN 3
-          WHEN (max_end_time - EXTRACT(EPOCH FROM NOW()))::numeric <= 60 * 86400 THEN 4
-          WHEN (max_end_time - EXTRACT(EPOCH FROM NOW()))::numeric <= 90 * 86400 THEN 5
-          WHEN (max_end_time - EXTRACT(EPOCH FROM NOW()))::numeric <= 180 * 86400 THEN 6
-          ELSE 7
-        END AS bucket,
-        oi
-      FROM per_prediction
+      WHERE c."chainId" = ${chainId}
+      GROUP BY pi."pickConfigId"
     )
     SELECT
-      bucket,
-      SUM(oi)::text AS total_oi,
+      CASE
+        WHEN (x.max_end_time - EXTRACT(EPOCH FROM NOW()))::numeric <= 86400 THEN 1
+        WHEN (x.max_end_time - EXTRACT(EPOCH FROM NOW()))::numeric <= 7 * 86400 THEN 2
+        WHEN (x.max_end_time - EXTRACT(EPOCH FROM NOW()))::numeric <= 30 * 86400 THEN 3
+        WHEN (x.max_end_time - EXTRACT(EPOCH FROM NOW()))::numeric <= 60 * 86400 THEN 4
+        WHEN (x.max_end_time - EXTRACT(EPOCH FROM NOW()))::numeric <= 90 * 86400 THEN 5
+        WHEN (x.max_end_time - EXTRACT(EPOCH FROM NOW()))::numeric <= 180 * 86400 THEN 6
+        ELSE 7
+      END AS bucket,
+      SUM(
+        CAST(p."predictorCollateral" AS numeric) +
+        CAST(p."counterpartyCollateral" AS numeric)
+      )::text AS total_oi,
       COUNT(*)::bigint AS prediction_count
-    FROM bucketed
+    FROM "Prediction" p
+    JOIN "Picks" pk ON pk.id = p."pickConfigId"
+    JOIN per_pick_config x ON x.pick_config_id = pk.id
+    WHERE pk.resolved = false
+      AND pk."chainId" = ${chainId}
+      AND x.all_public
     GROUP BY bucket
     ORDER BY bucket
   `;
 
-  return rows.map((row) => ({
-    bucket: row.bucket,
-    label: TTR_BUCKET_LABELS[row.bucket] ?? String(row.bucket),
-    openInterest: row.total_oi,
-    predictionCount: Number(row.prediction_count),
-  }));
-};
+    return rows.map((row) => ({
+      bucket: row.bucket,
+      label: TTR_BUCKET_LABELS[row.bucket] ?? String(row.bucket),
+      openInterest: row.total_oi,
+      predictionCount: Number(row.prediction_count),
+    }));
+  },
+  ANALYTICS_CACHE_TTL_MS
+);
+
+export const openInterestByTimeToResolution: NonNullable<
+  QueryResolvers['openInterestByTimeToResolution']
+> = () => fetchOpenInterestByTimeToResolution();

--- a/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
@@ -8,12 +8,15 @@
  * a continuously-updating in-progress bar that closes when cron fires.
  */
 
+import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
+import { contracts, normalizeLegacyEntry } from '@sapience/sdk/contracts';
 import type {
   QueryResolvers,
   ProtocolStat,
+  CategoryOpenInterest,
+  Category,
+  TimeToResolutionBucket,
 } from '../../__generated__/resolvers';
-import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
-import { contracts, normalizeLegacyEntry } from '@sapience/sdk/contracts';
 import prisma from '../../../../db';
 import {
   calculateVaultFlows,
@@ -272,4 +275,145 @@ export const protocolStats: NonNullable<
   }
 
   return results;
+};
+
+interface CategoryOpenInterestRow {
+  category_id: number;
+  category_name: string;
+  category_slug: string;
+  category_created_at: Date;
+  total_oi: string;
+}
+
+/**
+ * Query.openInterestByCategory — protocol-wide open interest aggregated by category.
+ *
+ * Mirrors the canonical "what's a market" filter from the questions resolver:
+ * sums each ConditionGroup's pre-computed totalOpenInterest plus each ungrouped
+ * public condition's openInterest. Returns only categories with non-zero OI,
+ * sorted descending so the donut chart renders largest slice first.
+ */
+export const openInterestByCategory: NonNullable<
+  QueryResolvers['openInterestByCategory']
+> = async (): Promise<CategoryOpenInterest[]> => {
+  const rows = await prisma.$queryRaw<CategoryOpenInterestRow[]>`
+    WITH combined AS (
+      SELECT cg."categoryId" AS category_id, cg."totalOpenInterest"::numeric AS oi
+      FROM condition_group cg
+      WHERE cg."publicConditionCount" > 0 AND cg."categoryId" IS NOT NULL
+
+      UNION ALL
+
+      SELECT c."categoryId" AS category_id, c."openInterest"::numeric AS oi
+      FROM condition c
+      WHERE c.public = true
+        AND c."conditionGroupId" IS NULL
+        AND c."categoryId" IS NOT NULL
+    )
+    SELECT
+      cat.id AS category_id,
+      cat.name AS category_name,
+      cat.slug AS category_slug,
+      cat."createdAt" AS category_created_at,
+      SUM(combined.oi)::text AS total_oi
+    FROM combined
+    INNER JOIN category cat ON cat.id = combined.category_id
+    GROUP BY cat.id, cat.name, cat.slug, cat."createdAt"
+    HAVING SUM(combined.oi) > 0
+    ORDER BY SUM(combined.oi) DESC
+  `;
+
+  return rows.map((row) => ({
+    // Relation fields (conditions / conditionGroups) resolve lazily through
+    // their own field resolvers if the client requests them; the cast keeps
+    // codegen happy without forcing us to load them eagerly here.
+    category: {
+      id: row.category_id,
+      name: row.category_name,
+      slug: row.category_slug,
+      createdAt: row.category_created_at,
+    } as unknown as Category,
+    openInterest: row.total_oi,
+  }));
+};
+
+interface TimeToResolutionRow {
+  bucket: number;
+  total_oi: string;
+  prediction_count: bigint;
+}
+
+const TTR_BUCKET_LABELS: Record<number, string> = {
+  1: '≤1d',
+  2: '2-7d',
+  3: '8-30d',
+  4: '1-2mo',
+  5: '2-3mo',
+  6: '3-6mo',
+  7: '6mo+',
+};
+
+/**
+ * Query.openInterestByTimeToResolution — protocol-wide OI bucketed by how soon
+ * each prediction's collateral can finally be claimed. For each unsettled
+ * prediction we take the MAX endTime across the conditions it touches (combo
+ * predictions resolve only when *all* legs settle), then bucket the prediction's
+ * total collateral by that horizon. Predictions whose latest endTime is in the
+ * past but haven't been resolved roll into bucket 1 (imminent / overdue).
+ *
+ * Mirrors the privacy filter used by the OI time-series resolver: drops any
+ * prediction that touches a non-public condition, so the totals reconcile with
+ * what's shown elsewhere.
+ */
+export const openInterestByTimeToResolution: NonNullable<
+  QueryResolvers['openInterestByTimeToResolution']
+> = async (): Promise<TimeToResolutionBucket[]> => {
+  const rows = await prisma.$queryRaw<TimeToResolutionRow[]>`
+    WITH per_prediction AS (
+      SELECT
+        p.id,
+        (CAST(p."predictorCollateral" AS numeric) +
+         CAST(p."counterpartyCollateral" AS numeric)) AS oi,
+        MAX(c."endTime") AS max_end_time
+      FROM "Prediction" p
+      JOIN "Picks" pk ON pk.id = p."pickConfigId"
+      JOIN "Pick" pi ON pi."pickConfigId" = pk.id
+      JOIN "condition" c ON c.id = pi."conditionId"
+      WHERE pk."resolvedAt" IS NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM "Pick" pi2
+          JOIN "condition" c2 ON c2.id = pi2."conditionId"
+          WHERE pi2."pickConfigId" = pk.id AND c2.public = false
+        )
+      GROUP BY p.id, p."predictorCollateral", p."counterpartyCollateral"
+    ),
+    bucketed AS (
+      SELECT
+        CASE
+          WHEN (max_end_time - EXTRACT(EPOCH FROM NOW()))::numeric <= 86400 THEN 1
+          WHEN (max_end_time - EXTRACT(EPOCH FROM NOW()))::numeric <= 7 * 86400 THEN 2
+          WHEN (max_end_time - EXTRACT(EPOCH FROM NOW()))::numeric <= 30 * 86400 THEN 3
+          WHEN (max_end_time - EXTRACT(EPOCH FROM NOW()))::numeric <= 60 * 86400 THEN 4
+          WHEN (max_end_time - EXTRACT(EPOCH FROM NOW()))::numeric <= 90 * 86400 THEN 5
+          WHEN (max_end_time - EXTRACT(EPOCH FROM NOW()))::numeric <= 180 * 86400 THEN 6
+          ELSE 7
+        END AS bucket,
+        oi
+      FROM per_prediction
+    )
+    SELECT
+      bucket,
+      SUM(oi)::text AS total_oi,
+      COUNT(*)::bigint AS prediction_count
+    FROM bucketed
+    GROUP BY bucket
+    ORDER BY bucket
+  `;
+
+  return rows.map((row) => ({
+    bucket: row.bucket,
+    label: TTR_BUCKET_LABELS[row.bucket] ?? String(row.bucket),
+    openInterest: row.total_oi,
+    predictionCount: Number(row.prediction_count),
+  }));
 };

--- a/packages/api/src/graphql/sdl/schema/schema.graphql
+++ b/packages/api/src/graphql/sdl/schema/schema.graphql
@@ -1411,6 +1411,29 @@ Protocol-wide statistics snapshot including vault metrics, volume, and PnL.
 Cadence is controlled by the snapshot cron; periodPnL and periodVolume are
 deltas over that interval.
 """
+type CategoryOpenInterest {
+  category: Category!
+  """Open interest in wei (decimal string)"""
+  openInterest: String!
+}
+
+"""
+Open-interest aggregated by time-to-resolution bucket. Each unsettled
+prediction's collateral is bucketed by the latest endTime among the conditions
+it touches (the moment its OI can finally be claimed). One row per non-empty
+bucket, ordered from soonest (bucket = 1) to furthest out.
+"""
+type TimeToResolutionBucket {
+  """Sort order: 1 = soonest, increasing for further-out buckets"""
+  bucket: Int!
+  """Display label, e.g. "≤1d", "2-7d", "1-2mo" """
+  label: String!
+  """Open interest in wei (decimal string)"""
+  openInterest: String!
+  """Number of predictions contributing to this bucket"""
+  predictionCount: Int!
+}
+
 type ProtocolStat {
   cumulativeVolume: String!
 
@@ -1535,6 +1558,16 @@ type Query {
   Profit leaderboard — addresses ranked by total PnL across all positions
   """
   profitLeaderboard(limit: Int! = 10, skip: Int! = 0): [ProfitEntry!]!
+
+  """
+  Open interest aggregated per category — protocol-wide. Sums each ConditionGroup's pre-computed totalOpenInterest plus each ungrouped public condition's openInterest, returning categories with non-zero OI sorted descending.
+  """
+  openInterestByCategory: [CategoryOpenInterest!]!
+
+  """
+  Open interest bucketed by time-to-resolution — protocol-wide. Each unsettled prediction's collateral falls into the bucket of its latest condition endTime; expired-but-pending predictions roll into the soonest bucket.
+  """
+  openInterestByTimeToResolution: [TimeToResolutionBucket!]!
 
   """
   Protocol statistics time series at the configured snapshot cadence — vault balance, volume, PnL, and open interest

--- a/packages/api/src/graphql/sdl/schema/schema.graphql
+++ b/packages/api/src/graphql/sdl/schema/schema.graphql
@@ -1406,11 +1406,7 @@ type ProfitRank {
   totalPnL: String!
 }
 
-"""
-Protocol-wide statistics snapshot including vault metrics, volume, and PnL.
-Cadence is controlled by the snapshot cron; periodPnL and periodVolume are
-deltas over that interval.
-"""
+"""Open-interest aggregated for a single category."""
 type CategoryOpenInterest {
   category: Category!
   """Open interest in wei (decimal string)"""
@@ -1434,6 +1430,11 @@ type TimeToResolutionBucket {
   predictionCount: Int!
 }
 
+"""
+Protocol-wide statistics snapshot including vault metrics, volume, and PnL.
+Cadence is controlled by the snapshot cron; periodPnL and periodVolume are
+deltas over that interval.
+"""
 type ProtocolStat {
   cumulativeVolume: String!
 

--- a/packages/api/test/contract/__snapshots__/introspection.json
+++ b/packages/api/test/contract/__snapshots__/introspection.json
@@ -2887,6 +2887,49 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "CategoryOpenInterest",
+        "description": "Open-interest aggregated for a single category.",
+        "fields": [
+          {
+            "name": "category",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Category",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "openInterest",
+            "description": "Open interest in wei (decimal string)",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "CategoryOrderByWithRelationInput",
         "description": null,
@@ -16143,6 +16186,54 @@
             "deprecationReason": null
           },
           {
+            "name": "openInterestByCategory",
+            "description": "Open interest aggregated per category — protocol-wide. Sums each ConditionGroup's pre-computed totalOpenInterest plus each ungrouped public condition's openInterest, returning categories with non-zero OI sorted descending.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CategoryOpenInterest",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "openInterestByTimeToResolution",
+            "description": "Open interest bucketed by time-to-resolution — protocol-wide. Each unsettled prediction's collateral falls into the bucket of its latest condition endTime; expired-but-pending predictions roll into the soonest bucket.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "TimeToResolutionBucket",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "protocolStats",
             "description": "Protocol statistics time series at the configured snapshot cadence — vault balance, volume, PnL, and open interest",
             "args": [
@@ -18067,6 +18158,81 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "TimeToResolutionBucket",
+        "description": "Open-interest aggregated by time-to-resolution bucket. Each unsettled\nprediction's collateral is bucketed by the latest endTime among the conditions\nit touches (the moment its OI can finally be claimed). One row per non-empty\nbucket, ordered from soonest (bucket = 1) to furthest out.",
+        "fields": [
+          {
+            "name": "bucket",
+            "description": "Sort order: 1 = soonest, increasing for further-out buckets",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "label",
+            "description": "Display label, e.g. \"≤1d\", \"2-7d\", \"1-2mo\" ",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "openInterest",
+            "description": "Open interest in wei (decimal string)",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "predictionCount",
+            "description": "Number of predictions contributing to this bucket",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {

--- a/packages/api/test/contract/__snapshots__/operations/openInterestByCategory.json
+++ b/packages/api/test/contract/__snapshots__/operations/openInterestByCategory.json
@@ -1,0 +1,3 @@
+{
+  "openInterestByCategory": []
+}

--- a/packages/api/test/contract/__snapshots__/schema.sdl.graphql
+++ b/packages/api/test/contract/__snapshots__/schema.sdl.graphql
@@ -279,6 +279,14 @@ input CategoryNullableRelationFilter {
   isNot: CategoryWhereInput
 }
 
+"""Open-interest aggregated for a single category."""
+type CategoryOpenInterest {
+  category: Category!
+
+  """Open interest in wei (decimal string)"""
+  openInterest: String!
+}
+
 input CategoryOrderByWithRelationInput {
   conditionGroups: ConditionGroupOrderByRelationAggregateInput
   conditions: ConditionOrderByRelationAggregateInput
@@ -1498,6 +1506,16 @@ type Query {
   conditionGroups(cursor: ConditionGroupWhereUniqueInput, distinct: [ConditionGroupScalarFieldEnum!], orderBy: [ConditionGroupOrderByWithRelationInput!], skip: Int, take: Int, where: ConditionGroupWhereInput): [ConditionGroup!]!
   conditions(cursor: ConditionWhereUniqueInput, distinct: [ConditionScalarFieldEnum!], orderBy: [ConditionOrderByWithRelationInput!], skip: Int, take: Int, where: ConditionWhereInput): [Condition!]!
 
+  """
+  Open interest aggregated per category — protocol-wide. Sums each ConditionGroup's pre-computed totalOpenInterest plus each ungrouped public condition's openInterest, returning categories with non-zero OI sorted descending.
+  """
+  openInterestByCategory: [CategoryOpenInterest!]!
+
+  """
+  Open interest bucketed by time-to-resolution — protocol-wide. Each unsettled prediction's collateral falls into the bucket of its latest condition endTime; expired-but-pending predictions roll into the soonest bucket.
+  """
+  openInterestByTimeToResolution: [TimeToResolutionBucket!]!
+
   """Look up a single pick configuration by ID"""
   pickConfiguration(id: String!): PickConfiguration
 
@@ -1715,6 +1733,26 @@ enum TimeInterval {
   HOUR
   MONTH
   WEEK
+}
+
+"""
+Open-interest aggregated by time-to-resolution bucket. Each unsettled
+prediction's collateral is bucketed by the latest endTime among the conditions
+it touches (the moment its OI can finally be claimed). One row per non-empty
+bucket, ordered from soonest (bucket = 1) to furthest out.
+"""
+type TimeToResolutionBucket {
+  """Sort order: 1 = soonest, increasing for further-out buckets"""
+  bucket: Int!
+
+  """Display label, e.g. "≤1d", "2-7d", "1-2mo" """
+  label: String!
+
+  """Open interest in wei (decimal string)"""
+  openInterest: String!
+
+  """Number of predictions contributing to this bucket"""
+  predictionCount: Int!
 }
 
 """

--- a/packages/api/test/contract/operations/openInterestByCategory.test.ts
+++ b/packages/api/test/contract/operations/openInterestByCategory.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { GET_OPEN_INTEREST_BY_CATEGORY } from '@sapience/sdk/queries';
+import { executeOperation } from '../../helpers/testApollo';
+import { stabilize } from '../../helpers/stableSerializer';
+
+interface OpenInterestByCategoryResult {
+  openInterestByCategory: Array<{
+    category: { id: number; name: string; slug: string };
+    openInterest: string;
+  }>;
+}
+
+// The contract fixture's data lives on chain 13374202 (Ethereal Testnet),
+// while DEFAULT_CHAIN_ID in the test env is the Ethereal mainnet. The
+// resolver filters by DEFAULT_CHAIN_ID, so the snapshot here will be empty
+// in the default contract-test setup — the structural-invariant test still
+// runs the resolver end-to-end and verifies the response shape. Configure
+// the env to the fixture chain (DEFAULT_CHAIN_ID=13374202) to exercise the
+// non-empty path.
+describe('OpenInterestByCategory query', () => {
+  it('matches the recorded contract', async () => {
+    const result = await executeOperation<OpenInterestByCategoryResult>(
+      GET_OPEN_INTEREST_BY_CATEGORY
+    );
+    expect(result.errors).toBeUndefined();
+    await expect(
+      JSON.stringify(stabilize(result.data), null, 2)
+    ).toMatchFileSnapshot(
+      '../__snapshots__/operations/openInterestByCategory.json'
+    );
+  });
+
+  it('returns rows with positive OI sorted descending', async () => {
+    const result = await executeOperation<OpenInterestByCategoryResult>(
+      GET_OPEN_INTEREST_BY_CATEGORY
+    );
+    expect(result.errors).toBeUndefined();
+    const rows = result.data?.openInterestByCategory ?? [];
+
+    for (const row of rows) {
+      expect(row.openInterest).toMatch(/^\d+$/);
+      expect(BigInt(row.openInterest)).toBeGreaterThan(0n);
+      expect(row.category.id).toBeTypeOf('number');
+      expect(row.category.name).toBeTypeOf('string');
+      expect(row.category.slug).toBeTypeOf('string');
+    }
+
+    for (let i = 1; i < rows.length; i++) {
+      expect(BigInt(rows[i - 1].openInterest)).toBeGreaterThanOrEqual(
+        BigInt(rows[i].openInterest)
+      );
+    }
+  });
+});

--- a/packages/api/test/contract/operations/openInterestByTimeToResolution.test.ts
+++ b/packages/api/test/contract/operations/openInterestByTimeToResolution.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { GET_OPEN_INTEREST_BY_TIME_TO_RESOLUTION } from '@sapience/sdk/queries';
+import { executeOperation } from '../../helpers/testApollo';
+
+interface TTRResult {
+  openInterestByTimeToResolution: Array<{
+    bucket: number;
+    label: string;
+    openInterest: string;
+    predictionCount: number;
+  }>;
+}
+
+// Bucket assignments depend on `NOW() - condition.endTime`, so a JSON snapshot
+// would drift across days as fixture endTimes recede into the past. We assert
+// structural invariants the resolver guarantees regardless of when the suite
+// runs. The contract fixture's pickConfigs are on the Ethereal Testnet chain
+// (13374202); DEFAULT_CHAIN_ID in the test env is Ethereal mainnet, so rows
+// are empty by default — set DEFAULT_CHAIN_ID=13374202 to exercise the
+// non-empty path against the fixture.
+describe('OpenInterestByTimeToResolution query', () => {
+  it('returns well-shaped rows in ascending bucket order', async () => {
+    const result = await executeOperation<TTRResult>(
+      GET_OPEN_INTEREST_BY_TIME_TO_RESOLUTION
+    );
+    expect(result.errors).toBeUndefined();
+
+    const rows = result.data?.openInterestByTimeToResolution ?? [];
+
+    const seenBuckets = new Set<number>();
+    for (const row of rows) {
+      expect(row.bucket).toBeGreaterThanOrEqual(1);
+      expect(row.bucket).toBeLessThanOrEqual(7);
+      expect(seenBuckets.has(row.bucket)).toBe(false);
+      seenBuckets.add(row.bucket);
+
+      expect(row.label.length).toBeGreaterThan(0);
+      expect(row.openInterest).toMatch(/^\d+$/);
+      expect(BigInt(row.openInterest)).toBeGreaterThan(0n);
+      expect(row.predictionCount).toBeGreaterThan(0);
+    }
+
+    for (let i = 1; i < rows.length; i++) {
+      expect(rows[i].bucket).toBeGreaterThan(rows[i - 1].bucket);
+    }
+  });
+});

--- a/packages/app/src/components/analytics/OpenInterestByCategoryChart.tsx
+++ b/packages/app/src/components/analytics/OpenInterestByCategoryChart.tsx
@@ -54,7 +54,7 @@ export default function OpenInterestByCategoryChart() {
 
         {isLoading ? (
           <div className="flex-1 flex items-center justify-center">
-            <Loader />
+            <Loader className="w-8 h-8" />
           </div>
         ) : slices.length === 0 ? (
           <div className="flex-1 flex items-center justify-center text-sm text-muted-foreground">

--- a/packages/app/src/components/analytics/OpenInterestByCategoryChart.tsx
+++ b/packages/app/src/components/analytics/OpenInterestByCategoryChart.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Cell, Pie, PieChart, ResponsiveContainer } from 'recharts';
+import { Card, CardContent } from '@sapience/ui/components/ui/card';
+import { useOpenInterestByCategory } from '~/hooks/graphql/useAnalytics';
+import { getCategoryColor } from '~/components/markets/market-helpers';
+import { getCategoryIcon } from '~/lib/theme/categoryIcons';
+import Loader from '~/components/shared/Loader';
+
+interface SliceDatum {
+  id: number;
+  name: string;
+  slug: string;
+  color: string;
+  /** OI as a Number (already divided by 1e18). */
+  value: number;
+  /** % of total, 0–100. */
+  percent: number;
+}
+
+export default function OpenInterestByCategoryChart() {
+  const { data, isLoading } = useOpenInterestByCategory();
+
+  const slices = useMemo<SliceDatum[]>(() => {
+    if (!data || data.length === 0) return [];
+    const numeric = data.map((d) => ({
+      id: d.category.id,
+      name: d.category.name,
+      slug: d.category.slug,
+      raw: BigInt(d.openInterest || '0'),
+    }));
+    const total = numeric.reduce((acc, s) => acc + s.raw, 0n);
+    const totalNum = Number(total) / 1e18;
+    return numeric.map((s) => {
+      const value = Number(s.raw) / 1e18;
+      return {
+        id: s.id,
+        name: s.name,
+        slug: s.slug,
+        color: getCategoryColor(s.slug),
+        value,
+        percent: totalNum > 0 ? (value / totalNum) * 100 : 0,
+      };
+    });
+  }, [data]);
+
+  return (
+    <Card className="bg-brand-black border border-brand-white/10 h-full">
+      <CardContent className="p-6 h-full flex flex-col">
+        <h3 className="sc-heading text-foreground mb-4">
+          Open Interest by Category
+        </h3>
+
+        {isLoading ? (
+          <div className="flex-1 flex items-center justify-center">
+            <Loader />
+          </div>
+        ) : slices.length === 0 ? (
+          <div className="flex-1 flex items-center justify-center text-sm text-muted-foreground">
+            No open interest yet.
+          </div>
+        ) : (
+          <div className="flex-1 grid grid-cols-1 sm:grid-cols-[1fr_minmax(0,220px)] gap-4 items-center">
+            <div className="h-full min-h-[240px] max-h-[300px] mx-auto w-full">
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Pie
+                    data={slices}
+                    dataKey="value"
+                    nameKey="name"
+                    cx="50%"
+                    cy="50%"
+                    innerRadius="55%"
+                    outerRadius="95%"
+                    paddingAngle={0.5}
+                    minAngle={3}
+                    stroke="hsl(var(--brand-black))"
+                    strokeWidth={1.5}
+                    isAnimationActive={false}
+                    activeIndex={-1}
+                  >
+                    {slices.map((s) => (
+                      <Cell key={s.id} fill={s.color} />
+                    ))}
+                  </Pie>
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+            <ul className="divide-y divide-border/40 text-sm max-h-full overflow-y-auto pr-2">
+              {slices.map((s) => {
+                const Icon = getCategoryIcon(s.slug);
+                return (
+                  <li
+                    key={s.id}
+                    className="flex items-center justify-between gap-3 py-2 first:pt-0 last:pb-0"
+                  >
+                    <span className="flex items-center gap-2 min-w-0">
+                      <span
+                        className="flex-shrink-0 h-5 w-5 rounded-full flex items-center justify-center"
+                        style={{
+                          backgroundColor: `color-mix(in srgb, ${s.color} 18%, transparent)`,
+                        }}
+                      >
+                        <Icon className="h-3 w-3" style={{ color: s.color }} />
+                      </span>
+                      <span className="truncate">{s.name}</span>
+                    </span>
+                    <span className="font-mono text-xs text-muted-foreground whitespace-nowrap">
+                      {s.percent.toFixed(1)}%
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/app/src/components/analytics/OpenInterestByTimeToResolutionChart.tsx
+++ b/packages/app/src/components/analytics/OpenInterestByTimeToResolutionChart.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { useMemo } from 'react';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { Card, CardContent } from '@sapience/ui/components/ui/card';
+import { COLLATERAL_SYMBOLS, DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
+import { useOpenInterestByTimeToResolution } from '~/hooks/graphql/useAnalytics';
+import Loader from '~/components/shared/Loader';
+
+const BUCKET_LABELS: Array<{ bucket: number; label: string }> = [
+  { bucket: 1, label: '≤1 day' },
+  { bucket: 2, label: '2-7 days' },
+  { bucket: 3, label: '8-30 days' },
+  { bucket: 4, label: '1-2 mo.' },
+  { bucket: 5, label: '2-3 mo.' },
+  { bucket: 6, label: '3-6 mo.' },
+  { bucket: 7, label: '6 mo.+' },
+];
+
+interface BarDatum {
+  bucket: number;
+  label: string;
+  value: number;
+  predictionCount: number;
+}
+
+function formatChartValue(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return value.toFixed(0);
+}
+
+function ResolutionTooltip({
+  active,
+  payload,
+  symbol,
+}: {
+  active?: boolean;
+  payload?: Array<{ payload: BarDatum }>;
+  symbol: string;
+}) {
+  if (!active || !payload?.length) return null;
+  const datum = payload[0].payload;
+  const formatted = datum.value.toLocaleString('en-US', {
+    maximumFractionDigits: 2,
+  });
+  return (
+    <div className="rounded-md border border-border/60 bg-background/95 backdrop-blur px-3 py-2 text-sm shadow-lg">
+      <div className="text-xs font-medium text-muted-foreground mb-1">
+        Resolves in {datum.label}
+      </div>
+      <div className="font-mono text-base">
+        {formatted} {symbol}
+      </div>
+      <div className="text-xs text-muted-foreground">
+        {datum.predictionCount}{' '}
+        {datum.predictionCount === 1 ? 'prediction' : 'predictions'}
+      </div>
+    </div>
+  );
+}
+
+export default function OpenInterestByTimeToResolutionChart() {
+  const { data, isLoading } = useOpenInterestByTimeToResolution();
+  const symbol = COLLATERAL_SYMBOLS[DEFAULT_CHAIN_ID] ?? 'USDe';
+
+  const bars = useMemo<BarDatum[]>(() => {
+    const byBucket = new Map<number, { oi: bigint; count: number }>();
+    for (const row of data ?? []) {
+      byBucket.set(row.bucket, {
+        oi: BigInt(row.openInterest || '0'),
+        count: row.predictionCount,
+      });
+    }
+    return BUCKET_LABELS.map(({ bucket, label }) => {
+      const entry = byBucket.get(bucket);
+      const value = entry ? Number(entry.oi) / 1e18 : 0;
+      return {
+        bucket,
+        label,
+        value,
+        predictionCount: entry?.count ?? 0,
+      };
+    });
+  }, [data]);
+
+  const hasData = bars.some((b) => b.value > 0);
+
+  return (
+    <Card className="bg-brand-black border border-brand-white/10">
+      <CardContent className="p-6">
+        <div className="flex flex-col gap-4">
+          <h3 className="sc-heading text-foreground">
+            Open Interest by Time to Resolution
+          </h3>
+
+          {isLoading ? (
+            <div className="h-[260px] flex items-center justify-center">
+              <Loader />
+            </div>
+          ) : !hasData ? (
+            <div className="h-[260px] flex items-center justify-center text-sm text-muted-foreground">
+              No active open interest.
+            </div>
+          ) : (
+            <div className="h-[260px]">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart
+                  data={bars}
+                  margin={{ top: 10, right: 4, left: -4, bottom: 0 }}
+                >
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    stroke="hsl(var(--brand-white) / 0.1)"
+                  />
+                  <XAxis
+                    dataKey="label"
+                    tick={{
+                      fill: 'hsl(var(--muted-foreground))',
+                      fontSize: 11,
+                    }}
+                    axisLine={{ stroke: 'hsl(var(--brand-white) / 0.3)' }}
+                    tickLine={{ stroke: 'hsl(var(--brand-white) / 0.3)' }}
+                    height={28}
+                  />
+                  <YAxis
+                    tick={{
+                      fill: 'hsl(var(--muted-foreground))',
+                      fontSize: 11,
+                    }}
+                    axisLine={{ stroke: 'hsl(var(--brand-white) / 0.3)' }}
+                    tickLine={{ stroke: 'hsl(var(--brand-white) / 0.3)' }}
+                    tickFormatter={formatChartValue}
+                    width={44}
+                  />
+                  <Tooltip
+                    cursor={{ fill: 'hsl(var(--brand-white) / 0.05)' }}
+                    content={<ResolutionTooltip symbol={symbol} />}
+                  />
+                  <Bar
+                    dataKey="value"
+                    fill="hsl(var(--accent-gold) / 0.6)"
+                    name="value"
+                  />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/app/src/components/analytics/OpenInterestByTimeToResolutionChart.tsx
+++ b/packages/app/src/components/analytics/OpenInterestByTimeToResolutionChart.tsx
@@ -104,7 +104,7 @@ export default function OpenInterestByTimeToResolutionChart() {
 
           {isLoading ? (
             <div className="h-[260px] flex items-center justify-center">
-              <Loader />
+              <Loader className="w-8 h-8" />
             </div>
           ) : !hasData ? (
             <div className="h-[260px] flex items-center justify-center text-sm text-muted-foreground">

--- a/packages/app/src/components/analytics/pages/AnalyticsPageContent.tsx
+++ b/packages/app/src/components/analytics/pages/AnalyticsPageContent.tsx
@@ -191,9 +191,9 @@ function AnalyticsPageContent(): React.ReactElement {
   const collateralSymbol = COLLATERAL_SYMBOLS[DEFAULT_CHAIN_ID] || 'USDe';
 
   // Period states for each chart
-  const [volumePeriod, setVolumePeriod] = useState<Period>('1W');
-  const [oiPeriod, setOiPeriod] = useState<Period>('1W');
-  const [tvlPeriod, setTvlPeriod] = useState<Period>('1W');
+  const [volumePeriod, setVolumePeriod] = useState<Period>('1M');
+  const [oiPeriod, setOiPeriod] = useState<Period>('1M');
+  const [tvlPeriod, setTvlPeriod] = useState<Period>('1M');
 
   // Fetch protocol stats and daily volumes
   const { data: protocolStats, isLoading: statsLoading } = useProtocolStats();

--- a/packages/app/src/components/analytics/pages/AnalyticsPageContent.tsx
+++ b/packages/app/src/components/analytics/pages/AnalyticsPageContent.tsx
@@ -25,6 +25,8 @@ import {
   useProtocolStats,
 } from '~/hooks/graphql/useAnalytics';
 import Loader from '~/components/shared/Loader';
+import OpenInterestByCategoryChart from '~/components/analytics/OpenInterestByCategoryChart';
+import OpenInterestByTimeToResolutionChart from '~/components/analytics/OpenInterestByTimeToResolutionChart';
 import PeriodFilter, {
   type Period,
   PERIOD_DAYS,
@@ -367,27 +369,17 @@ function AnalyticsPageContent(): React.ReactElement {
 
         {/* Charts */}
         <div className="space-y-4 md:space-y-8">
+          {/* Open Interest distribution: by category + by time-to-resolution */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-8">
+            <OpenInterestByCategoryChart />
+            <OpenInterestByTimeToResolutionChart />
+          </div>
+
           <Card className="bg-brand-black border border-brand-white/10">
             <CardContent className="p-6">
               <div className="flex items-center justify-between mb-4">
                 <h3 className="sc-heading text-foreground flex items-center gap-1.5">
-                  Volume
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <button className="text-muted-foreground hover:text-foreground transition-colors">
-                        <Info className="h-4 w-4" />
-                      </button>
-                    </PopoverTrigger>
-                    <PopoverContent
-                      className="w-auto bg-background border border-border p-3"
-                      align="start"
-                    >
-                      <p className="text-sm text-muted-foreground">
-                        Volume per snapshot interval. Includes volume from
-                        prediction mints and secondary market trades.
-                      </p>
-                    </PopoverContent>
-                  </Popover>
+                  Daily Volume
                 </h3>
                 <PeriodFilter value={volumePeriod} onChange={setVolumePeriod} />
               </div>
@@ -450,22 +442,6 @@ function AnalyticsPageContent(): React.ReactElement {
               <div className="flex items-center justify-between mb-4">
                 <h3 className="sc-heading text-foreground flex items-center gap-1.5">
                   Open Interest
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <button className="text-muted-foreground hover:text-foreground transition-colors">
-                        <Info className="h-4 w-4" />
-                      </button>
-                    </PopoverTrigger>
-                    <PopoverContent
-                      className="w-auto bg-background border border-border p-3"
-                      align="start"
-                    >
-                      <p className="text-sm text-muted-foreground">
-                        Includes open interest from both V1 (legacy) and V2
-                        (escrow) prediction markets.
-                      </p>
-                    </PopoverContent>
-                  </Popover>
                 </h3>
                 <PeriodFilter value={oiPeriod} onChange={setOiPeriod} />
               </div>

--- a/packages/app/src/hooks/graphql/useAnalytics.ts
+++ b/packages/app/src/hooks/graphql/useAnalytics.ts
@@ -1,5 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
-import { fetchProtocolStats, type ProtocolStat } from '@sapience/sdk/queries';
+import {
+  fetchOpenInterestByCategory,
+  fetchOpenInterestByTimeToResolution,
+  fetchProtocolStats,
+  type CategoryOpenInterest,
+  type ProtocolStat,
+  type TimeToResolutionBucket,
+} from '@sapience/sdk/queries';
 
 const CACHE_TIME_MS = 60 * 1000;
 
@@ -12,7 +19,25 @@ export function useProtocolStats(vaultAddress?: string) {
   });
 }
 
-export type { ProtocolStat };
+export function useOpenInterestByCategory() {
+  return useQuery<CategoryOpenInterest[]>({
+    queryKey: ['openInterestByCategory'],
+    queryFn: fetchOpenInterestByCategory,
+    staleTime: CACHE_TIME_MS,
+    refetchInterval: CACHE_TIME_MS,
+  });
+}
+
+export function useOpenInterestByTimeToResolution() {
+  return useQuery<TimeToResolutionBucket[]>({
+    queryKey: ['openInterestByTimeToResolution'],
+    queryFn: fetchOpenInterestByTimeToResolution,
+    staleTime: CACHE_TIME_MS,
+    refetchInterval: CACHE_TIME_MS,
+  });
+}
+
+export type { CategoryOpenInterest, ProtocolStat, TimeToResolutionBucket };
 
 /**
  * Protocol TVL = escrow balance + undeployed vault funds (wei).

--- a/packages/sdk/queries/analytics.ts
+++ b/packages/sdk/queries/analytics.ts
@@ -48,3 +48,66 @@ export async function fetchProtocolStats(
   }>(GET_PROTOCOL_STATS, { vaultAddress });
   return data?.protocolStats ?? [];
 }
+
+export interface CategoryOpenInterest {
+  category: {
+    id: number;
+    name: string;
+    slug: string;
+  };
+  /** Open interest in wei (decimal string). */
+  openInterest: string;
+}
+
+export const GET_OPEN_INTEREST_BY_CATEGORY = /* GraphQL */ `
+  query OpenInterestByCategory {
+    openInterestByCategory {
+      category {
+        id
+        name
+        slug
+      }
+      openInterest
+    }
+  }
+`;
+
+export async function fetchOpenInterestByCategory(): Promise<
+  CategoryOpenInterest[]
+> {
+  const data = await graphqlRequest<{
+    openInterestByCategory: CategoryOpenInterest[];
+  }>(GET_OPEN_INTEREST_BY_CATEGORY);
+  return data?.openInterestByCategory ?? [];
+}
+
+export interface TimeToResolutionBucket {
+  /** Sort order: 1 = soonest. */
+  bucket: number;
+  /** Display label, e.g. "≤1d", "2-7d". */
+  label: string;
+  /** Open interest in wei (decimal string). */
+  openInterest: string;
+  /** Number of predictions in this bucket. */
+  predictionCount: number;
+}
+
+export const GET_OPEN_INTEREST_BY_TIME_TO_RESOLUTION = /* GraphQL */ `
+  query OpenInterestByTimeToResolution {
+    openInterestByTimeToResolution {
+      bucket
+      label
+      openInterest
+      predictionCount
+    }
+  }
+`;
+
+export async function fetchOpenInterestByTimeToResolution(): Promise<
+  TimeToResolutionBucket[]
+> {
+  const data = await graphqlRequest<{
+    openInterestByTimeToResolution: TimeToResolutionBucket[];
+  }>(GET_OPEN_INTEREST_BY_TIME_TO_RESOLUTION);
+  return data?.openInterestByTimeToResolution ?? [];
+}

--- a/packages/sdk/types/graphql.ts
+++ b/packages/sdk/types/graphql.ts
@@ -336,6 +336,18 @@ export type CategoryNullableRelationFilter = {
   isNot?: InputMaybe<CategoryWhereInput>;
 };
 
+/**
+ * Protocol-wide statistics snapshot including vault metrics, volume, and PnL.
+ * Cadence is controlled by the snapshot cron; periodPnL and periodVolume are
+ * deltas over that interval.
+ */
+export type CategoryOpenInterest = {
+  __typename?: 'CategoryOpenInterest';
+  category: Category;
+  /** Open interest in wei (decimal string) */
+  openInterest: Scalars['String']['output'];
+};
+
 export type CategoryOrderByWithRelationInput = {
   conditionGroups?: InputMaybe<ConditionGroupOrderByRelationAggregateInput>;
   conditions?: InputMaybe<ConditionOrderByRelationAggregateInput>;
@@ -1539,11 +1551,6 @@ export type ProfitRank = {
   totalPnL: Scalars['String']['output'];
 };
 
-/**
- * Protocol-wide statistics snapshot including vault metrics, volume, and PnL.
- * Cadence is controlled by the snapshot cron; periodPnL and periodVolume are
- * deltas over that interval.
- */
 export type ProtocolStat = {
   __typename?: 'ProtocolStat';
   cumulativeVolume: Scalars['String']['output'];
@@ -1601,6 +1608,8 @@ export type Query = {
   conditionGroup?: Maybe<ConditionGroup>;
   conditionGroups: Array<ConditionGroup>;
   conditions: Array<Condition>;
+  /** Open interest aggregated per category — protocol-wide. Sums each ConditionGroup's pre-computed totalOpenInterest plus each ungrouped public condition's openInterest, returning categories with non-zero OI sorted descending. */
+  openInterestByCategory: Array<CategoryOpenInterest>;
   /** Look up a single pick configuration by ID */
   pickConfiguration?: Maybe<PickConfiguration>;
   /** Paginated list of pick configurations, filterable by chain, resolution status, and result */


### PR DESCRIPTION
## Summary

Adds two protocol-wide distribution charts to `/analytics`, side-by-side at the top of the charts section:

- **Open Interest by Category** (donut)
  - Server-side aggregation: SQL `UNION ALL` of `condition_group.totalOpenInterest` (for grouped public conditions) plus ungrouped `condition.openInterest`. Reconciles with the per-market OI shown on `/markets`.
  - Legend reuses the existing Lucide category icons (TrendingUp, CloudSun, Landmark, Coins, FlaskConical, Medal, Tv) with color-tinted background chips matching each category's color.
  - `minAngle` on the pie so sub-1% slices (e.g. Culture at 0.2%) stay visible.

- **Open Interest by Time to Resolution** (histogram)
  - Buckets each unsettled prediction by the **latest** `endTime` among the conditions it touches — i.e. when its collateral can finally be claimed (combo predictions resolve only when *every* leg settles).
  - Buckets: `≤1 day`, `2-7 days`, `8-30 days`, `1-2 mo.`, `2-3 mo.`, `3-6 mo.`, `6 mo.+`
  - Privacy filter mirrors the OI time-series resolver (drops any prediction touching a non-public condition), so totals reconcile across surfaces.
  - Tooltip shows OI + count of predictions in the bucket.

Also:
- Renamed the "Volume" chart heading to **Daily Volume**.
- Removed the unused Info popovers next to the Volume / Open Interest section headings.

## Files

- `packages/api/src/graphql/sdl/schema/schema.graphql` — new `TimeToResolutionBucket` type + query
- `packages/api/src/graphql/sdl/resolvers/queries/analytics.ts` — both resolvers (`openInterestByCategory`, `openInterestByTimeToResolution`)
- `packages/sdk/queries/analytics.ts` — typed fetchers
- `packages/app/src/hooks/graphql/useAnalytics.ts` — `useOpenInterestByCategory`, `useOpenInterestByTimeToResolution`
- `packages/app/src/components/analytics/OpenInterestByCategoryChart.tsx` — new
- `packages/app/src/components/analytics/OpenInterestByTimeToResolutionChart.tsx` — new
- `packages/app/src/components/analytics/pages/AnalyticsPageContent.tsx` — wire-up + heading tweaks

## Test plan

- [ ] `/analytics` renders the two charts side-by-side on desktop (md+) and stacks on mobile
- [ ] Donut slice percentages sum to 100% and the largest categories match the OI column on `/markets`
- [ ] Histogram buckets sum to roughly the protocol-wide OI total shown in the "Open Interest" summary card
- [ ] Hover tooltip on the histogram shows USDe value + prediction count
- [ ] Empty states render correctly when no data