### PR TITLE
fix(app): render position size in neutral color regardless of outcome

### DIFF
--- a/packages/app/src/components/positions/PositionSummary.tsx
+++ b/packages/app/src/components/positions/PositionSummary.tsx
@@ -275,16 +275,12 @@ export default function PositionSummary({
     </div>
   );
 
-  const renderStakeCell = (stake: number, sideWon: boolean | undefined) => (
+  const renderStakeCell = (stake: number) => (
     <div className="flex flex-col gap-1 min-w-0">
       <div className="text-[11px] uppercase tracking-wider text-muted-foreground font-normal font-mono">
         Position Size
       </div>
-      <span
-        className={`text-sm md:text-base font-medium tabular-nums ${
-          isSettled && sideWon ? 'text-green-600' : 'text-foreground'
-        }`}
-      >
+      <span className="text-sm md:text-base font-medium tabular-nums text-foreground">
         <NumberDisplay value={stake} className="tabular-nums" />
         <span className="ml-1 text-xs font-normal text-muted-foreground">
           {collateralSymbol}
@@ -387,9 +383,9 @@ export default function PositionSummary({
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-x-4 gap-y-6">
           {/* Row 1: parties with stakes */}
           {renderPartyCell('Predictor', predictorAddress)}
-          {renderStakeCell(predictorStake, predictorWon)}
+          {renderStakeCell(predictorStake)}
           {renderPartyCell('Counterparty', counterpartyAddress)}
-          {renderStakeCell(counterpartyStake, counterpartyWon)}
+          {renderStakeCell(counterpartyStake)}
 
           {/* Row 2: lifecycle */}
           {renderCreatedCell()}


### PR DESCRIPTION
## Summary
The symmetric prediction-detail summary (used in the position dialog and on `/predictions/[id]`) was tinting the winner's **Position Size** cell green. The win/loss signal already lives in the **Winner** cell and in the row-level WON / LOST badge, so the extra color on the stake adds visual noise without conveying new information. Render Position Size with `text-foreground` for both parties unconditionally.

## Changes
- `packages/app/src/components/positions/PositionSummary.tsx` — drop the `isSettled && sideWon ? 'text-green-600' : 'text-foreground'` branch from `renderStakeCell`; remove the now-unused `sideWon` parameter and update the two call sites.
- `predictorWon` / `counterpartyWon` props are still consumed by `renderStatusCell` (the Winner cell), so they stay.

## Test plan
- [x] `pnpm --filter @sapience/app run type-check`
- [x] `pnpm --filter @sapience/app run test` (528 / 528 pass)
- [ ] Open a settled prediction in the position dialog — confirm both Position Size cells render with the default foreground color regardless of which side won, and the Winner cell + row WON / LOST badge still convey outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)