### PR TITLE
fix(app): hide zero-OI categories from OI chart and legend

### DIFF
--- a/packages/app/src/components/analytics/OpenInterestByCategoryChart.tsx
+++ b/packages/app/src/components/analytics/OpenInterestByCategoryChart.tsx
@@ -37,16 +37,18 @@ export default function OpenInterestByCategoryChart() {
 
     const total = merged.reduce((acc, s) => acc + s.raw, 0n);
     const totalNum = Number(total) / 1e18;
-    return merged.map((s) => {
-      const value = Number(s.raw) / 1e18;
-      return {
-        name: s.name,
-        slug: s.slug,
-        color: getCategoryColor(s.slug),
-        value,
-        percent: totalNum > 0 ? (value / totalNum) * 100 : 0,
-      };
-    });
+    return merged
+      .filter((s) => s.raw > 0n)
+      .map((s) => {
+        const value = Number(s.raw) / 1e18;
+        return {
+          name: s.name,
+          slug: s.slug,
+          color: getCategoryColor(s.slug),
+          value,
+          percent: totalNum > 0 ? (value / totalNum) * 100 : 0,
+        };
+      });
   }, [data]);
 
   return (


### PR DESCRIPTION
## Summary
- Filter out categories with `0` open interest before rendering the OI by Category donut, so both the chart slices and the legend stop listing 0.0% rows.
- One-line filter in the existing `useMemo`; both the `<Pie>` and the legend `<ul>` iterate the same `slices` array, so a single change covers both.

## Test plan
- [ ] Visit the analytics page; confirm Tech & Science / Prices (and any other 0% categories) no longer appear in the donut or the legend.
- [ ] Confirm non-zero categories still render with correct percentages.
- [ ] Confirm the empty-state copy still appears when there is no OI at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)