### PR TITLE
fix(api): attribute vault secondary trades + redefine airdrop gains

### DIFF
--- a/packages/api/prisma/migrations/20260428000000_add_vault_secondary_flow_columns/migration.sql
+++ b/packages/api/prisma/migrations/20260428000000_add_vault_secondary_flow_columns/migration.sql
@@ -1,0 +1,10 @@
+-- Track vault cash flows from secondary-market trades alongside settlement PnL.
+--
+-- Previously the residual airdrop bucket absorbed any unexplained wUSDe move
+-- in/out of the vault, including secondary-market buys and sells. With these
+-- columns the snapshot can attribute trade flow explicitly so that
+-- `vaultAirdropGains` only carries truly independent inflows.
+
+ALTER TABLE "protocol_stats_snapshot"
+  ADD COLUMN "vaultSecondaryBought" VARCHAR NOT NULL DEFAULT '0',
+  ADD COLUMN "vaultSecondarySold"   VARCHAR NOT NULL DEFAULT '0';

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -464,8 +464,10 @@ model ProtocolStatsSnapshot {
   escrowBalance String   @db.VarChar
 
   /// Vault PnL metrics
-  vaultRealizedPnL      String   @default("0") @db.VarChar  // Total realized PnL from predictions
-  vaultAirdropGains     String   @default("0") @db.VarChar  // Unexpected balance increases
+  vaultRealizedPnL      String   @default("0") @db.VarChar  // Settlement PnL: gross payouts to vault holder − vault primary-creation collateral
+  vaultAirdropGains     String   @default("0") @db.VarChar  // wUSDe transfers in not explained by deposits, settlement payouts, or secondary sales
+  vaultSecondaryBought  String   @default("0") @db.VarChar  // Total wUSDe paid by vault in secondary buys
+  vaultSecondarySold    String   @default("0") @db.VarChar  // Total wUSDe received by vault in secondary sells
   vaultDeposits         String   @default("0") @db.VarChar  // Total user deposits
   vaultWithdrawals      String   @default("0") @db.VarChar  // Total user withdrawals
   vaultPositionsWon     Int      @default(0)

--- a/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
@@ -19,8 +19,10 @@ import type {
 } from '../../__generated__/resolvers';
 import prisma from '../../../../db';
 import {
+  calculateVaultAirdrops,
   calculateVaultFlows,
   calculateVaultPnL,
+  calculateVaultSecondaryFlows,
   fetchVaultAvailableAssets,
   fetchVaultDeployed,
   fetchVaultTVL,
@@ -175,16 +177,24 @@ export const protocolStats: NonNullable<
   // moment of measurement".
   const interval = resolveSnapshotIntervalSeconds();
 
+  // Cumulative PnL surfaced to the chart rolls up trading activity:
+  // settlement PnL plus net secondary-market trade flow. Airdrops are
+  // tracked separately so they can be reported alongside without
+  // distorting the trading return shown in the PnL chart.
+  const cumulativePnL = (s: (typeof protocolSnapshots)[number]): bigint =>
+    BigInt(s.vaultRealizedPnL) +
+    BigInt(s.vaultSecondarySold) -
+    BigInt(s.vaultSecondaryBought);
+
   const results: ProtocolStat[] = protocolSnapshots.map((snapshot, i) => {
     const cumVol = volumeMap.get(snapshot.timestamp) || '0';
     const prevCumVol =
       i > 0 ? volumeMap.get(protocolSnapshots[i - 1].timestamp) || '0' : '0';
     const periodVolume = (BigInt(cumVol) - BigInt(prevCumVol)).toString();
 
-    const prevPnL = i > 0 ? protocolSnapshots[i - 1].vaultRealizedPnL : '0';
-    const periodPnL = (
-      BigInt(snapshot.vaultRealizedPnL) - BigInt(prevPnL)
-    ).toString();
+    const cumPnL = cumulativePnL(snapshot);
+    const prevCumPnL = i > 0 ? cumulativePnL(protocolSnapshots[i - 1]) : 0n;
+    const periodPnL = (cumPnL - prevCumPnL).toString();
 
     return {
       timestamp: snapshot.timestamp - interval,
@@ -194,12 +204,14 @@ export const protocolStats: NonNullable<
       vaultAvailableAssets: snapshot.vaultAvailableAssets,
       vaultDeployed: snapshot.vaultDeployed,
       escrowBalance: snapshot.escrowBalance,
-      vaultCumulativePnL: snapshot.vaultRealizedPnL,
+      vaultCumulativePnL: cumPnL.toString(),
       vaultPositionsWon: snapshot.vaultPositionsWon,
       vaultPositionsLost: snapshot.vaultPositionsLost,
       vaultDeposits: snapshot.vaultDeposits,
       vaultWithdrawals: snapshot.vaultWithdrawals,
       vaultAirdropGains: snapshot.vaultAirdropGains,
+      vaultSecondaryBought: snapshot.vaultSecondaryBought,
+      vaultSecondarySold: snapshot.vaultSecondarySold,
       periodPnL,
       periodVolume,
     };
@@ -220,6 +232,8 @@ export const protocolStats: NonNullable<
       liveEscrowBalance,
       livePnlResult,
       liveFlowsResult,
+      liveSecondaryFlows,
+      liveAirdropGains,
     ] = await Promise.all([
       fetchVaultTVL(chainId),
       fetchVaultAvailableAssets(chainId),
@@ -230,21 +244,17 @@ export const protocolStats: NonNullable<
       sumEscrowBalancesAtBlock(getProviderForChain(chainId), chainId),
       calculateVaultPnL(chainId),
       calculateVaultFlows(chainId),
+      calculateVaultSecondaryFlows(chainId),
+      calculateVaultAirdrops(chainId),
     ]);
 
+    const liveCumulativePnL =
+      livePnlResult.realizedPnL +
+      liveSecondaryFlows.sold -
+      liveSecondaryFlows.bought;
     const livePeriodPnL = (
-      livePnlResult.realizedPnL - BigInt(lastSnapshot.vaultRealizedPnL)
+      liveCumulativePnL - cumulativePnL(lastSnapshot)
     ).toString();
-
-    const liveActualTotalAssets = liveVaultBalance + liveVaultDeployed;
-    const liveExpectedTotalAssets =
-      liveFlowsResult.totalDeposits -
-      liveFlowsResult.totalWithdrawals +
-      livePnlResult.realizedPnL;
-    const liveAirdropGains =
-      liveActualTotalAssets > liveExpectedTotalAssets
-        ? liveActualTotalAssets - liveExpectedTotalAssets
-        : 0n;
 
     // Live candle = current in-progress period; label at start of current
     // interval (matches the display shift for closed bars).
@@ -258,12 +268,14 @@ export const protocolStats: NonNullable<
       vaultAvailableAssets: liveVaultAvailableAssets.toString(),
       vaultDeployed: liveVaultDeployed.toString(),
       escrowBalance: liveEscrowBalance.toString(),
-      vaultCumulativePnL: livePnlResult.realizedPnL.toString(),
+      vaultCumulativePnL: liveCumulativePnL.toString(),
       vaultPositionsWon: livePnlResult.positionsWon,
       vaultPositionsLost: livePnlResult.positionsLost,
       vaultDeposits: liveFlowsResult.totalDeposits.toString(),
       vaultWithdrawals: liveFlowsResult.totalWithdrawals.toString(),
       vaultAirdropGains: liveAirdropGains.toString(),
+      vaultSecondaryBought: liveSecondaryFlows.bought.toString(),
+      vaultSecondarySold: liveSecondaryFlows.sold.toString(),
       periodPnL: livePeriodPnL,
       periodVolume: livePeriodVolume,
     });

--- a/packages/api/src/graphql/sdl/schema/schema.graphql
+++ b/packages/api/src/graphql/sdl/schema/schema.graphql
@@ -1456,6 +1456,12 @@ type ProtocolStat {
   vaultDeposits: String!
   vaultPositionsLost: Int!
   vaultPositionsWon: Int!
+
+  """Cumulative wUSDe paid by the vault on secondary-market buys"""
+  vaultSecondaryBought: String!
+
+  """Cumulative wUSDe received by the vault on secondary-market sells"""
+  vaultSecondarySold: String!
   vaultWithdrawals: String!
 }
 

--- a/packages/api/src/helpers/protocolStats.test.ts
+++ b/packages/api/src/helpers/protocolStats.test.ts
@@ -7,6 +7,9 @@ const { mockPrisma, mockReadContract } = vi.hoisted(() => {
   const mockPrisma = {
     prediction: { findMany: vi.fn() },
     vaultFlowEvent: { findMany: vi.fn() },
+    close: { findMany: vi.fn() },
+    secondaryTrade: { findMany: vi.fn() },
+    collateralTransfer: { findMany: vi.fn() },
     protocolStatsSnapshot: {
       upsert: vi.fn(),
       findFirst: vi.fn(),
@@ -53,6 +56,7 @@ vi.mock('@sapience/sdk/contracts', () => ({
       42161: { address: '0xVault' },
     },
   },
+  normalizeLegacyEntry: (entry: unknown) => entry,
 }));
 
 vi.mock('@sapience/sdk/abis', () => ({
@@ -64,6 +68,8 @@ vi.mock('@sapience/sdk/constants', () => ({
 }));
 
 import {
+  calculateVaultSecondaryFlows,
+  calculateVaultAirdrops,
   fetchVaultDeployed,
   computeAndStoreProtocolStats,
   getLatestProtocolStats,
@@ -71,6 +77,17 @@ import {
   buildVaultAggregator,
   sumEscrowBalancesAtBlock,
 } from './protocolStats';
+
+// Helper for the default "no settlement, no flow, no trades, no transfers" baseline.
+function resetEmptyState() {
+  mockPrisma.prediction.findMany.mockResolvedValue([]);
+  mockPrisma.vaultFlowEvent.findMany.mockResolvedValue([]);
+  mockPrisma.close.findMany.mockResolvedValue([]);
+  mockPrisma.secondaryTrade.findMany.mockResolvedValue([]);
+  mockPrisma.collateralTransfer.findMany.mockResolvedValue([]);
+  mockPrisma.protocolStatsSnapshot.upsert.mockResolvedValue({});
+  mockReadContract.mockResolvedValue(1000000000000000000n);
+}
 
 // ─── fetchVaultDeployed ─────────────────────────────────────────────────────
 
@@ -146,53 +163,127 @@ describe('fetchVaultDeployed', () => {
   });
 });
 
+// ─── calculateVaultSecondaryFlows ───────────────────────────────────────────
+
+describe('calculateVaultSecondaryFlows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetEmptyState();
+  });
+
+  it('sums prices on the side where vault is buyer or seller', async () => {
+    mockPrisma.secondaryTrade.findMany.mockResolvedValue([
+      { buyer: '0xvault', seller: '0xother', price: '700000000000000000' },
+      { buyer: '0xother', seller: '0xvault', price: '400000000000000000' },
+      { buyer: '0xother', seller: '0xvault', price: '100000000000000000' },
+    ]);
+
+    const result = await calculateVaultSecondaryFlows(42161);
+
+    expect(result.bought).toBe(700000000000000000n);
+    expect(result.sold).toBe(500000000000000000n);
+  });
+
+  it('returns zero when no trades touch the vault', async () => {
+    mockPrisma.secondaryTrade.findMany.mockResolvedValue([]);
+    const result = await calculateVaultSecondaryFlows(42161);
+    expect(result).toEqual({ bought: 0n, sold: 0n });
+  });
+
+  it('passes beforeTimestamp through to the executedAt filter', async () => {
+    mockPrisma.secondaryTrade.findMany.mockResolvedValue([]);
+    await calculateVaultSecondaryFlows(42161, 1700000000);
+    const call = mockPrisma.secondaryTrade.findMany.mock.calls[0][0];
+    expect(call.where.executedAt).toEqual({ lte: 1700000000 });
+  });
+});
+
+// ─── calculateVaultAirdrops ─────────────────────────────────────────────────
+
+describe('calculateVaultAirdrops', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetEmptyState();
+  });
+
+  it('subtracts deposits, settlement payouts, and secondary sale proceeds from gross transfers in', async () => {
+    // 5 wUSDe arrived in the vault. 1 was a deposit, 2 was a settlement
+    // payout, 1 was secondary sale proceeds. The remaining 1 is airdrop.
+    mockPrisma.collateralTransfer.findMany.mockResolvedValue([
+      { value: '5000000000000000000' },
+    ]);
+    mockPrisma.vaultFlowEvent.findMany.mockResolvedValue([
+      { assets: '1000000000000000000', eventType: 'deposit' },
+    ]);
+    mockPrisma.close.findMany.mockResolvedValue([
+      {
+        predictorHolder: '0xother',
+        counterpartyHolder: '0xvault',
+        predictorPayout: '0',
+        counterpartyPayout: '2000000000000000000',
+      },
+    ]);
+    mockPrisma.secondaryTrade.findMany.mockResolvedValue([
+      { buyer: '0xother', seller: '0xvault', price: '1000000000000000000' },
+    ]);
+
+    const result = await calculateVaultAirdrops(42161);
+    expect(result).toBe(1000000000000000000n);
+  });
+
+  it('clamps to zero when the explained inflows exceed gross transfers in (indexer drift)', async () => {
+    mockPrisma.collateralTransfer.findMany.mockResolvedValue([
+      { value: '500000000000000000' },
+    ]);
+    mockPrisma.vaultFlowEvent.findMany.mockResolvedValue([
+      { assets: '2000000000000000000', eventType: 'deposit' },
+    ]);
+    const result = await calculateVaultAirdrops(42161);
+    expect(result).toBe(0n);
+  });
+
+  it('returns zero when no transfers landed in the vault', async () => {
+    const result = await calculateVaultAirdrops(42161);
+    expect(result).toBe(0n);
+  });
+});
+
 // ─── computeAndStoreProtocolStats ───────────────────────────────────────────
 
 describe('computeAndStoreProtocolStats', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default: no predictions, no flow events
-    mockPrisma.prediction.findMany.mockResolvedValue([]);
-    mockPrisma.vaultFlowEvent.findMany.mockResolvedValue([]);
-    mockPrisma.protocolStatsSnapshot.upsert.mockResolvedValue({});
-    // readContract returns 1e18 for all calls (vault balance, available assets, escrow balance)
-    mockReadContract.mockResolvedValue(1000000000000000000n);
+    resetEmptyState();
   });
 
-  it('computes airdrop gains when actual > expected', async () => {
-    // vault balance (readContract call 1) = 1e18
-    // vault available (readContract call 2) = 1e18
-    // escrow balance (readContract call 3) = 1e18
-    // vault deployed = 0 (no predictions)
-    // deposits = 500000000000000000 (0.5e18), withdrawals = 0
-    // PnL = 0 (no positions)
-    // actual = vaultBalance + vaultDeployed = 1e18 + 0 = 1e18
-    // expected = deposits - withdrawals + pnl = 0.5e18 - 0 + 0 = 0.5e18
-    // airdropGains = 1e18 - 0.5e18 = 0.5e18
+  it('computes airdrop gains from the direct CollateralTransfer query, not a residual', async () => {
+    // 1.5e18 arrived in the vault, 0.5e18 was a deposit → airdrop = 1e18.
+    // Note: residual would be 1e18 (vaultBalance) − 0.5e18 (deposit) = 0.5e18.
+    // The new direct calc reports the actual external inflow regardless.
+    mockPrisma.collateralTransfer.findMany.mockResolvedValue([
+      { value: '1500000000000000000' },
+    ]);
     mockPrisma.vaultFlowEvent.findMany.mockResolvedValue([
       { assets: '500000000000000000', eventType: 'deposit' },
     ]);
 
     await computeAndStoreProtocolStats(42161);
 
-    expect(mockPrisma.protocolStatsSnapshot.upsert).toHaveBeenCalledTimes(1);
     const upsertCall = mockPrisma.protocolStatsSnapshot.upsert.mock.calls[0][0];
-    expect(upsertCall.create.vaultAirdropGains).toBe('500000000000000000');
+    expect(upsertCall.create.vaultAirdropGains).toBe('1000000000000000000');
   });
 
-  it('sets airdrop gains to 0 when actual <= expected', async () => {
-    // vault balance = 1e18, vault deployed = 0
-    // deposits = 2e18, withdrawals = 0, PnL = 0
-    // actual = 1e18, expected = 2e18
-    // airdropGains = 0 (actual < expected)
-    mockPrisma.vaultFlowEvent.findMany.mockResolvedValue([
-      { assets: '2000000000000000000', eventType: 'deposit' },
+  it('persists secondary-market trade flow on the snapshot', async () => {
+    mockPrisma.secondaryTrade.findMany.mockResolvedValue([
+      { buyer: '0xvault', seller: '0xother', price: '300000000000000000' },
+      { buyer: '0xother', seller: '0xvault', price: '900000000000000000' },
     ]);
 
     await computeAndStoreProtocolStats(42161);
 
     const upsertCall = mockPrisma.protocolStatsSnapshot.upsert.mock.calls[0][0];
-    expect(upsertCall.create.vaultAirdropGains).toBe('0');
+    expect(upsertCall.create.vaultSecondaryBought).toBe('300000000000000000');
+    expect(upsertCall.create.vaultSecondarySold).toBe('900000000000000000');
   });
 
   it('upserts snapshot with all fields correctly mapped', async () => {
@@ -205,13 +296,11 @@ describe('computeAndStoreProtocolStats', () => {
     expect(mockPrisma.protocolStatsSnapshot.upsert).toHaveBeenCalledTimes(1);
     const upsertCall = mockPrisma.protocolStatsSnapshot.upsert.mock.calls[0][0];
 
-    // Verify where clause structure
     expect(upsertCall.where.chainId_vaultAddress_timestamp).toMatchObject({
       chainId: 42161,
       vaultAddress: '0xvault',
     });
 
-    // Verify create payload has all expected fields
     const create = upsertCall.create;
     expect(create.chainId).toBe(42161);
     expect(create.vaultAddress).toBe('0xvault');
@@ -220,6 +309,8 @@ describe('computeAndStoreProtocolStats', () => {
     expect(create.vaultDeployed).toBe('0');
     expect(create.escrowBalance).toBe('1000000000000000000');
     expect(create.vaultRealizedPnL).toBe('0');
+    expect(create.vaultSecondaryBought).toBe('0');
+    expect(create.vaultSecondarySold).toBe('0');
     expect(create.vaultDeposits).toBe('1000000000000000000');
     expect(create.vaultWithdrawals).toBe('0');
     expect(create.vaultPositionsWon).toBe(0);
@@ -227,7 +318,6 @@ describe('computeAndStoreProtocolStats', () => {
     expect(create.vaultCollateralWon).toBe('0');
     expect(create.vaultCollateralLost).toBe('0');
 
-    // Verify update payload matches create payload for all value fields
     const update = upsertCall.update;
     expect(update.vaultBalance).toBe(create.vaultBalance);
     expect(update.vaultAvailableAssets).toBe(create.vaultAvailableAssets);
@@ -235,6 +325,8 @@ describe('computeAndStoreProtocolStats', () => {
     expect(update.escrowBalance).toBe(create.escrowBalance);
     expect(update.vaultRealizedPnL).toBe(create.vaultRealizedPnL);
     expect(update.vaultAirdropGains).toBe(create.vaultAirdropGains);
+    expect(update.vaultSecondaryBought).toBe(create.vaultSecondaryBought);
+    expect(update.vaultSecondarySold).toBe(create.vaultSecondarySold);
     expect(update.vaultDeposits).toBe(create.vaultDeposits);
     expect(update.vaultWithdrawals).toBe(create.vaultWithdrawals);
     expect(update.vaultPositionsWon).toBe(create.vaultPositionsWon);
@@ -339,19 +431,30 @@ describe('computeAndStoreProtocolStats', () => {
 });
 
 // ─── calculateVaultPnL (via computeAndStoreProtocolStats) ───────────────────
+//
+// New semantics: realized PnL = sum(payout to vault holder via Close)
+//                              − sum(vault primary collateral on resolved
+//                                     predictions). The Prediction record
+//                              still drives cost basis; Close drives gross
+//                              payouts the vault actually received.
 
 describe('vault PnL calculation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockPrisma.prediction.findMany.mockResolvedValue([]);
-    mockPrisma.vaultFlowEvent.findMany.mockResolvedValue([]);
-    mockPrisma.protocolStatsSnapshot.upsert.mockResolvedValue({});
-    mockReadContract.mockResolvedValue(1000000000000000000n);
+    resetEmptyState();
   });
 
-  it('calculates gains when vault wins as counterparty', async () => {
-    // fetchVaultDeployed call returns no active predictions
-    // calculateVaultPnL call returns resolved prediction where vault won
+  it('credits gross settlement payout and subtracts primary collateral when vault held the winning side', async () => {
+    // Vault was original counterparty with 0.7e18 collateral, held til
+    // settlement, received the full pot of 1e18.
+    mockPrisma.close.findMany.mockResolvedValue([
+      {
+        predictorHolder: '0xother',
+        counterpartyHolder: '0xvault',
+        predictorPayout: '0',
+        counterpartyPayout: '1000000000000000000',
+      },
+    ]);
     mockPrisma.prediction.findMany
       .mockResolvedValueOnce([]) // fetchVaultDeployed
       .mockResolvedValueOnce([
@@ -360,94 +463,111 @@ describe('vault PnL calculation', () => {
           counterparty: '0xvault',
           predictorCollateral: '300000000000000000',
           counterpartyCollateral: '700000000000000000',
-          pickConfiguration: { result: 'COUNTERPARTY_WINS' },
         },
       ]);
 
     await computeAndStoreProtocolStats(42161);
 
     const upsertCall = mockPrisma.protocolStatsSnapshot.upsert.mock.calls[0][0];
-    // Vault won as counterparty: gains = predictorCollateral = 0.3e18
     expect(upsertCall.create.vaultRealizedPnL).toBe('300000000000000000');
     expect(upsertCall.create.vaultPositionsWon).toBe(1);
     expect(upsertCall.create.vaultPositionsLost).toBe(0);
-    expect(upsertCall.create.vaultCollateralWon).toBe('300000000000000000');
-    expect(upsertCall.create.vaultCollateralLost).toBe('0');
   });
 
-  it('calculates losses when vault loses as counterparty', async () => {
+  it('records a loss when vault held the losing side and got zero payout', async () => {
+    mockPrisma.close.findMany.mockResolvedValue([
+      {
+        predictorHolder: '0xother',
+        counterpartyHolder: '0xvault',
+        predictorPayout: '1000000000000000000',
+        counterpartyPayout: '0',
+      },
+    ]);
     mockPrisma.prediction.findMany
-      .mockResolvedValueOnce([]) // fetchVaultDeployed
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([
         {
           predictor: '0xuser',
           counterparty: '0xvault',
           predictorCollateral: '300000000000000000',
           counterpartyCollateral: '700000000000000000',
-          pickConfiguration: { result: 'PREDICTOR_WINS' },
         },
       ]);
 
     await computeAndStoreProtocolStats(42161);
 
     const upsertCall = mockPrisma.protocolStatsSnapshot.upsert.mock.calls[0][0];
-    // Vault lost as counterparty: loss = counterpartyCollateral = 0.7e18
+    // 0 payout − 0.7e18 cost basis = −0.7e18
     expect(upsertCall.create.vaultRealizedPnL).toBe('-700000000000000000');
     expect(upsertCall.create.vaultPositionsWon).toBe(0);
     expect(upsertCall.create.vaultPositionsLost).toBe(1);
     expect(upsertCall.create.vaultCollateralLost).toBe('700000000000000000');
   });
 
-  it('handles mixed wins and losses', async () => {
+  it('does NOT credit settlement payout for positions vault sold before close (only primary collateral remains as cost)', async () => {
+    // Vault was original counterparty for 0.7e18, but sold the token on
+    // secondary before close. Holder at close is 0xbuyer. Settlement does
+    // not contribute payout to vault; only the primary collateral cost
+    // remains. The sale proceeds get tracked via the secondaryTrade row.
+    mockPrisma.close.findMany.mockResolvedValue([
+      {
+        predictorHolder: '0xother',
+        counterpartyHolder: '0xbuyer',
+        predictorPayout: '0',
+        counterpartyPayout: '1000000000000000000',
+      },
+    ]);
     mockPrisma.prediction.findMany
-      .mockResolvedValueOnce([]) // fetchVaultDeployed
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([
         {
-          predictor: '0xuser1',
+          predictor: '0xother',
           counterparty: '0xvault',
-          predictorCollateral: '200000000000000000',
-          counterpartyCollateral: '800000000000000000',
-          pickConfiguration: { result: 'COUNTERPARTY_WINS' },
-        },
-        {
-          predictor: '0xuser2',
-          counterparty: '0xvault',
-          predictorCollateral: '500000000000000000',
-          counterpartyCollateral: '500000000000000000',
-          pickConfiguration: { result: 'PREDICTOR_WINS' },
+          predictorCollateral: '300000000000000000',
+          counterpartyCollateral: '700000000000000000',
         },
       ]);
+    mockPrisma.secondaryTrade.findMany.mockResolvedValue([
+      { buyer: '0xbuyer', seller: '0xvault', price: '900000000000000000' },
+    ]);
 
     await computeAndStoreProtocolStats(42161);
 
     const upsertCall = mockPrisma.protocolStatsSnapshot.upsert.mock.calls[0][0];
-    // Win: +0.2e18, Loss: -0.5e18, Net: -0.3e18
-    expect(upsertCall.create.vaultRealizedPnL).toBe('-300000000000000000');
-    expect(upsertCall.create.vaultPositionsWon).toBe(1);
-    expect(upsertCall.create.vaultPositionsLost).toBe(1);
-    expect(upsertCall.create.vaultCollateralWon).toBe('200000000000000000');
-    expect(upsertCall.create.vaultCollateralLost).toBe('500000000000000000');
+    // Settlement PnL: 0 payout − 0.7e18 collateral = −0.7e18
+    // Net realized including sale: −0.7e18 + 0.9e18 = +0.2e18 (split across
+    // the two snapshot fields).
+    expect(upsertCall.create.vaultRealizedPnL).toBe('-700000000000000000');
+    expect(upsertCall.create.vaultSecondarySold).toBe('900000000000000000');
+    expect(upsertCall.create.vaultSecondaryBought).toBe('0');
   });
 
-  it('skips predictions with UNRESOLVED result', async () => {
+  it('credits gross payout (no cost basis) when vault bought the position on secondary', async () => {
+    // Vault was not original counterparty/predictor; bought the winning
+    // token on secondary for 0.6e18. At settlement vault is the holder,
+    // receives 1e18. Settlement contribution: 1e18 (no primary cost).
+    // Cost basis sits in vaultSecondaryBought.
+    mockPrisma.close.findMany.mockResolvedValue([
+      {
+        predictorHolder: '0xvault',
+        counterpartyHolder: '0xother',
+        predictorPayout: '1000000000000000000',
+        counterpartyPayout: '0',
+      },
+    ]);
     mockPrisma.prediction.findMany
       .mockResolvedValueOnce([]) // fetchVaultDeployed
-      .mockResolvedValueOnce([
-        {
-          predictor: '0xuser',
-          counterparty: '0xvault',
-          predictorCollateral: '500000000000000000',
-          counterpartyCollateral: '500000000000000000',
-          pickConfiguration: { result: 'UNRESOLVED' },
-        },
-      ]);
+      .mockResolvedValueOnce([]); // calculateVaultPnL primary lookup
+    mockPrisma.secondaryTrade.findMany.mockResolvedValue([
+      { buyer: '0xvault', seller: '0xother', price: '600000000000000000' },
+    ]);
 
     await computeAndStoreProtocolStats(42161);
 
     const upsertCall = mockPrisma.protocolStatsSnapshot.upsert.mock.calls[0][0];
-    expect(upsertCall.create.vaultRealizedPnL).toBe('0');
-    expect(upsertCall.create.vaultPositionsWon).toBe(0);
-    expect(upsertCall.create.vaultPositionsLost).toBe(0);
+    expect(upsertCall.create.vaultRealizedPnL).toBe('1000000000000000000');
+    expect(upsertCall.create.vaultSecondaryBought).toBe('600000000000000000');
+    expect(upsertCall.create.vaultPositionsWon).toBe(1);
   });
 });
 
@@ -517,7 +637,6 @@ describe('getProtocolStatsTimeSeries', () => {
     const call = mockPrisma.protocolStatsSnapshot.findMany.mock.calls[0][0];
     const startTimestamp = call.where.timestamp.gte;
 
-    // getUtcMidnightTimestamp strips time to UTC midnight, then subtracts days*86400
     const now = new Date();
     const todayMidnightUtc = Math.floor(
       Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()) / 1000
@@ -632,9 +751,9 @@ describe('buildVaultAggregator', () => {
     expect(agg.deployedAt(T)).toBe(500n);
   });
 
-  it('pnlAt: resolved win/loss + UNRESOLVED skip + future-resolution skip', async () => {
+  it('pnlAt: gross payouts via Close minus primary collateral, with UNRESOLVED + future-close skips', async () => {
     mockPrisma.prediction.findMany.mockResolvedValue([
-      // Vault wins as counterparty: gains = predictorCollateral
+      // Vault wins as counterparty: cost basis 700, gross payout 1000 → +300
       {
         predictor: '0xuser',
         counterparty: '0xvault',
@@ -648,7 +767,7 @@ describe('buildVaultAggregator', () => {
           result: 'COUNTERPARTY_WINS',
         },
       },
-      // Vault loses as predictor: loss = predictorCollateral
+      // Vault loses as predictor: cost basis 500, gross payout 0 → -500
       {
         predictor: '0xvault',
         counterparty: '0xuser',
@@ -662,7 +781,7 @@ describe('buildVaultAggregator', () => {
           result: 'COUNTERPARTY_WINS',
         },
       },
-      // UNRESOLVED — skipped
+      // UNRESOLVED — primary collateral skipped
       {
         predictor: '0xuser',
         counterparty: '0xvault',
@@ -676,7 +795,7 @@ describe('buildVaultAggregator', () => {
           result: 'UNRESOLVED',
         },
       },
-      // Resolved AFTER t — skipped at this snapshot
+      // Resolved AFTER t — primary collateral skipped at this snapshot
       {
         predictor: '0xuser',
         counterparty: '0xvault',
@@ -692,14 +811,45 @@ describe('buildVaultAggregator', () => {
       },
     ]);
     mockPrisma.vaultFlowEvent.findMany.mockResolvedValue([]);
+    mockPrisma.close.findMany.mockResolvedValue([
+      // pc1 burned at T-50: vault held counterparty token, received full pot
+      {
+        burnedAt: T - 50,
+        predictorHolder: '0xuser',
+        counterpartyHolder: '0xvault',
+        predictorPayout: '0',
+        counterpartyPayout: '1000',
+      },
+      // pc2 burned at T-40: vault held predictor token, got 0
+      {
+        burnedAt: T - 40,
+        predictorHolder: '0xvault',
+        counterpartyHolder: '0xuser',
+        predictorPayout: '0',
+        counterpartyPayout: '1000',
+      },
+      // future close (after t) — payout skipped at this snapshot
+      {
+        burnedAt: T + 5,
+        predictorHolder: '0xvault',
+        counterpartyHolder: '0xuser',
+        predictorPayout: '999',
+        counterpartyPayout: '0',
+      },
+    ]);
+    mockPrisma.secondaryTrade.findMany.mockResolvedValue([]);
+    mockPrisma.collateralTransfer.findMany.mockResolvedValue([]);
 
     const agg = await buildVaultAggregator(42161);
     const result = agg.pnlAt(T);
-    expect(result.realizedPnL).toBe(300n - 500n);
+    // grossPayouts = 1000 (pc1) + 0 (pc2) = 1000
+    // primaryCollateral = 700 (pc1) + 500 (pc2) = 1200
+    // realizedPnL = 1000 − 1200 = −200
+    expect(result.realizedPnL).toBe(-200n);
     expect(result.positionsWon).toBe(1);
     expect(result.positionsLost).toBe(1);
-    expect(result.totalCollateralWon).toBe(300n);
-    expect(result.totalCollateralLost).toBe(500n);
+    expect(result.totalCollateralWon).toBe(1000n);
+    expect(result.totalCollateralLost).toBe(1200n);
   });
 
   it('flowsAt: filters by timestamp <= t and partitions deposit vs withdrawal', async () => {

--- a/packages/api/src/helpers/protocolStats.ts
+++ b/packages/api/src/helpers/protocolStats.ts
@@ -28,6 +28,11 @@ interface VaultFlowsResult {
   totalWithdrawals: bigint;
 }
 
+interface VaultSecondaryFlowsResult {
+  bought: bigint;
+  sold: bigint;
+}
+
 interface ProtocolStatsData {
   vaultBalance: bigint;
   vaultAvailableAssets: bigint;
@@ -35,6 +40,8 @@ interface ProtocolStatsData {
   escrowBalance: bigint;
   vaultRealizedPnL: bigint;
   vaultAirdropGains: bigint;
+  vaultSecondaryBought: bigint;
+  vaultSecondarySold: bigint;
   vaultDeposits: bigint;
   vaultWithdrawals: bigint;
   vaultPositionsWon: number;
@@ -350,11 +357,25 @@ export async function sumEscrowBalancesAtBlock(
 }
 
 /**
- * Calculate vault's realized PnL from resolved predictions.
+ * Calculate vault's realized settlement PnL.
  *
- * Uses Picks.resolved (set automatically when all conditions settle)
- * rather than Prediction.settled (requires an explicit on-chain settle() call
- * that may never happen for losing predictions).
+ * Sources gross settlement payouts from `Close` (the actual on-chain holder
+ * and payout at burn time) rather than `Prediction.predictor` /
+ * `Prediction.counterparty` (creation-time addresses). This matters because
+ * NFT positions can transfer on the secondary market: only the holder at
+ * close time receives the payout, even though the original predictor and
+ * counterparty addresses are immutable on the Prediction record.
+ *
+ * Cost basis (the original collateral the vault committed at primary
+ * creation) still comes from `Prediction`, scoped to predictions whose
+ * pickConfig has resolved. Secondary-market cost basis is tracked
+ * separately via `calculateVaultSecondaryFlows`.
+ *
+ *   realizedPnL = sum(payout to vault holder via Close)
+ *               − sum(vault's primary collateral on resolved predictions)
+ *
+ * Reconciles against `vaultBalance + vaultDeployed` together with deposits,
+ * withdrawals, secondary buys/sells, and airdrops.
  */
 export async function calculateVaultPnL(
   chainId: number,
@@ -372,6 +393,58 @@ export async function calculateVaultPnL(
   }
   const vaultAddressLower = vaultAddress.toLowerCase();
 
+  // Gross payouts: what the vault actually received from settlement,
+  // based on who held the position tokens when they were burned.
+  const closes = await prisma.close.findMany({
+    where: {
+      chainId,
+      ...(beforeTimestamp ? { burnedAt: { lte: beforeTimestamp } } : {}),
+      OR: [
+        { predictorHolder: vaultAddressLower },
+        { counterpartyHolder: vaultAddressLower },
+      ],
+    },
+    select: {
+      predictorHolder: true,
+      counterpartyHolder: true,
+      predictorPayout: true,
+      counterpartyPayout: true,
+    },
+  });
+
+  let grossPayouts = 0n;
+  let positionsWon = 0;
+  let positionsLost = 0;
+  let totalCollateralWon = 0n;
+  let totalCollateralLost = 0n;
+
+  for (const close of closes) {
+    if (close.predictorHolder.toLowerCase() === vaultAddressLower) {
+      const payout = BigInt(close.predictorPayout);
+      grossPayouts += payout;
+      if (payout > 0n) {
+        positionsWon++;
+        totalCollateralWon += payout;
+      } else {
+        positionsLost++;
+      }
+    }
+    if (close.counterpartyHolder.toLowerCase() === vaultAddressLower) {
+      const payout = BigInt(close.counterpartyPayout);
+      grossPayouts += payout;
+      if (payout > 0n) {
+        positionsWon++;
+        totalCollateralWon += payout;
+      } else {
+        positionsLost++;
+      }
+    }
+  }
+
+  // Cost basis: primary-creation collateral the vault committed for
+  // predictions whose pickConfig has now resolved. Sold-on-secondary
+  // positions still count here — the cost was paid at creation, and the
+  // sale proceeds are tracked separately in vaultSecondarySold.
   const predictions = await prisma.prediction.findMany({
     where: {
       chainId,
@@ -386,47 +459,26 @@ export async function calculateVaultPnL(
         { counterparty: vaultAddressLower },
       ],
     },
-    include: {
-      pickConfiguration: { select: { result: true } },
+    select: {
+      predictor: true,
+      counterparty: true,
+      predictorCollateral: true,
+      counterpartyCollateral: true,
     },
   });
 
-  let realizedPnL = 0n;
-  let positionsWon = 0;
-  let positionsLost = 0;
-  let totalCollateralWon = 0n;
-  let totalCollateralLost = 0n;
-
-  for (const prediction of predictions) {
-    const picksResult = prediction.pickConfiguration?.result;
-    if (!picksResult || picksResult === SettlementResult.UNRESOLVED) continue;
-
-    const predictorCollateral = BigInt(prediction.predictorCollateral);
-    const counterpartyCollateral = BigInt(prediction.counterpartyCollateral);
-
-    const isVaultPredictor =
-      prediction.predictor.toLowerCase() === vaultAddressLower;
-
-    const vaultWon =
-      (isVaultPredictor && picksResult === SettlementResult.PREDICTOR_WINS) ||
-      (!isVaultPredictor && picksResult === SettlementResult.COUNTERPARTY_WINS);
-
-    if (vaultWon) {
-      const gains = isVaultPredictor
-        ? counterpartyCollateral
-        : predictorCollateral;
-      realizedPnL += gains;
-      positionsWon++;
-      totalCollateralWon += gains;
-    } else {
-      const loss = isVaultPredictor
-        ? predictorCollateral
-        : counterpartyCollateral;
-      realizedPnL -= loss;
-      positionsLost++;
-      totalCollateralLost += loss;
+  let primaryCollateral = 0n;
+  for (const p of predictions) {
+    if (p.predictor.toLowerCase() === vaultAddressLower) {
+      primaryCollateral += BigInt(p.predictorCollateral);
+    }
+    if (p.counterparty.toLowerCase() === vaultAddressLower) {
+      primaryCollateral += BigInt(p.counterpartyCollateral);
     }
   }
+
+  totalCollateralLost = primaryCollateral;
+  const realizedPnL = grossPayouts - primaryCollateral;
 
   return {
     realizedPnL,
@@ -435,6 +487,124 @@ export async function calculateVaultPnL(
     totalCollateralWon,
     totalCollateralLost,
   };
+}
+
+/**
+ * Calculate vault's cumulative secondary-market trade flow.
+ *
+ * Sums total wUSDe paid (`bought`) and received (`sold`) by the vault on
+ * the secondary market up through `beforeTimestamp` (exclusive of later
+ * trades when supplied). These are gross cash movements; PnL realized
+ * from secondary trades is `sold − bought` netted against any cost basis
+ * still represented inside `realizedPnL`.
+ */
+export async function calculateVaultSecondaryFlows(
+  chainId: number,
+  beforeTimestamp?: number
+): Promise<VaultSecondaryFlowsResult> {
+  const vaultAddress = contracts.predictionMarketVault[chainId]?.address;
+  if (!vaultAddress) return { bought: 0n, sold: 0n };
+  const vaultAddressLower = vaultAddress.toLowerCase();
+
+  const trades = await prisma.secondaryTrade.findMany({
+    where: {
+      chainId,
+      ...(beforeTimestamp ? { executedAt: { lte: beforeTimestamp } } : {}),
+      OR: [{ buyer: vaultAddressLower }, { seller: vaultAddressLower }],
+    },
+    select: { buyer: true, seller: true, price: true },
+  });
+
+  let bought = 0n;
+  let sold = 0n;
+  for (const t of trades) {
+    if (t.buyer.toLowerCase() === vaultAddressLower) {
+      bought += BigInt(t.price);
+    }
+    if (t.seller.toLowerCase() === vaultAddressLower) {
+      sold += BigInt(t.price);
+    }
+  }
+  return { bought, sold };
+}
+
+/**
+ * Calculate vault's airdrop gains: wUSDe transferred into the vault from
+ * sources the protocol doesn't otherwise track.
+ *
+ *   airdrop = sum(CollateralTransfer.value where to = vault)
+ *           − sum(VaultFlowEvent deposits)
+ *           − sum(Close payouts to vault holder)
+ *           − sum(SecondaryTrade.price where seller = vault)
+ *
+ * In a fully-reconciled state this is zero unless real wUSDe arrives via
+ * a path outside the protocol (sapience emissions, partner rewards, etc).
+ * Clamped at zero — a negative residual indicates an indexer gap and is
+ * surfaced via the snapshot console log rather than corrupting the chart.
+ */
+export async function calculateVaultAirdrops(
+  chainId: number,
+  beforeTimestamp?: number
+): Promise<bigint> {
+  const vaultAddress = contracts.predictionMarketVault[chainId]?.address;
+  if (!vaultAddress) return 0n;
+  const vaultAddressLower = vaultAddress.toLowerCase();
+
+  const transferWhere: {
+    chainId: number;
+    to: string;
+    timestamp?: { lte: Date };
+  } = {
+    chainId,
+    to: vaultAddressLower,
+  };
+  if (beforeTimestamp) {
+    transferWhere.timestamp = { lte: new Date(beforeTimestamp * 1000) };
+  }
+
+  const transfers = await prisma.collateralTransfer.findMany({
+    where: transferWhere,
+    select: { value: true },
+  });
+  let transfersIn = 0n;
+  for (const t of transfers) transfersIn += BigInt(t.value);
+
+  const flows = await calculateVaultFlows(chainId, beforeTimestamp);
+
+  // Gross settlement payouts the vault received as the on-chain holder.
+  const closes = await prisma.close.findMany({
+    where: {
+      chainId,
+      ...(beforeTimestamp ? { burnedAt: { lte: beforeTimestamp } } : {}),
+      OR: [
+        { predictorHolder: vaultAddressLower },
+        { counterpartyHolder: vaultAddressLower },
+      ],
+    },
+    select: {
+      predictorHolder: true,
+      counterpartyHolder: true,
+      predictorPayout: true,
+      counterpartyPayout: true,
+    },
+  });
+  let settlementInflow = 0n;
+  for (const c of closes) {
+    if (c.predictorHolder.toLowerCase() === vaultAddressLower) {
+      settlementInflow += BigInt(c.predictorPayout);
+    }
+    if (c.counterpartyHolder.toLowerCase() === vaultAddressLower) {
+      settlementInflow += BigInt(c.counterpartyPayout);
+    }
+  }
+
+  const secondary = await calculateVaultSecondaryFlows(
+    chainId,
+    beforeTimestamp
+  );
+
+  const explained = flows.totalDeposits + settlementInflow + secondary.sold;
+  return transfersIn > explained ? transfersIn - explained : 0n;
 }
 
 /**
@@ -485,6 +655,8 @@ export interface VaultAggregator {
   deployedAt: (timestamp: number) => bigint;
   pnlAt: (timestamp: number) => VaultPnLResult;
   flowsAt: (timestamp: number) => VaultFlowsResult;
+  secondaryAt: (timestamp: number) => VaultSecondaryFlowsResult;
+  airdropsAt: (timestamp: number) => bigint;
 }
 
 export async function buildVaultAggregator(
@@ -504,13 +676,14 @@ export async function buildVaultAggregator(
         totalCollateralLost: 0n,
       }),
       flowsAt: () => ({ totalDeposits: 0n, totalWithdrawals: 0n }),
+      secondaryAt: () => ({ bought: 0n, sold: 0n }),
+      airdropsAt: () => 0n,
     };
   }
 
-  // Fetch the union of every prediction either the deployed-collateral
-  // aggregator or the PnL aggregator could possibly need: anything where the
-  // vault is on either side of the trade.
-  const [predictions, flows] = await Promise.all([
+  // Fetch the union of every prediction, flow event, close, secondary trade,
+  // and inbound collateral transfer the per-iter aggregators could ever need.
+  const [predictions, flows, closes, trades, transfers] = await Promise.all([
     prisma.prediction.findMany({
       where: {
         chainId,
@@ -532,11 +705,42 @@ export async function buildVaultAggregator(
       where: { chainId },
       select: { timestamp: true, eventType: true, assets: true },
     }),
+    prisma.close.findMany({
+      where: {
+        chainId,
+        OR: [
+          { predictorHolder: vaultAddress },
+          { counterpartyHolder: vaultAddress },
+        ],
+      },
+      select: {
+        burnedAt: true,
+        predictorHolder: true,
+        counterpartyHolder: true,
+        predictorPayout: true,
+        counterpartyPayout: true,
+      },
+    }),
+    prisma.secondaryTrade.findMany({
+      where: {
+        chainId,
+        OR: [{ buyer: vaultAddress }, { seller: vaultAddress }],
+      },
+      select: {
+        executedAt: true,
+        buyer: true,
+        seller: true,
+        price: true,
+      },
+    }),
+    prisma.collateralTransfer.findMany({
+      where: { chainId, to: vaultAddress },
+      select: { timestamp: true, value: true },
+    }),
   ]);
 
-  // Predicate ports of the SQL filters in `fetchVaultDeployed` /
-  // `calculateVaultPnL`. Keep these inline so a future reader can audit the
-  // JS branches against the SQL directly.
+  // Predicate ports of the SQL filters in the async helpers. Keep these
+  // inline so a future reader can audit the JS branches against the SQL.
   const deployedAt = (t: number): bigint => {
     let total = 0n;
     for (const p of predictions) {
@@ -555,55 +759,62 @@ export async function buildVaultAggregator(
     return total;
   };
 
+  // Settlement PnL: gross payouts from Close (the actual on-chain holder at
+  // burn time) minus primary-creation collateral the vault committed for
+  // resolved predictions. See the `calculateVaultPnL` docstring for the full
+  // reconciliation identity.
   const pnlAt = (t: number): VaultPnLResult => {
-    let realizedPnL = 0n;
+    let grossPayouts = 0n;
     let positionsWon = 0;
     let positionsLost = 0;
     let totalCollateralWon = 0n;
-    let totalCollateralLost = 0n;
 
+    for (const c of closes) {
+      if (c.burnedAt > t) continue;
+      if (c.predictorHolder.toLowerCase() === vaultAddress) {
+        const payout = BigInt(c.predictorPayout);
+        grossPayouts += payout;
+        if (payout > 0n) {
+          positionsWon++;
+          totalCollateralWon += payout;
+        } else {
+          positionsLost++;
+        }
+      }
+      if (c.counterpartyHolder.toLowerCase() === vaultAddress) {
+        const payout = BigInt(c.counterpartyPayout);
+        grossPayouts += payout;
+        if (payout > 0n) {
+          positionsWon++;
+          totalCollateralWon += payout;
+        } else {
+          positionsLost++;
+        }
+      }
+    }
+
+    let primaryCollateral = 0n;
     for (const p of predictions) {
       if (p.pickConfigId === null) continue;
       const pc = p.pickConfiguration;
       if (!pc || !pc.resolved) continue;
       if (pc.result === SettlementResult.UNRESOLVED) continue;
-      // SQL `resolvedAt <= t` excludes nulls (NULL comparisons are false).
       if (pc.resolvedAt === null || pc.resolvedAt > t) continue;
 
-      const predictorIsVault = p.predictor.toLowerCase() === vaultAddress;
-      const counterpartyIsVault = p.counterparty.toLowerCase() === vaultAddress;
-      if (!predictorIsVault && !counterpartyIsVault) continue;
-
-      const predictorCollateral = BigInt(p.predictorCollateral);
-      const counterpartyCollateral = BigInt(p.counterpartyCollateral);
-
-      const vaultWon =
-        (predictorIsVault && pc.result === SettlementResult.PREDICTOR_WINS) ||
-        (!predictorIsVault && pc.result === SettlementResult.COUNTERPARTY_WINS);
-
-      if (vaultWon) {
-        const gains = predictorIsVault
-          ? counterpartyCollateral
-          : predictorCollateral;
-        realizedPnL += gains;
-        positionsWon++;
-        totalCollateralWon += gains;
-      } else {
-        const loss = predictorIsVault
-          ? predictorCollateral
-          : counterpartyCollateral;
-        realizedPnL -= loss;
-        positionsLost++;
-        totalCollateralLost += loss;
+      if (p.predictor.toLowerCase() === vaultAddress) {
+        primaryCollateral += BigInt(p.predictorCollateral);
+      }
+      if (p.counterparty.toLowerCase() === vaultAddress) {
+        primaryCollateral += BigInt(p.counterpartyCollateral);
       }
     }
 
     return {
-      realizedPnL,
+      realizedPnL: grossPayouts - primaryCollateral,
       positionsWon,
       positionsLost,
       totalCollateralWon,
-      totalCollateralLost,
+      totalCollateralLost: primaryCollateral,
     };
   };
 
@@ -619,7 +830,46 @@ export async function buildVaultAggregator(
     return { totalDeposits, totalWithdrawals };
   };
 
-  return { deployedAt, pnlAt, flowsAt };
+  const secondaryAt = (t: number): VaultSecondaryFlowsResult => {
+    let bought = 0n;
+    let sold = 0n;
+    for (const tr of trades) {
+      if (tr.executedAt > t) continue;
+      if (tr.buyer.toLowerCase() === vaultAddress) bought += BigInt(tr.price);
+      if (tr.seller.toLowerCase() === vaultAddress) sold += BigInt(tr.price);
+    }
+    return { bought, sold };
+  };
+
+  // Airdrops: total wUSDe transfers in to vault, minus inflows already
+  // accounted for via deposits, settlement payouts, and secondary sales.
+  // Mirrors the async `calculateVaultAirdrops` definition.
+  const airdropsAt = (t: number): bigint => {
+    let transfersIn = 0n;
+    for (const tr of transfers) {
+      if (Math.floor(tr.timestamp.getTime() / 1000) > t) continue;
+      transfersIn += BigInt(tr.value);
+    }
+
+    let settlementInflow = 0n;
+    for (const c of closes) {
+      if (c.burnedAt > t) continue;
+      if (c.predictorHolder.toLowerCase() === vaultAddress) {
+        settlementInflow += BigInt(c.predictorPayout);
+      }
+      if (c.counterpartyHolder.toLowerCase() === vaultAddress) {
+        settlementInflow += BigInt(c.counterpartyPayout);
+      }
+    }
+
+    const flowsRes = flowsAt(t);
+    const secondary = secondaryAt(t);
+    const explained =
+      flowsRes.totalDeposits + settlementInflow + secondary.sold;
+    return transfersIn > explained ? transfersIn - explained : 0n;
+  };
+
+  return { deployedAt, pnlAt, flowsAt, secondaryAt, airdropsAt };
 }
 
 /**
@@ -655,6 +905,8 @@ async function upsertProtocolStatsSnapshot(
       escrowBalance: data.escrowBalance.toString(),
       vaultRealizedPnL: data.vaultRealizedPnL.toString(),
       vaultAirdropGains: data.vaultAirdropGains.toString(),
+      vaultSecondaryBought: data.vaultSecondaryBought.toString(),
+      vaultSecondarySold: data.vaultSecondarySold.toString(),
       vaultDeposits: data.vaultDeposits.toString(),
       vaultWithdrawals: data.vaultWithdrawals.toString(),
       vaultPositionsWon: data.vaultPositionsWon,
@@ -669,6 +921,8 @@ async function upsertProtocolStatsSnapshot(
       escrowBalance: data.escrowBalance.toString(),
       vaultRealizedPnL: data.vaultRealizedPnL.toString(),
       vaultAirdropGains: data.vaultAirdropGains.toString(),
+      vaultSecondaryBought: data.vaultSecondaryBought.toString(),
+      vaultSecondarySold: data.vaultSecondarySold.toString(),
       vaultDeposits: data.vaultDeposits.toString(),
       vaultWithdrawals: data.vaultWithdrawals.toString(),
       vaultPositionsWon: data.vaultPositionsWon,
@@ -798,22 +1052,28 @@ export async function computeAndStoreProtocolStats(
     `[ProtocolStats] Deposits: ${formatUnits(flowsResult.totalDeposits, 18)}, Withdrawals: ${formatUnits(flowsResult.totalWithdrawals, 18)}, Deployed: ${formatUnits(vaultDeployed, 18)}`
   );
 
-  // Calculate airdrop gains: unexplained balance increases
-  // Actual total assets = vaultBalance + vaultDeployed
-  // Expected total assets = deposits - withdrawals + realizedPnL
-  // Airdrop gains = actual - expected
+  // Calculate secondary-market trade flow attributable to the vault, pinned
+  // to the snapshot timestamp like every other DB-derived aggregate.
+  const secondaryFlows = await calculateVaultSecondaryFlows(chainId, timestamp);
+  console.log(
+    `[ProtocolStats] Secondary bought: ${formatUnits(secondaryFlows.bought, 18)}, sold: ${formatUnits(secondaryFlows.sold, 18)}`
+  );
+
+  // Calculate airdrops: wUSDe transfers in not explained by deposits,
+  // settlement payouts, or secondary sales. Surface a residual diagnostic
+  // alongside it so we can spot indexer drift.
+  const airdropGains = await calculateVaultAirdrops(chainId, timestamp);
   const actualTotalAssets = vaultBalance + vaultDeployed;
   const expectedTotalAssets =
     flowsResult.totalDeposits -
     flowsResult.totalWithdrawals +
-    pnlResult.realizedPnL;
-  const airdropGains =
-    actualTotalAssets > expectedTotalAssets
-      ? actualTotalAssets - expectedTotalAssets
-      : 0n;
-
+    pnlResult.realizedPnL +
+    secondaryFlows.sold -
+    secondaryFlows.bought +
+    airdropGains;
+  const reconciliationDelta = actualTotalAssets - expectedTotalAssets;
   console.log(
-    `[ProtocolStats] Airdrop gains: ${formatUnits(airdropGains, 18)} USDe`
+    `[ProtocolStats] Airdrop gains: ${formatUnits(airdropGains, 18)} USDe (reconciliation Δ ${formatUnits(reconciliationDelta, 18)})`
   );
 
   await upsertProtocolStatsSnapshot(timestamp, chainId, vaultAddress, {
@@ -823,6 +1083,8 @@ export async function computeAndStoreProtocolStats(
     escrowBalance,
     vaultRealizedPnL: pnlResult.realizedPnL,
     vaultAirdropGains: airdropGains,
+    vaultSecondaryBought: secondaryFlows.bought,
+    vaultSecondarySold: secondaryFlows.sold,
     vaultDeposits: flowsResult.totalDeposits,
     vaultWithdrawals: flowsResult.totalWithdrawals,
     vaultPositionsWon: pnlResult.positionsWon,
@@ -1035,6 +1297,8 @@ export async function backfillProtocolStats(
             escrowBalance: 0n,
             vaultRealizedPnL: 0n,
             vaultAirdropGains: 0n,
+            vaultSecondaryBought: 0n,
+            vaultSecondarySold: 0n,
             vaultDeposits: 0n,
             vaultWithdrawals: 0n,
             vaultPositionsWon: 0,
@@ -1116,23 +1380,15 @@ export async function backfillProtocolStats(
             : vaultAvailableAssetsOrNull;
 
         // DB-derived metrics — sync in-memory aggregation against the
-        // pre-fetched superset. Replaces three findMany calls per iter.
+        // pre-fetched superset. Replaces five findMany calls per iter.
         const tDb = performance.now();
         const vaultDeployed = aggregator.deployedAt(timestamp);
         const pnlResult = aggregator.pnlAt(timestamp);
         const flowsResult = aggregator.flowsAt(timestamp);
+        const secondaryFlows = aggregator.secondaryAt(timestamp);
+        const airdropGains = aggregator.airdropsAt(timestamp);
         const dbMs = performance.now() - tDb;
         totals.dbReads += dbMs;
-
-        const actualTotalAssets = vaultBalance + vaultDeployed;
-        const expectedTotalAssets =
-          flowsResult.totalDeposits -
-          flowsResult.totalWithdrawals +
-          pnlResult.realizedPnL;
-        const airdropGains =
-          actualTotalAssets > expectedTotalAssets
-            ? actualTotalAssets - expectedTotalAssets
-            : 0n;
 
         const tUpsert = performance.now();
         await upsertProtocolStatsSnapshot(timestamp, chainId, vaultAddress, {
@@ -1142,6 +1398,8 @@ export async function backfillProtocolStats(
           escrowBalance,
           vaultRealizedPnL: pnlResult.realizedPnL,
           vaultAirdropGains: airdropGains,
+          vaultSecondaryBought: secondaryFlows.bought,
+          vaultSecondarySold: secondaryFlows.sold,
           vaultDeposits: flowsResult.totalDeposits,
           vaultWithdrawals: flowsResult.totalWithdrawals,
           vaultPositionsWon: pnlResult.positionsWon,

--- a/packages/sdk/queries/analytics.ts
+++ b/packages/sdk/queries/analytics.ts
@@ -14,6 +14,8 @@ export interface ProtocolStat {
   vaultDeposits: string;
   vaultWithdrawals: string;
   vaultAirdropGains: string;
+  vaultSecondaryBought: string;
+  vaultSecondarySold: string;
   periodPnL: string;
   periodVolume: string;
 }
@@ -34,6 +36,8 @@ export const GET_PROTOCOL_STATS = /* GraphQL */ `
       vaultDeposits
       vaultWithdrawals
       vaultAirdropGains
+      vaultSecondaryBought
+      vaultSecondarySold
       periodPnL
       periodVolume
     }


### PR DESCRIPTION
## Summary

The vault PnL chart on `/vaults` silently double-counted (or missed entirely) cash flow from secondary-market trades involving the vault.

- `calculateVaultPnL` keyed off `Prediction.predictor` / `.counterparty` (creation-time addresses) rather than the actual on-chain holder at settlement, so a position the vault sold on secondary still credited the vault for the eventual settlement payout.
- The existing \"airdrop gains\" residual then absorbed any leftover cash, mixing trade flow into a bucket that was supposed to mean \"wUSDe that landed in the vault independently.\"

This change splits the attribution into clean buckets that reconcile against actual vault assets.

## Changes

- **Settlement PnL** now sources gross payouts from `Close.predictorHolder` / `Close.counterpartyHolder` (the actual NFT holder at burn time). Cost basis still comes from `Prediction` (only counts when the vault was the original creator and the pickConfig has resolved). Sold-on-secondary positions stop being credited at settlement.
- **New `vaultSecondaryBought` / `vaultSecondarySold`** columns on `protocol_stats_snapshot` (+ migration), populated by a new `calculateVaultSecondaryFlows` helper that aggregates `SecondaryTrade.price` by buyer/seller.
- **Airdrops** redefined as a direct `CollateralTransfer` query: total wUSDe transfers in to the vault minus deposits, settlement payouts received, and secondary sale proceeds. Replaces the old residual.
- **Resolver** rolls `vaultCumulativePnL` up as `settlement + (sold − bought)` so the chart's PnL line includes secondary trade flow. Airdrops remain a separate metric.
- **Backfill aggregator** (`buildVaultAggregator`) extended with `secondaryAt` / `airdropsAt` so the parallel backfill stays in lockstep with the async cron path; `pnlAt` switched to the same Close-based attribution.
- **Tests:** rewrote `protocolStats.test.ts` with new fixtures covering held-through-settlement, sold-before-settlement, bought-on-secondary, and airdrop-vs-residual paths. 36 tests pass.

## Reconciliation identity

```
vaultBalance + vaultDeployed
  = deposits − withdrawals
  + settlementPnL          (Close-based)
  + secondarySold − secondaryBought
  + airdrops               (true unexplained inflows)
```

The cron snapshot logs `reconciliation Δ` so we'll spot indexer drift directly.

## Test plan

- [ ] Run prisma migrate on staging DB
- [ ] Trigger `backfillProtocolStats` to repopulate snapshots with the new attribution
- [ ] Verify `/vaults` chart still renders (uses `vaultCumulativePnL`, semantics broadened to include secondary flow)
- [ ] Spot-check `vaultSecondaryBought` / `vaultSecondarySold` against a known secondary trade where the vault was on one side
- [ ] Confirm `vaultAirdropGains` no longer absorbs trade flow (compare pre/post on a snapshot during a known sale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)