### PR TITLE
fix(app): trim 1s from displayed bid deadlines for inclusion latency

### DIFF
--- a/packages/app/src/components/markets/CreatePositionForm/PositionForm.tsx
+++ b/packages/app/src/components/markets/CreatePositionForm/PositionForm.tsx
@@ -44,6 +44,7 @@ import {
   parsePythEndDate,
 } from '~/lib/auction/pythPredictionDisplay';
 import { selectBestBid } from '~/lib/auction/selectBestBid';
+import { effectiveDeadlineMs } from '~/lib/auction/bidExpiry';
 import type { AuctionParams, QuoteBid } from '~/lib/auction/useAuctionStart';
 import { useCreatePositionContext } from '~/lib/context/CreatePositionContext';
 import ConditionTitleLink from '~/components/markets/ConditionTitleLink';
@@ -429,7 +430,7 @@ export default function PositionForm({
     // Estimator bids use deadline=1 (sentinel) and should not cause clearing.
     const hasAnyNonExpired = bids.some(
       (b) =>
-        b.counterpartyDeadline * 1000 > nowMs ||
+        effectiveDeadlineMs(b.counterpartyDeadline) > nowMs ||
         b.counterparty?.toLowerCase() ===
           PREFERRED_ESTIMATE_QUOTER.toLowerCase()
     );

--- a/packages/app/src/components/markets/CreatePositionForm/index.tsx
+++ b/packages/app/src/components/markets/CreatePositionForm/index.tsx
@@ -60,6 +60,7 @@ import { usePositionProgress } from '~/hooks/forms/usePositionProgress';
 import { useSponsorStatus } from '~/hooks/sponsorship/useSponsorStatus';
 import { useConnectedWallet } from '~/hooks/useConnectedWallet';
 import { useAuctionStart, type QuoteBid } from '~/lib/auction/useAuctionStart';
+import { isBidExpired } from '~/lib/auction/bidExpiry';
 import { FOCUS_AREAS } from '~/lib/constants/focusAreas';
 import {
   CollateralBalanceProvider,
@@ -651,10 +652,9 @@ const CreatePositionFormInner = ({
       return;
     }
 
-    // Validate the bid hasn't expired
-    const nowSec = Math.floor(Date.now() / 1000);
-
-    if (bid.counterpartyDeadline <= nowSec) {
+    // Validate the bid hasn't expired (with a small buffer so the inclusion
+    // latency doesn't push us past the on-chain deadline)
+    if (isBidExpired(bid.counterpartyDeadline, Date.now())) {
       toast({
         title: 'Bid expired',
         description: 'The bid has expired. Please wait for new bids.',

--- a/packages/app/src/components/markets/forms/shared/BidDisplay.tsx
+++ b/packages/app/src/components/markets/forms/shared/BidDisplay.tsx
@@ -8,6 +8,10 @@ import RiskDisclaimer from './RiskDisclaimer';
 import Loader from '~/components/shared/Loader';
 import { formatNumber } from '~/lib/utils/util';
 import { quoteBidsToAuctionBids } from '~/lib/auction/bidAdapter';
+import {
+  isBidExpired as checkBidExpired,
+  remainingMsToDeadline,
+} from '~/lib/auction/bidExpiry';
 import AuctionBidsChart from '~/components/shared/AuctionBidsChart';
 import type { QuoteBid } from '~/lib/auction/useAuctionStart';
 
@@ -136,9 +140,10 @@ export default function BidDisplay({
   // Convert QuoteBids to AuctionBidData for the chart
   const chartBids = useMemo(() => quoteBidsToAuctionBids(allBids), [allBids]);
 
-  // Check if the current best bid is expired
+  // Check if the current best bid is expired (uses a small buffer ahead of
+  // the on-chain deadline so the user has room for inclusion latency)
   const isBidExpired = bestBid
-    ? bestBid.counterpartyDeadline * 1000 - nowMs <= 0
+    ? checkBidExpired(bestBid.counterpartyDeadline, nowMs)
     : true;
 
   // Unified UI state - single source of truth for all UI rendering
@@ -166,7 +171,10 @@ export default function BidDisplay({
 
     const humanTotalVal = calculatePayoutAmount(bestBid, positionSize);
 
-    const remainingMs = bestBid.counterpartyDeadline * 1000 - nowMs;
+    const remainingMs = remainingMsToDeadline(
+      bestBid.counterpartyDeadline,
+      nowMs
+    );
     const secs = Math.max(0, Math.ceil(remainingMs / 1000));
 
     return { humanTotal: humanTotalVal, remainingSecs: secs };

--- a/packages/app/src/components/shared/AuctionBidsChart.tsx
+++ b/packages/app/src/components/shared/AuctionBidsChart.tsx
@@ -19,6 +19,7 @@ import {
 import { formatEther } from 'viem';
 import TradePopoverContent from '~/components/shared/TradePopoverContent';
 import ExpiresInLabel from '~/components/shared/ExpiresInLabel';
+import { effectiveDeadlineMs } from '~/lib/auction/bidExpiry';
 
 export type AuctionBidData = {
   auctionId: string;
@@ -120,7 +121,7 @@ const AuctionBidsChart: React.FC<Props> = ({
           }
           // Use receivedAtMs if available, otherwise estimate from deadline
           const start = Number(b?.receivedAtMs || nowMs - 30000);
-          const end = Number(b?.counterpartyDeadline || 0) * 1000;
+          const end = effectiveDeadlineMs(Number(b?.counterpartyDeadline || 0));
           if (
             !Number.isFinite(amount) ||
             amount <= 0 ||

--- a/packages/app/src/components/shared/MarketPredictionRequest.tsx
+++ b/packages/app/src/components/shared/MarketPredictionRequest.tsx
@@ -12,6 +12,7 @@ import { conditionalTokensConditionResolver } from '@sapience/sdk/contracts';
 import type { PredictedOutcomeInputStub } from '@sapience/sdk/auction/buildAuctionPayload';
 import { PREFERRED_ESTIMATE_QUOTER } from '~/lib/constants';
 import { useAuctionStart, type QuoteBid } from '~/lib/auction/useAuctionStart';
+import { effectiveDeadlineMs } from '~/lib/auction/bidExpiry';
 import PercentChance from '~/components/shared/PercentChance';
 
 const FADE_VARIANTS = {
@@ -199,7 +200,7 @@ const MarketPredictionRequestInner: React.FC<MarketPredictionRequestProps> = ({
         const valid = filteredBids.filter((b) => {
           try {
             const dl = Number(b?.counterpartyDeadline || 0);
-            return Number.isFinite(dl) ? dl * 1000 > nowMs : true;
+            return Number.isFinite(dl) ? effectiveDeadlineMs(dl) > nowMs : true;
           } catch {
             return true;
           }

--- a/packages/app/src/components/terminal/AuctionRequestInfo.tsx
+++ b/packages/app/src/components/terminal/AuctionRequestInfo.tsx
@@ -4,9 +4,6 @@ import type React from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { formatDistanceToNowStrict } from 'date-fns';
 import { formatEther } from 'viem';
-import EnsAvatar from '~/components/shared/EnsAvatar';
-import { AddressDisplay } from '~/components/shared/AddressDisplay';
-import PlaceBidForm from '~/components/terminal/PlaceBidForm';
 import {
   Tooltip,
   TooltipContent,
@@ -14,8 +11,15 @@ import {
   TooltipTrigger,
 } from '@sapience/ui/components/ui/tooltip';
 import { HelpCircle } from 'lucide-react';
+import EnsAvatar from '~/components/shared/EnsAvatar';
+import { AddressDisplay } from '~/components/shared/AddressDisplay';
+import PlaceBidForm from '~/components/terminal/PlaceBidForm';
 import ExpiresInLabel from '~/components/shared/ExpiresInLabel';
 import PercentChance from '~/components/shared/PercentChance';
+import {
+  effectiveDeadlineMs,
+  remainingMsToDeadline,
+} from '~/lib/auction/bidExpiry';
 
 type SubmitData = {
   amount: string;
@@ -66,7 +70,7 @@ const BestBid: React.FC<BestBidProps> = ({
         const deadlineSec = Number(b?.counterpartyDeadline || 0);
         const ms =
           Number.isFinite(deadlineSec) && deadlineSec > 0
-            ? deadlineSec * 1000
+            ? effectiveDeadlineMs(deadlineSec)
             : Number.POSITIVE_INFINITY;
         if (ms > now) return b;
       }
@@ -90,9 +94,9 @@ const BestBid: React.FC<BestBidProps> = ({
                 const secondsRemaining = (() => {
                   if (!Number.isFinite(deadlineSec) || deadlineSec <= 0)
                     return null;
-                  const ms = deadlineSec * 1000;
-                  const diff = Math.max(0, Math.round((ms - now) / 1000));
-                  return diff;
+                  return Math.round(
+                    remainingMsToDeadline(deadlineSec, now) / 1000
+                  );
                 })();
                 const payoutStr = (() => {
                   try {
@@ -275,7 +279,7 @@ const AuctionRequestInfo: React.FC<Props> = ({
     } catch {
       return null;
     }
-  }, [maxEndTimeSec, now]);
+  }, [maxEndTimeSec]);
 
   const maxRemainingExpirySeconds = useMemo(() => {
     try {
@@ -301,7 +305,7 @@ const AuctionRequestInfo: React.FC<Props> = ({
           return false;
         const deadlineSec = Number(b?.counterpartyDeadline || 0);
         if (!Number.isFinite(deadlineSec) || deadlineSec <= 0) return true;
-        return deadlineSec * 1000 > now;
+        return effectiveDeadlineMs(deadlineSec) > now;
       });
       if (candidates.length === 0) return null;
       return candidates.reduce((best, b) => {

--- a/packages/app/src/components/terminal/AuctionRequestInfo.tsx
+++ b/packages/app/src/components/terminal/AuctionRequestInfo.tsx
@@ -279,7 +279,10 @@ const AuctionRequestInfo: React.FC<Props> = ({
     } catch {
       return null;
     }
-  }, [maxEndTimeSec]);
+    // `now` is intentionally a dep: formatDistanceToNowStrict reads the clock
+    // internally, so without it the memoized label freezes at first render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [maxEndTimeSec, now]);
 
   const maxRemainingExpirySeconds = useMemo(() => {
     try {

--- a/packages/app/src/hooks/auction/useComboQuotes.ts
+++ b/packages/app/src/hooks/auction/useComboQuotes.ts
@@ -9,6 +9,7 @@ import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
 import type { OutcomeSide } from '@sapience/sdk/types';
 import { canonicalizePicks } from '@sapience/sdk/auction/escrowEncoding';
 import { PREFERRED_ESTIMATE_QUOTER } from '~/lib/constants';
+import { effectiveDeadlineMs } from '~/lib/auction/bidExpiry';
 import { useSettings } from '~/lib/context/SettingsContext';
 import { toAuctionWsUrl } from '~/lib/ws/auctionUrl';
 import { getSharedAuctionWsClient } from '~/lib/ws/AuctionWsClient';
@@ -163,7 +164,7 @@ export function useComboQuotes(combos: RecentCombo[], chainId: number) {
       const nowMs = Date.now();
       const valid = bids.filter((b) => {
         const dl = Number(b?.counterpartyDeadline || 0);
-        return Number.isFinite(dl) ? dl * 1000 > nowMs : true;
+        return Number.isFinite(dl) ? effectiveDeadlineMs(dl) > nowMs : true;
       });
       const list = valid.length > 0 ? valid : bids;
       const best = list.reduce((acc, cur) =>

--- a/packages/app/src/hooks/auction/usePreprocessedBids.ts
+++ b/packages/app/src/hooks/auction/usePreprocessedBids.ts
@@ -7,6 +7,7 @@ import { validateBidFull } from '@sapience/sdk/auction/validation';
 import type { ValidationResult } from '@sapience/sdk/auction/validation';
 import type { AuctionBid } from '~/lib/auction/useAuctionBidsHub';
 import { effectiveDeadlineMs } from '~/lib/auction/bidExpiry';
+import { useSecondTick } from '~/hooks/useSecondTick';
 import { getPublicClientForChainId } from '~/lib/utils/util';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -316,16 +317,18 @@ export function usePreprocessedBids(
     });
   }, [rawBids, validationResults, canValidate]);
 
-  // Filter to valid + non-expired
+  // Filter to valid + non-expired. Tick once per second so a bid drops out
+  // when its (buffered) deadline elapses even if no new bids arrive.
+  const tickedNowMs = useSecondTick();
   const validBids = useMemo((): PreprocessedBid[] => {
-    const nowMs = Date.now();
+    const nowMs = tickedNowMs ?? Date.now();
     return processedBids.filter((bid) => {
       if (bid.validationStatus !== 'valid') return false;
       const deadlineSec = Number(bid.counterpartyDeadline || 0);
       if (!Number.isFinite(deadlineSec) || deadlineSec <= 0) return false;
       return effectiveDeadlineMs(deadlineSec) > nowMs;
     });
-  }, [processedBids]);
+  }, [processedBids, tickedNowMs]);
 
   const excludedBidCount = useMemo(() => {
     return processedBids.filter(

--- a/packages/app/src/hooks/auction/usePreprocessedBids.ts
+++ b/packages/app/src/hooks/auction/usePreprocessedBids.ts
@@ -6,6 +6,7 @@ import type { PickJson } from '@sapience/sdk/types';
 import { validateBidFull } from '@sapience/sdk/auction/validation';
 import type { ValidationResult } from '@sapience/sdk/auction/validation';
 import type { AuctionBid } from '~/lib/auction/useAuctionBidsHub';
+import { effectiveDeadlineMs } from '~/lib/auction/bidExpiry';
 import { getPublicClientForChainId } from '~/lib/utils/util';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -322,7 +323,7 @@ export function usePreprocessedBids(
       if (bid.validationStatus !== 'valid') return false;
       const deadlineSec = Number(bid.counterpartyDeadline || 0);
       if (!Number.isFinite(deadlineSec) || deadlineSec <= 0) return false;
-      return deadlineSec * 1000 > nowMs;
+      return effectiveDeadlineMs(deadlineSec) > nowMs;
     });
   }, [processedBids]);
 

--- a/packages/app/src/hooks/auction/useValidatedBids.ts
+++ b/packages/app/src/hooks/auction/useValidatedBids.ts
@@ -7,6 +7,7 @@ import type { ValidationResult } from '@sapience/sdk/auction/validation';
 import { validateBidOnChain } from '@sapience/sdk/auction/validation';
 import type { QuoteBid } from '~/lib/auction/useAuctionStart';
 import { effectiveDeadlineMs } from '~/lib/auction/bidExpiry';
+import { useSecondTick } from '~/hooks/useSecondTick';
 import { logBidValidation, formatBidForLog } from '~/lib/auction/bidLogger';
 import { PREFERRED_ESTIMATE_QUOTER } from '~/lib/constants';
 import { getPublicClientForChainId } from '~/lib/utils/util';
@@ -339,15 +340,18 @@ export function useValidatedBids(
   }, [rawBids, validationResults, canValidate]);
 
   // Filter to valid + non-expired bids
+  // Tick once per second so a bid drops out when its (buffered) deadline
+  // elapses even if no new bids arrive.
+  const tickedNowMs = useSecondTick();
   const validBids = useMemo((): QuoteBid[] => {
-    const nowMs = Date.now();
+    const nowMs = tickedNowMs ?? Date.now();
     return validatedBids.filter((bid) => {
       if (bid.validationStatus !== 'valid') return false;
       const deadlineSec = Number(bid.counterpartyDeadline || 0);
       if (!Number.isFinite(deadlineSec) || deadlineSec <= 0) return false;
       return effectiveDeadlineMs(deadlineSec) > nowMs;
     });
-  }, [validatedBids]);
+  }, [validatedBids, tickedNowMs]);
 
   const invalidBidCount = useMemo(() => {
     return validatedBids.filter((bid) => bid.validationStatus === 'invalid')

--- a/packages/app/src/hooks/auction/useValidatedBids.ts
+++ b/packages/app/src/hooks/auction/useValidatedBids.ts
@@ -6,6 +6,7 @@ import type { Pick, PickJson } from '@sapience/sdk/types';
 import type { ValidationResult } from '@sapience/sdk/auction/validation';
 import { validateBidOnChain } from '@sapience/sdk/auction/validation';
 import type { QuoteBid } from '~/lib/auction/useAuctionStart';
+import { effectiveDeadlineMs } from '~/lib/auction/bidExpiry';
 import { logBidValidation, formatBidForLog } from '~/lib/auction/bidLogger';
 import { PREFERRED_ESTIMATE_QUOTER } from '~/lib/constants';
 import { getPublicClientForChainId } from '~/lib/utils/util';
@@ -344,7 +345,7 @@ export function useValidatedBids(
       if (bid.validationStatus !== 'valid') return false;
       const deadlineSec = Number(bid.counterpartyDeadline || 0);
       if (!Number.isFinite(deadlineSec) || deadlineSec <= 0) return false;
-      return deadlineSec * 1000 > nowMs;
+      return effectiveDeadlineMs(deadlineSec) > nowMs;
     });
   }, [validatedBids]);
 

--- a/packages/app/src/hooks/forms/useSingleConditionAuction.ts
+++ b/packages/app/src/hooks/forms/useSingleConditionAuction.ts
@@ -8,6 +8,7 @@ import { conditionalTokensConditionResolver } from '@sapience/sdk/contracts';
 import { OutcomeSide } from '@sapience/sdk/types';
 import { useSession } from '~/lib/context/SessionContext';
 import type { AuctionParams, QuoteBid } from '~/lib/auction/useAuctionStart';
+import { effectiveDeadlineMs } from '~/lib/auction/bidExpiry';
 
 interface UseSingleConditionAuctionProps {
   conditionId: string | null;
@@ -67,7 +68,7 @@ export function useSingleConditionAuction({
     if (!bids || bids.length === 0) return null;
 
     const validBids = bids.filter(
-      (bid) => bid.counterpartyDeadline * 1000 > nowMs
+      (bid) => effectiveDeadlineMs(bid.counterpartyDeadline) > nowMs
     );
     if (validBids.length === 0) return null;
 
@@ -111,7 +112,7 @@ export function useSingleConditionAuction({
           null;
         const params: AuctionParams = {
           wager: positionSizeWei,
-          predictor: selectedTakerAddress,
+          predictor: selectedTakerAddressRef.current,
           predictorNonce: Number(generateRandomNonce()),
           chainId,
           picks: effectiveResolver

--- a/packages/app/src/lib/auction/__tests__/bidExpiry.test.ts
+++ b/packages/app/src/lib/auction/__tests__/bidExpiry.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEADLINE_DISPLAY_BUFFER_SECS,
+  effectiveDeadlineMs,
+  effectiveDeadlineSecs,
+  isBidExpired,
+  remainingMsToDeadline,
+} from '~/lib/auction/bidExpiry';
+
+const NOW_MS = 1_700_000_000_000;
+const NOW_SEC = Math.floor(NOW_MS / 1000);
+
+describe('bidExpiry', () => {
+  it('exposes a 1-second display buffer', () => {
+    expect(DEADLINE_DISPLAY_BUFFER_SECS).toBe(1);
+  });
+
+  describe('effectiveDeadlineSecs / effectiveDeadlineMs', () => {
+    it('subtracts the buffer in seconds and milliseconds', () => {
+      const deadline = NOW_SEC + 30;
+      expect(effectiveDeadlineSecs(deadline)).toBe(NOW_SEC + 29);
+      expect(effectiveDeadlineMs(deadline)).toBe((NOW_SEC + 29) * 1000);
+    });
+  });
+
+  describe('isBidExpired', () => {
+    it('treats a bid as expired one second before its on-chain deadline', () => {
+      const deadlineSec = NOW_SEC + 1;
+      expect(isBidExpired(deadlineSec, NOW_MS)).toBe(true);
+    });
+
+    it('treats a bid with >1s remaining as live', () => {
+      const deadlineSec = NOW_SEC + 2;
+      expect(isBidExpired(deadlineSec, NOW_MS)).toBe(false);
+    });
+
+    it('treats an on-chain-expired bid as expired', () => {
+      const deadlineSec = NOW_SEC - 5;
+      expect(isBidExpired(deadlineSec, NOW_MS)).toBe(true);
+    });
+  });
+
+  describe('remainingMsToDeadline', () => {
+    it('returns the buffered remaining time in ms', () => {
+      const deadlineSec = NOW_SEC + 30;
+      expect(remainingMsToDeadline(deadlineSec, NOW_MS)).toBe(29_000);
+    });
+
+    it('clamps to zero when the buffered deadline has passed', () => {
+      const deadlineSec = NOW_SEC;
+      expect(remainingMsToDeadline(deadlineSec, NOW_MS)).toBe(0);
+    });
+
+    it('clamps to zero exactly at the buffered deadline', () => {
+      const deadlineSec = NOW_SEC + 1;
+      expect(remainingMsToDeadline(deadlineSec, NOW_MS)).toBe(0);
+    });
+  });
+});

--- a/packages/app/src/lib/auction/bidExpiry.ts
+++ b/packages/app/src/lib/auction/bidExpiry.ts
@@ -1,0 +1,32 @@
+/**
+ * Seconds subtracted from a counterparty bid's on-chain deadline when
+ * deciding whether to display it as expired or accept a submit click.
+ * Intent: a user who acts at the last visible moment still leaves time for
+ * the UserOp bundler / inclusion latency — otherwise the on-chain deadline
+ * check returns false and the protocol surfaces it as
+ * `InvalidCounterpartySignature`.
+ */
+export const DEADLINE_DISPLAY_BUFFER_SECS = 1;
+
+/** Effective deadline (in seconds) used for client-side checks. */
+export function effectiveDeadlineSecs(deadlineSecs: number): number {
+  return deadlineSecs - DEADLINE_DISPLAY_BUFFER_SECS;
+}
+
+/** Effective deadline in milliseconds (convenience for `* 1000` comparisons). */
+export function effectiveDeadlineMs(deadlineSecs: number): number {
+  return effectiveDeadlineSecs(deadlineSecs) * 1000;
+}
+
+/** Remaining ms against the effective (buffered) deadline; never negative. */
+export function remainingMsToDeadline(
+  deadlineSecs: number,
+  nowMs: number
+): number {
+  return Math.max(0, effectiveDeadlineMs(deadlineSecs) - nowMs);
+}
+
+/** True when the bid should be treated as expired client-side. */
+export function isBidExpired(deadlineSecs: number, nowMs: number): boolean {
+  return effectiveDeadlineMs(deadlineSecs) <= nowMs;
+}

--- a/packages/app/src/lib/auction/selectBestBid.ts
+++ b/packages/app/src/lib/auction/selectBestBid.ts
@@ -1,4 +1,5 @@
 import { PREFERRED_ESTIMATE_QUOTER } from '~/lib/constants';
+import { effectiveDeadlineMs } from '~/lib/auction/bidExpiry';
 import type { QuoteBid } from '~/lib/auction/useAuctionStart';
 
 export type SelectBestBidResult = {
@@ -44,7 +45,7 @@ export function selectBestBid(
   );
 
   const nonExpiredBids = regularBids.filter(
-    (bid) => bid.counterpartyDeadline * 1000 > nowMs
+    (bid) => effectiveDeadlineMs(bid.counterpartyDeadline) > nowMs
   );
 
   if (nonExpiredBids.length === 0 && estimatorBids.length === 0) {


### PR DESCRIPTION
## Summary
- Introduce `DEADLINE_DISPLAY_BUFFER_SECS = 1` plus `effectiveDeadlineMs` / `remainingMsToDeadline` / `isBidExpired` helpers in `packages/app/src/lib/auction/bidExpiry.ts`, and apply them everywhere the app compares a counterparty bid's deadline against `nowMs` for user-facing purposes.
- The submitted on-chain `counterpartyDeadline` value is unchanged — we only nudge the visible window in by 1s so a user who acts at the last moment still leaves room for the UserOp bundler / inclusion latency. Without this buffer the on-chain deadline check silently returns `false` and the protocol surfaces the failure as `InvalidCounterpartySignature`.

### Touched
- `BidDisplay`: countdown text + `isBidExpired` (drives the submit-button gate)
- `CreatePositionForm/index`: submit-click defense in depth
- `PositionForm`, `selectBestBid`: best-bid selection
- `AuctionRequestInfo`: terminal countdown + top/winning-bid filters
- `MarketPredictionRequest`, `AuctionBidsChart`: auxiliary displays
- `usePreprocessedBids`, `useValidatedBids`, `useComboQuotes`, `useSingleConditionAuction`: bid-list filters that drive what the UI ends up showing

### Drive-bys
The precommit hook surfaced two pre-existing lint warnings on files I touched, both fixed:
- `AuctionRequestInfo`: import order (third-party before local)
- `useSingleConditionAuction`: switched the direct `selectedTakerAddress` read inside `triggerQuoteRequest` to `selectedTakerAddressRef.current`, matching the ref pattern the same callback already uses on its early-return guard

## Test plan
- [x] `pnpm --filter @sapience/app run type-check`
- [x] `pnpm --filter @sapience/app run test` (528 / 528 pass)
- [ ] Open a market, request a bid, watch the countdown — confirm "Xs" displays one second short of the on-chain `counterpartyDeadline` and the SUBMIT button disables one second before it would have on `staging`.
- [ ] In the terminal, watch a bid in `AuctionRequestInfo` tick down to 0 and confirm it disappears from the best-bid table 1s earlier than the underlying deadline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)