### PR TITLE
fix(app): default vault PnL chart to ALL

### DIFF
--- a/packages/app/src/components/vaults/VaultPnlChart.tsx
+++ b/packages/app/src/components/vaults/VaultPnlChart.tsx
@@ -185,7 +185,7 @@ export default function VaultPnlChart({
   chartAnchorSec,
 }: VaultPnlChartProps) {
   const collateralSymbol = COLLATERAL_SYMBOLS[DEFAULT_CHAIN_ID] || 'USDe';
-  const [internalPeriod, setInternalPeriod] = useState<Period>('1W');
+  const [internalPeriod, setInternalPeriod] = useState<Period>('ALL');
   const period = externalPeriod ?? internalPeriod;
   const setPeriod = setInternalPeriod;
   const [displayMode, setDisplayMode] = useState<DisplayMode>('pct');


### PR DESCRIPTION
## Summary
- Switch the internal default period of `VaultPnlChart` from `'1W'` to `'ALL'` so the vault page lands on the full-history view by default; users can still narrow to 1W/1M/3M via the existing tabs.

## Test plan
- [x] `pnpm --filter @sapience/app run type-check`
- [x] `pnpm --filter @sapience/app run test` (528 / 528 pass)
- [ ] Visit the vault page and confirm the chart opens on **ALL** with the tab highlighted, then verify the other tabs still switch as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)