### PR TITLE
fix(app): canonical picks in mint payload + surface UserOp reverts

### DIFF
--- a/packages/app/src/components/markets/CreatePositionForm/index.tsx
+++ b/packages/app/src/components/markets/CreatePositionForm/index.tsx
@@ -699,14 +699,25 @@ const CreatePositionFormInner = ({
           // from the auction params (threaded when user clicked "Use" on the sponsor indicator).
           // No manual override needed — it must match what the counterparty signed over.
 
+          // Open the progress dialog immediately so the user sees feedback the moment
+          // they click submit, instead of staring at a frozen button while the mint
+          // signs, simulates, and submits. The dialog tracks `progressState` and
+          // advances through SUBMITTING → INDEXING → COMPLETE on its own.
+          setShareDialogData(dialogData);
+          setShowShareDialog(true);
+          startSubmission();
+
           // Submit the mint request (includes Tier 3 simulation before sending tx).
-          // Only show share dialog and close form if submission succeeds.
           const success = await submitPosition(mintReq);
 
           if (success) {
-            setShareDialogData(dialogData);
-            setShowShareDialog(true);
             setIsPopoverOpen(false);
+          } else {
+            // Submission failed — close the progress dialog and reset state so
+            // the user can retry. The error toast is surfaced by submitPosition.
+            setShowShareDialog(false);
+            setShareDialogData(null);
+            resetProgress();
           }
           return;
         }
@@ -720,6 +731,9 @@ const CreatePositionFormInner = ({
         duration: 5000,
       });
     } catch {
+      setShowShareDialog(false);
+      setShareDialogData(null);
+      resetProgress();
       toast({
         title: 'Submission error',
         description: 'An error occurred while submitting your prediction.',

--- a/packages/app/src/hooks/blockchain/transactionExecutor.test.ts
+++ b/packages/app/src/hooks/blockchain/transactionExecutor.test.ts
@@ -257,9 +257,14 @@ describe('resolveEoaBatchResult', () => {
 describe('executeViaSessionKeyDefault', () => {
   const mockEncodeCalls = vi.fn().mockResolvedValue('0xencoded');
   const mockSendUserOperation = vi.fn().mockResolvedValue('0xuserophash');
+  const mockWaitForReceipt = vi.fn().mockResolvedValue({
+    success: true,
+    receipt: { transactionHash: '0xtxhash' },
+  });
   const mockClient: SessionClient = {
     account: { encodeCalls: mockEncodeCalls },
     sendUserOperation: mockSendUserOperation,
+    waitForUserOperationReceipt: mockWaitForReceipt,
   };
 
   beforeEach(() => {
@@ -307,9 +312,25 @@ describe('executeViaSessionKeyDefault', () => {
     ).rejects.toThrow(/Session expired/);
   });
 
+  it('throws when UserOp reverts on-chain and surfaces the revert reason', async () => {
+    mockWaitForReceipt.mockResolvedValueOnce({
+      success: false,
+      reason: 'CounterpartyDeadlineExceeded',
+      receipt: { transactionHash: '0xreverttx' },
+    });
+    const onReceiptConfirmed = vi.fn();
+    await expect(
+      executeViaSessionKeyDefault(mockClient, [], CHAIN_ID_ETHEREAL, {
+        onReceiptConfirmed,
+      })
+    ).rejects.toThrow(/CounterpartyDeadlineExceeded/);
+    expect(onReceiptConfirmed).not.toHaveBeenCalled();
+  });
+
   it('throws if account is missing', async () => {
     const noAccountClient: SessionClient = {
       sendUserOperation: mockSendUserOperation,
+      waitForUserOperationReceipt: mockWaitForReceipt,
     };
     await expect(
       executeViaSessionKeyDefault(noAccountClient, [], CHAIN_ID_ETHEREAL, {})
@@ -339,6 +360,7 @@ describe('executeTransaction', () => {
           sessionClient: {
             account: { encodeCalls: vi.fn() },
             sendUserOperation: vi.fn(),
+            waitForUserOperationReceipt: vi.fn(),
           },
           executeViaSessionKey,
         }
@@ -353,6 +375,7 @@ describe('executeTransaction', () => {
       const newClient: SessionClient = {
         account: { encodeCalls: vi.fn() },
         sendUserOperation: vi.fn(),
+        waitForUserOperationReceipt: vi.fn(),
       };
       const createArbitrumSessionIfNeeded = vi
         .fn()
@@ -400,6 +423,7 @@ describe('executeTransaction', () => {
           sessionClient: {
             account: { encodeCalls: vi.fn() },
             sendUserOperation: vi.fn(),
+            waitForUserOperationReceipt: vi.fn(),
           },
           executeViaSessionKey,
         })

--- a/packages/app/src/hooks/blockchain/transactionExecutor.ts
+++ b/packages/app/src/hooks/blockchain/transactionExecutor.ts
@@ -41,11 +41,20 @@ export interface WriteContractParams {
   chainId?: number;
 }
 
+export interface UserOperationReceipt {
+  success: boolean;
+  reason?: string;
+  receipt: { transactionHash: Hash };
+}
+
 export interface SessionClient {
   account?: {
     encodeCalls: (calls: TransactionCall[]) => Promise<Hex>;
   };
   sendUserOperation: (params: { callData: Hex }) => Promise<Hash>;
+  waitForUserOperationReceipt: (params: {
+    hash: Hash;
+  }) => Promise<UserOperationReceipt>;
 }
 
 export interface SessionConfig {
@@ -267,6 +276,25 @@ export async function executeViaSessionKeyDefault(
   });
 
   deps.onTxSent?.(userOpHash);
+
+  // Wait for the UserOp to be included on-chain so we can surface execution
+  // reverts to the caller. Without this, a reverted UserOp returns silently
+  // and the UI hangs (e.g. "INDEXING POSITION..." forever) because the
+  // indexer never sees the position.
+  const receipt = await sessionClient.waitForUserOperationReceipt({
+    hash: userOpHash,
+  });
+
+  if (!receipt.success) {
+    const txHash = receipt.receipt?.transactionHash;
+    const detail = receipt.reason
+      ? `: ${receipt.reason}`
+      : txHash
+        ? ` (tx ${txHash})`
+        : '';
+    throw new Error(`Transaction reverted onchain${detail}`);
+  }
+
   deps.onReceiptConfirmed?.();
 
   return userOpHash;

--- a/packages/app/src/hooks/blockchain/useSapienceWriteContract.ts
+++ b/packages/app/src/hooks/blockchain/useSapienceWriteContract.ts
@@ -387,9 +387,7 @@ export function useSapienceWriteContract({
           onReceiptConfirmed,
         }
       );
-      console.log(
-        `[SessionTx] Total: ${Date.now() - startTime}ms (skipping on-chain wait)`
-      );
+      console.log(`[SessionTx] Total: ${Date.now() - startTime}ms`);
       return hash;
     },
     [sessionConfig, onTxSending, onTxSent, onReceiptConfirmed]

--- a/packages/app/src/lib/auction/useAuctionStart.ts
+++ b/packages/app/src/lib/auction/useAuctionStart.ts
@@ -8,6 +8,7 @@ import {
   prepareAuctionRFQ,
   type SignableTypedData,
 } from '@sapience/sdk/auction/initiate';
+import { canonicalizePicks } from '@sapience/sdk/auction/escrowEncoding';
 import { useSettings } from '~/lib/context/SettingsContext';
 import { useSession } from '~/lib/context/SessionContext';
 import { toAuctionWsUrl } from '~/lib/ws/auctionUrl';
@@ -369,12 +370,32 @@ export function useAuctionStart(options?: UseAuctionStartOptions) {
         ? (effectiveAddressRef.current ?? params.predictor)
         : (walletAddress ?? params.predictor);
 
+      // Canonicalize picks once up-front: bidders sign over the canonical
+      // (keccak256-sorted) order shipped by prepareAuctionRFQ, so every
+      // downstream consumer (mint payload, off-chain validation, indexer
+      // tracking) must agree on that order or predictionHash diverges and the
+      // counterparty signature won't validate. Doing this here guarantees
+      // currentAuctionParams, lastAuctionRef, and the RFQ all use the same
+      // pick order.
+      const canonicalizedParamPicks: AuctionParams['picks'] =
+        params.picks && params.picks.length > 0
+          ? canonicalizePicks(params.picks as Pick[]).map((p) => ({
+              conditionResolver: p.conditionResolver,
+              conditionId: p.conditionId,
+              predictedOutcome: p.predictedOutcome,
+            }))
+          : params.picks;
+      const canonicalizedParams: AuctionParams = {
+        ...params,
+        picks: canonicalizedParamPicks,
+      };
+
       const requestPayload = {
-        wager: params.wager,
-        picks: params.picks,
+        wager: canonicalizedParams.wager,
+        picks: canonicalizedParams.picks,
         predictor: effectivePredictor,
-        predictorNonce: params.predictorNonce,
-        chainId: params.chainId,
+        predictorNonce: canonicalizedParams.predictorNonce,
+        chainId: canonicalizedParams.chainId,
       };
 
       const key = jsonStableStringify({
@@ -397,10 +418,19 @@ export function useAuctionStart(options?: UseAuctionStartOptions) {
       setBids([]);
       pendingBidsRef.current.clear();
       // Store params with effectivePredictor so buildMintRequestDataFromBid uses the correct address
-      lastAuctionRef.current = { ...params, predictor: effectivePredictor };
-      setCurrentAuctionParams({ ...params, predictor: effectivePredictor });
+      lastAuctionRef.current = {
+        ...canonicalizedParams,
+        predictor: effectivePredictor,
+      };
+      setCurrentAuctionParams({
+        ...canonicalizedParams,
+        predictor: effectivePredictor,
+      });
 
-      if (!params.picks || params.picks.length === 0) {
+      if (
+        !canonicalizedParams.picks ||
+        canonicalizedParams.picks.length === 0
+      ) {
         console.error(
           '[Auction] Escrow picks missing — all auctions require escrow format'
         );
@@ -408,7 +438,7 @@ export function useAuctionStart(options?: UseAuctionStartOptions) {
         return;
       }
 
-      const chainId = params.chainId;
+      const chainId = canonicalizedParams.chainId;
 
       // Build the signed auction payload via SDK
       // prepareAuctionRFQ handles: pick canonicalization, deadline computation,
@@ -428,21 +458,20 @@ export function useAuctionStart(options?: UseAuctionStartOptions) {
 
       let escrowPayload: Record<string, unknown>;
       let predictorDeadline: number;
-      let canonicalPicks: Pick[];
 
       try {
         const prepared = await prepareAuctionRFQ({
-          picks: params.picks.map(
+          picks: canonicalizedParams.picks.map(
             (p): Pick => ({
               conditionResolver: p.conditionResolver,
               conditionId: p.conditionId,
               predictedOutcome: p.predictedOutcome,
             })
           ),
-          predictorCollateral: BigInt(params.wager),
+          predictorCollateral: BigInt(canonicalizedParams.wager),
           predictor: effectivePredictor,
           chainId,
-          nonce: params.predictorNonce,
+          nonce: canonicalizedParams.predictorNonce,
           signIntent: async (typedData: SignableTypedData): Promise<Hex> => {
             if (
               isUsingSessionRef.current &&
@@ -467,8 +496,8 @@ export function useAuctionStart(options?: UseAuctionStartOptions) {
           options: {
             deadlineSeconds: 30,
             skipIntentSigning: skipSigning,
-            predictorSponsor: params.predictorSponsor,
-            predictorSponsorData: params.predictorSponsorData,
+            predictorSponsor: canonicalizedParams.predictorSponsor,
+            predictorSponsorData: canonicalizedParams.predictorSponsorData,
             sessionKeyData: etherealSessionApprovalRef.current
               ? JSON.stringify({
                   approval: etherealSessionApprovalRef.current.approval,
@@ -482,7 +511,6 @@ export function useAuctionStart(options?: UseAuctionStartOptions) {
 
         escrowPayload = prepared.payload as unknown as Record<string, unknown>;
         predictorDeadline = prepared.deadline;
-        canonicalPicks = prepared.canonicalPicks;
 
         if (prepared.payload.intentSignature) {
           log(
@@ -497,17 +525,11 @@ export function useAuctionStart(options?: UseAuctionStartOptions) {
         return;
       }
 
-      // Store predictorDeadline on the auction ref so buildMintRequestDataFromBid can access it.
-      // Also overwrite picks with the canonical ordering used by prepareAuctionRFQ — bidders
-      // sign over canonical picks, so the mint payload must use the same order or
-      // verifyMintPartySignature reverts with InvalidCounterpartySignature.
+      // Store predictorDeadline on the auction ref so buildMintRequestDataFromBid
+      // can access it. Picks were already canonicalized up-front and stamped
+      // into both lastAuctionRef and currentAuctionParams; nothing to overwrite.
       lastAuctionRef.current = {
         ...lastAuctionRef.current,
-        picks: canonicalPicks.map((p) => ({
-          conditionResolver: p.conditionResolver,
-          conditionId: p.conditionId,
-          predictedOutcome: p.predictedOutcome,
-        })),
         predictorDeadline,
       };
 

--- a/packages/app/src/lib/auction/useAuctionStart.ts
+++ b/packages/app/src/lib/auction/useAuctionStart.ts
@@ -377,17 +377,13 @@ export function useAuctionStart(options?: UseAuctionStartOptions) {
       // counterparty signature won't validate. Doing this here guarantees
       // currentAuctionParams, lastAuctionRef, and the RFQ all use the same
       // pick order.
-      const canonicalizedParamPicks: AuctionParams['picks'] =
-        params.picks && params.picks.length > 0
-          ? canonicalizePicks(params.picks as Pick[]).map((p) => ({
-              conditionResolver: p.conditionResolver,
-              conditionId: p.conditionId,
-              predictedOutcome: p.predictedOutcome,
-            }))
-          : params.picks;
       const canonicalizedParams: AuctionParams = {
         ...params,
-        picks: canonicalizedParamPicks,
+        picks: params.picks?.length
+          ? (canonicalizePicks(
+              params.picks as Pick[]
+            ) as AuctionParams['picks'])
+          : params.picks,
       };
 
       const requestPayload = {

--- a/packages/app/src/lib/auction/useAuctionStart.ts
+++ b/packages/app/src/lib/auction/useAuctionStart.ts
@@ -428,6 +428,7 @@ export function useAuctionStart(options?: UseAuctionStartOptions) {
 
       let escrowPayload: Record<string, unknown>;
       let predictorDeadline: number;
+      let canonicalPicks: Pick[];
 
       try {
         const prepared = await prepareAuctionRFQ({
@@ -481,6 +482,7 @@ export function useAuctionStart(options?: UseAuctionStartOptions) {
 
         escrowPayload = prepared.payload as unknown as Record<string, unknown>;
         predictorDeadline = prepared.deadline;
+        canonicalPicks = prepared.canonicalPicks;
 
         if (prepared.payload.intentSignature) {
           log(
@@ -495,9 +497,17 @@ export function useAuctionStart(options?: UseAuctionStartOptions) {
         return;
       }
 
-      // Store predictorDeadline on the auction ref so buildMintRequestDataFromBid can access it
+      // Store predictorDeadline on the auction ref so buildMintRequestDataFromBid can access it.
+      // Also overwrite picks with the canonical ordering used by prepareAuctionRFQ — bidders
+      // sign over canonical picks, so the mint payload must use the same order or
+      // verifyMintPartySignature reverts with InvalidCounterpartySignature.
       lastAuctionRef.current = {
         ...lastAuctionRef.current,
+        picks: canonicalPicks.map((p) => ({
+          conditionResolver: p.conditionResolver,
+          conditionId: p.conditionId,
+          predictedOutcome: p.predictedOutcome,
+        })),
         predictorDeadline,
       };
 


### PR DESCRIPTION
## Summary

- **Root-cause fix**: Multi-pick parlays were silently failing on-chain with `InvalidCounterpartySignature()` (selector `0x98595156`) for ~50% of orderings. `useAuctionStart` stored picks in the user's input order while the bidder/vault signed over the canonical (keccak256-sorted) order shipped by `prepareAuctionRFQ`. The on-chain `predictionHash` recomputed by `mint()` therefore diverged from what the counterparty signed. Fixed by writing `prepared.canonicalPicks` back into `lastAuctionRef.current.picks` so `buildMintRequestDataFromBid` produces a payload whose `predictionHash` matches the counterparty's signature.
- **Surface UserOp reverts**: `executeViaSessionKeyDefault` now awaits `waitForUserOperationReceipt` and throws on revert. Previously, a reverted UserOp returned silently and the UI hung on "INDEXING POSITION..." forever because the indexer never saw a position. Now the user gets a real error toast (`Transaction reverted onchain: <selector or reason>`).
- **Dialog UX**: The progress dialog opens immediately when the user clicks submit (in `SUBMITTING` stage) instead of after `submitPosition` resolves. On failure, dialog closes and progress resets so the user can retry.
- **Toast wording**: "Transaction reverted onchain" (no hyphen).
- **Regression test** in `transactionExecutor.test.ts` covers the new revert-surfacing behavior.

## Test plan

- [x] `pnpm --filter @sapience/app run type-check`
- [x] `pnpm --filter @sapience/app exec vitest run src/hooks/blockchain/transactionExecutor.test.ts` (38 passing)
- [x] Manually reproduced and confirmed fix: 2-pick parlay (Keiko Fujimori NO + Haley Stevens YES) submitted successfully against the mainnet `0x1f5fF6…` vault from a smart-account predictor. Same flow had reverted with `InvalidCounterpartySignature()` before this change.
- [ ] Verify on staging deploy that single-pick mints still work (canonicalization is a no-op there but worth confirming).
- [ ] Verify on staging that a forced revert still shows a clear toast and the dialog closes / lets the user retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)