### PR TITLE
perf(app): render homepage ticker from estimatedPrice, no RFQ

### DIFF
--- a/packages/app/src/components/home/FeaturedMarketGroupCards.tsx
+++ b/packages/app/src/components/home/FeaturedMarketGroupCards.tsx
@@ -15,7 +15,6 @@ import TickerMarketCard from './ticker/TickerMarketCard';
 import { getActivePublicConditions } from './featuredConditions';
 import { useConditions } from '~/hooks/graphql/useConditions';
 import { getCategoryStyle } from '~/lib/utils/categoryStyle';
-import MarketPredictionRequest from '~/components/shared/MarketPredictionRequest';
 
 // Interface for featured conditions in the homepage carousel
 interface FeaturedCondition {
@@ -28,32 +27,19 @@ interface FeaturedCondition {
   color: string;
   categoryId: string;
   categorySlug: string;
+  estimatedPrice?: number | null;
 }
 
 export default function FeaturedMarketGroupCards() {
   // Fetch recent conditions for the currently selected chain
   const chainId = DEFAULT_CHAIN_ID;
   const { data: conditions, isLoading: isLoadingConditions } = useConditions({
-    take: 100,
+    take: 24,
     chainId,
   });
 
   // Per-mount random seed to vary picks between mounts but keep them stable within a session
   const [randomSeed] = React.useState<number>(() => Math.random());
-  const [predictionMap, setPredictionMap] = React.useState<
-    Record<string, number>
-  >({});
-
-  const handlePredictionReady = React.useCallback(
-    (conditionId: string, probability: number) => {
-      setPredictionMap((prev) => {
-        if (!conditionId) return prev;
-        if (prev[conditionId] != null) return prev;
-        return { ...prev, [conditionId]: probability };
-      });
-    },
-    []
-  );
 
   // Simple seeded RNG (Mulberry32)
   const createRng = React.useCallback((seed: number) => {
@@ -92,6 +78,7 @@ export default function FeaturedMarketGroupCards() {
         color,
         categoryId: String(c.category?.id ?? ''),
         categorySlug: slug,
+        estimatedPrice: c.estimatedPrice,
       };
     });
 
@@ -160,63 +147,30 @@ export default function FeaturedMarketGroupCards() {
         {featuredConditions.length === 0 ? (
           <div className="relative" />
         ) : (
-          <MobileAndDesktopLists
-            items={featuredConditions}
-            predictionMap={predictionMap}
-            onPredictionReady={handlePredictionReady}
-          />
+          <MobileAndDesktopLists items={featuredConditions} />
         )}
       </div>
     </section>
   );
 }
 
-function MobileAndDesktopLists({
-  items,
-  predictionMap,
-  onPredictionReady,
-}: {
-  items: FeaturedCondition[];
-  predictionMap: Record<string, number>;
-  onPredictionReady: (conditionId: string, probability: number) => void;
-}) {
+function MobileAndDesktopLists({ items }: { items: FeaturedCondition[] }) {
   const { state, openMobile } = useSidebar();
   const [mobileApi, setMobileApi] = React.useState<CarouselApi | null>(null);
   const [desktopApi, setDesktopApi] = React.useState<CarouselApi | null>(null);
   const hasRandomizedMobileStart = React.useRef(false);
   const hasRandomizedDesktopStart = React.useRef(false);
-  const [hasShown, setHasShown] = React.useState(false);
   const minSlidesForScroll = 6;
-  const readyItems = React.useMemo(
-    () =>
-      items.filter(
-        (item) => item.conditionId && predictionMap[item.conditionId] != null
-      ),
-    [items, predictionMap]
-  );
   const loopItems = React.useMemo(() => {
-    if (readyItems.length === 0) return [];
+    if (items.length === 0) return [];
     // Ensure enough slides to overflow on ultra-wide screens so auto-scroll runs.
-    if (readyItems.length >= minSlidesForScroll) return readyItems;
-    const repeated: typeof readyItems = [];
+    if (items.length >= minSlidesForScroll) return items;
+    const repeated: typeof items = [];
     for (let i = 0; i < minSlidesForScroll; i++) {
-      repeated.push(readyItems[i % readyItems.length]);
+      repeated.push(items[i % items.length]);
     }
     return repeated;
-  }, [readyItems, minSlidesForScroll]);
-  const canAutoScroll = loopItems.length >= minSlidesForScroll;
-  React.useEffect(() => {
-    if (canAutoScroll && !hasShown) {
-      setHasShown(true);
-    }
-  }, [canAutoScroll, hasShown]);
-  const pendingItems = React.useMemo(
-    () =>
-      items.filter(
-        (item) => item.conditionId && predictionMap[item.conditionId] == null
-      ),
-    [items, predictionMap]
-  );
+  }, [items, minSlidesForScroll]);
 
   const autoScrollPluginMobile = React.useMemo(
     () =>
@@ -250,57 +204,40 @@ function MobileAndDesktopLists({
   // Randomize starting slide (mobile) once on init
   React.useEffect(() => {
     if (!mobileApi || hasRandomizedMobileStart.current) return;
-    if (readyItems.length === 0) return;
-    const startIndex = Math.floor(Math.random() * readyItems.length);
+    if (items.length === 0) return;
+    const startIndex = Math.floor(Math.random() * items.length);
     try {
       mobileApi.scrollTo(startIndex, true);
     } catch {
       console.error('Error scrolling to random index', startIndex);
     }
     hasRandomizedMobileStart.current = true;
-  }, [mobileApi, readyItems.length]);
+  }, [mobileApi, items.length]);
 
   // Randomize starting slide (desktop) once on init
   React.useEffect(() => {
     if (!desktopApi || hasRandomizedDesktopStart.current) return;
-    if (readyItems.length === 0) return;
-    const startIndex = Math.floor(Math.random() * readyItems.length);
+    if (items.length === 0) return;
+    const startIndex = Math.floor(Math.random() * items.length);
     try {
       desktopApi.scrollTo(startIndex, true);
     } catch {
       console.error('Error scrolling to random index', startIndex);
     }
     hasRandomizedDesktopStart.current = true;
-  }, [desktopApi, readyItems.length]);
+  }, [desktopApi, items.length]);
 
   const desktopItemClass = 'pl-0 w-auto flex-none';
 
   return (
     <div className="relative">
-      {/* Prefetch prediction requests offscreen so cards only render once ready */}
-      <div
-        aria-hidden
-        className="fixed top-0 left-0 w-px h-px overflow-hidden opacity-0 pointer-events-none"
-      >
-        {pendingItems.map((c) => (
-          <MarketPredictionRequest
-            key={`prefetch-${c.conditionId}-${c.categorySlug}`}
-            conditionId={c.conditionId}
-            suppressLoadingPlaceholder
-            skipViewportCheck
-            onPrediction={(prob) => onPredictionReady(c.conditionId, prob)}
-          />
-        ))}
-      </div>
-
-      {readyItems.length === 0 ? (
+      {loopItems.length === 0 ? (
         <div className="relative" />
       ) : (
         <motion.div
           initial={{ opacity: 0 }}
-          animate={{ opacity: hasShown ? 1 : 0 }}
+          animate={{ opacity: 1 }}
           transition={{ duration: 0.35, ease: 'easeOut' }}
-          style={{ pointerEvents: hasShown ? 'auto' : 'none' }}
         >
           {/* Mobile: Embla carousel with auto-scroll */}
           <div className="xl:hidden w-full px-0">
@@ -325,11 +262,7 @@ function MobileAndDesktopLists({
                           resolver: c.resolver,
                         }}
                         color={c.color}
-                        predictionProbability={
-                          c.conditionId
-                            ? (predictionMap[c.conditionId] ?? null)
-                            : null
-                        }
+                        estimatedPrice={c.estimatedPrice ?? null}
                       />
                     </CarouselItem>
                     <CarouselItem className="w-px flex-none">
@@ -364,11 +297,7 @@ function MobileAndDesktopLists({
                           resolver: c.resolver,
                         }}
                         color={c.color}
-                        predictionProbability={
-                          c.conditionId
-                            ? (predictionMap[c.conditionId] ?? null)
-                            : null
-                        }
+                        estimatedPrice={c.estimatedPrice ?? null}
                       />
                     </CarouselItem>
                     <CarouselItem className="w-px flex-none">

--- a/packages/app/src/components/home/Ticker.tsx
+++ b/packages/app/src/components/home/Ticker.tsx
@@ -1,27 +1,22 @@
 'use client';
 
 import * as React from 'react';
-import { motion } from 'framer-motion';
 import FeaturedMarketGroupCards from './FeaturedMarketGroupCards';
-import { useConditions } from '~/hooks/graphql/useConditions';
-import { hasActivePublicConditions } from './featuredConditions';
 
 export default function Ticker() {
-  const { data: conditions } = useConditions({ take: 100 });
   const containerRef = React.useRef<HTMLDivElement | null>(null);
 
-  const nowSeconds = React.useMemo(() => Date.now() / 1000, []);
-  const hasItems = hasActivePublicConditions(conditions, nowSeconds);
-
-  // Expose current ticker height so pages can reserve space only when needed.
+  // Expose current ticker height so pages can reserve space.
   React.useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
 
     const setHeightVar = () => {
       const measured = el.offsetHeight || 40;
-      const nextHeight = `${measured}px`;
-      document.documentElement.style.setProperty('--ticker-height', nextHeight);
+      document.documentElement.style.setProperty(
+        '--ticker-height',
+        `${measured}px`
+      );
     };
 
     setHeightVar();
@@ -33,21 +28,16 @@ export default function Ticker() {
       resizeObserver.disconnect();
       document.documentElement.style.setProperty('--ticker-height', '0px');
     };
-  }, [hasItems]);
+  }, []);
 
   return (
     <div
       ref={containerRef}
       className="absolute bottom-0 left-0 right-0 z-[45] w-full overflow-hidden bg-brand-black border-y border-brand-white/10 text-foreground h-[40px] min-h-[40px]"
     >
-      <motion.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: hasItems ? 1 : 0 }}
-        transition={{ duration: 0.35, ease: 'easeOut' }}
-        className="h-full flex items-center"
-      >
+      <div className="h-full flex items-center">
         <FeaturedMarketGroupCards />
-      </motion.div>
+      </div>
     </div>
   );
 }

--- a/packages/app/src/components/home/ticker/TickerMarketCard.tsx
+++ b/packages/app/src/components/home/ticker/TickerMarketCard.tsx
@@ -1,12 +1,11 @@
 'use client';
 
 import * as React from 'react';
-import { motion } from 'framer-motion';
 import { useRouter } from 'next/navigation';
 import ConditionTitleLink from '~/components/markets/ConditionTitleLink';
 import { useCreatePositionContext } from '~/lib/context/CreatePositionContext';
 import YesNoSplitButton from '~/components/shared/YesNoSplitButton';
-import MarketPredictionRequest from '~/components/shared/MarketPredictionRequest';
+import PercentChance from '~/components/shared/PercentChance';
 import MarketBadge from '~/components/markets/MarketBadge';
 
 interface TickerMarketCardProps {
@@ -20,13 +19,13 @@ interface TickerMarketCardProps {
     resolver?: string | null;
   };
   color: string;
-  predictionProbability?: number | null;
+  estimatedPrice?: number | null;
 }
 
 const TickerMarketCard: React.FC<TickerMarketCardProps> = ({
   condition,
   color,
-  predictionProbability = null,
+  estimatedPrice = null,
 }) => {
   const {
     id,
@@ -112,12 +111,7 @@ const TickerMarketCard: React.FC<TickerMarketCardProps> = ({
 
   return (
     <div className="w-auto">
-      <motion.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 0.3, ease: 'easeOut' }}
-        className="flex flex-row items-stretch relative overflow-hidden"
-      >
+      <div className="flex flex-row items-stretch relative overflow-hidden">
         <div className="w-auto max-w-none md:max-w-[720px]">
           <div className="pl-4 pr-0.5 py-2">
             <div className="flex items-center gap-2 md:gap-3 min-w-0">
@@ -139,13 +133,15 @@ const TickerMarketCard: React.FC<TickerMarketCardProps> = ({
                 />
               </div>
               <div className="flex items-center gap-1 text-sm text-foreground/70 shrink-0">
-                <MarketPredictionRequest
-                  conditionId={id}
-                  className="text-sm"
-                  eager={predictionProbability == null}
-                  suppressLoadingPlaceholder
-                  prefetchedProbability={predictionProbability}
-                />
+                {estimatedPrice != null && (
+                  <PercentChance
+                    probability={estimatedPrice}
+                    showLabel
+                    label="chance"
+                    className="font-mono text-sm"
+                    colorByProbability
+                  />
+                )}
               </div>
               <YesNoSplitButton
                 onYes={handleYes}
@@ -162,7 +158,7 @@ const TickerMarketCard: React.FC<TickerMarketCardProps> = ({
             </div>
           </div>
         </div>
-      </motion.div>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- The homepage hero ticker was waiting on a `conditions` list query plus N RFQ roundtrips (one per featured card, gated to ≥6 of 8) before anything appeared. Render the cards directly off the persisted `estimatedPrice` field already returned by the conditions query and drop the auction machinery from the ticker entirely.
- Dedupe the duplicate `useConditions` call between `Ticker` and `FeaturedMarketGroupCards` (different params → separate cache keys) and shrink `take` from 100 to 24.
- Strip the per-card and per-carousel framer-motion fades that no longer gate on data; keep one fade-in on the carousel container so cards feel intentional when they first arrive.

Net effect: ticker is visible as fast as the GraphQL roundtrip with a probability painted on first render, instead of `1 GraphQL + 8 RFQs` before anything shows.

## Test plan
- [ ] On first load, the 40px black ticker bar is visible immediately at the bottom of the hero (the bar shell ships in SSR HTML)
- [ ] Cards appear with their `estimatedPrice` % chance and fade in once
- [ ] No "Requesting…" placeholders or RFQ network traffic from the ticker
- [ ] Auto-scroll still works on both mobile and desktop carousels
- [ ] Yes/No buttons still navigate to `/markets` with the selection added
- [ ] Reload and confirm only one `Conditions` GraphQL request is fired

🤖 Generated with [Claude Code](https://claude.com/claude-code)