### PR TITLE
feat(profile): show realized PnL on closed positions

### DIFF
--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -1321,10 +1321,11 @@ type Position {
   chainId: Int!
   createdAt: DateTimeISO!
   holder: String!
-  id: Int!
+  id: String!
   isPredictorToken: Boolean!
   pickConfig: PickConfiguration
   pickConfigId: String!
+  realizedPnL: String
   tokenAddress: String!
   totalPayout: String
   updatedAt: DateTimeISO!

--- a/packages/api/src/graphql/sdl/resolvers/queries/escrow.test.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/escrow.test.ts
@@ -1,0 +1,442 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockPrisma = vi.hoisted(() => ({
+  position: { findMany: vi.fn(), count: vi.fn() },
+  secondaryTrade: { findMany: vi.fn() },
+  pick: { findMany: vi.fn() },
+  $queryRaw: vi.fn(),
+}));
+
+vi.mock('../../../../db', () => ({ default: mockPrisma }));
+
+import { positions, positionCount } from './escrow';
+
+const ALICE = '0xalice';
+const BOB = '0xbob';
+const TOKEN_PRED = '0xtokenpred';
+const TOKEN_CP = '0xtokencp';
+const PC_ID = 'pc-1';
+
+// Use explicit integer-second timestamps so mint < buy < sell ordering
+// is unambiguous when interleaving Predictions (Date) with SecondaryTrades
+// (integer seconds) in the resolver's WAC walk.
+const TS_MINT = 1_000_000;
+const TS_BUY = 2_000_000;
+const TS_SELL = 3_000_000;
+const baseCreatedAt = new Date(TS_MINT * 1000);
+const baseUpdatedAt = new Date(TS_SELL * 1000);
+
+type Prediction = {
+  predictionId: string;
+  predictor: string;
+  counterparty: string;
+  predictorCollateral: string;
+  counterpartyCollateral: string;
+  createdAt: Date;
+};
+
+type PickConfig = {
+  id: string;
+  chainId: number;
+  marketAddress: string;
+  totalPredictorCollateral: string;
+  totalCounterpartyCollateral: string;
+  claimedPredictorCollateral: string;
+  claimedCounterpartyCollateral: string;
+  resolved: boolean;
+  result: string;
+  resolvedAt: number | null;
+  predictorToken: string | null;
+  counterpartyToken: string | null;
+  endsAt: number | null;
+  isLegacy: boolean;
+  picks: never[];
+  predictions: Prediction[];
+};
+
+const makePickConfig = (overrides: Partial<PickConfig> = {}): PickConfig => ({
+  id: PC_ID,
+  chainId: 1,
+  marketAddress: '0xmarket',
+  totalPredictorCollateral: '0',
+  totalCounterpartyCollateral: '0',
+  claimedPredictorCollateral: '0',
+  claimedCounterpartyCollateral: '0',
+  resolved: false,
+  result: 'UNRESOLVED',
+  resolvedAt: null,
+  predictorToken: TOKEN_PRED,
+  counterpartyToken: TOKEN_CP,
+  endsAt: null,
+  isLegacy: false,
+  picks: [],
+  predictions: [],
+  ...overrides,
+});
+
+const makePosition = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  chainId: 1,
+  tokenAddress: TOKEN_PRED,
+  pickConfigId: PC_ID,
+  isPredictorToken: true,
+  holder: ALICE,
+  balance: '0',
+  createdAt: baseCreatedAt,
+  updatedAt: baseUpdatedAt,
+  pickConfiguration: makePickConfig(),
+  ...overrides,
+});
+
+const makePrediction = (overrides: Partial<Prediction> = {}): Prediction => ({
+  predictionId: 'p-1',
+  predictor: ALICE,
+  counterparty: BOB,
+  predictorCollateral: '100',
+  counterpartyCollateral: '100',
+  createdAt: baseCreatedAt,
+  ...overrides,
+});
+
+const makeTrade = (overrides: {
+  seller: string;
+  buyer: string;
+  price: string;
+  tokenAmount: string;
+  executedAt: number;
+  tradeHash: string;
+  token?: string;
+}) => ({
+  chainId: 1,
+  token: TOKEN_PRED,
+  ...overrides,
+});
+
+const callPositions = (args: Partial<Parameters<typeof positions>[1]> = {}) => {
+  return positions(
+    undefined as never,
+    {
+      take: 50,
+      skip: 0,
+      holder: ALICE,
+      ...args,
+    } as Parameters<typeof positions>[1],
+    undefined as never,
+    undefined as never
+  );
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.secondaryTrade.findMany.mockResolvedValue([]);
+});
+
+describe('positions resolver — synthetic row emission', () => {
+  it('never-sold open position: emits one open row with mint cost basis', async () => {
+    mockPrisma.position.findMany.mockResolvedValue([
+      makePosition({
+        balance: '200',
+        pickConfiguration: makePickConfig({
+          predictions: [makePrediction()], // alice is predictor, mints 100
+        }),
+      }),
+    ]);
+
+    const result = await callPositions();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: '1',
+      balance: '200',
+      userCollateral: '100',
+      totalPayout: '200',
+      realizedPnL: null,
+    });
+  });
+
+  it('full secondary sale: emits one SOLD row, no open row', async () => {
+    mockPrisma.position.findMany.mockResolvedValue([
+      makePosition({
+        balance: '0',
+        pickConfiguration: makePickConfig({
+          predictions: [makePrediction()],
+        }),
+      }),
+    ]);
+    mockPrisma.secondaryTrade.findMany.mockResolvedValue([
+      makeTrade({
+        seller: ALICE,
+        buyer: '0xcarol',
+        price: '150',
+        tokenAmount: '200',
+        executedAt: TS_SELL,
+        tradeHash: '0xtrade1',
+      }),
+    ]);
+
+    const result = await callPositions();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: '1-sell-0xtrade1',
+      balance: '0',
+      userCollateral: '100',
+      realizedPnL: '50', // 150 proceeds - 100 cost
+    });
+  });
+
+  it('partial secondary sale: emits SOLD row + open row with remaining cost', async () => {
+    mockPrisma.position.findMany.mockResolvedValue([
+      makePosition({
+        balance: '100',
+        pickConfiguration: makePickConfig({
+          predictions: [makePrediction()],
+        }),
+      }),
+    ]);
+    mockPrisma.secondaryTrade.findMany.mockResolvedValue([
+      makeTrade({
+        seller: ALICE,
+        buyer: '0xcarol',
+        price: '60',
+        tokenAmount: '100',
+        executedAt: TS_SELL,
+        tradeHash: '0xtrade1',
+      }),
+    ]);
+
+    const result = await callPositions();
+
+    expect(result).toHaveLength(2);
+    const sold = result.find((r) => r!.id.includes('-sell-'));
+    const open = result.find((r) => !r!.id.includes('-sell-'));
+    // WAC: cost=100, shares=200; sell 100 shares → allocated = 100*100/200 = 50.
+    expect(sold).toMatchObject({
+      userCollateral: '50',
+      realizedPnL: '10', // 60 - 50
+      balance: '0',
+    });
+    expect(open).toMatchObject({
+      id: '1',
+      balance: '100',
+      userCollateral: '50', // remaining
+      realizedPnL: null,
+    });
+  });
+
+  it('multi-mint single pickConfig: cost basis aggregates across predictions', async () => {
+    mockPrisma.position.findMany.mockResolvedValue([
+      makePosition({
+        balance: '600',
+        pickConfiguration: makePickConfig({
+          predictions: [
+            makePrediction({
+              predictionId: 'p-1',
+              predictorCollateral: '100',
+              counterpartyCollateral: '100',
+            }),
+            makePrediction({
+              predictionId: 'p-2',
+              predictorCollateral: '50',
+              counterpartyCollateral: '150',
+            }),
+          ],
+        }),
+      }),
+    ]);
+
+    const result = await callPositions();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      userCollateral: '150', // 100 + 50
+      totalPayout: '400', // 200 + 200
+    });
+  });
+
+  it('secondary buy then sell: cost basis reflects WAC', async () => {
+    mockPrisma.position.findMany.mockResolvedValue([
+      makePosition({
+        balance: '0',
+        pickConfiguration: makePickConfig({
+          predictions: [makePrediction()], // alice mints: cost=100, shares=200
+        }),
+      }),
+    ]);
+    mockPrisma.secondaryTrade.findMany.mockResolvedValue([
+      // alice buys 100 more shares for 80
+      makeTrade({
+        seller: '0xcarol',
+        buyer: ALICE,
+        price: '80',
+        tokenAmount: '100',
+        executedAt: TS_BUY,
+        tradeHash: '0xbuy1',
+      }),
+      // alice sells all 300 shares for 270
+      makeTrade({
+        seller: ALICE,
+        buyer: '0xdave',
+        price: '270',
+        tokenAmount: '300',
+        executedAt: TS_SELL,
+        tradeHash: '0xsell1',
+      }),
+    ]);
+
+    const result = await callPositions();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: '1-sell-0xsell1',
+      // WAC at sell: cost pool = 180, shares pool = 300; allocate
+      // 180 * 300 / 300 = 180.
+      userCollateral: '180',
+      realizedPnL: '90', // 270 - 180
+    });
+  });
+
+  it('zero balance, unresolved, no sells (transferred away): emits no rows', async () => {
+    mockPrisma.position.findMany.mockResolvedValue([
+      makePosition({
+        balance: '0',
+        pickConfiguration: makePickConfig({
+          predictions: [makePrediction()],
+        }),
+      }),
+    ]);
+
+    const result = await callPositions();
+
+    expect(result).toEqual([]);
+  });
+
+  it('resolved position: emits the underlying row regardless of sells', async () => {
+    mockPrisma.position.findMany.mockResolvedValue([
+      makePosition({
+        balance: '200',
+        pickConfiguration: makePickConfig({
+          resolved: true,
+          result: 'PREDICTOR_WINS',
+          predictions: [makePrediction()],
+        }),
+      }),
+    ]);
+    // Even with a sell on a resolved pickConfig, no synthetic disposal row
+    // should be emitted — the existing settlement-PnL flow takes over.
+    mockPrisma.secondaryTrade.findMany.mockResolvedValue([
+      makeTrade({
+        seller: ALICE,
+        buyer: '0xcarol',
+        price: '150',
+        tokenAmount: '100',
+        executedAt: TS_SELL,
+        tradeHash: '0xtrade1',
+      }),
+    ]);
+
+    const result = await callPositions();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: '1',
+      balance: '200',
+      realizedPnL: null,
+    });
+  });
+
+  it('counterparty-side holder: cost basis comes from counterpartyCollateral', async () => {
+    mockPrisma.position.findMany.mockResolvedValue([
+      makePosition({
+        isPredictorToken: false,
+        tokenAddress: TOKEN_CP,
+        holder: BOB,
+        balance: '200',
+        pickConfiguration: makePickConfig({
+          predictions: [
+            makePrediction({
+              predictorCollateral: '70',
+              counterpartyCollateral: '130',
+            }),
+          ],
+        }),
+      }),
+    ]);
+
+    const result = await callPositions({ holder: BOB });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      userCollateral: '130',
+      totalPayout: '200',
+    });
+  });
+});
+
+describe('positions resolver — ordering', () => {
+  it('sorts synthetic rows by updatedAt across positions, not grouped under parent', async () => {
+    // Two positions: an old one that just had a sell (sell ts = TS_SELL,
+    // most recent activity) and a newer one that's still open (updatedAt
+    // between mint and sell). Synthetic SOLD row from the old position
+    // should appear before the newer open row when sorted desc by updatedAt.
+    mockPrisma.position.findMany.mockResolvedValue([
+      makePosition({
+        id: 1,
+        balance: '0',
+        createdAt: new Date(TS_MINT * 1000),
+        updatedAt: new Date(TS_MINT * 1000),
+        pickConfiguration: makePickConfig({ predictions: [makePrediction()] }),
+      }),
+      makePosition({
+        id: 2,
+        tokenAddress: TOKEN_CP,
+        isPredictorToken: false,
+        balance: '200',
+        createdAt: new Date(TS_BUY * 1000),
+        updatedAt: new Date(TS_BUY * 1000),
+        pickConfiguration: makePickConfig({
+          predictions: [
+            makePrediction({
+              predictor: BOB,
+              counterparty: ALICE,
+            }),
+          ],
+        }),
+      }),
+    ]);
+    mockPrisma.secondaryTrade.findMany.mockResolvedValue([
+      makeTrade({
+        seller: ALICE,
+        buyer: '0xcarol',
+        price: '150',
+        tokenAmount: '200',
+        executedAt: TS_SELL,
+        tradeHash: '0xtrade1',
+      }),
+    ]);
+
+    const result = await callPositions();
+
+    expect(result.map((r) => r!.id)).toEqual(['1-sell-0xtrade1', '2']);
+  });
+});
+
+describe('positionCount resolver', () => {
+  it('applies the same zero-balance/unresolved exclusion as positions', async () => {
+    mockPrisma.position.count.mockResolvedValue(3);
+
+    const result = await positionCount(
+      undefined as never,
+      { holder: ALICE } as Parameters<typeof positionCount>[1],
+      undefined as never,
+      undefined as never
+    );
+
+    expect(result).toBe(3);
+    const callArgs = mockPrisma.position.count.mock.calls[0][0];
+    expect(callArgs.where).toMatchObject({
+      holder: ALICE.toLowerCase(),
+      NOT: { balance: '0', pickConfiguration: { resolved: false } },
+    });
+  });
+});

--- a/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
@@ -66,8 +66,12 @@ export const predictionCount: NonNullable<
 export const positionCount: NonNullable<
   QueryResolvers['positionCount']
 > = async (_parent, { holder, settled, chainId }) => {
+  // Mirror the visibility rule applied in `positions`: drop zero-balance
+  // unresolved rows (off-platform transfers/burns) so the count matches the
+  // set of underlying positions surfaced to clients.
   const where: Prisma.PositionWhereInput = {
     holder: holder.toLowerCase(),
+    NOT: { balance: '0', pickConfiguration: { resolved: false } },
   };
   if (settled !== undefined && settled !== null) {
     where.pickConfiguration = { resolved: settled };
@@ -344,52 +348,36 @@ export const positions: NonNullable<QueryResolvers['positions']> = async (
   });
 
   // For each Position row we build a chronological event stream of primary
-  // mints (Predictions), secondary trades (buys + sells matching token+holder),
-  // and Claims, then walk it with running WAC. Each disposal event produces
-  // its own synthetic Closed row; if balance > 0 at the end, we also emit an
-  // Open row carrying the remaining cost basis.
+  // mints (Predictions) and secondary trades (buys + sells matching
+  // token+holder), then walk it with running WAC. Each sell produces a
+  // synthetic Closed row; if balance > 0 at the end, we also emit an Open
+  // row carrying the remaining cost basis. Claims are intentionally excluded
+  // — the contract reverts redeem() unless the pickConfig is resolved, so
+  // any Claim is post-settlement and the existing settlement-PnL flow on a
+  // resolved Position already covers it.
   const chainIds = Array.from(new Set(rows.map((r) => r.chainId)));
   const tokenAddresses = Array.from(new Set(rows.map((r) => r.tokenAddress)));
   const holders = Array.from(new Set(rows.map((r) => r.holder)));
-  const [trades, claimRows] =
+  const trades =
     rows.length === 0
-      ? [[], []]
-      : await Promise.all([
-          prisma.secondaryTrade.findMany({
-            where: {
-              chainId: { in: chainIds },
-              token: { in: tokenAddresses },
-              OR: [{ seller: { in: holders } }, { buyer: { in: holders } }],
-            },
-            select: {
-              id: true,
-              chainId: true,
-              token: true,
-              seller: true,
-              buyer: true,
-              price: true,
-              tokenAmount: true,
-              executedAt: true,
-              tradeHash: true,
-            },
-          }),
-          prisma.claim.findMany({
-            where: {
-              chainId: { in: chainIds },
-              positionToken: { in: tokenAddresses },
-              holder: { in: holders },
-            },
-            select: {
-              id: true,
-              chainId: true,
-              positionToken: true,
-              holder: true,
-              tokensBurned: true,
-              collateralPaid: true,
-              redeemedAt: true,
-            },
-          }),
-        ]);
+      ? []
+      : await prisma.secondaryTrade.findMany({
+          where: {
+            chainId: { in: chainIds },
+            token: { in: tokenAddresses },
+            OR: [{ seller: { in: holders } }, { buyer: { in: holders } }],
+          },
+          select: {
+            chainId: true,
+            token: true,
+            seller: true,
+            buyer: true,
+            price: true,
+            tokenAmount: true,
+            executedAt: true,
+            tradeHash: true,
+          },
+        });
 
   const positionKey = (chainId: number, token: string, holder: string) =>
     `${chainId}:${token}:${holder}`;
@@ -401,13 +389,6 @@ export const positions: NonNullable<QueryResolvers['positions']> = async (
       if (arr) arr.push(t);
       else tradesByPos.set(k, [t]);
     }
-  }
-  const claimsByPos = new Map<string, typeof claimRows>();
-  for (const c of claimRows) {
-    const k = positionKey(c.chainId, c.positionToken, c.holder);
-    const arr = claimsByPos.get(k);
-    if (arr) arr.push(c);
-    else claimsByPos.set(k, [c]);
   }
 
   type PositionShape = {
@@ -435,8 +416,7 @@ export const positions: NonNullable<QueryResolvers['positions']> = async (
     // Primary-mint events from Predictions tied to this position
     type Acquire = { ts: number; cost: bigint; shares: bigint };
     type Disposal = {
-      kind: 'sell' | 'claim';
-      idStr: string;
+      tradeHash: string;
       ts: number;
       proceeds: bigint;
       shares: bigint;
@@ -475,22 +455,12 @@ export const positions: NonNullable<QueryResolvers['positions']> = async (
       }
       if (t.seller === r.holder) {
         disposals.push({
-          kind: 'sell',
-          idStr: t.tradeHash,
+          tradeHash: t.tradeHash,
           ts: t.executedAt,
           proceeds: price,
           shares,
         });
       }
-    }
-    for (const c of claimsByPos.get(k) ?? []) {
-      disposals.push({
-        kind: 'claim',
-        idStr: String(c.id),
-        ts: c.redeemedAt,
-        proceeds: BigInt(c.collateralPaid),
-        shares: BigInt(c.tokensBurned),
-      });
     }
 
     const acquiresSorted = [...acquires].sort((a, b) => a.ts - b.ts);
@@ -503,8 +473,7 @@ export const positions: NonNullable<QueryResolvers['positions']> = async (
     let sharesPool = 0n;
     let acqIdx = 0;
     type DisposalRow = {
-      kind: 'sell' | 'claim';
-      idStr: string;
+      tradeHash: string;
       ts: number;
       proceeds: bigint;
       shares: bigint;
@@ -540,12 +509,12 @@ export const positions: NonNullable<QueryResolvers['positions']> = async (
     const balanceBn = BigInt(r.balance);
     const isResolved = pc?.resolved ?? false;
 
-    // Emit one synthetic row per disposal (only meaningful for unresolved
+    // Emit one synthetic row per sell (only meaningful for unresolved
     // pickConfigs — once settled, the existing PnL flow takes over).
     if (!isResolved) {
       for (const d of disposalRows) {
         synthesized.push({
-          id: `${r.id}-${d.kind}-${d.idStr}`,
+          id: `${r.id}-sell-${d.tradeHash}`,
           chainId: r.chainId,
           tokenAddress: r.tokenAddress,
           pickConfigId: r.pickConfigId,
@@ -562,10 +531,11 @@ export const positions: NonNullable<QueryResolvers['positions']> = async (
       }
     }
 
-    // Open / parent row: keep when there's still balance OR when we didn't
-    // emit any disposals (preserves today's behavior for never-traded and
-    // resolved positions).
-    if (balanceBn > 0n || disposalRows.length === 0 || isResolved) {
+    // Open / parent row: keep when there's still balance, or when the
+    // position is settled (existing settlement-PnL flow handles it). A
+    // zero-balance unresolved row with no sells means the holder transferred
+    // or burned the tokens off-platform — drop it, matching prior behavior.
+    if (balanceBn > 0n || isResolved) {
       const remainingCost =
         !isResolved && disposalRows.length > 0 ? costPool : totalUserCollateral;
       synthesized.push({

--- a/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
@@ -555,6 +555,16 @@ export const positions: NonNullable<QueryResolvers['positions']> = async (
       });
     }
   }
+
+  // Re-sort by the requested field. Synthetic sell rows carry the trade's
+  // executedAt as their updatedAt, so without this they'd appear grouped
+  // under their parent Position rather than interleaved by recency.
+  const sortKey: keyof Pick<PositionShape, 'createdAt' | 'updatedAt'> =
+    posOrderField === 'createdAt' ? 'createdAt' : 'updatedAt';
+  synthesized.sort((a, b) => {
+    const diff = b[sortKey].getTime() - a[sortKey].getTime();
+    return posOrderDirection === 'asc' ? -diff : diff;
+  });
   return synthesized;
 };
 

--- a/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
@@ -68,7 +68,6 @@ export const positionCount: NonNullable<
 > = async (_parent, { holder, settled, chainId }) => {
   const where: Prisma.PositionWhereInput = {
     holder: holder.toLowerCase(),
-    NOT: { balance: '0', pickConfiguration: { resolved: false } },
   };
   if (settled !== undefined && settled !== null) {
     where.pickConfiguration = { resolved: settled };
@@ -326,12 +325,6 @@ export const positions: NonNullable<QueryResolvers['positions']> = async (
     }
   }
 
-  // Hide zero-balance positions that aren't settled yet (user burned or
-  // transferred the tokens before settlement — these would display as
-  // "0.00 USDe / PENDING" on the client). Post-settlement zero-balance
-  // positions are kept since they carry PnL data.
-  where.NOT = { balance: '0', pickConfiguration: { resolved: false } };
-
   // PositionSortField SDL enum values are CREATED_AT / UPDATED_AT; map
   // to the Prisma column name for orderBy.
   const posOrderDirection = orderDirection === 'asc' ? 'asc' : 'desc';
@@ -350,42 +343,249 @@ export const positions: NonNullable<QueryResolvers['positions']> = async (
     },
   });
 
-  return rows.map((r) => {
+  // For each Position row we build a chronological event stream of primary
+  // mints (Predictions), secondary trades (buys + sells matching token+holder),
+  // and Claims, then walk it with running WAC. Each disposal event produces
+  // its own synthetic Closed row; if balance > 0 at the end, we also emit an
+  // Open row carrying the remaining cost basis.
+  const chainIds = Array.from(new Set(rows.map((r) => r.chainId)));
+  const tokenAddresses = Array.from(new Set(rows.map((r) => r.tokenAddress)));
+  const holders = Array.from(new Set(rows.map((r) => r.holder)));
+  const [trades, claimRows] =
+    rows.length === 0
+      ? [[], []]
+      : await Promise.all([
+          prisma.secondaryTrade.findMany({
+            where: {
+              chainId: { in: chainIds },
+              token: { in: tokenAddresses },
+              OR: [{ seller: { in: holders } }, { buyer: { in: holders } }],
+            },
+            select: {
+              id: true,
+              chainId: true,
+              token: true,
+              seller: true,
+              buyer: true,
+              price: true,
+              tokenAmount: true,
+              executedAt: true,
+              tradeHash: true,
+            },
+          }),
+          prisma.claim.findMany({
+            where: {
+              chainId: { in: chainIds },
+              positionToken: { in: tokenAddresses },
+              holder: { in: holders },
+            },
+            select: {
+              id: true,
+              chainId: true,
+              positionToken: true,
+              holder: true,
+              tokensBurned: true,
+              collateralPaid: true,
+              redeemedAt: true,
+            },
+          }),
+        ]);
+
+  const positionKey = (chainId: number, token: string, holder: string) =>
+    `${chainId}:${token}:${holder}`;
+  const tradesByPos = new Map<string, typeof trades>();
+  for (const t of trades) {
+    for (const role of [t.seller, t.buyer] as const) {
+      const k = positionKey(t.chainId, t.token, role);
+      const arr = tradesByPos.get(k);
+      if (arr) arr.push(t);
+      else tradesByPos.set(k, [t]);
+    }
+  }
+  const claimsByPos = new Map<string, typeof claimRows>();
+  for (const c of claimRows) {
+    const k = positionKey(c.chainId, c.positionToken, c.holder);
+    const arr = claimsByPos.get(k);
+    if (arr) arr.push(c);
+    else claimsByPos.set(k, [c]);
+  }
+
+  type PositionShape = {
+    id: string;
+    chainId: number;
+    tokenAddress: string;
+    pickConfigId: string;
+    isPredictorToken: boolean;
+    holder: string;
+    balance: string;
+    userCollateral: string | null;
+    totalPayout: string | null;
+    realizedPnL: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+    pickConfig: ReturnType<typeof mapPickConfig> | null;
+  };
+
+  const synthesized: PositionShape[] = [];
+  for (const r of rows) {
     const pc = r.pickConfiguration;
-    let userCollateral = 0n;
     let totalPayout = 0n;
     let predictionId: string | null = null;
+
+    // Primary-mint events from Predictions tied to this position
+    type Acquire = { ts: number; cost: bigint; shares: bigint };
+    type Disposal = {
+      kind: 'sell' | 'claim';
+      idStr: string;
+      ts: number;
+      proceeds: bigint;
+      shares: bigint;
+    };
+    const acquires: Acquire[] = [];
+    const disposals: Disposal[] = [];
+
     if (pc) {
       for (const pred of pc.predictions) {
         const predCollateral = BigInt(pred.predictorCollateral);
         const cpCollateral = BigInt(pred.counterpartyCollateral);
         const predictionTotal = predCollateral + cpCollateral;
-        if (r.isPredictorToken && pred.predictor === r.holder) {
-          predictionId = pred.predictionId;
-          userCollateral += predCollateral;
-          totalPayout += predictionTotal;
-        } else if (!r.isPredictorToken && pred.counterparty === r.holder) {
-          predictionId = pred.predictionId;
-          userCollateral += cpCollateral;
-          totalPayout += predictionTotal;
-        }
+        const isHolderSide =
+          (r.isPredictorToken && pred.predictor === r.holder) ||
+          (!r.isPredictorToken && pred.counterparty === r.holder);
+        if (!isHolderSide) continue;
+        predictionId ??= pred.predictionId;
+        totalPayout += predictionTotal;
+        // Mint amount on both sides equals total collateral pool (see
+        // PredictionMarketEscrow.sol). Cost is just the holder's share.
+        const cost = r.isPredictorToken ? predCollateral : cpCollateral;
+        acquires.push({
+          ts: pred.createdAt.getTime() / 1000,
+          cost,
+          shares: predictionTotal,
+        });
       }
     }
-    return {
-      id: r.id,
-      chainId: r.chainId,
-      tokenAddress: r.tokenAddress,
-      pickConfigId: r.pickConfigId,
-      isPredictorToken: r.isPredictorToken,
-      holder: r.holder,
-      balance: r.balance,
-      userCollateral: userCollateral > 0n ? userCollateral.toString() : null,
-      totalPayout: totalPayout > 0n ? totalPayout.toString() : null,
-      createdAt: r.createdAt,
-      updatedAt: r.updatedAt,
-      pickConfig: pc ? mapPickConfig(pc, { predictionId }) : null,
+
+    const k = positionKey(r.chainId, r.tokenAddress, r.holder);
+    for (const t of tradesByPos.get(k) ?? []) {
+      const price = BigInt(t.price);
+      const shares = BigInt(t.tokenAmount);
+      if (t.buyer === r.holder) {
+        acquires.push({ ts: t.executedAt, cost: price, shares });
+      }
+      if (t.seller === r.holder) {
+        disposals.push({
+          kind: 'sell',
+          idStr: t.tradeHash,
+          ts: t.executedAt,
+          proceeds: price,
+          shares,
+        });
+      }
+    }
+    for (const c of claimsByPos.get(k) ?? []) {
+      disposals.push({
+        kind: 'claim',
+        idStr: String(c.id),
+        ts: c.redeemedAt,
+        proceeds: BigInt(c.collateralPaid),
+        shares: BigInt(c.tokensBurned),
+      });
+    }
+
+    const acquiresSorted = [...acquires].sort((a, b) => a.ts - b.ts);
+    const disposalsSorted = [...disposals].sort((a, b) => a.ts - b.ts);
+
+    // Walk acquires + disposals in chronological order, maintaining running
+    // WAC. Each disposal records the cost basis allocated to its shares
+    // using the WAC at that moment.
+    let costPool = 0n;
+    let sharesPool = 0n;
+    let acqIdx = 0;
+    type DisposalRow = {
+      kind: 'sell' | 'claim';
+      idStr: string;
+      ts: number;
+      proceeds: bigint;
+      shares: bigint;
+      costBasis: bigint;
     };
-  });
+    const disposalRows: DisposalRow[] = [];
+    for (const d of disposalsSorted) {
+      while (
+        acqIdx < acquiresSorted.length &&
+        acquiresSorted[acqIdx].ts <= d.ts
+      ) {
+        costPool += acquiresSorted[acqIdx].cost;
+        sharesPool += acquiresSorted[acqIdx].shares;
+        acqIdx += 1;
+      }
+      const allocated =
+        sharesPool > 0n ? (costPool * d.shares) / sharesPool : 0n;
+      disposalRows.push({ ...d, costBasis: allocated });
+      costPool -= allocated;
+      sharesPool -= d.shares;
+      if (sharesPool < 0n) sharesPool = 0n;
+      if (costPool < 0n) costPool = 0n;
+    }
+    while (acqIdx < acquiresSorted.length) {
+      costPool += acquiresSorted[acqIdx].cost;
+      sharesPool += acquiresSorted[acqIdx].shares;
+      acqIdx += 1;
+    }
+
+    const totalUserCollateral = acquires.reduce((s, a) => s + a.cost, 0n);
+    const totalPayoutStr = totalPayout > 0n ? totalPayout.toString() : null;
+    const mappedPickConfig = pc ? mapPickConfig(pc, { predictionId }) : null;
+    const balanceBn = BigInt(r.balance);
+    const isResolved = pc?.resolved ?? false;
+
+    // Emit one synthetic row per disposal (only meaningful for unresolved
+    // pickConfigs — once settled, the existing PnL flow takes over).
+    if (!isResolved) {
+      for (const d of disposalRows) {
+        synthesized.push({
+          id: `${r.id}-${d.kind}-${d.idStr}`,
+          chainId: r.chainId,
+          tokenAddress: r.tokenAddress,
+          pickConfigId: r.pickConfigId,
+          isPredictorToken: r.isPredictorToken,
+          holder: r.holder,
+          balance: '0',
+          userCollateral: d.costBasis.toString(),
+          totalPayout: totalPayoutStr,
+          realizedPnL: (d.proceeds - d.costBasis).toString(),
+          createdAt: r.createdAt,
+          updatedAt: new Date(d.ts * 1000),
+          pickConfig: mappedPickConfig,
+        });
+      }
+    }
+
+    // Open / parent row: keep when there's still balance OR when we didn't
+    // emit any disposals (preserves today's behavior for never-traded and
+    // resolved positions).
+    if (balanceBn > 0n || disposalRows.length === 0 || isResolved) {
+      const remainingCost =
+        !isResolved && disposalRows.length > 0 ? costPool : totalUserCollateral;
+      synthesized.push({
+        id: String(r.id),
+        chainId: r.chainId,
+        tokenAddress: r.tokenAddress,
+        pickConfigId: r.pickConfigId,
+        isPredictorToken: r.isPredictorToken,
+        holder: r.holder,
+        balance: r.balance,
+        userCollateral: remainingCost > 0n ? remainingCost.toString() : null,
+        totalPayout: totalPayoutStr,
+        realizedPnL: null,
+        createdAt: r.createdAt,
+        updatedAt: r.updatedAt,
+        pickConfig: mappedPickConfig,
+      });
+    }
+  }
+  return synthesized;
 };
 
 export const closes: NonNullable<QueryResolvers['closes']> = async (

--- a/packages/api/src/graphql/sdl/schema/schema.graphql
+++ b/packages/api/src/graphql/sdl/schema/schema.graphql
@@ -1318,10 +1318,11 @@ type Position {
   chainId: Int!
   createdAt: DateTimeISO!
   holder: String!
-  id: Int!
+  id: String!
   isPredictorToken: Boolean!
   pickConfig: PickConfiguration
   pickConfigId: String!
+  realizedPnL: String
   tokenAddress: String!
   totalPayout: String
   updatedAt: DateTimeISO!

--- a/packages/app/src/components/positions/PositionSummary.tsx
+++ b/packages/app/src/components/positions/PositionSummary.tsx
@@ -407,7 +407,7 @@ export default function PositionSummary({
               {showHolder && (
                 <div className="space-y-1">
                   <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
-                    Holder
+                    Account
                   </div>
                   <div className="inline-flex items-center gap-1.5 text-sm md:text-base font-medium tabular-nums text-foreground">
                     <Link

--- a/packages/app/src/components/positions/PositionsTable.tsx
+++ b/packages/app/src/components/positions/PositionsTable.tsx
@@ -117,12 +117,30 @@ function PositionRow({
     ((isPredictorToken && result === 'COUNTERPARTY_WINS') ||
       (!isPredictorToken && result === 'PREDICTOR_WINS'));
 
-  // PnL: profit if won (payout - positionSize), loss if lost (-positionSize)
+  // Per-disposal synthetic rows have ids like `${dbId}-sell-...` or
+  // `${dbId}-claim-...`; the open / parent row is just `${dbId}`.
+  const disposalKind: 'SOLD' | 'REDEEMED' | null = position.id.includes(
+    '-sell-'
+  )
+    ? 'SOLD'
+    : position.id.includes('-claim-')
+      ? 'REDEEMED'
+      : null;
+  const isClosed = !isResolved && BigInt(position.balance) === 0n;
+  const realizedPnLFormatted =
+    position.realizedPnL != null
+      ? parseFloat(formatEther(BigInt(position.realizedPnL)))
+      : null;
+
+  // PnL: profit if won (payout - positionSize), loss if lost (-positionSize),
+  // or the resolver-computed realized value for closed-but-unresolved positions.
   const pnlValue = isResolved
     ? holderWon
       ? payoutFormatted - positionSizeFormatted
       : -positionSizeFormatted
-    : null;
+    : isClosed
+      ? realizedPnLFormatted
+      : null;
   const roi =
     pnlValue !== null && positionSizeFormatted > 0
       ? (pnlValue / positionSizeFormatted) * 100
@@ -252,6 +270,35 @@ function PositionRow({
       );
     }
 
+    // Closed (balance=0, unresolved) → realized PnL from secondary trades + claims
+    if (isClosed && pnlValue !== null) {
+      const colorClass =
+        pnlValue > 0
+          ? 'text-green-500'
+          : pnlValue < 0
+            ? 'text-red-500'
+            : 'text-muted-foreground';
+      return (
+        <div
+          className={`whitespace-nowrap tabular-nums font-mono flex items-baseline gap-1.5 ${colorClass}`}
+        >
+          <NumberDisplay
+            value={pnlValue}
+            className={`tabular-nums font-mono ${colorClass}`}
+          />{' '}
+          <span className={colorClass}>{collateralSymbol}</span>
+          {positionSizeFormatted > 0 && (
+            <span
+              className={`text-[10px] leading-tight tabular-nums font-mono ${colorClass}`}
+            >
+              {roi >= 0 ? '+' : ''}
+              {Math.round(roi).toLocaleString()}%
+            </span>
+          )}
+        </div>
+      );
+    }
+
     // Not resolved → PENDING + optional Sell button
     return (
       <div className="flex items-center gap-2">
@@ -275,12 +322,19 @@ function PositionRow({
   return (
     <TableRow>
       <TableCell>
-        <PicksSummary
-          picks={picks}
-          predictionId={pickConfig?.predictionId}
-          onClick={onOpenDialog}
-        />
-        {pickConfig?.isLegacy && <LegacyBadge />}
+        <div className="flex items-center gap-2 flex-wrap">
+          <PicksSummary
+            picks={picks}
+            predictionId={pickConfig?.predictionId}
+            onClick={onOpenDialog}
+          />
+          {pickConfig?.isLegacy && <LegacyBadge />}
+          {disposalKind && (
+            <span className="inline-flex items-center px-1.5 py-0.5 text-xs font-medium !rounded-md shrink-0 font-mono uppercase border border-muted-foreground/40 bg-muted/20 text-muted-foreground">
+              {disposalKind}
+            </span>
+          )}
+        </div>
       </TableCell>
       <TableCell>
         <NumberDisplay

--- a/packages/app/src/components/positions/PositionsTable.tsx
+++ b/packages/app/src/components/positions/PositionsTable.tsx
@@ -56,6 +56,15 @@ import { useSession } from '~/lib/context/SessionContext';
 import SellPositionDialog from '~/components/secondary/SellPositionDialog';
 import { useFeatureFlag } from '~/hooks/useFeatureFlag';
 
+// Render an ROI percentage with sign. Sub-1%-magnitude non-zero values
+// collapse to "<1%" so a 0.4% gain doesn't render as "+0%". Color carries
+// the direction at the call site, so the sign on tiny values is omitted.
+const formatRoi = (roi: number): string => {
+  if (roi !== 0 && Math.abs(roi) < 1) return '<1%';
+  const sign = roi >= 0 ? '+' : '';
+  return `${sign}${Math.round(roi).toLocaleString()}%`;
+};
+
 function PositionRow({
   position,
   collateralSymbol,
@@ -201,8 +210,7 @@ function PositionRow({
             <span
               className={`text-[10px] leading-tight tabular-nums font-mono ${pnlValue >= 0 ? 'text-green-500' : 'text-red-500'}`}
             >
-              {roi >= 0 ? '+' : ''}
-              {Math.round(roi).toLocaleString()}%
+              {formatRoi(roi)}
             </span>
           )}
         </div>
@@ -241,7 +249,7 @@ function PositionRow({
           <span className="text-green-500">{collateralSymbol}</span>
           {positionSizeFormatted > 0 && (
             <span className="text-[10px] leading-tight tabular-nums font-mono text-green-500">
-              +{Math.round(roi).toLocaleString()}%
+              {formatRoi(roi)}
             </span>
           )}
         </div>
@@ -285,8 +293,7 @@ function PositionRow({
             <span
               className={`text-[10px] leading-tight tabular-nums font-mono ${colorClass}`}
             >
-              {roi >= 0 ? '+' : ''}
-              {Math.round(roi).toLocaleString()}%
+              {formatRoi(roi)}
             </span>
           )}
         </div>

--- a/packages/app/src/components/positions/PositionsTable.tsx
+++ b/packages/app/src/components/positions/PositionsTable.tsx
@@ -117,15 +117,9 @@ function PositionRow({
     ((isPredictorToken && result === 'COUNTERPARTY_WINS') ||
       (!isPredictorToken && result === 'PREDICTOR_WINS'));
 
-  // Per-disposal synthetic rows have ids like `${dbId}-sell-...` or
-  // `${dbId}-claim-...`; the open / parent row is just `${dbId}`.
-  const disposalKind: 'SOLD' | 'REDEEMED' | null = position.id.includes(
-    '-sell-'
-  )
-    ? 'SOLD'
-    : position.id.includes('-claim-')
-      ? 'REDEEMED'
-      : null;
+  // Synthetic sell rows have ids like `${dbId}-sell-${tradeHash}`; the open
+  // / parent row is just `${dbId}`.
+  const isSoldRow = position.id.includes('-sell-');
   const isClosed = !isResolved && BigInt(position.balance) === 0n;
   const realizedPnLFormatted =
     position.realizedPnL != null
@@ -329,9 +323,9 @@ function PositionRow({
             onClick={onOpenDialog}
           />
           {pickConfig?.isLegacy && <LegacyBadge />}
-          {disposalKind && (
+          {isSoldRow && (
             <span className="inline-flex items-center px-1.5 py-0.5 text-xs font-medium !rounded-md shrink-0 font-mono uppercase border border-muted-foreground/40 bg-muted/20 text-muted-foreground">
-              {disposalKind}
+              SOLD
             </span>
           )}
         </div>

--- a/packages/app/src/components/positions/__tests__/PositionDialog.test.tsx
+++ b/packages/app/src/components/positions/__tests__/PositionDialog.test.tsx
@@ -187,7 +187,7 @@ describe('PositionDialog', () => {
       />
     );
 
-    expect(screen.getByText('Holder')).toBeInTheDocument();
+    expect(screen.getByText('Account')).toBeInTheDocument();
     // AddressDisplay renders the address in a truncated form; its link href
     // is the full holder address → profile page.
     const profileLink = screen.getByRole('link', { name: /0x1f5f/i });

--- a/packages/app/src/components/profile/pages/ProfilePageContent.tsx
+++ b/packages/app/src/components/profile/pages/ProfilePageContent.tsx
@@ -116,7 +116,7 @@ const ProfilePageContent = ({
   );
 
   return (
-    <div className="mx-auto pb-0 px-3 md:px-6 lg:px-8 w-full pt-4 md:pt-0">
+    <div className="mx-auto pb-3 md:pb-6 lg:pb-8 px-3 md:px-6 lg:px-8 w-full pt-4 md:pt-0">
       <ShareAfterRedirect address={address} />
       <div className="mb-6 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
         <ProfileHeader address={address} className="mb-0" />

--- a/packages/app/src/hooks/graphql/usePositions.ts
+++ b/packages/app/src/hooks/graphql/usePositions.ts
@@ -68,7 +68,7 @@ export type PickConfigData = {
  * Position Balance - ERC20 token balance for a user
  */
 export type PositionBalance = {
-  id: number;
+  id: string;
   chainId: number;
   tokenAddress: string;
   pickConfigId: string;
@@ -77,6 +77,7 @@ export type PositionBalance = {
   balance: string;
   userCollateral?: string | null;
   totalPayout?: string | null;
+  realizedPnL?: string | null;
   createdAt: string;
   updatedAt: string;
   pickConfig?: PickConfigData | null;
@@ -232,6 +233,7 @@ const POSITION_BALANCES_QUERY = /* GraphQL */ `
       balance
       userCollateral
       totalPayout
+      realizedPnL
       createdAt
       updatedAt
       pickConfig {
@@ -284,6 +286,7 @@ const POSITION_BALANCES_BY_CONDITION_QUERY = /* GraphQL */ `
       balance
       userCollateral
       totalPayout
+      realizedPnL
       createdAt
       updatedAt
       pickConfig {

--- a/packages/sdk/types/graphql.ts
+++ b/packages/sdk/types/graphql.ts
@@ -336,11 +336,7 @@ export type CategoryNullableRelationFilter = {
   isNot?: InputMaybe<CategoryWhereInput>;
 };
 
-/**
- * Protocol-wide statistics snapshot including vault metrics, volume, and PnL.
- * Cadence is controlled by the snapshot cron; periodPnL and periodVolume are
- * deltas over that interval.
- */
+/** Open-interest aggregated for a single category. */
 export type CategoryOpenInterest = {
   __typename?: 'CategoryOpenInterest';
   category: Category;
@@ -1470,10 +1466,11 @@ export type Position = {
   chainId: Scalars['Int']['output'];
   createdAt: Scalars['DateTimeISO']['output'];
   holder: Scalars['String']['output'];
-  id: Scalars['Int']['output'];
+  id: Scalars['String']['output'];
   isPredictorToken: Scalars['Boolean']['output'];
   pickConfig?: Maybe<PickConfiguration>;
   pickConfigId: Scalars['String']['output'];
+  realizedPnL?: Maybe<Scalars['String']['output']>;
   tokenAddress: Scalars['String']['output'];
   totalPayout?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTimeISO']['output'];
@@ -1551,6 +1548,11 @@ export type ProfitRank = {
   totalPnL: Scalars['String']['output'];
 };
 
+/**
+ * Protocol-wide statistics snapshot including vault metrics, volume, and PnL.
+ * Cadence is controlled by the snapshot cron; periodPnL and periodVolume are
+ * deltas over that interval.
+ */
 export type ProtocolStat = {
   __typename?: 'ProtocolStat';
   cumulativeVolume: Scalars['String']['output'];
@@ -1610,6 +1612,8 @@ export type Query = {
   conditions: Array<Condition>;
   /** Open interest aggregated per category — protocol-wide. Sums each ConditionGroup's pre-computed totalOpenInterest plus each ungrouped public condition's openInterest, returning categories with non-zero OI sorted descending. */
   openInterestByCategory: Array<CategoryOpenInterest>;
+  /** Open interest bucketed by time-to-resolution — protocol-wide. Each unsettled prediction's collateral falls into the bucket of its latest condition endTime; expired-but-pending predictions roll into the soonest bucket. */
+  openInterestByTimeToResolution: Array<TimeToResolutionBucket>;
   /** Look up a single pick configuration by ID */
   pickConfiguration?: Maybe<PickConfiguration>;
   /** Paginated list of pick configurations, filterable by chain, resolution status, and result */
@@ -2106,6 +2110,24 @@ export type TimeInterval =
   | 'HOUR'
   | 'MONTH'
   | 'WEEK';
+
+/**
+ * Open-interest aggregated by time-to-resolution bucket. Each unsettled
+ * prediction's collateral is bucketed by the latest endTime among the conditions
+ * it touches (the moment its OI can finally be claimed). One row per non-empty
+ * bucket, ordered from soonest (bucket = 1) to furthest out.
+ */
+export type TimeToResolutionBucket = {
+  __typename?: 'TimeToResolutionBucket';
+  /** Sort order: 1 = soonest, increasing for further-out buckets */
+  bucket: Scalars['Int']['output'];
+  /** Display label, e.g. "≤1d", "2-7d", "1-2mo"  */
+  label: Scalars['String']['output'];
+  /** Open interest in wei (decimal string) */
+  openInterest: Scalars['String']['output'];
+  /** Number of predictions contributing to this bucket */
+  predictionCount: Scalars['Int']['output'];
+};
 
 /** Secondary market trade record where position tokens are exchanged between users */
 export type Trade = {


### PR DESCRIPTION
## Summary
- Closed positions on the profile Positions tab no longer disappear — the resolver emits one synthetic row per secondary sale plus an Open row for any leftover balance, so users see the residual PnL of trades they've already exited.
- Cost basis is allocated using **running WAC** over a chronologically-merged event stream of `Prediction` mints and `SecondaryTrade` buys/sells. Mint-ratio confirmed via `PredictionMarketEscrow.sol:344-354`: both predictor and counterparty token mint amounts equal the total collateral pool, used as the WAC denominator from each Prediction.
- `Position.id` is now `String!` so synthetic ids (`{dbId}-sell-{tradeHash}`) have first-class identity. Frontend `PositionBalance.id` updated to match.
- Frontend: each sell row shows realized PnL in the P/L column with a green/red tint, and a `SOLD` badge inline with the picks summary (matching the `TypeBadge` style from `ActivityTable`). The `HOLDER` label in the position dialog is renamed to `ACCOUNT`. The profile page gets `pb-3 md:pb-6 lg:pb-8` mirroring its existing `px-*` gutters so the table cards have breathing room above the viewport edge.

## Visibility rules

| Scenario | Balance | Sells | Resolved | Rendered rows |
|---|---|---|---|---|
| Never sold, still open | > 0 | 0 | no | 1 (open, unchanged) |
| Transferred / burned off-platform | 0 | 0 | no | 0 (hidden, matches prior behavior) |
| Settled (with or without claim) | any | n/a | yes | 1 (existing settlement-PnL flow) |
| Partial secondary sale | > 0 | ≥1 | no | N SOLD + 1 open with remaining balance/cost |
| Full secondary sale | 0 | ≥1 | no | N SOLD rows, no open row |

`Claim` is intentionally not rendered as its own row: `redeem()` reverts unless `config.resolved`, so any claim is post-settlement and the existing settlement-PnL flow on the resolved Position covers it.

## Schema changes (breaking)
- `Position.id`: `Int!` → `String!` to fit synthetic ids. Any external GraphQL consumer or persisted Apollo cache holding a numeric `Position.id` will need to update.
- `Position.realizedPnL: String` (new, nullable) — wei-encoded decimal string consistent with `userCollateral` / `totalPayout`. Populated only on synthetic sell rows.

## Pagination semantics
`positions(take, skip)` paginates underlying Position rows; with sell expansion a single page can render more rows than `take`. `positionCount` mirrors the visibility rule (drops zero-balance unresolved rows) but counts underlying positions, not rendered rows.

## Tests
Vitest unit suite at `packages/api/src/graphql/sdl/resolvers/queries/escrow.test.ts` covers: never-sold open row, full sale, partial sale + remaining open row, multi-mint cost-basis aggregation, buy-then-sell WAC, transferred-away (zero rows), resolved pass-through, counterparty-side cost basis, cross-position recency ordering, and `positionCount`'s exclusion filter.

## Manual test plan
- [ ] Open the profile of an address that has fully sold a position via secondary — verify a `SOLD` row appears with realized PnL = sale proceeds − cost basis
- [ ] Open the profile of an address that partially sold — verify N `SOLD` rows appear plus one Open row with remaining balance and remaining cost basis as Position Size
- [ ] Confirm a never-traded open position still renders as a single Open row with `PENDING` and a `Sell` button
- [ ] Confirm a settled position is unchanged (single row, existing settlement-PnL flow)
- [ ] Verify the position dialog shows `ACCOUNT` instead of `HOLDER`
- [ ] Verify all three profile tabs (Positions / Forecasts / Activity) have visible bottom space matching the side gutters