### PR TITLE
docs: unify bug bounty disclosure process

### DIFF
--- a/packages/docs/docs/pages/user-guide/other-resources/bugbounty.mdx
+++ b/packages/docs/docs/pages/user-guide/other-resources/bugbounty.mdx
@@ -7,24 +7,12 @@ description: 'Sapience bug bounty program details and responsible disclosure pol
 
 Please allow reasonable time for remediation before any public disclosure.
 
-## Smart Contract Vulnerabilities
-
-Report smart contract and on-chain protocol vulnerabilities through our [Immunefi bug bounty program](https://immunefi.com/bug-bounty/sapience/information/). Rewards are paid according to the severity guidelines published there.
-
-## Offchain Vulnerabilities
-
 Sapience is [open source](https://github.com/sapiencexyz/sapience). Nothing stored in the database is considered private — all data is either sourced from or derived from public on-chain state.
-To report an offchain vulnerability:
+
+To report a vulnerability:
 
 1. **Open a support ticket** in [Discord](https://discord.gg/sapience) to let us know. If you're unsure whether something qualifies, reach out first.
 2. **Write a failing test** that demonstrates the issue.
 3. **Submit a pull request** with both the test and your fix so the test passes.
 
 We will review submissions and reward based on severity at our discretion.
-
-### Out of Scope
-
-- Frontend typos or cosmetic issues
-- Social engineering or phishing
-- Spam or rate-limiting
-- Publicly known vulnerabilities in third-party dependencies


### PR DESCRIPTION
## Summary
- Remove Immunefi as the smart-contract / on-chain protocol disclosure path
- Apply the same Discord ticket → failing test → PR flow to all vulnerability reports (on-chain and offchain)
- Drop the Out of Scope list

## Test plan
- [ ] Visit `/user-guide/other-resources/bugbounty` and confirm copy reads as intended