### PR TITLE
fix(api): replay legacy vaults in flow backfill

### DIFF
--- a/packages/api/scripts/backfillVaultFlows.ts
+++ b/packages/api/scripts/backfillVaultFlows.ts
@@ -1,10 +1,12 @@
 /**
  * One-shot backfill for vault_flow_event. Reads PendingRequestProcessed +
- * EmergencyWithdrawal events from chain for every configured vault (main,
- * Pyth options, single-leg) and writes rows tagged with the source vault.
+ * EmergencyWithdrawal events from chain for every configured vault deployment
+ * (current primaries plus legacy redeploys) and writes rows tagged with the
+ * source vault address.
  *
- * Why: no cron writes to this table today; it is regenerated manually after
- * schema changes or vault redeployments. Downstream consumers
+ * Why: live protocol-stats cron snapshots read the latest configured vaults,
+ * but this historical rebuild must replay every deployment because migrations
+ * can truncate vault_flow_event and downstream consumers
  * (protocol_stats_snapshot, airdrop gains, cumulative flows) re-derive from
  * these events.
  *
@@ -19,6 +21,7 @@ import { parseAbiItem } from 'viem';
 import prisma from '../src/core/db';
 import { getProviderForChain } from '../src/lib/utils';
 import { getConfiguredVaults } from '../src/services/protocolStats';
+import { normalizeLegacyEntry } from '@sapience/sdk/contracts';
 
 const CHAIN_ID = (() => {
   const eq = process.argv.find((a) => a.startsWith('--chainId='));
@@ -47,6 +50,38 @@ interface PreviewRow {
   user: string;
   assets: string;
   shares: string;
+}
+
+interface VaultDeployment {
+  kind: string;
+  address: string;
+  blockCreated: number;
+}
+
+function getVaultDeployments(chainId: number): VaultDeployment[] {
+  const deployments = new Map<string, VaultDeployment>();
+
+  for (const vault of getConfiguredVaults(chainId)) {
+    deployments.set(vault.address, {
+      kind: `${vault.kind}:current`,
+      address: vault.address,
+      blockCreated: vault.config.blockCreated,
+    });
+
+    for (const [index, legacy] of (vault.config.legacy ?? []).entries()) {
+      const normalized = normalizeLegacyEntry(legacy);
+      const address = normalized.address.toLowerCase();
+      deployments.set(address, {
+        kind: `${vault.kind}:legacy#${index + 1}`,
+        address,
+        blockCreated: normalized.blockCreated,
+      });
+    }
+  }
+
+  return [...deployments.values()].sort(
+    (a, b) => a.blockCreated - b.blockCreated || a.kind.localeCompare(b.kind)
+  );
 }
 
 async function backfillVault(
@@ -191,18 +226,22 @@ async function backfillVault(
 }
 
 async function main() {
-  const vaults = getConfiguredVaults(CHAIN_ID);
-  if (vaults.length === 0) {
-    throw new Error(`No vaults configured for chain ${CHAIN_ID}`);
+  const vaultDeployments = getVaultDeployments(CHAIN_ID);
+  if (vaultDeployments.length === 0) {
+    throw new Error(`No vault deployments configured for chain ${CHAIN_ID}`);
   }
 
   const client = getProviderForChain(CHAIN_ID);
   const toBlock = await client.getBlockNumber();
 
+  console.log(
+    `[backfillVaultFlows] Replaying ${vaultDeployments.length} vault deployment(s) on chain ${CHAIN_ID}`
+  );
+
   const previewRows: PreviewRow[] = [];
   let totalUpserted = 0;
-  for (const vault of vaults) {
-    const fromBlock = BigInt(vault.config.blockCreated);
+  for (const vault of vaultDeployments) {
+    const fromBlock = BigInt(vault.blockCreated);
     totalUpserted += await backfillVault(
       CHAIN_ID,
       vault.kind,

--- a/packages/api/src/services/protocolStats.test.ts
+++ b/packages/api/src/services/protocolStats.test.ts
@@ -54,13 +54,25 @@ vi.mock('@sapience/sdk/contracts', () => ({
       42161: { address: '0xEscrow' },
     },
     predictionMarketVault: {
-      42161: { address: '0xVault' },
+      42161: {
+        address: '0xVault',
+        blockCreated: 100,
+        legacy: [
+          { address: '0xLegacyVault', blockCreated: 50 },
+          ['0xTupleLegacyVault', 25],
+        ],
+      },
     },
     pythPredictionMarketVault: {},
     singleLegVault: {},
     predictionMarketVaultStrategyB: {},
   },
-  normalizeLegacyEntry: (entry: unknown) => entry,
+  normalizeLegacyEntry: (
+    entry: { address: string; blockCreated: number } | readonly [string, number]
+  ) =>
+    Array.isArray(entry)
+      ? { address: entry[0], blockCreated: entry[1] }
+      : entry,
 }));
 
 vi.mock('@sapience/sdk/abis', () => ({
@@ -79,6 +91,7 @@ import {
   getLatestProtocolStats,
   getProtocolStatsTimeSeries,
   buildVaultAggregator,
+  getConfiguredVaultDeploymentAddresses,
   sumEscrowBalancesAtBlock,
 } from './protocolStats';
 
@@ -93,6 +106,18 @@ function resetEmptyState() {
   mockPrisma.protocolStatsSnapshot.upsert.mockResolvedValue({});
   mockReadContract.mockResolvedValue(1000000000000000000n);
 }
+
+// ─── configured vault deployments ───────────────────────────────────────────
+
+describe('getConfiguredVaultDeploymentAddresses', () => {
+  it('includes current and legacy vault deployments', () => {
+    expect(getConfiguredVaultDeploymentAddresses(42161)).toEqual([
+      '0xvault',
+      '0xlegacyvault',
+      '0xtuplelegacyvault',
+    ]);
+  });
+});
 
 // ─── fetchVaultDeployed ─────────────────────────────────────────────────────
 

--- a/packages/api/src/services/protocolStats.ts
+++ b/packages/api/src/services/protocolStats.ts
@@ -482,6 +482,25 @@ export function getConfiguredVaults(chainId: number): ConfiguredVault[] {
 }
 
 /**
+ * Return every deployed vault address known to the SDK config, including legacy
+ * deployments. Historical backfills need the full address set because DB rows
+ * were written against the address that existed at the time, while the live
+ * cron path normally only touches current primaries from `getConfiguredVaults`.
+ */
+export function getConfiguredVaultDeploymentAddresses(
+  chainId: number
+): string[] {
+  const addresses = new Set<string>();
+  for (const vault of getConfiguredVaults(chainId)) {
+    addresses.add(vault.address);
+    for (const legacy of vault.config.legacy ?? []) {
+      addresses.add(normalizeLegacyEntry(legacy).address.toLowerCase());
+    }
+  }
+  return [...addresses];
+}
+
+/**
  * Resolve a vault address override (or default to the protocol primary) and
  * return it lowercased, ready for prisma string-equality comparisons.
  */
@@ -1238,7 +1257,7 @@ export interface VaultAggregator {
 export async function buildVaultAggregator(
   chainId: number
 ): Promise<VaultAggregator> {
-  const vaultAddresses = getConfiguredVaults(chainId).map((v) => v.address);
+  const vaultAddresses = getConfiguredVaultDeploymentAddresses(chainId);
   if (vaultAddresses.length === 0) {
     return {
       deployedAt: () => 0n,


### PR DESCRIPTION
## Why

Vlad called out that the vault flow rebuild needs to cover every vault deployment, not just the current configured primaries. The live protocol-stats cron still reads the latest configured vaults, but historical rebuilds need legacy deployment addresses too because migrations can truncate `vault_flow_event` and then rehydrate from chain logs.

## What

- Replays `backfillVaultFlows.ts` across current + legacy vault deployments from SDK config.
- Adds `getConfiguredVaultDeploymentAddresses()` so protocol-stats historical aggregation prefetches current + legacy vault addresses.
- Adds regression coverage for current + legacy deployment address expansion.

## Verification

- `pnpm exec vitest run src/services/protocolStats.test.ts --pool=forks --poolOptions.forks.singleFork`
- `pnpm dlx prettier@3.5.3 --check packages/api/src/services/protocolStats.ts packages/api/src/services/protocolStats.test.ts packages/api/scripts/backfillVaultFlows.ts`
- `pnpm exec eslint src/services/protocolStats.ts src/services/protocolStats.test.ts scripts/backfillVaultFlows.ts --quiet`

Note: full `@sapience/api` type-check is blocked in this lightweight worktree by existing/generated-deps setup issues (`prisma:generate` sees the old Prisma CLI shape / missing generated resolver artifacts). Targeted Vitest + ESLint + Prettier are green on the touched files.
