### PR TITLE
test(api): refresh contract snapshots for new ReferralCode shape

### DIFF
--- a/packages/api/test/contract/__snapshots__/introspection.json
+++ b/packages/api/test/contract/__snapshots__/introspection.json
@@ -16831,6 +16831,53 @@
             "deprecationReason": null
           },
           {
+            "name": "referralCodes",
+            "description": "Public referral analytics. Referral codes are attribution hints, not\nauthorization credentials: using someone else's code credits that referrer's\nvolume/claims, but does not grant access to funds or admin capabilities.\n\nReturns paginated referral codes with claim count and aggregate trading volume /\nposition count baked in. Pass `id` to filter to a single code (e.g. for the\nanalytics dialog). Per-claimant breakdown is available via the nested\n`claimants` field.",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "100"
+              },
+              {
+                "name": "cursor",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ReferralCodesPage",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "trade",
             "description": "Look up a single secondary market trade by its trade hash",
             "args": [
@@ -17304,123 +17351,10 @@
       {
         "kind": "OBJECT",
         "name": "ReferralCode",
-        "description": null,
+        "description": "Public referral code metadata and analytics. This intentionally includes creator,\nclaim counts, aggregate volume/position stats, and claimant breakdowns.\n\nReferral codes are low-security attribution hints: using someone else's code only\ncredits that referrer; it does not grant access to funds or privileged actions.\n\n`codeHash` is intentionally omitted from GraphQL because public clients should\nnot need it, and referral-code identity in this API is the integer `id`.\nCredentialed create/update REST paths may still return hashes to the caller that\ncreated or administers the code.",
         "fields": [
           {
-            "name": "_count",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "ReferralCodeCount",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "claimedBy",
-            "description": null,
-            "args": [
-              {
-                "name": "cursor",
-                "description": null,
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "UserWhereUniqueInput",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "distinct",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "UserScalarFieldEnum",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "orderBy",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "UserOrderByWithRelationInput",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "skip",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "take",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "where",
-                "description": null,
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "UserWhereInput",
-                  "ofType": null
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "User",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "codeHash",
+            "name": "id",
             "description": null,
             "args": [],
             "type": {
@@ -17428,7 +17362,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Int",
                 "ofType": null
               }
             },
@@ -17437,6 +17371,22 @@
           },
           {
             "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTimeISO",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
             "description": null,
             "args": [],
             "type": {
@@ -17484,19 +17434,7 @@
             "deprecationReason": null
           },
           {
-            "name": "expiresAt",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
+            "name": "maxClaims",
             "description": null,
             "args": [],
             "type": {
@@ -17528,7 +17466,115 @@
             "deprecationReason": null
           },
           {
-            "name": "maxClaims",
+            "name": "expiresAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "claimCount",
+            "description": "Total number of users who have claimed this code, across all pages.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalVolume",
+            "description": "Sum of trading volume across every claimant's positions (predictor +\ncounterparty sides), as a stringified bigint. Aggregated server-side.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalPositions",
+            "description": "Total position count across every claimant. A position with both predictor\nand counterparty in the claimant set is counted twice, matching the\nper-side semantics.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "claimants",
+            "description": "Paginated per-claimant breakdown with trading volume + position count.",
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "100"
+              },
+              {
+                "name": "cursor",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ReferralCodeClaimantsPage",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ReferralCodeClaimant",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
             "description": null,
             "args": [],
             "type": {
@@ -17544,7 +17590,23 @@
             "deprecationReason": null
           },
           {
-            "name": "updatedAt",
+            "name": "address",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "claimedAt",
             "description": null,
             "args": [],
             "type": {
@@ -17553,6 +17615,38 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "DateTimeISO",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tradingVolume",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "positionCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               }
             },
@@ -17567,32 +17661,41 @@
       },
       {
         "kind": "OBJECT",
-        "name": "ReferralCodeCount",
+        "name": "ReferralCodeClaimantsPage",
         "description": null,
         "fields": [
           {
-            "name": "claimedBy",
+            "name": "items",
             "description": null,
-            "args": [
-              {
-                "name": "where",
-                "description": null,
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "UserWhereInput",
-                  "ofType": null
-                },
-                "defaultValue": null
-              }
-            ],
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ReferralCodeClaimant",
+                    "ofType": null
+                  }
+                }
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nextCursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -17640,26 +17743,6 @@
         "description": null,
         "fields": null,
         "inputFields": [
-          {
-            "name": "claimedBy",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "UserOrderByRelationAggregateInput",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "codeHash",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "SortOrder",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
           {
             "name": "createdAt",
             "description": null,
@@ -17746,6 +17829,53 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "ReferralCodesPage",
+        "description": null,
+        "fields": [
+          {
+            "name": "items",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ReferralCode",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nextCursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "ReferralCodeWhereInput",
         "description": null,
@@ -17802,26 +17932,6 @@
                   "ofType": null
                 }
               }
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "claimedBy",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "UserListRelationFilter",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "codeHash",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "StringFilter",
-              "ofType": null
             },
             "defaultValue": null
           },

--- a/packages/api/test/contract/__snapshots__/schema.sdl.graphql
+++ b/packages/api/test/contract/__snapshots__/schema.sdl.graphql
@@ -1591,6 +1591,18 @@ type Query {
   """
   questions(categorySlugs: [String!], chainId: Int, maxEstimatedPrice: Float, maxSimilarMarketVolume: Float, minEndTime: Int, minEstimatedPrice: Float, minSimilarMarketVolume: Float, resolutionStatus: ResolutionStatus, search: String, similarMarketVolumeWindow: VolumeWindow, skip: Int! = 0, sortDirection: SortOrder! = desc, sortField: QuestionSortField, tag: String, take: Int! = 50): [Question!]!
 
+  """
+  Public referral analytics. Referral codes are attribution hints, not
+  authorization credentials: using someone else's code credits that referrer's
+  volume/claims, but does not grant access to funds or admin capabilities.
+  
+  Returns paginated referral codes with claim count and aggregate trading volume /
+  position count baked in. Pass `id` to filter to a single code (e.g. for the
+  analytics dialog). Per-claimant breakdown is available via the nested
+  `claimants` field.
+  """
+  referralCodes(cursor: Int, id: Int, limit: Int = 100): ReferralCodesPage!
+
   """Look up a single secondary market trade by its trade hash"""
   trade(id: String!): Trade
 
@@ -1637,10 +1649,24 @@ enum QuestionSortField {
   similarMarketVolume
 }
 
+"""
+Public referral code metadata and analytics. This intentionally includes creator,
+claim counts, aggregate volume/position stats, and claimant breakdowns.
+
+Referral codes are low-security attribution hints: using someone else's code only
+credits that referrer; it does not grant access to funds or privileged actions.
+
+`codeHash` is intentionally omitted from GraphQL because public clients should
+not need it, and referral-code identity in this API is the integer `id`.
+Credentialed create/update REST paths may still return hashes to the caller that
+created or administers the code.
+"""
 type ReferralCode {
-  _count: ReferralCodeCount
-  claimedBy(cursor: UserWhereUniqueInput, distinct: [UserScalarFieldEnum!], orderBy: [UserOrderByWithRelationInput!], skip: Int, take: Int, where: UserWhereInput): [User!]!
-  codeHash: String!
+  """Total number of users who have claimed this code, across all pages."""
+  claimCount: Int!
+
+  """Paginated per-claimant breakdown with trading volume + position count."""
+  claimants(cursor: Int, limit: Int = 100): ReferralCodeClaimantsPage!
   createdAt: DateTimeISO!
   createdBy: String!
   creatorType: String!
@@ -1648,11 +1674,33 @@ type ReferralCode {
   id: Int!
   isActive: Boolean!
   maxClaims: Int!
+
+  """
+  Total position count across every claimant. A position with both predictor
+  and counterparty in the claimant set is counted twice, matching the
+  per-side semantics.
+  """
+  totalPositions: Int!
+
+  """
+  Sum of trading volume across every claimant's positions (predictor +
+  counterparty sides), as a stringified bigint. Aggregated server-side.
+  """
+  totalVolume: String!
   updatedAt: DateTimeISO!
 }
 
-type ReferralCodeCount {
-  claimedBy(where: UserWhereInput): Int!
+type ReferralCodeClaimant {
+  address: String!
+  claimedAt: DateTimeISO!
+  id: Int!
+  positionCount: Int!
+  tradingVolume: String!
+}
+
+type ReferralCodeClaimantsPage {
+  items: [ReferralCodeClaimant!]!
+  nextCursor: Int
 }
 
 input ReferralCodeNullableRelationFilter {
@@ -1661,8 +1709,6 @@ input ReferralCodeNullableRelationFilter {
 }
 
 input ReferralCodeOrderByWithRelationInput {
-  claimedBy: UserOrderByRelationAggregateInput
-  codeHash: SortOrder
   createdAt: SortOrder
   createdBy: SortOrder
   creatorType: SortOrder
@@ -1677,8 +1723,6 @@ input ReferralCodeWhereInput {
   AND: [ReferralCodeWhereInput!]
   NOT: [ReferralCodeWhereInput!]
   OR: [ReferralCodeWhereInput!]
-  claimedBy: UserListRelationFilter
-  codeHash: StringFilter
   createdAt: DateTimeFilter
   createdBy: StringFilter
   creatorType: StringFilter
@@ -1687,6 +1731,11 @@ input ReferralCodeWhereInput {
   isActive: BoolFilter
   maxClaims: IntFilter
   updatedAt: DateTimeFilter
+}
+
+type ReferralCodesPage {
+  items: [ReferralCode!]!
+  nextCursor: Int
 }
 
 """Filter questions by their resolution status"""


### PR DESCRIPTION
## Summary

#1664 changed `Query.referralCodes` and the `ReferralCode` type but did not update the contract test snapshots, so test:contract was failing on staging once the schema regen (#1675) closed the docstring drift.

## Diff

- `packages/api/test/contract/__snapshots__/schema.sdl.graphql`
- `packages/api/test/contract/__snapshots__/introspection.json`

Both regenerated by running `pnpm --filter @sapience/api run test:contract -u` against a local DB. Net effect: `_count`, `claimedBy`, `codeHash` on `ReferralCode` are gone; `claimCount`, `claimants`, `totalVolume`, `totalPositions`, the new `Query.referralCodes` field, and the new `ReferralCodesPage` / `ReferralCodeClaimantsPage` / `ReferralCodeClaimant` types are present.

## Test plan

- [x] `test:contract` passes locally
- [ ] CI green on this PR