### PR TITLE
fix(api): cast generated resolver to callable in analytics test

### DIFF
--- a/packages/api/src/graphql/sdl/resolvers/queries/analytics.test.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/analytics.test.ts
@@ -30,6 +30,14 @@ vi.mock('../../../../lib/utils', () => ({
 
 const { protocolStats } = await import('./analytics');
 
+type ProtocolStatsFn = (
+  parent: unknown,
+  args: { vaultAddress?: string | null },
+  ctx: unknown,
+  info: unknown
+) => Promise<unknown[]>;
+const protocolStatsFn = protocolStats as unknown as ProtocolStatsFn;
+
 describe('Query.protocolStats', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -46,7 +54,7 @@ describe('Query.protocolStats', () => {
   });
 
   it('returns [] for an unknown vaultAddress instead of falling back to all vaults', async () => {
-    const result = await protocolStats(
+    const result = await protocolStatsFn(
       {} as never,
       { vaultAddress: '0xdeadbeef' },
       {} as never,


### PR DESCRIPTION
## Summary
- `lint-api` and `test-api` have been red on `staging` since #1655 with `TS2349: This expression is not callable` at `analytics.test.ts:49:26`.
- Generated GraphQL resolver types are a union (`ResolverFn | StitchingResolver | { resolve, subscribe? }`), so calling the export directly fails type-check.
- Cast `protocolStats` to a plain function before invoking, mirroring the existing pattern in `collateralBalance.test.ts`.

## Test plan
- [x] `pnpm --filter @sapience/api run type-check`
- [x] `pnpm --filter @sapience/api run test src/graphql/sdl/resolvers/queries/analytics.test.ts`
- [ ] CI lint-api + test-api green