### PR TITLE
Cherry-pick relayer observability (#1657) onto staging

### DIFF
--- a/packages/relayer/src/__tests__/handlers.test.ts
+++ b/packages/relayer/src/__tests__/handlers.test.ts
@@ -84,7 +84,9 @@ import {
   auctionReceivedAckRejected,
   clientsIdentified,
   serviceLabel,
+  variantLabel,
   KNOWN_SERVICE_LABELS,
+  KNOWN_VARIANT_LABELS,
 } from '../metrics';
 import { handleIdentify, handleAuctionReceived } from '../handlers/escrow';
 import { _resetBroadcastLedgerForTests } from '../broadcastLedger';
@@ -98,6 +100,7 @@ function mockClient(id = crypto.randomUUID()): ClientConnection {
   return {
     id,
     service: 'anonymous',
+    variant: 'default',
     send: vi.fn().mockReturnValue(true),
     close: vi.fn(),
     get isOpen() {
@@ -312,6 +315,7 @@ describe('Escrow Handlers', () => {
       handleAuctionReceived(recipient, { auctionId: 'auction-123' });
       expect(auctionReceivedAcks.inc).toHaveBeenCalledWith({
         service: 'anonymous',
+        variant: 'default',
       });
 
       vi.clearAllMocks();
@@ -322,7 +326,7 @@ describe('Escrow Handlers', () => {
       });
     });
 
-    it('uses bounded service label in broadcast metric', async () => {
+    it('uses bounded service+variant labels in broadcast metric', async () => {
       _resetBroadcastLedgerForTests();
       vi.mocked(validateAuctionRFQ).mockResolvedValue({ status: 'valid' });
       const details = { auctionId: 'auction-456', picks: [] };
@@ -330,6 +334,7 @@ describe('Escrow Handlers', () => {
 
       const evil = mockClient('cccccccc-0000-0000-0000-000000000000');
       evil.service = 'evil-service-not-on-allowlist';
+      evil.variant = 'rogue-variant';
       const ctx2 = { allClients: () => [evil] };
       const client = mockClient();
 
@@ -342,6 +347,43 @@ describe('Escrow Handlers', () => {
 
       expect(auctionBroadcastSends.inc).toHaveBeenCalledWith({
         service: 'unknown',
+        variant: 'unknown',
+        ok: 'true',
+      });
+    });
+
+    it('breaks out broadcast metric per (service, variant) pair', async () => {
+      _resetBroadcastLedgerForTests();
+      vi.mocked(validateAuctionRFQ).mockResolvedValue({ status: 'valid' });
+      const details = { auctionId: 'auction-789', picks: [] };
+      vi.mocked(getEscrowAuctionDetails).mockReturnValue(details as never);
+
+      const main = mockClient('mmmmmmmm-0000-0000-0000-000000000000');
+      main.service = 'auction-bidder';
+      main.variant = 'default';
+
+      const pyth = mockClient('pppppppp-0000-0000-0000-000000000000');
+      pyth.service = 'auction-bidder';
+      pyth.variant = 'pyth';
+
+      const ctx2 = { allClients: () => [main, pyth] };
+      const client = mockClient();
+
+      await handleAuctionStart(
+        client,
+        baseAuctionPayload as never,
+        mockSubs(),
+        ctx2
+      );
+
+      expect(auctionBroadcastSends.inc).toHaveBeenCalledWith({
+        service: 'auction-bidder',
+        variant: 'default',
+        ok: 'true',
+      });
+      expect(auctionBroadcastSends.inc).toHaveBeenCalledWith({
+        service: 'auction-bidder',
+        variant: 'pyth',
         ok: 'true',
       });
     });
@@ -953,23 +995,55 @@ describe('serviceLabel allowlist', () => {
   });
 });
 
+describe('variantLabel allowlist', () => {
+  it('returns the raw value for known variants', () => {
+    for (const known of KNOWN_VARIANT_LABELS) {
+      expect(variantLabel(known)).toBe(known);
+    }
+  });
+  it('falls back to "default" for empty/undefined', () => {
+    expect(variantLabel('')).toBe('default');
+    expect(variantLabel(undefined)).toBe('default');
+  });
+  it('collapses unknown variants to "unknown"', () => {
+    expect(variantLabel('rogue')).toBe('unknown');
+    expect(variantLabel('attacker-' + 'v'.repeat(100))).toBe('unknown');
+  });
+});
+
 describe('handleIdentify', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('sets service / instanceId / chainId on the client', () => {
+  it('sets service / variant / instanceId / chainId on the client', () => {
     const client = mockClient();
     handleIdentify(client, {
       service: 'auction-bidder',
+      variant: 'pyth',
       instanceId: 'inst-1',
       chainId: 5064014,
     });
     expect(client.service).toBe('auction-bidder');
+    expect(client.variant).toBe('pyth');
     expect(client.instanceId).toBe('inst-1');
     expect(client.chainId).toBe(5064014);
     expect(clientsIdentified.inc).toHaveBeenCalledWith({
       service: 'auction-bidder',
+      variant: 'pyth',
+    });
+  });
+
+  it('defaults variant to "default" when omitted', () => {
+    const client = mockClient();
+    handleIdentify(client, {
+      service: 'auction-bidder',
+      instanceId: 'inst-1',
+    });
+    expect(client.variant).toBe('default');
+    expect(clientsIdentified.inc).toHaveBeenCalledWith({
+      service: 'auction-bidder',
+      variant: 'default',
     });
   });
 
@@ -977,31 +1051,42 @@ describe('handleIdentify', () => {
     const client = mockClient();
     handleIdentify(client, {
       service: 'attacker-' + 'a'.repeat(100),
+      variant: 'rogue',
       instanceId: 'inst-x',
     });
-    // raw (truncated to 64) is what shows up in logs
+    // raw (truncated) is what shows up in logs
     expect(client.service.length).toBeLessThanOrEqual(64);
     expect(client.service.startsWith('attacker-')).toBe(true);
-    // metric label collapsed to 'unknown' so cardinality stays bounded
-    expect(clientsIdentified.inc).toHaveBeenCalledWith({ service: 'unknown' });
+    expect(client.variant).toBe('rogue');
+    // metric labels collapsed so cardinality stays bounded
+    expect(clientsIdentified.inc).toHaveBeenCalledWith({
+      service: 'unknown',
+      variant: 'unknown',
+    });
   });
 
   it('strips control characters from logged identity fields', () => {
     const client = mockClient();
     handleIdentify(client, {
       service: 'auction-bidder\nINJECTED',
+      variant: 'pyth\r\n!!!',
       instanceId: 'inst\r\n!!!',
     });
     expect(client.service).toBe('auction-bidder?INJECTED');
+    expect(client.variant).toBe('pyth??!!!');
     expect(client.instanceId).toBe('inst??!!!');
-    // raw service is not in the allowlist after sanitization → 'unknown'
-    expect(clientsIdentified.inc).toHaveBeenCalledWith({ service: 'unknown' });
+    // raw values aren't in either allowlist after sanitization
+    expect(clientsIdentified.inc).toHaveBeenCalledWith({
+      service: 'unknown',
+      variant: 'unknown',
+    });
   });
 
   it('ignores malformed payload', () => {
     const client = mockClient();
     handleIdentify(client, undefined);
     expect(client.service).toBe('anonymous');
+    expect(client.variant).toBe('default');
     expect(clientsIdentified.inc).not.toHaveBeenCalled();
   });
 });

--- a/packages/relayer/src/__tests__/handlers.test.ts
+++ b/packages/relayer/src/__tests__/handlers.test.ts
@@ -24,6 +24,9 @@ vi.mock('../metrics', () => ({
   errorsTotal: { inc: vi.fn() },
   subscriptionsActive: { inc: vi.fn(), dec: vi.fn() },
   vaultQuotesPublished: { inc: vi.fn() },
+  auctionBroadcastSends: { inc: vi.fn() },
+  auctionReceivedAcks: { inc: vi.fn() },
+  clientsIdentified: { inc: vi.fn() },
 }));
 
 // ── Mock viem ──────────────────────────────────────────────────────────────
@@ -79,7 +82,8 @@ import { verifyMessage } from 'viem';
 function mockClient(id = crypto.randomUUID()): ClientConnection {
   return {
     id,
-    send: vi.fn(),
+    service: 'anonymous',
+    send: vi.fn().mockReturnValue(true),
     close: vi.fn(),
     get isOpen() {
       return true;

--- a/packages/relayer/src/__tests__/handlers.test.ts
+++ b/packages/relayer/src/__tests__/handlers.test.ts
@@ -18,16 +18,23 @@ vi.mock('../escrowRegistry', () => ({
 }));
 
 // ── Mock metrics (no-op counters) ──────────────────────────────────────────
-vi.mock('../metrics', () => ({
-  auctionsStarted: { inc: vi.fn() },
-  bidsSubmitted: { inc: vi.fn() },
-  errorsTotal: { inc: vi.fn() },
-  subscriptionsActive: { inc: vi.fn(), dec: vi.fn() },
-  vaultQuotesPublished: { inc: vi.fn() },
-  auctionBroadcastSends: { inc: vi.fn() },
-  auctionReceivedAcks: { inc: vi.fn() },
-  clientsIdentified: { inc: vi.fn() },
-}));
+vi.mock('../metrics', async (importOriginal) => {
+  // Use the real `serviceLabel` (and KNOWN_SERVICE_LABELS) so allowlist
+  // behavior is exercised in tests; only counters are stubbed.
+  const actual = await importOriginal<typeof import('../metrics')>();
+  return {
+    ...actual,
+    auctionsStarted: { inc: vi.fn() },
+    bidsSubmitted: { inc: vi.fn() },
+    errorsTotal: { inc: vi.fn() },
+    subscriptionsActive: { inc: vi.fn(), dec: vi.fn() },
+    vaultQuotesPublished: { inc: vi.fn() },
+    auctionBroadcastSends: { inc: vi.fn() },
+    auctionReceivedAcks: { inc: vi.fn() },
+    auctionReceivedAckRejected: { inc: vi.fn() },
+    clientsIdentified: { inc: vi.fn() },
+  };
+});
 
 // ── Mock viem ──────────────────────────────────────────────────────────────
 vi.mock('viem', () => ({
@@ -72,7 +79,15 @@ import {
   errorsTotal,
   subscriptionsActive,
   vaultQuotesPublished,
+  auctionBroadcastSends,
+  auctionReceivedAcks,
+  auctionReceivedAckRejected,
+  clientsIdentified,
+  serviceLabel,
+  KNOWN_SERVICE_LABELS,
 } from '../metrics';
+import { handleIdentify, handleAuctionReceived } from '../handlers/escrow';
+import { _resetBroadcastLedgerForTests } from '../broadcastLedger';
 import { verifyMessage } from 'viem';
 
 // ============================================================================
@@ -271,6 +286,64 @@ describe('Escrow Handlers', () => {
       expect(bot2.send).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'auction.started' })
       );
+    });
+
+    it('records broadcast recipients only when send succeeded', async () => {
+      _resetBroadcastLedgerForTests();
+      vi.mocked(validateAuctionRFQ).mockResolvedValue({ status: 'valid' });
+      const details = { auctionId: 'auction-123', picks: [] };
+      vi.mocked(getEscrowAuctionDetails).mockReturnValue(details as never);
+
+      const recipient = mockClient('aaaaaaaa-0000-0000-0000-000000000000');
+      const failing = mockClient('bbbbbbbb-0000-0000-0000-000000000000');
+      // simulate a transport-level send failure
+      (failing.send as ReturnType<typeof vi.fn>).mockReturnValue(false);
+      const ctx2 = { allClients: () => [recipient, failing] };
+      const client = mockClient();
+
+      await handleAuctionStart(
+        client,
+        baseAuctionPayload as never,
+        mockSubs(),
+        ctx2
+      );
+
+      // recipient was acknowledged into the ledger; failing was not
+      handleAuctionReceived(recipient, { auctionId: 'auction-123' });
+      expect(auctionReceivedAcks.inc).toHaveBeenCalledWith({
+        service: 'anonymous',
+      });
+
+      vi.clearAllMocks();
+      handleAuctionReceived(failing, { auctionId: 'auction-123' });
+      expect(auctionReceivedAcks.inc).not.toHaveBeenCalled();
+      expect(auctionReceivedAckRejected.inc).toHaveBeenCalledWith({
+        reason: 'not_recipient',
+      });
+    });
+
+    it('uses bounded service label in broadcast metric', async () => {
+      _resetBroadcastLedgerForTests();
+      vi.mocked(validateAuctionRFQ).mockResolvedValue({ status: 'valid' });
+      const details = { auctionId: 'auction-456', picks: [] };
+      vi.mocked(getEscrowAuctionDetails).mockReturnValue(details as never);
+
+      const evil = mockClient('cccccccc-0000-0000-0000-000000000000');
+      evil.service = 'evil-service-not-on-allowlist';
+      const ctx2 = { allClients: () => [evil] };
+      const client = mockClient();
+
+      await handleAuctionStart(
+        client,
+        baseAuctionPayload as never,
+        mockSubs(),
+        ctx2
+      );
+
+      expect(auctionBroadcastSends.inc).toHaveBeenCalledWith({
+        service: 'unknown',
+        ok: 'true',
+      });
     });
 
     it('echoes requestId in ack when provided', async () => {
@@ -858,6 +931,128 @@ describe('Vault Handlers', () => {
       expect(vaultQuotesPublished.inc).toHaveBeenCalledWith({
         status: 'error',
       });
+    });
+  });
+});
+
+// ============================================================================
+// Identity + spoof-resistant ack
+// ============================================================================
+
+describe('serviceLabel allowlist', () => {
+  it('returns the raw value for known services', () => {
+    for (const known of KNOWN_SERVICE_LABELS) {
+      expect(serviceLabel(known)).toBe(known);
+    }
+  });
+  it('collapses unknown services to "unknown"', () => {
+    expect(serviceLabel('evil')).toBe('unknown');
+    expect(serviceLabel('attacker-' + 'x'.repeat(100))).toBe('unknown');
+    expect(serviceLabel('')).toBe('unknown');
+    expect(serviceLabel(undefined)).toBe('unknown');
+  });
+});
+
+describe('handleIdentify', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sets service / instanceId / chainId on the client', () => {
+    const client = mockClient();
+    handleIdentify(client, {
+      service: 'auction-bidder',
+      instanceId: 'inst-1',
+      chainId: 5064014,
+    });
+    expect(client.service).toBe('auction-bidder');
+    expect(client.instanceId).toBe('inst-1');
+    expect(client.chainId).toBe(5064014);
+    expect(clientsIdentified.inc).toHaveBeenCalledWith({
+      service: 'auction-bidder',
+    });
+  });
+
+  it('keeps the raw service in the client field but uses bounded label for the metric', () => {
+    const client = mockClient();
+    handleIdentify(client, {
+      service: 'attacker-' + 'a'.repeat(100),
+      instanceId: 'inst-x',
+    });
+    // raw (truncated to 64) is what shows up in logs
+    expect(client.service.length).toBeLessThanOrEqual(64);
+    expect(client.service.startsWith('attacker-')).toBe(true);
+    // metric label collapsed to 'unknown' so cardinality stays bounded
+    expect(clientsIdentified.inc).toHaveBeenCalledWith({ service: 'unknown' });
+  });
+
+  it('strips control characters from logged identity fields', () => {
+    const client = mockClient();
+    handleIdentify(client, {
+      service: 'auction-bidder\nINJECTED',
+      instanceId: 'inst\r\n!!!',
+    });
+    expect(client.service).toBe('auction-bidder?INJECTED');
+    expect(client.instanceId).toBe('inst??!!!');
+    // raw service is not in the allowlist after sanitization → 'unknown'
+    expect(clientsIdentified.inc).toHaveBeenCalledWith({ service: 'unknown' });
+  });
+
+  it('ignores malformed payload', () => {
+    const client = mockClient();
+    handleIdentify(client, undefined);
+    expect(client.service).toBe('anonymous');
+    expect(clientsIdentified.inc).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleAuctionReceived (anti-spoof)', () => {
+  beforeEach(() => {
+    _resetBroadcastLedgerForTests();
+    vi.clearAllMocks();
+  });
+
+  it('rejects acks for auctions that were never broadcast to the client', () => {
+    const client = mockClient();
+    handleAuctionReceived(client, { auctionId: 'never-sent' });
+    expect(auctionReceivedAcks.inc).not.toHaveBeenCalled();
+    expect(auctionReceivedAckRejected.inc).toHaveBeenCalledWith({
+      reason: 'not_recipient',
+    });
+  });
+
+  it('rejects malformed payloads', () => {
+    const client = mockClient();
+    handleAuctionReceived(client, undefined);
+    handleAuctionReceived(client, { auctionId: 123 } as never);
+    expect(auctionReceivedAcks.inc).not.toHaveBeenCalled();
+    expect(auctionReceivedAckRejected.inc).toHaveBeenCalledWith({
+      reason: 'invalid_payload',
+    });
+  });
+
+  it('does not let client A ack an auction broadcast only to client B', async () => {
+    vi.mocked(validateAuctionRFQ).mockResolvedValue({ status: 'valid' });
+    const details = { auctionId: 'auction-123', picks: [] };
+    vi.mocked(getEscrowAuctionDetails).mockReturnValue(details as never);
+
+    const recipient = mockClient('rrrrrrrr-0000-0000-0000-000000000000');
+    const spoofer = mockClient('ssssssss-0000-0000-0000-000000000000');
+    spoofer.service = 'auction-bidder'; // pretend to be the funded bidder
+    const ctx2 = { allClients: () => [recipient] };
+    const client = mockClient();
+
+    await handleAuctionStart(
+      client,
+      baseAuctionPayload as never,
+      mockSubs(),
+      ctx2
+    );
+
+    handleAuctionReceived(spoofer, { auctionId: 'auction-123' });
+    expect(auctionReceivedAcks.inc).not.toHaveBeenCalled();
+    expect(auctionReceivedAckRejected.inc).toHaveBeenCalledWith({
+      reason: 'not_recipient',
     });
   });
 });

--- a/packages/relayer/src/__tests__/secondaryMarket.test.ts
+++ b/packages/relayer/src/__tests__/secondaryMarket.test.ts
@@ -394,10 +394,12 @@ function createMockClient(): MockClient {
   return {
     send: (msg: unknown) => {
       messages.push(msg);
+      return true;
     },
     close: () => {},
     isOpen: true,
     id: `test-client-${Math.random().toString(36).slice(2)}`,
+    service: 'anonymous',
     _messages: messages,
   } as MockClient;
 }

--- a/packages/relayer/src/__tests__/secondaryMarket.test.ts
+++ b/packages/relayer/src/__tests__/secondaryMarket.test.ts
@@ -400,6 +400,7 @@ function createMockClient(): MockClient {
     isOpen: true,
     id: `test-client-${Math.random().toString(36).slice(2)}`,
     service: 'anonymous',
+    variant: 'default',
     _messages: messages,
   } as MockClient;
 }

--- a/packages/relayer/src/__tests__/transport.test.ts
+++ b/packages/relayer/src/__tests__/transport.test.ts
@@ -9,6 +9,7 @@ function mockClient(
   return {
     id,
     service: 'anonymous',
+    variant: 'default',
     send: vi.fn().mockReturnValue(true),
     close: vi.fn(),
     get isOpen() {

--- a/packages/relayer/src/__tests__/transport.test.ts
+++ b/packages/relayer/src/__tests__/transport.test.ts
@@ -8,7 +8,8 @@ function mockClient(
 ): ClientConnection {
   return {
     id,
-    send: vi.fn(),
+    service: 'anonymous',
+    send: vi.fn().mockReturnValue(true),
     close: vi.fn(),
     get isOpen() {
       return open;

--- a/packages/relayer/src/__tests__/wsTransport.test.ts
+++ b/packages/relayer/src/__tests__/wsTransport.test.ts
@@ -38,7 +38,11 @@ describe('createWsClientConnection', () => {
     it('JSON-serializes objects and sends when OPEN', () => {
       const ws = mockWs();
       const client = createWsClientConnection(ws);
-      client.send({ type: 'auction.ack', payload: { auctionId: '123' } });
+      const ok = client.send({
+        type: 'auction.ack',
+        payload: { auctionId: '123' },
+      });
+      expect(ok).toBe(true);
       expect(ws.send).toHaveBeenCalledWith(
         JSON.stringify({ type: 'auction.ack', payload: { auctionId: '123' } })
       );
@@ -55,8 +59,25 @@ describe('createWsClientConnection', () => {
     it('does not send when socket is not OPEN', () => {
       const ws = mockWs(WebSocket.CLOSED);
       const client = createWsClientConnection(ws);
-      client.send({ type: 'test' });
+      const ok = client.send({ type: 'test' });
+      expect(ok).toBe(false);
       expect(ws.send).not.toHaveBeenCalled();
+    });
+
+    it('returns false when ws.send throws', () => {
+      const ws = mockWs();
+      (ws.send as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        throw new Error('boom');
+      });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const client = createWsClientConnection(ws);
+      const ok = client.send({ type: 'test' });
+      expect(ok).toBe(false);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('ws.send() failed'),
+        expect.anything()
+      );
+      warnSpy.mockRestore();
     });
 
     it('logs warning when socket is not OPEN', () => {

--- a/packages/relayer/src/broadcastLedger.ts
+++ b/packages/relayer/src/broadcastLedger.ts
@@ -1,0 +1,42 @@
+/**
+ * Per-(auctionId, clientId) record of which clients the relayer attempted to
+ * deliver `auction.started` to. Used to gate `auction.received` acks so a
+ * malicious or buggy WS client can't fabricate proof-of-delivery for an
+ * auction it never received.
+ *
+ * In-memory and process-local — same scope as the escrow auction registry.
+ * Memory bound: <connections> * <auctions in TTL window>, both small.
+ */
+
+const TTL_MS = 90_000; // a bit over the 60s auction TTL to tolerate late acks
+const SWEEP_INTERVAL_MS = 30_000;
+
+const ledger = new Map<string, Map<string, number>>();
+
+export function recordBroadcast(auctionId: string, clientId: string): void {
+  let inner = ledger.get(auctionId);
+  if (!inner) {
+    inner = new Map();
+    ledger.set(auctionId, inner);
+  }
+  inner.set(clientId, Date.now());
+}
+
+export function wasBroadcastTo(auctionId: string, clientId: string): boolean {
+  return ledger.get(auctionId)?.has(clientId) ?? false;
+}
+
+/** Test-only — never call from production code. */
+export function _resetBroadcastLedgerForTests(): void {
+  ledger.clear();
+}
+
+setInterval(() => {
+  const cutoff = Date.now() - TTL_MS;
+  for (const [auctionId, inner] of ledger) {
+    for (const [clientId, ts] of inner) {
+      if (ts < cutoff) inner.delete(clientId);
+    }
+    if (inner.size === 0) ledger.delete(auctionId);
+  }
+}, SWEEP_INTERVAL_MS).unref?.();

--- a/packages/relayer/src/escrowTypes.ts
+++ b/packages/relayer/src/escrowTypes.ts
@@ -37,6 +37,8 @@ export function isEscrowClientMessage(
       msgObj.type === 'auction.subscribe' ||
       msgObj.type === 'auction.unsubscribe' ||
       msgObj.type === 'bid.submit' ||
+      msgObj.type === 'identify' ||
+      msgObj.type === 'auction.received' ||
       msgObj.type === 'ping')
   );
 }

--- a/packages/relayer/src/handlers/escrow.ts
+++ b/packages/relayer/src/handlers/escrow.ts
@@ -37,6 +37,7 @@ import {
   auctionReceivedAckRejected,
   clientsIdentified,
   serviceLabel,
+  variantLabel,
 } from '../metrics';
 import { recordBroadcast, wasBroadcastTo } from '../broadcastLedger';
 import { config } from '../config';
@@ -167,6 +168,7 @@ export async function handleAuctionStart(
       }
       auctionBroadcastSends.inc({
         service: serviceLabel(c.service),
+        variant: variantLabel(c.variant),
         ok: ok ? 'true' : 'false',
       });
       if (ok) {
@@ -175,14 +177,14 @@ export async function handleAuctionStart(
         console.log(
           `[Relayer] auction.broadcast.send auctionId=${auctionShort} clientId=${short(
             c.id
-          )} service=${c.service} instance=${short(c.instanceId)} ok=true`
+          )} service=${c.service} variant=${c.variant} instance=${short(c.instanceId)} ok=true`
         );
       } else {
         failed++;
         console.warn(
           `[Relayer] auction.broadcast.send auctionId=${auctionShort} clientId=${short(
             c.id
-          )} service=${c.service} instance=${short(c.instanceId)} ok=false`
+          )} service=${c.service} variant=${c.variant} instance=${short(c.instanceId)} ok=false`
         );
       }
     }
@@ -367,6 +369,10 @@ export function handleIdentify(
     typeof payload.service === 'string' && payload.service.length > 0
       ? sanitizeForLog(payload.service.slice(0, 64))
       : 'anonymous';
+  const rawVariant =
+    typeof payload.variant === 'string' && payload.variant.length > 0
+      ? sanitizeForLog(payload.variant.slice(0, 32))
+      : 'default';
   const instanceId =
     typeof payload.instanceId === 'string' && payload.instanceId.length > 0
       ? sanitizeForLog(payload.instanceId.slice(0, 64))
@@ -377,12 +383,16 @@ export function handleIdentify(
       : undefined;
 
   client.service = rawService;
+  client.variant = rawVariant;
   client.instanceId = instanceId;
   client.chainId = chainId;
 
-  clientsIdentified.inc({ service: serviceLabel(rawService) });
+  clientsIdentified.inc({
+    service: serviceLabel(rawService),
+    variant: variantLabel(rawVariant),
+  });
   console.log(
-    `[Relayer] client.identified clientId=${short(client.id)} service=${rawService} instance=${short(
+    `[Relayer] client.identified clientId=${short(client.id)} service=${rawService} variant=${rawVariant} instance=${short(
       instanceId
     )} chainId=${chainId ?? 'none'} serviceInstance=${
       typeof payload.serviceInstance === 'string'
@@ -434,12 +444,15 @@ export function handleAuctionReceived(
     );
     return;
   }
-  auctionReceivedAcks.inc({ service: serviceLabel(client.service) });
+  auctionReceivedAcks.inc({
+    service: serviceLabel(client.service),
+    variant: variantLabel(client.variant),
+  });
   console.log(
     `[Relayer] auction.client_ack auctionId=${payload.auctionId.slice(
       0,
       8
-    )} clientId=${short(client.id)} service=${client.service} instance=${short(
+    )} clientId=${short(client.id)} service=${client.service} variant=${client.variant} instance=${short(
       client.instanceId
     )}`
   );

--- a/packages/relayer/src/handlers/escrow.ts
+++ b/packages/relayer/src/handlers/escrow.ts
@@ -149,7 +149,7 @@ export async function handleAuctionStart(
   const details = getEscrowAuctionDetails(auctionId);
   if (details) {
     const broadcastMsg = { type: 'auction.started', payload: details };
-    const auctionShort = auctionId.slice(0, 8);
+    const auctionShort = short(auctionId);
     let attempted = 0;
     let sent = 0;
     let failed = 0;
@@ -175,16 +175,16 @@ export async function handleAuctionStart(
         sent++;
         recordBroadcast(auctionId, c.id);
         console.log(
-          `[Relayer] auction.broadcast.send auctionId=${auctionShort} clientId=${short(
+          `[Relayer] auction.broadcast.send ok=true auctionId=${auctionShort} clientId=${short(
             c.id
-          )} service=${c.service} variant=${c.variant} instance=${short(c.instanceId)} ok=true`
+          )} service=${c.service} variant=${c.variant} instance=${short(c.instanceId)}`
         );
       } else {
         failed++;
         console.warn(
-          `[Relayer] auction.broadcast.send auctionId=${auctionShort} clientId=${short(
+          `[Relayer] auction.broadcast.send ok=false auctionId=${auctionShort} clientId=${short(
             c.id
-          )} service=${c.service} variant=${c.variant} instance=${short(c.instanceId)} ok=false`
+          )} service=${c.service} variant=${c.variant} instance=${short(c.instanceId)}`
         );
       }
     }
@@ -437,9 +437,8 @@ export function handleAuctionReceived(
   if (!wasBroadcastTo(payload.auctionId, client.id)) {
     auctionReceivedAckRejected.inc({ reason: 'not_recipient' });
     console.warn(
-      `[Relayer] auction.received rejected (no broadcast record) auctionId=${payload.auctionId.slice(
-        0,
-        8
+      `[Relayer] auction.received rejected (no broadcast record) auctionId=${short(
+        payload.auctionId
       )} clientId=${short(client.id)} service=${client.service}`
     );
     return;
@@ -449,9 +448,8 @@ export function handleAuctionReceived(
     variant: variantLabel(client.variant),
   });
   console.log(
-    `[Relayer] auction.client_ack auctionId=${payload.auctionId.slice(
-      0,
-      8
+    `[Relayer] auction.client_ack auctionId=${short(
+      payload.auctionId
     )} clientId=${short(client.id)} service=${client.service} variant=${client.variant} instance=${short(
       client.instanceId
     )}`

--- a/packages/relayer/src/handlers/escrow.ts
+++ b/packages/relayer/src/handlers/escrow.ts
@@ -12,6 +12,10 @@ import type {
   BidPayload,
   ServerToClientMessage,
 } from '../escrowTypes';
+import type {
+  IdentifyPayload,
+  AuctionReceivedPayload,
+} from '@sapience/sdk/types';
 import {
   validateAuctionRFQ,
   validateBid,
@@ -28,8 +32,15 @@ import {
   bidsSubmitted,
   errorsTotal,
   subscriptionsActive,
+  auctionBroadcastSends,
+  auctionReceivedAcks,
+  clientsIdentified,
 } from '../metrics';
 import { config } from '../config';
+
+// Identity helpers — keep clientId/instanceId short in logs.
+const short = (s: string | undefined): string =>
+  s ? s.slice(0, 8) : 'unknown';
 
 // Structured timing log for observability
 function logTiming(
@@ -120,22 +131,60 @@ export async function handleAuctionStart(
   client.send({ type: 'auction.ack', payload: ackPayload });
   logTiming(auctionId, 'ack_sent', startTime);
 
-  // Broadcast auction.started with auction details to all connected clients
+  // Broadcast auction.started with auction details to all connected clients.
+  // Per-client logging here is intentional: it's the only ground truth we
+  // have for "did the relayer attempt to deliver this auction to this bot."
+  // Without it, a silent miss (auction received, but bot never saw it) is
+  // indistinguishable from a relayer-side failure.
   const details = getEscrowAuctionDetails(auctionId);
   if (details) {
     const broadcastMsg = { type: 'auction.started', payload: details };
-    let botCount = 0;
+    const auctionShort = auctionId.slice(0, 8);
+    let attempted = 0;
+    let sent = 0;
+    let failed = 0;
+    let skippedClosed = 0;
     for (const c of ctx.allClients()) {
-      if (c.isOpen) {
-        try {
-          c.send(broadcastMsg);
-          botCount++;
-        } catch {
-          /* skip dead connections */
-        }
+      if (!c.isOpen) {
+        skippedClosed++;
+        continue;
+      }
+      attempted++;
+      let ok = false;
+      try {
+        ok = c.send(broadcastMsg);
+      } catch {
+        ok = false;
+      }
+      auctionBroadcastSends.inc({
+        service: c.service,
+        ok: ok ? 'true' : 'false',
+      });
+      if (ok) {
+        sent++;
+        console.log(
+          `[Relayer] auction.broadcast.send auctionId=${auctionShort} clientId=${short(
+            c.id
+          )} service=${c.service} instance=${short(c.instanceId)} ok=true`
+        );
+      } else {
+        failed++;
+        console.warn(
+          `[Relayer] auction.broadcast.send auctionId=${auctionShort} clientId=${short(
+            c.id
+          )} service=${c.service} instance=${short(c.instanceId)} ok=false`
+        );
       }
     }
-    logTiming(auctionId, 'broadcast', startTime, { bots: botCount });
+    console.log(
+      `[Relayer] auction.broadcast.done auctionId=${auctionShort} attempted=${attempted} sent=${sent} failed=${failed} skippedClosed=${skippedClosed}`
+    );
+    logTiming(auctionId, 'broadcast', startTime, {
+      attempted,
+      sent,
+      failed,
+      skippedClosed,
+    });
   }
 
   // Immediately stream current bids if any
@@ -289,4 +338,77 @@ export async function handleBidSubmit(
   });
 
   return false;
+}
+
+/**
+ * Identify handshake — clients announce service/instance identity so per-client
+ * broadcast logs are useful. No-op if payload is malformed; we don't penalize
+ * because identify is best-effort observability, not auth.
+ */
+export function handleIdentify(
+  client: ClientConnection,
+  payload: IdentifyPayload | undefined
+): void {
+  if (!payload || typeof payload !== 'object') return;
+  const service =
+    typeof payload.service === 'string' && payload.service.length > 0
+      ? payload.service.slice(0, 64)
+      : 'anonymous';
+  const instanceId =
+    typeof payload.instanceId === 'string' && payload.instanceId.length > 0
+      ? payload.instanceId.slice(0, 64)
+      : undefined;
+  const chainId =
+    typeof payload.chainId === 'number' && Number.isFinite(payload.chainId)
+      ? payload.chainId
+      : undefined;
+
+  client.service = service;
+  client.instanceId = instanceId;
+  client.chainId = chainId;
+
+  clientsIdentified.inc({ service });
+  console.log(
+    `[Relayer] client.identified clientId=${short(client.id)} service=${service} instance=${short(
+      instanceId
+    )} chainId=${chainId ?? 'none'} serviceInstance=${
+      typeof payload.serviceInstance === 'string'
+        ? payload.serviceInstance.slice(0, 32)
+        : 'none'
+    } deploy=${
+      typeof payload.deploymentId === 'string'
+        ? payload.deploymentId.slice(0, 12)
+        : 'none'
+    } replica=${
+      typeof payload.replicaId === 'string'
+        ? payload.replicaId.slice(0, 12)
+        : 'none'
+    } version=${
+      typeof payload.version === 'string'
+        ? payload.version.slice(0, 16)
+        : 'none'
+    }`
+  );
+}
+
+/**
+ * Bot ack for auction.started — proves end-to-end delivery (the bot's WS
+ * handler ran and saw the auction). Without this ack, a successful `ws.send`
+ * is the strongest signal we have, and it only proves the kernel buffer
+ * accepted the bytes.
+ */
+export function handleAuctionReceived(
+  client: ClientConnection,
+  payload: AuctionReceivedPayload | undefined
+): void {
+  if (!payload || typeof payload.auctionId !== 'string') return;
+  auctionReceivedAcks.inc({ service: client.service });
+  console.log(
+    `[Relayer] auction.client_ack auctionId=${payload.auctionId.slice(
+      0,
+      8
+    )} clientId=${short(client.id)} service=${client.service} instance=${short(
+      client.instanceId
+    )}`
+  );
 }

--- a/packages/relayer/src/handlers/escrow.ts
+++ b/packages/relayer/src/handlers/escrow.ts
@@ -34,13 +34,22 @@ import {
   subscriptionsActive,
   auctionBroadcastSends,
   auctionReceivedAcks,
+  auctionReceivedAckRejected,
   clientsIdentified,
+  serviceLabel,
 } from '../metrics';
+import { recordBroadcast, wasBroadcastTo } from '../broadcastLedger';
 import { config } from '../config';
 
 // Identity helpers — keep clientId/instanceId short in logs.
 const short = (s: string | undefined): string =>
   s ? s.slice(0, 8) : 'unknown';
+
+// Strip non-printable ASCII so a client can't inject newlines/control chars
+// into our log lines via the `service` field.
+const sanitizeForLog = (s: string): string =>
+  // eslint-disable-next-line no-control-regex
+  s.replace(/[^\x20-\x7E]/g, '?');
 
 // Structured timing log for observability
 function logTiming(
@@ -157,11 +166,12 @@ export async function handleAuctionStart(
         ok = false;
       }
       auctionBroadcastSends.inc({
-        service: c.service,
+        service: serviceLabel(c.service),
         ok: ok ? 'true' : 'false',
       });
       if (ok) {
         sent++;
+        recordBroadcast(auctionId, c.id);
         console.log(
           `[Relayer] auction.broadcast.send auctionId=${auctionShort} clientId=${short(
             c.id
@@ -350,42 +360,45 @@ export function handleIdentify(
   payload: IdentifyPayload | undefined
 ): void {
   if (!payload || typeof payload !== 'object') return;
-  const service =
+  // The raw service is stored on the client and used in log lines (verbatim,
+  // sanitized for log injection). The Prometheus label is bounded separately
+  // via serviceLabel() so a client cannot inflate metric cardinality.
+  const rawService =
     typeof payload.service === 'string' && payload.service.length > 0
-      ? payload.service.slice(0, 64)
+      ? sanitizeForLog(payload.service.slice(0, 64))
       : 'anonymous';
   const instanceId =
     typeof payload.instanceId === 'string' && payload.instanceId.length > 0
-      ? payload.instanceId.slice(0, 64)
+      ? sanitizeForLog(payload.instanceId.slice(0, 64))
       : undefined;
   const chainId =
     typeof payload.chainId === 'number' && Number.isFinite(payload.chainId)
       ? payload.chainId
       : undefined;
 
-  client.service = service;
+  client.service = rawService;
   client.instanceId = instanceId;
   client.chainId = chainId;
 
-  clientsIdentified.inc({ service });
+  clientsIdentified.inc({ service: serviceLabel(rawService) });
   console.log(
-    `[Relayer] client.identified clientId=${short(client.id)} service=${service} instance=${short(
+    `[Relayer] client.identified clientId=${short(client.id)} service=${rawService} instance=${short(
       instanceId
     )} chainId=${chainId ?? 'none'} serviceInstance=${
       typeof payload.serviceInstance === 'string'
-        ? payload.serviceInstance.slice(0, 32)
+        ? sanitizeForLog(payload.serviceInstance.slice(0, 32))
         : 'none'
     } deploy=${
       typeof payload.deploymentId === 'string'
-        ? payload.deploymentId.slice(0, 12)
+        ? sanitizeForLog(payload.deploymentId.slice(0, 12))
         : 'none'
     } replica=${
       typeof payload.replicaId === 'string'
-        ? payload.replicaId.slice(0, 12)
+        ? sanitizeForLog(payload.replicaId.slice(0, 12))
         : 'none'
     } version=${
       typeof payload.version === 'string'
-        ? payload.version.slice(0, 16)
+        ? sanitizeForLog(payload.version.slice(0, 16))
         : 'none'
     }`
   );
@@ -396,13 +409,32 @@ export function handleIdentify(
  * handler ran and saw the auction). Without this ack, a successful `ws.send`
  * is the strongest signal we have, and it only proves the kernel buffer
  * accepted the bytes.
+ *
+ * Anti-spoof: the relayer only honors an ack if it has a record of having
+ * broadcast that exact `auctionId` to this exact `clientId`. A client that
+ * fabricates an ack for an auction it never received gets dropped (and
+ * counted in `auctionReceivedAckRejected`), so the `auction.client_ack`
+ * log line is a real proof-of-delivery signal rather than self-reported.
  */
 export function handleAuctionReceived(
   client: ClientConnection,
   payload: AuctionReceivedPayload | undefined
 ): void {
-  if (!payload || typeof payload.auctionId !== 'string') return;
-  auctionReceivedAcks.inc({ service: client.service });
+  if (!payload || typeof payload.auctionId !== 'string') {
+    auctionReceivedAckRejected.inc({ reason: 'invalid_payload' });
+    return;
+  }
+  if (!wasBroadcastTo(payload.auctionId, client.id)) {
+    auctionReceivedAckRejected.inc({ reason: 'not_recipient' });
+    console.warn(
+      `[Relayer] auction.received rejected (no broadcast record) auctionId=${payload.auctionId.slice(
+        0,
+        8
+      )} clientId=${short(client.id)} service=${client.service}`
+    );
+    return;
+  }
+  auctionReceivedAcks.inc({ service: serviceLabel(client.service) });
   console.log(
     `[Relayer] auction.client_ack auctionId=${payload.auctionId.slice(
       0,

--- a/packages/relayer/src/metrics.ts
+++ b/packages/relayer/src/metrics.ts
@@ -80,14 +80,21 @@ export const auctionsStarted = new Counter({
 export const auctionBroadcastSends = new Counter({
   name: 'relayer_auction_broadcast_sends_total',
   help: 'Per-client auction.started broadcast attempts',
-  labelNames: ['service', 'ok'], // service: 'market-maker' | 'estimator' | 'anonymous' | ...; ok: 'true' | 'false'
+  labelNames: ['service', 'ok'], // service is bounded to KNOWN_SERVICE_LABELS via serviceLabel()
   registers: [register],
 });
 
 export const auctionReceivedAcks = new Counter({
   name: 'relayer_auction_received_acks_total',
-  help: 'Per-client auction.received acks (proves end-to-end delivery)',
+  help: 'Per-client auction.received acks gated by the broadcast ledger (proves end-to-end delivery)',
   labelNames: ['service'],
+  registers: [register],
+});
+
+export const auctionReceivedAckRejected = new Counter({
+  name: 'relayer_auction_received_ack_rejected_total',
+  help: 'auction.received messages dropped because the relayer never broadcast that auction to that client',
+  labelNames: ['reason'], // 'not_recipient' (no broadcast record) | 'invalid_payload'
   registers: [register],
 });
 
@@ -97,6 +104,36 @@ export const clientsIdentified = new Counter({
   labelNames: ['service'],
   registers: [register],
 });
+
+// ============================================================================
+// Service label allowlist
+// ============================================================================
+
+/**
+ * Bounded set of service names that may appear as Prometheus label values.
+ * Anything sent by a client that doesn't match collapses to `'unknown'` so a
+ * misbehaving (or malicious) bot cannot blow up metric cardinality by sending
+ * a fresh `service` string on every connect.
+ *
+ * Adding a new service requires a code change here AND a relayer redeploy —
+ * which is the right tradeoff for a Prometheus label.
+ */
+export const KNOWN_SERVICE_LABELS = [
+  'auction-bidder',
+  'estimator',
+  'secondary-bidder',
+  'vault-quoter',
+  'anonymous',
+] as const;
+
+const KNOWN_SERVICE_LABEL_SET: ReadonlySet<string> = new Set(
+  KNOWN_SERVICE_LABELS
+);
+
+export function serviceLabel(rawService: string | undefined): string {
+  if (!rawService) return 'unknown';
+  return KNOWN_SERVICE_LABEL_SET.has(rawService) ? rawService : 'unknown';
+}
 
 export const bidsSubmitted = new Counter({
   name: 'relayer_bids_submitted_total',

--- a/packages/relayer/src/metrics.ts
+++ b/packages/relayer/src/metrics.ts
@@ -80,14 +80,16 @@ export const auctionsStarted = new Counter({
 export const auctionBroadcastSends = new Counter({
   name: 'relayer_auction_broadcast_sends_total',
   help: 'Per-client auction.started broadcast attempts',
-  labelNames: ['service', 'ok'], // service is bounded to KNOWN_SERVICE_LABELS via serviceLabel()
+  // service+variant are bounded via serviceLabel()/variantLabel() so cardinality
+  // can't grow with arbitrary client-supplied strings.
+  labelNames: ['service', 'variant', 'ok'],
   registers: [register],
 });
 
 export const auctionReceivedAcks = new Counter({
   name: 'relayer_auction_received_acks_total',
   help: 'Per-client auction.received acks gated by the broadcast ledger (proves end-to-end delivery)',
-  labelNames: ['service'],
+  labelNames: ['service', 'variant'],
   registers: [register],
 });
 
@@ -101,22 +103,26 @@ export const auctionReceivedAckRejected = new Counter({
 export const clientsIdentified = new Counter({
   name: 'relayer_clients_identified_total',
   help: 'Total identify handshakes accepted',
-  labelNames: ['service'],
+  labelNames: ['service', 'variant'],
   registers: [register],
 });
 
 // ============================================================================
-// Service label allowlist
+// Service / variant label allowlists
 // ============================================================================
 
 /**
- * Bounded set of service names that may appear as Prometheus label values.
- * Anything sent by a client that doesn't match collapses to `'unknown'` so a
- * misbehaving (or malicious) bot cannot blow up metric cardinality by sending
- * a fresh `service` string on every connect.
+ * Bounded sets of identifier values that may appear as Prometheus label
+ * values. Anything sent by a client that doesn't match collapses to
+ * `'unknown'` so a misbehaving (or malicious) bot cannot blow up metric
+ * cardinality by sending a fresh string on every connect.
  *
- * Adding a new service requires a code change here AND a relayer redeploy —
- * which is the right tradeoff for a Prometheus label.
+ * `service` is the logical service name (kind of bot). `variant` is the
+ * strategy/vault flavor — kept orthogonal so we have at most one bot family
+ * per service, and `sum by (service) (...)` reports across all variants.
+ *
+ * Adding a value requires a code change here AND a relayer redeploy — the
+ * right tradeoff for a Prometheus label.
  */
 export const KNOWN_SERVICE_LABELS = [
   'auction-bidder',
@@ -126,13 +132,27 @@ export const KNOWN_SERVICE_LABELS = [
   'anonymous',
 ] as const;
 
+export const KNOWN_VARIANT_LABELS = [
+  'default',
+  'pyth',
+  'experimental',
+] as const;
+
 const KNOWN_SERVICE_LABEL_SET: ReadonlySet<string> = new Set(
   KNOWN_SERVICE_LABELS
+);
+const KNOWN_VARIANT_LABEL_SET: ReadonlySet<string> = new Set(
+  KNOWN_VARIANT_LABELS
 );
 
 export function serviceLabel(rawService: string | undefined): string {
   if (!rawService) return 'unknown';
   return KNOWN_SERVICE_LABEL_SET.has(rawService) ? rawService : 'unknown';
+}
+
+export function variantLabel(rawVariant: string | undefined): string {
+  if (!rawVariant) return 'default';
+  return KNOWN_VARIANT_LABEL_SET.has(rawVariant) ? rawVariant : 'unknown';
 }
 
 export const bidsSubmitted = new Counter({

--- a/packages/relayer/src/metrics.ts
+++ b/packages/relayer/src/metrics.ts
@@ -77,6 +77,27 @@ export const auctionsStarted = new Counter({
   registers: [register],
 });
 
+export const auctionBroadcastSends = new Counter({
+  name: 'relayer_auction_broadcast_sends_total',
+  help: 'Per-client auction.started broadcast attempts',
+  labelNames: ['service', 'ok'], // service: 'market-maker' | 'estimator' | 'anonymous' | ...; ok: 'true' | 'false'
+  registers: [register],
+});
+
+export const auctionReceivedAcks = new Counter({
+  name: 'relayer_auction_received_acks_total',
+  help: 'Per-client auction.received acks (proves end-to-end delivery)',
+  labelNames: ['service'],
+  registers: [register],
+});
+
+export const clientsIdentified = new Counter({
+  name: 'relayer_clients_identified_total',
+  help: 'Total identify handshakes accepted',
+  labelNames: ['service'],
+  registers: [register],
+});
+
 export const bidsSubmitted = new Counter({
   name: 'relayer_bids_submitted_total',
   help: 'Total number of bids submitted',

--- a/packages/relayer/src/transport/subscriptions.ts
+++ b/packages/relayer/src/transport/subscriptions.ts
@@ -64,13 +64,18 @@ export class InMemorySubscriptionManager implements SubscriptionManager {
 
     let count = 0;
     for (const client of set) {
-      if (client.isOpen) {
-        try {
-          client.send(raw);
-          count++;
-        } catch {
-          set.delete(client);
-        }
+      if (!client.isOpen) {
+        set.delete(client);
+        continue;
+      }
+      let ok = false;
+      try {
+        ok = client.send(raw);
+      } catch {
+        ok = false;
+      }
+      if (ok) {
+        count++;
       } else {
         set.delete(client);
       }

--- a/packages/relayer/src/transport/types.ts
+++ b/packages/relayer/src/transport/types.ts
@@ -15,6 +15,12 @@ export interface ClientConnection {
    * `service: 'anonymous'` so log lines always have a value.
    */
   service: string;
+  /**
+   * Strategy/vault flavor a bot serves (e.g. `'default'`, `'pyth'`).
+   * Used in tandem with `service` to break out metrics — see
+   * `KNOWN_VARIANT_LABELS` in metrics.ts.
+   */
+  variant: string;
   instanceId?: string;
   chainId?: number;
   /** @returns `true` if the underlying transport accepted the message synchronously. */

--- a/packages/relayer/src/transport/types.ts
+++ b/packages/relayer/src/transport/types.ts
@@ -9,7 +9,16 @@
 /** Opaque handle to a connected client — transport-agnostic. */
 export interface ClientConnection {
   readonly id: string;
-  send(msg: unknown): void;
+  /**
+   * Mutable identity fields populated by the `identify` handshake.
+   * Anonymous clients (pre-handshake or clients that never identify) carry
+   * `service: 'anonymous'` so log lines always have a value.
+   */
+  service: string;
+  instanceId?: string;
+  chainId?: number;
+  /** @returns `true` if the underlying transport accepted the message synchronously. */
+  send(msg: unknown): boolean;
   close(code?: number, reason?: string): void;
   readonly isOpen: boolean;
 }

--- a/packages/relayer/src/transport/wsTransport.ts
+++ b/packages/relayer/src/transport/wsTransport.ts
@@ -11,21 +11,27 @@ export function createWsClientConnection(
   hooks?: ConnectionHooks
 ): ClientConnection {
   const id = crypto.randomUUID();
-  return {
+  const conn: ClientConnection = {
     id,
-    send(msg: unknown) {
+    service: 'anonymous',
+    instanceId: undefined,
+    chainId: undefined,
+    send(msg: unknown): boolean {
       if (ws.readyState !== WebSocket.OPEN) {
         console.warn(
-          `[Relayer] Attempted to send on non-OPEN socket (state=${ws.readyState})`
+          `[Relayer] Attempted to send on non-OPEN socket clientId=${id.slice(0, 8)} service=${conn.service} state=${ws.readyState}`
         );
-        return;
+        return false;
       }
       const data = typeof msg === 'string' ? msg : JSON.stringify(msg);
       try {
         ws.send(data);
       } catch (err) {
-        console.warn('[Relayer] ws.send() failed:', err);
-        return;
+        console.warn(
+          `[Relayer] ws.send() failed clientId=${id.slice(0, 8)} service=${conn.service}:`,
+          err
+        );
+        return false;
       }
       // Fire onSend hook — extract message type for metrics
       if (hooks?.onSend) {
@@ -40,6 +46,7 @@ export function createWsClientConnection(
           hooks.onSend('unknown');
         }
       }
+      return true;
     },
     close(code?: number, reason?: string) {
       ws.close(code, reason);
@@ -48,4 +55,5 @@ export function createWsClientConnection(
       return ws.readyState === WebSocket.OPEN;
     },
   };
+  return conn;
 }

--- a/packages/relayer/src/transport/wsTransport.ts
+++ b/packages/relayer/src/transport/wsTransport.ts
@@ -14,6 +14,7 @@ export function createWsClientConnection(
   const conn: ClientConnection = {
     id,
     service: 'anonymous',
+    variant: 'default',
     instanceId: undefined,
     chainId: undefined,
     send(msg: unknown): boolean {

--- a/packages/relayer/src/ws.ts
+++ b/packages/relayer/src/ws.ts
@@ -16,6 +16,8 @@ import {
   handleAuctionSubscribe,
   handleAuctionUnsubscribe,
   handleBidSubmit,
+  handleIdentify,
+  handleAuctionReceived,
 } from './handlers/escrow';
 import {
   handleVaultObserve,
@@ -178,6 +180,9 @@ export function createAuctionWebSocketServer() {
     });
     connectionMap.set(ws, client);
     allClients.add(client);
+    console.log(
+      `[Relayer] client.connected clientId=${client.id.slice(0, 8)} ip=${ip}`
+    );
 
     // Idle timeout
     let idleTimeout: NodeJS.Timeout | null = null;
@@ -377,6 +382,18 @@ export function createAuctionWebSocketServer() {
                 subs
               );
               break;
+            case 'identify':
+              handleIdentify(
+                client,
+                msg.payload as Parameters<typeof handleIdentify>[1]
+              );
+              break;
+            case 'auction.received':
+              handleAuctionReceived(
+                client,
+                msg.payload as Parameters<typeof handleAuctionReceived>[1]
+              );
+              break;
           }
 
           // Track validation failures and disconnect abusive clients
@@ -529,7 +546,9 @@ export function createAuctionWebSocketServer() {
       const reasonStr = reason?.toString() ?? '';
       connectionsClosed.inc({ reason: reasonStr || `code_${code}` });
       console.log(
-        `[Relayer] Socket closed from ${ip} code=${code} reason=${reasonStr}`
+        `[Relayer] client.closed clientId=${client.id.slice(0, 8)} service=${client.service} instance=${
+          client.instanceId ? client.instanceId.slice(0, 8) : 'unknown'
+        } ip=${ip} code=${code} reason=${reasonStr}`
       );
 
       // Clean up subscriptions by type so metrics are properly decremented

--- a/packages/sdk/types/escrow.ts
+++ b/packages/sdk/types/escrow.ts
@@ -343,6 +343,14 @@ export interface IdentifyPayload {
    * pricing strategy vs the default strategy in a separate Railway service.
    */
   serviceInstance?: string;
+  /**
+   * Optional bounded label for which strategy/vault flavor this bot serves
+   * (e.g. `'default'`, `'pyth'`, `'experimental'`). Lets metrics break out
+   * `auction-bidder` connections by which vault they bid against without
+   * exploding cardinality. Relayer collapses any value outside its allowlist
+   * to `'unknown'`.
+   */
+  variant?: string;
 }
 
 /** Optional ack a client sends on receiving auction.started — proves end-to-end delivery. */

--- a/packages/sdk/types/escrow.ts
+++ b/packages/sdk/types/escrow.ts
@@ -319,11 +319,44 @@ export interface BidPayload {
 
 // ----- Client to Server Messages -----
 
+/**
+ * Client identity announced after WS connect. Backwards-compatible:
+ * relayer treats clients without identify as anonymous.
+ *
+ * Three identity layers stack here:
+ *   - clientId  (assigned by relayer per WS connection — changes on every reconnect)
+ *   - instanceId (assigned by client per process — stable across reconnects, changes on restart)
+ *   - service   (logical service name — non-unique by design)
+ */
+export interface IdentifyPayload {
+  service: string;
+  instanceId: string;
+  chainId?: number;
+  bootAt?: number;
+  version?: string;
+  deploymentId?: string;
+  replicaId?: string;
+  /**
+   * Optional human-readable label for the deployment hosting this process
+   * (e.g. Railway service name). Distinguishes two deployments that share the
+   * same logical `service` — for instance an `auction-bidder` running the Pyth
+   * pricing strategy vs the default strategy in a separate Railway service.
+   */
+  serviceInstance?: string;
+}
+
+/** Optional ack a client sends on receiving auction.started — proves end-to-end delivery. */
+export interface AuctionReceivedPayload {
+  auctionId: string;
+}
+
 export type ClientToServerMessage =
   | { type: 'auction.start'; payload: AuctionRFQPayload }
   | { type: 'auction.subscribe'; payload: { auctionId: string } }
   | { type: 'auction.unsubscribe'; payload: { auctionId: string } }
   | { type: 'bid.submit'; payload: BidPayload }
+  | { type: 'identify'; payload: IdentifyPayload }
+  | { type: 'auction.received'; payload: AuctionReceivedPayload }
   | { type: 'ping' };
 
 // ----- Server to Client Messages -----


### PR DESCRIPTION
## Summary
Brings the relayer per-bot broadcast observability work from main onto staging without dragging in the squash-merged #1651 noise. This is the only main-only change staging is missing.

Cherry-picked from PR #1657:
- `cd3ced6f4` feat(relayer): per-bot broadcast observability and identify handshake
- `87419ef03` fix(relayer): bound service metric labels and gate auction.received acks against broadcast ledger
- `abd7f12e6` feat(relayer): add bounded variant label so multiple bot deployments break out cleanly in metrics
- `9efe92658` fix(relayer): use short() helper consistently and put ok= first in broadcast log lines

A full main→staging merge was attempted in #1668 but conflicted heavily because #1651 squash-merged ~50 staging commits into a single commit on main; staging still has those as individual commits, so git can't reconcile them.

## Test plan
- [ ] CI green on relayer suite