### PR TITLE
fix(api): drop trailing space in TimeToResolutionBucket.label description

### DIFF
--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -1746,7 +1746,7 @@ type TimeToResolutionBucket {
   """Sort order: 1 = soonest, increasing for further-out buckets"""
   bucket: Int!
 
-  """Display label, e.g. "≤1d", "2-7d", "1-2mo" """
+  """Display label, e.g. ≤1d / 2-7d / 1-2mo"""
   label: String!
 
   """Open interest in wei (decimal string)"""

--- a/packages/api/src/graphql/sdl/schema/schema.graphql
+++ b/packages/api/src/graphql/sdl/schema/schema.graphql
@@ -1423,7 +1423,7 @@ bucket, ordered from soonest (bucket = 1) to furthest out.
 type TimeToResolutionBucket {
   """Sort order: 1 = soonest, increasing for further-out buckets"""
   bucket: Int!
-  """Display label, e.g. "≤1d", "2-7d", "1-2mo" """
+  """Display label, e.g. ≤1d / 2-7d / 1-2mo"""
   label: String!
   """Open interest in wei (decimal string)"""
   openInterest: String!

--- a/packages/api/test/contract/__snapshots__/introspection.json
+++ b/packages/api/test/contract/__snapshots__/introspection.json
@@ -18195,7 +18195,7 @@
           },
           {
             "name": "label",
-            "description": "Display label, e.g. \"≤1d\", \"2-7d\", \"1-2mo\" ",
+            "description": "Display label, e.g. ≤1d / 2-7d / 1-2mo",
             "args": [],
             "type": {
               "kind": "NON_NULL",

--- a/packages/api/test/contract/__snapshots__/schema.sdl.graphql
+++ b/packages/api/test/contract/__snapshots__/schema.sdl.graphql
@@ -1746,7 +1746,7 @@ type TimeToResolutionBucket {
   """Sort order: 1 = soonest, increasing for further-out buckets"""
   bucket: Int!
 
-  """Display label, e.g. "≤1d", "2-7d", "1-2mo" """
+  """Display label, e.g. ≤1d / 2-7d / 1-2mo"""
   label: String!
 
   """Open interest in wei (decimal string)"""

--- a/packages/sdk/types/graphql.ts
+++ b/packages/sdk/types/graphql.ts
@@ -2121,7 +2121,7 @@ export type TimeToResolutionBucket = {
   __typename?: 'TimeToResolutionBucket';
   /** Sort order: 1 = soonest, increasing for further-out buckets */
   bucket: Scalars['Int']['output'];
-  /** Display label, e.g. "≤1d", "2-7d", "1-2mo"  */
+  /** Display label, e.g. ≤1d / 2-7d / 1-2mo */
   label: Scalars['String']['output'];
   /** Open interest in wei (decimal string) */
   openInterest: Scalars['String']['output'];


### PR DESCRIPTION
## Summary
The introspection contract test was still failing on Staging→main CI ([run 25078055620](https://github.com/sapiencexyz/sapience/actions/runs/25078055620)) on a single character — a trailing space inside a SDL block-string description.

\`\`\`
- "Display label, e.g. \"≤1d\", \"2-7d\", \"1-2mo\" "
+ "Display label, e.g. \"≤1d\", \"2-7d\", \"1-2mo\""
\`\`\`

The original SDL had ` \`\`\`Display label, e.g. \"≤1d\", \"2-7d\", \"1-2mo\" \`\`\` ` — note the trailing space before the closing delimiter, which sits next to a quote. Local GraphQL block-string parsing preserved that trailing space; CI's stripped it, and the snapshot kept drifting.

Rewrote the description as ` \`\`\`Display label, e.g. ≤1d / 2-7d / 1-2mo\`\`\` ` — no quote-then-space adjacency to confuse parsers, same documentation intent. Regenerated `schema.graphql`, `sdk/types/graphql.ts`, and the introspection / schema-SDL snapshots.

## Verification
- `pnpm --filter @sapience/api run test:contract` — 18/18 pass