### PR TITLE
fix(api): return empty stats for unknown vault address

### DIFF
--- a/packages/api/src/graphql/sdl/resolvers/queries/analytics.test.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/analytics.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetConfiguredVaults = vi.fn();
+const mockGetProtocolStatsTimeSeries = vi.fn();
+
+vi.mock('../../../../services/protocolStats', () => ({
+  getConfiguredVaults: mockGetConfiguredVaults,
+  getProtocolStatsTimeSeries: mockGetProtocolStatsTimeSeries,
+  resolveSnapshotIntervalSeconds: vi.fn(() => 86400),
+  calculateVaultAirdrops: vi.fn(),
+  calculateVaultFlows: vi.fn(),
+  calculateVaultPnL: vi.fn(),
+  calculateVaultSecondaryFlows: vi.fn(),
+  calculateVaultUnredeemedClaim: vi.fn(),
+  fetchVaultAvailableAssets: vi.fn(),
+  fetchVaultDeployed: vi.fn(),
+  fetchVaultTVL: vi.fn(),
+  sumEscrowBalancesAtBlock: vi.fn(),
+}));
+
+vi.mock('../../../../core/db', () => ({
+  default: {
+    $queryRaw: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../lib/utils', () => ({
+  getProviderForChain: vi.fn(),
+}));
+
+const { protocolStats } = await import('./analytics');
+
+describe('Query.protocolStats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetConfiguredVaults.mockReturnValue([
+      {
+        kind: 'protocol',
+        address: '0xprotocol',
+        config: {
+          address: '0xprotocol',
+          legacy: [],
+        },
+      },
+    ]);
+  });
+
+  it('returns [] for an unknown vaultAddress instead of falling back to all vaults', async () => {
+    const result = await protocolStats(
+      {} as never,
+      { vaultAddress: '0xdeadbeef' },
+      {} as never,
+      {} as never
+    );
+
+    expect(result).toEqual([]);
+    expect(mockGetProtocolStatsTimeSeries).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
@@ -81,6 +81,14 @@ export const protocolStats: NonNullable<
     : configuredVaults.find((v) => v.kind === 'protocol');
   const vaultConfig = targetVault?.config;
 
+  // An explicit vaultAddress that doesn't map to any configured vault family
+  // should yield no rows, not silently fall back to the unfiltered all-vault
+  // series. The empty-array sentinel below means "no matched addresses", while
+  // an omitted argument still uses the default protocol vault family.
+  if (vaultAddressArg && !targetVault) {
+    return [];
+  }
+
   // Filter the snapshot time series by the full address history of the chosen
   // vault — current primary plus every demoted-to-legacy address. Without
   // the legacies, every SDK redeploy would orphan the entire historical chart


### PR DESCRIPTION
## Why

`Query.protocolStats(vaultAddress: ...)` could treat an unknown vault address like an empty address filter and return mixed all-vault snapshots instead of `[]`. That makes bad inputs look like valid cross-vault data.

This blocks the staging -> main promotion in #1651.

## What

- return `[]` early when an explicit `vaultAddress` does not match any configured vault family
- add a regression test covering the unknown-vault path

## Verification

- `pnpm exec vitest run src/graphql/sdl/resolvers/queries/analytics.test.ts --pool=forks --poolOptions.forks.singleFork --reporter=verbose`
- `pnpm exec prettier --check src/graphql/sdl/resolvers/queries/analytics.ts src/graphql/sdl/resolvers/queries/analytics.test.ts`