### PR TITLE
fix(api): recoverMissingPredictions dispatches per escrow contract

### DIFF
--- a/packages/api/scripts/recoverMissingPredictions.ts
+++ b/packages/api/scripts/recoverMissingPredictions.ts
@@ -25,11 +25,11 @@
  *   pnpm --filter @sapience/api exec tsx scripts/recoverMissingPredictions.ts --tx 0xabc...,0xdef...
  *   pnpm --filter @sapience/api exec tsx scripts/recoverMissingPredictions.ts --chainId 5064014
  */
-import prisma from '../src/core/db';
-import { contracts } from '@sapience/sdk/contracts';
-import PredictionMarketEscrowIndexer from '../src/workers/indexers/predictionMarketEscrowIndexer';
+import { contracts, normalizeLegacyEntry } from '@sapience/sdk/contracts';
 import type { Block, Log } from 'viem';
+import prisma from '../src/core/db';
 import { getProviderForChain } from '../src/lib/utils';
+import PredictionMarketEscrowIndexer from '../src/workers/indexers/predictionMarketEscrowIndexer';
 
 const DEFAULT_TXS_5064014 = [
   '0x3617d01b5e9cc4967498848ac755d6b618ed271075bc8798ada27302fb675a71',
@@ -59,16 +59,51 @@ async function main(): Promise<void> {
   }
 
   const client = getProviderForChain(chainId);
-  const indexer = new PredictionMarketEscrowIndexer(chainId);
-  // processLog is private; cast to bypass for the one-shot.
-  const processLog = (
-    indexer as unknown as {
-      processLog: (log: Log, block: Block) => Promise<void>;
-    }
-  ).processLog.bind(indexer);
+
+  // Build a per-escrow indexer cache. When dispatching a log we pick the
+  // indexer instance whose contractAddress matches `log.address`, because
+  // the handlers' `getPrediction(predictionId)` RPC call only succeeds
+  // against the escrow that originally minted the prediction. Using the
+  // current escrow for a legacy-minted prediction returns `0x` and forces
+  // the handler down its "RPC failed → create Prediction without
+  // pickConfigId" fallback path, leaving Picks missing.
+  type EscrowEntry = { address: string; isLegacy: boolean; blockCreated: number };
+  const escrows: EscrowEntry[] = [
+    {
+      address: escrowConfig.address.toLowerCase(),
+      isLegacy: false,
+      blockCreated: escrowConfig.blockCreated ?? 0,
+    },
+    ...(escrowConfig.legacy ?? []).map((le) => {
+      const norm = normalizeLegacyEntry(le);
+      return {
+        address: norm.address.toLowerCase(),
+        isLegacy: true,
+        blockCreated: norm.blockCreated,
+      };
+    }),
+  ];
+  const indexerByAddr = new Map<
+    string,
+    (log: Log, block: Block) => Promise<void>
+  >();
+  for (const e of escrows) {
+    const ix = new PredictionMarketEscrowIndexer(
+      chainId,
+      e.address as `0x${string}`,
+      e.isLegacy,
+      e.blockCreated
+    );
+    const dispatch = (
+      ix as unknown as {
+        processLog: (log: Log, block: Block) => Promise<void>;
+      }
+    ).processLog.bind(ix);
+    indexerByAddr.set(e.address, dispatch);
+  }
 
   console.log(
-    `[recover] chainId=${chainId} escrow=${escrowConfig.address}  txs=${txs.length}`
+    `[recover] chainId=${chainId}  txs=${txs.length}  escrows=${escrows.length} (1 primary + ${escrows.length - 1} legacy)`
   );
 
   for (const tx of txs) {
@@ -113,12 +148,22 @@ async function main(): Promise<void> {
       `  Block ${blockNumber}: ${receipt.logs.length} total logs, ${escrowLogs.length} from escrow`
     );
 
-    // 5. Re-dispatch each escrow log through the indexer.
+    // 5. Re-dispatch each escrow log through the indexer instance whose
+    //    contractAddress matches the log's emitter — see comment above the
+    //    indexer cache for why per-escrow dispatch is required.
     for (const log of escrowLogs) {
+      const emitter = log.address.toLowerCase();
+      const dispatch = indexerByAddr.get(emitter);
+      if (!dispatch) {
+        console.log(
+          `    ✗ no indexer registered for emitter=${emitter} — skipping logIndex=${log.logIndex}`
+        );
+        continue;
+      }
       console.log(
-        `    → processLog logIndex=${log.logIndex}  topics0=${log.topics[0]?.slice(0, 14)}…`
+        `    → processLog logIndex=${log.logIndex}  emitter=${emitter.slice(0, 10)}…  topics0=${log.topics[0]?.slice(0, 14)}…`
       );
-      await processLog(log, block);
+      await dispatch(log, block);
     }
 
     // 6. Verify Picks + Prediction now exist.


### PR DESCRIPTION
## Summary

Found while running `recoverMissingPredictions.ts` against a legacy-escrow tx (block 3759771, before the current escrow's `blockCreated: 4100000`):

```
[PredictionMarketEscrowIndexer:5064014] Error reading on-chain pick config data:
  ContractFunctionExecutionError: The contract function "getPrediction" returned no data ("0x").
  …
  contractAddress: '0xe7e515FC1DF93565A47770a4110f4366E26a2D3F'   ← current escrow
  args: ['0xf643953f8af4b229c696a3c8a341b04db8368b4feff06cd300636e2ad022c274']
[PredictionMarketEscrowIndexer:5064014] RPC failed for prediction … —
  creating prediction without positions, will repair on next encounter
…
  Prediction: RECREATED (predictor=…, cpColl=…, deposited=…)
  Picks: STILL MISSING (Prediction may have null pickConfigId)
```

### Root cause

The original script always instantiated a single `PredictionMarketEscrowIndexer` against the **current** escrow address. For predictions minted on a legacy escrow, `getPrediction(predictionId)` on the current escrow returns `0x` because the current escrow has no record of that predictionId in its storage. The handler then takes its "RPC failed → create Prediction without `pickConfigId`, will repair on next encounter" fallback at [predictionMarketEscrowIndexer.ts:672](packages/api/src/workers/indexers/predictionMarketEscrowIndexer.ts#L672), leaving `Picks` missing forever.

### Fix

Build a per-escrow indexer cache (primary + every legacy entry from `contracts.predictionMarketEscrow[chainId].legacy`), and pick the indexer instance whose `contractAddress` matches `log.address` for each log. Each handler now talks to the escrow that originally emitted the event, so `getPrediction` succeeds and the full `Picks` + `Prediction` state gets recreated.

### Re-running on a half-recovered Prediction

The fix also repairs Predictions left half-created by the buggy version. The indexer's existing repair path at [line 636](packages/api/src/workers/indexers/predictionMarketEscrowIndexer.ts#L636) (added in SAP-767) was specifically designed for this case:

```ts
if (existingPrediction) {
  if (!existingPrediction.pickConfigId) {
    // Repair: read pick config data and update.
    const repairData = await this.readPickConfigData(event, log);
    if (repairData) {
      await prisma.\$transaction(async (tx) => {
        await this.writePickConfigAndBalances(tx, event, repairData);
        await tx.prediction.update({
          where: { predictionId: predictionIdLower },
          data: { pickConfigId: repairData.pickConfigId },
        });
      });
    }
  }
  return;
}
```

So after this PR lands and the script is re-run, half-recovered Predictions will get their `Picks` + `pickConfigId` set without manual intervention.

## Test plan

- [x] Type-check clean (the unrelated `getProtocolAddressesForChain` TS error in `collateralBalance.ts` is pre-existing on staging).
- [x] Lint clean.
- [ ] Run against the previously-half-recovered tx (`0xeca15c899f6eba6eecb82cfe82ffd6ee763e74a7697d9e0fea07412f98028f2e`); expect `Picks: RECREATED` instead of `STILL MISSING`.
- [ ] Run against any pre-`blockCreated: 4100000` tx with a missing Prediction; expect full recovery.