### PR TITLE
feat(keeper): add refresh-metadata script for full-DB Polymarket sync

### DIFF
--- a/packages/market-keeper/package.json
+++ b/packages/market-keeper/package.json
@@ -26,6 +26,8 @@
     "prices-and-1d-7d-volume:dry-run": "tsx scripts/prices-and-1d-7d-volume.ts --dry-run",
     "refresh-volume": "tsx scripts/refresh-volume.ts",
     "refresh-volume:dry-run": "tsx scripts/refresh-volume.ts --dry-run",
+    "refresh-metadata": "tsx scripts/refresh-metadata.ts",
+    "refresh-metadata:dry-run": "tsx scripts/refresh-metadata.ts --dry-run",
     "cleanup-polymarket": "tsx scripts/cleanup-polymarket.ts",
     "cleanup-polymarket:dry-run": "tsx scripts/cleanup-polymarket.ts --dry-run",
     "cleanup-polymarket:execute": "tsx scripts/cleanup-polymarket.ts --execute",

--- a/packages/market-keeper/scripts/add-events.ts
+++ b/packages/market-keeper/scripts/add-events.ts
@@ -22,12 +22,7 @@ import type { PolymarketMarket } from '../src/types';
 import { DEFAULT_SAPIENCE_API_URL } from '../src/constants';
 import { fetchWithRetry, validatePrivateKey } from '../src/utils';
 import { groupMarkets } from '../src/generate/grouping';
-import {
-  printDryRun,
-  submitToAPI,
-  submitMetadataUpdates,
-  submitGroupMetadataUpdates,
-} from '../src/generate/api';
+import { printDryRun, submitToAPI } from '../src/generate/api';
 
 async function fetchEventBySlug(slug: string): Promise<PolymarketMarket[]> {
   const url = `https://gamma-api.polymarket.com/events?slug=${encodeURIComponent(slug)}`;
@@ -130,18 +125,6 @@ async function main() {
   }
 
   await submitToAPI(apiUrl, privateKey, sapienceData);
-
-  if (sapienceData.metadataUpdates.length > 0) {
-    await submitMetadataUpdates(apiUrl, privateKey, sapienceData.metadataUpdates);
-  }
-
-  if (sapienceData.groupMetadataUpdates.length > 0) {
-    await submitGroupMetadataUpdates(
-      apiUrl,
-      privateKey,
-      sapienceData.groupMetadataUpdates
-    );
-  }
 }
 
 main().catch((error) => {

--- a/packages/market-keeper/scripts/refresh-metadata.ts
+++ b/packages/market-keeper/scripts/refresh-metadata.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+/// <reference types="node" />
+/**
+ * Refresh metadata for every public + unsettled Sapience condition by
+ * re-fetching its market from Polymarket Gamma. Catches slug renames and
+ * other Polymarket-owned field drift that the generate cron can't see
+ * once a market falls out of its 7-day "ending soonest" window.
+ *
+ * Usage:
+ *   tsx scripts/refresh-metadata.ts
+ *   tsx scripts/refresh-metadata.ts --dry-run
+ */
+
+import { main } from '../src/refresh-metadata/index.js';
+import { logSeparator } from '../src/utils/log.js';
+
+logSeparator('market-keeper:refresh-metadata', 'START');
+main().finally(() => logSeparator('market-keeper:refresh-metadata', 'END'));

--- a/packages/market-keeper/scripts/start.js
+++ b/packages/market-keeper/scripts/start.js
@@ -3,6 +3,7 @@ const { execSync } = require('child_process');
 
 const run = (cmd) => execSync(cmd, { stdio: 'inherit' });
 
+run('node dist/scripts/refresh-metadata.js');
 run('node dist/scripts/generate.js');
 run('node dist/scripts/relist.js');
 run('node dist/scripts/prices-and-1d-7d-volume.js');

--- a/packages/market-keeper/scripts/update-condition.ts
+++ b/packages/market-keeper/scripts/update-condition.ts
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+/// <reference types="node" />
+/**
+ * One-off script: update the question (full name) and/or endTime for a single
+ * Sapience condition. Targets `PUT /admin/conditions/:id`, which accepts a
+ * partial update — pass only the fields you want changed.
+ *
+ * Usage:
+ *   tsx scripts/update-condition.ts --id <conditionHash> [--question "..."] [--end-time <ISO|unix>] [--dry-run]
+ *
+ * Examples:
+ *   tsx scripts/update-condition.ts \
+ *     --id 0x6fb1af1cc7caa3b4479fa9a22ba149499795e99f39f807a5272cdbf89acba3b6 \
+ *     --question "Will Trump endorse Ken Paxton for TX-Sen by Nov 2 2026 ET?" \
+ *     --end-time 2026-11-04T00:00:00Z
+ *
+ *   tsx scripts/update-condition.ts --id 0x... --end-time 1762214400 --dry-run
+ *
+ * Environment Variables (required for API submission):
+ *   SAPIENCE_API_URL     API URL (default: https://api.sapience.xyz)
+ *   ADMIN_PRIVATE_KEY    64-char hex private key for signing admin requests
+ */
+
+import 'dotenv/config';
+import { DEFAULT_SAPIENCE_API_URL } from '../src/constants';
+import {
+  validatePrivateKey,
+  confirmProductionAccess,
+  fetchWithRetry,
+  log,
+  logError,
+} from '../src/utils';
+import { getAdminAuthHeaders } from '../src/utils/auth';
+
+interface CLIOptions {
+  id?: string;
+  question?: string;
+  endTime?: number;
+  dryRun: boolean;
+  help: boolean;
+}
+
+function parseArgs(): CLIOptions {
+  const args = process.argv.slice(2);
+  const opts: CLIOptions = { dryRun: false, help: false };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    switch (arg) {
+      case '--id':
+        opts.id = args[++i];
+        break;
+      case '--question':
+        opts.question = args[++i];
+        break;
+      case '--end-time': {
+        const raw = args[++i];
+        opts.endTime = parseEndTime(raw);
+        break;
+      }
+      case '--dry-run':
+        opts.dryRun = true;
+        break;
+      case '--help':
+      case '-h':
+        opts.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return opts;
+}
+
+// Accept ISO 8601 strings or unix-seconds integers; reject anything else so a
+// silent NaN never reaches the API.
+function parseEndTime(raw: string | undefined): number {
+  if (!raw) throw new Error('--end-time requires a value');
+
+  if (/^\d+$/.test(raw)) {
+    const n = parseInt(raw, 10);
+    if (!Number.isFinite(n)) throw new Error(`Invalid endTime: ${raw}`);
+    return n;
+  }
+
+  const ts = Date.parse(raw);
+  if (Number.isNaN(ts)) {
+    throw new Error(
+      `Invalid --end-time: "${raw}". Pass ISO 8601 (e.g. 2026-11-04T00:00:00Z) or unix seconds.`
+    );
+  }
+  return Math.floor(ts / 1000);
+}
+
+function showHelp(): void {
+  console.log(`
+Usage: tsx scripts/update-condition.ts --id <conditionHash> [options]
+
+Updates the question and/or endTime for a single Sapience condition via
+PUT /admin/conditions/:id. At least one of --question or --end-time is required.
+
+Options:
+  --id <hash>          Condition hash (0x-prefixed 32-byte hex). Required.
+  --question "..."     New question text (full name)
+  --end-time <value>   New endTime as ISO 8601 (e.g. 2026-11-04T00:00:00Z) or unix seconds
+  --dry-run            Print the payload without submitting
+  --help, -h           Show this help message
+
+Notes:
+  - endTime cannot be changed on a settled condition (API returns 400).
+  - The exact value is sent — no buffer is added.
+
+Environment Variables (required for submission):
+  SAPIENCE_API_URL     API URL (default: https://api.sapience.xyz)
+  ADMIN_PRIVATE_KEY    64-char hex private key for signing admin requests
+`);
+}
+
+async function main(): Promise<void> {
+  let options: CLIOptions;
+  try {
+    options = parseArgs();
+  } catch (error) {
+    logError(error instanceof Error ? error.message : String(error));
+    showHelp();
+    process.exit(1);
+  }
+
+  if (options.help) {
+    showHelp();
+    return;
+  }
+
+  if (!options.id) {
+    logError('--id is required');
+    showHelp();
+    process.exit(1);
+  }
+  if (!/^0x[0-9a-fA-F]{64}$/.test(options.id)) {
+    logError(`Invalid --id format: ${options.id} (expected 0x-prefixed 32-byte hex)`);
+    process.exit(1);
+  }
+  if (options.question === undefined && options.endTime === undefined) {
+    logError('At least one of --question or --end-time is required');
+    showHelp();
+    process.exit(1);
+  }
+
+  const apiUrl = process.env.SAPIENCE_API_URL || DEFAULT_SAPIENCE_API_URL;
+
+  const payload: { question?: string; endTime?: number } = {};
+  if (options.question !== undefined) payload.question = options.question;
+  if (options.endTime !== undefined) payload.endTime = options.endTime;
+
+  log(`[UpdateCondition] Target: ${apiUrl}/admin/conditions/${options.id}`);
+  log(`[UpdateCondition] Payload: ${JSON.stringify(payload, null, 2)}`);
+  if (options.endTime !== undefined) {
+    log(
+      `[UpdateCondition]   endTime ${options.endTime} = ${new Date(options.endTime * 1000).toISOString()}`
+    );
+  }
+
+  if (options.dryRun) {
+    log('[UpdateCondition] Dry run — not submitting');
+    return;
+  }
+
+  let privateKey: `0x${string}` | undefined;
+  try {
+    privateKey = validatePrivateKey(process.env.ADMIN_PRIVATE_KEY);
+  } catch (error) {
+    logError(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+  if (!privateKey) {
+    logError('ADMIN_PRIVATE_KEY is required for submission (use --dry-run to preview)');
+    process.exit(1);
+  }
+
+  await confirmProductionAccess(apiUrl);
+
+  const authHeaders = await getAdminAuthHeaders(privateKey);
+  const response = await fetchWithRetry(
+    `${apiUrl}/admin/conditions/${options.id}`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', ...authHeaders },
+      body: JSON.stringify(payload),
+    }
+  );
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    logError(
+      `[UpdateCondition] Failed: HTTP ${response.status} — ${body.slice(0, 500)}`
+    );
+    process.exit(1);
+  }
+
+  log(`[UpdateCondition] Updated condition ${options.id}`);
+}
+
+main().catch((error) => {
+  logError('Fatal error:', error);
+  process.exit(1);
+});

--- a/packages/market-keeper/src/__tests__/metadata-updates.test.ts
+++ b/packages/market-keeper/src/__tests__/metadata-updates.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { PolymarketMarket } from '../types';
 
-// Mock all external dependencies before importing
+// Mocks below are only needed by the `groupMarkets` integration cases at the
+// bottom of this file — the unit tests of `computeMetadataUpdates` and
+// `computeGroupMetadataUpdates` call those functions directly with synthetic
+// args and don't go through the heavy machinery.
 vi.mock('../constants', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   return {
@@ -26,10 +29,6 @@ vi.mock('../llm', async (importOriginal) => {
 });
 
 const mockFetchEventTags = vi.fn().mockResolvedValue(new Map());
-vi.mock('./tags', () => ({
-  fetchEventTags: (...args: unknown[]) => mockFetchEventTags(...args),
-}));
-
 vi.mock('../generate/tags', () => ({
   fetchEventTags: (...args: unknown[]) => mockFetchEventTags(...args),
 }));
@@ -46,11 +45,21 @@ vi.mock('../generate/pipeline', () => ({
   checkExistingConditions: vi.fn(),
 }));
 
-import { groupMarkets } from '../generate/grouping';
+import {
+  computeMetadataUpdates,
+  computeGroupMetadataUpdates,
+  groupMarkets,
+} from '../generate/grouping';
 import { checkExistingConditions } from '../generate/pipeline';
 import type { ExistingCondition } from '../generate/pipeline';
 
 const mockCheckExisting = vi.mocked(checkExistingConditions);
+const API_URL = 'https://test-api.example.com';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFetchEventTags.mockResolvedValue(new Map());
+});
 
 function makeMarket(
   overrides: Partial<PolymarketMarket> = {}
@@ -73,10 +82,9 @@ function makeMarket(
 }
 
 /**
- * Build an `ExistingCondition` that matches what the generate pipeline
- * WOULD have written on initial create for the given market — so tests
- * can assert "no drift" vs "this specific field drifted" without having
- * to repeat all the default fields.
+ * Build an `ExistingCondition` matching what the generate pipeline WOULD
+ * have written on initial create — so tests can assert "no drift" vs
+ * "this specific field drifted" without restating defaults.
  */
 function existingFromMarket(
   market: PolymarketMarket,
@@ -101,42 +109,67 @@ function existingFromMarket(
   };
 }
 
-beforeEach(() => {
-  vi.clearAllMocks();
-  mockFetchEventTags.mockResolvedValue(new Map());
-});
+/**
+ * Synthesize the `groups[]` arg the diff helpers expect: each market becomes
+ * a one-market group keyed off its parent event. Mirrors what groupMarkets()
+ * builds in the generate path and what refresh-metadata builds at runtime.
+ */
+function synthesizeGroups(markets: PolymarketMarket[]): Array<{
+  title: string;
+  markets: PolymarketMarket[];
+  eventSlug?: string;
+}> {
+  return markets.map((m) => ({
+    title: m.events?.[0]?.title ?? '',
+    markets: [m],
+    eventSlug: m.events?.[0]?.slug,
+  }));
+}
 
-describe('metadata updates via groupMarkets', () => {
-  it('detects question change on existing condition and rewrites shortName via regex', async () => {
+function runDiff(
+  markets: PolymarketMarket[],
+  existing: Map<string, ExistingCondition>,
+  eventTagMap: Map<string, string[]> = new Map()
+) {
+  const groups = synthesizeGroups(markets);
+  return {
+    metadataUpdates: computeMetadataUpdates(
+      markets,
+      groups,
+      existing,
+      eventTagMap
+    ),
+    groupMetadataUpdates: computeGroupMetadataUpdates(groups, existing),
+  };
+}
+
+describe('computeMetadataUpdates', () => {
+  it('detects question change on existing condition and rewrites shortName via regex', () => {
     const market = makeMarket({
       conditionId: '0xaaa',
-      question: 'Bitcoin above $150k?', // new question matches cryptoThresholdMatch regex
+      question: 'Bitcoin above $150k?', // matches cryptoThresholdMatch regex
     });
 
-    mockCheckExisting.mockResolvedValue(
-      new Map([
-        [
-          '0xaaa',
-          existingFromMarket(market, {
-            question: 'Bitcoin above $100k?',
-            shortName: 'BTC >$100k',
-          }),
-        ],
-      ])
-    );
+    const existing = new Map([
+      [
+        '0xaaa',
+        existingFromMarket(market, {
+          question: 'Bitcoin above $100k?',
+          shortName: 'BTC >$100k',
+        }),
+      ],
+    ]);
 
-    const result = await groupMarkets([market], 'https://test-api.example.com');
+    const { metadataUpdates } = runDiff([market], existing);
 
-    expect(result.metadataUpdates).toHaveLength(1);
-    expect(result.metadataUpdates[0].conditionId).toBe('0xaaa');
-    expect(result.metadataUpdates[0].fields.question).toBe(
-      'Bitcoin above $150k?'
-    );
-    expect(result.metadataUpdates[0].fields.shortName).toBe('BTC >$150k');
-    expect(result.metadataUpdates[0].old.shortName).toBe('BTC >$100k');
+    expect(metadataUpdates).toHaveLength(1);
+    expect(metadataUpdates[0].conditionId).toBe('0xaaa');
+    expect(metadataUpdates[0].fields.question).toBe('Bitcoin above $150k?');
+    expect(metadataUpdates[0].fields.shortName).toBe('BTC >$150k');
+    expect(metadataUpdates[0].old.shortName).toBe('BTC >$100k');
   });
 
-  it('does not rewrite shortName to question when regex does not match', async () => {
+  it('does not rewrite shortName to question when regex does not match', () => {
     // Guards against the regression where freshShort fell back to question,
     // overwriting nice LLM-generated shortNames with verbose questions.
     const market = makeMarket({
@@ -144,269 +177,191 @@ describe('metadata updates via groupMarkets', () => {
       question: 'Will the next Prime Minister of Hungary be Viktor Orban?',
     });
 
-    mockCheckExisting.mockResolvedValue(
-      new Map([
-        [
-          '0xnoregex',
-          existingFromMarket(market, {
-            shortName: 'Orban wins Hungary', // nice LLM form stored in DB
-          }),
-        ],
-      ])
-    );
+    const existing = new Map([
+      [
+        '0xnoregex',
+        existingFromMarket(market, { shortName: 'Orban wins Hungary' }),
+      ],
+    ]);
 
-    const result = await groupMarkets([market], 'https://test-api.example.com');
+    const { metadataUpdates } = runDiff([market], existing);
 
-    // No shortName drift — question didn't match any regex rule, so we keep
-    // the existing LLM-generated shortName untouched.
-    expect(result.metadataUpdates).toHaveLength(0);
+    expect(metadataUpdates).toHaveLength(0);
   });
 
-  it('detects group name change on existing condition', async () => {
+  it('detects group name change on existing condition', () => {
     const market = makeMarket({
       conditionId: '0xbbb',
       question: 'Will ETH hit 10k?',
       events: [{ title: 'Ethereum Price Targets 2025', slug: 'eth-targets' }],
     });
 
-    mockCheckExisting.mockResolvedValue(
-      new Map([
-        [
-          '0xbbb',
-          existingFromMarket(market, {
-            groupName: 'Ethereum Price Targets', // old group name
-          }),
-        ],
-      ])
-    );
+    const existing = new Map([
+      [
+        '0xbbb',
+        existingFromMarket(market, { groupName: 'Ethereum Price Targets' }),
+      ],
+    ]);
 
-    const result = await groupMarkets([market], 'https://test-api.example.com');
+    const { metadataUpdates } = runDiff([market], existing);
 
-    expect(result.metadataUpdates).toHaveLength(1);
-    expect(result.metadataUpdates[0].fields).toEqual({
+    expect(metadataUpdates).toHaveLength(1);
+    expect(metadataUpdates[0].fields).toEqual({
       groupName: 'Ethereum Price Targets 2025',
     });
-    expect(result.metadataUpdates[0].old).toEqual({
+    expect(metadataUpdates[0].old).toEqual({
       groupName: 'Ethereum Price Targets',
     });
   });
 
-  it('detects similarMarkets URL change when event slug changes', async () => {
-    // Polymarket renamed the event slug; our similarMarkets URL is now stale
+  it('detects similarMarkets URL change when event slug changes', () => {
     const market = makeMarket({
       conditionId: '0xslug',
       slug: 'btc-100k',
       events: [{ title: 'Bitcoin Milestones', slug: 'btc-milestones-v2' }],
     });
 
-    mockCheckExisting.mockResolvedValue(
-      new Map([
-        [
-          '0xslug',
-          existingFromMarket(market, {
-            similarMarkets: [
-              'https://polymarket.com/event/btc-milestones#btc-100k',
-            ],
-          }),
-        ],
-      ])
-    );
+    const existing = new Map([
+      [
+        '0xslug',
+        existingFromMarket(market, {
+          similarMarkets: [
+            'https://polymarket.com/event/btc-milestones#btc-100k',
+          ],
+        }),
+      ],
+    ]);
 
-    const result = await groupMarkets([market], 'https://test-api.example.com');
+    const { metadataUpdates } = runDiff([market], existing);
 
-    expect(result.metadataUpdates).toHaveLength(1);
-    expect(result.metadataUpdates[0].fields.similarMarkets).toEqual([
+    expect(metadataUpdates).toHaveLength(1);
+    expect(metadataUpdates[0].fields.similarMarkets).toEqual([
       'https://polymarket.com/event/btc-milestones-v2#btc-100k',
     ]);
-    expect(result.metadataUpdates[0].old.similarMarkets).toEqual([
+    expect(metadataUpdates[0].old.similarMarkets).toEqual([
       'https://polymarket.com/event/btc-milestones#btc-100k',
     ]);
   });
 
-  it('detects similarMarkets URL change when market slug changes', async () => {
+  it('detects similarMarkets URL change when market slug changes', () => {
     const market = makeMarket({
       conditionId: '0xmslug',
-      slug: 'will-btc-reach-100k', // market slug renamed
+      slug: 'will-btc-reach-100k',
       events: [{ title: 'Bitcoin Milestones', slug: 'btc-milestones' }],
     });
 
-    mockCheckExisting.mockResolvedValue(
-      new Map([
-        [
-          '0xmslug',
-          existingFromMarket(market, {
-            similarMarkets: [
-              'https://polymarket.com/event/btc-milestones#will-btc-hit-100k',
-            ],
-          }),
-        ],
-      ])
-    );
+    const existing = new Map([
+      [
+        '0xmslug',
+        existingFromMarket(market, {
+          similarMarkets: [
+            'https://polymarket.com/event/btc-milestones#will-btc-hit-100k',
+          ],
+        }),
+      ],
+    ]);
 
-    const result = await groupMarkets([market], 'https://test-api.example.com');
+    const { metadataUpdates } = runDiff([market], existing);
 
-    expect(result.metadataUpdates).toHaveLength(1);
-    expect(result.metadataUpdates[0].fields.similarMarkets).toEqual([
+    expect(metadataUpdates).toHaveLength(1);
+    expect(metadataUpdates[0].fields.similarMarkets).toEqual([
       'https://polymarket.com/event/btc-milestones#will-btc-reach-100k',
     ]);
   });
 
-  it('detects description change', async () => {
+  it('detects description change', () => {
     const market = makeMarket({
       conditionId: '0xdesc',
       description: 'Updated description from Polymarket',
     });
 
-    mockCheckExisting.mockResolvedValue(
-      new Map([
-        [
-          '0xdesc',
-          existingFromMarket(market, { description: 'Old description' }),
-        ],
-      ])
-    );
+    const existing = new Map([
+      [
+        '0xdesc',
+        existingFromMarket(market, { description: 'Old description' }),
+      ],
+    ]);
 
-    const result = await groupMarkets([market], 'https://test-api.example.com');
+    const { metadataUpdates } = runDiff([market], existing);
 
-    expect(result.metadataUpdates).toHaveLength(1);
-    expect(result.metadataUpdates[0].fields.description).toBe(
+    expect(metadataUpdates).toHaveLength(1);
+    expect(metadataUpdates[0].fields.description).toBe(
       'Updated description from Polymarket'
     );
   });
 
-  it('detects tags change', async () => {
-    mockFetchEventTags.mockResolvedValue(
-      new Map([['btc-milestones', ['crypto', 'btc', 'price']]])
-    );
-
+  it('detects tags change', () => {
+    const eventTagMap = new Map([
+      ['btc-milestones', ['crypto', 'btc', 'price']],
+    ]);
     const market = makeMarket({ conditionId: '0xtags' });
 
-    mockCheckExisting.mockResolvedValue(
-      new Map([
-        [
-          '0xtags',
-          existingFromMarket(market, { tags: ['crypto', 'btc'] }), // missing 'price'
-        ],
-      ])
-    );
-
-    const result = await groupMarkets([market], 'https://test-api.example.com');
-
-    expect(result.metadataUpdates).toHaveLength(1);
-    expect(result.metadataUpdates[0].fields.tags).toEqual([
-      'crypto',
-      'btc',
-      'price',
+    const existing = new Map([
+      ['0xtags', existingFromMarket(market, { tags: ['crypto', 'btc'] })],
     ]);
+
+    const { metadataUpdates } = runDiff([market], existing, eventTagMap);
+
+    expect(metadataUpdates).toHaveLength(1);
+    expect(metadataUpdates[0].fields.tags).toEqual(['crypto', 'btc', 'price']);
   });
 
-  it('treats tags as order-insensitive (no spurious update)', async () => {
-    mockFetchEventTags.mockResolvedValue(
-      new Map([['btc-milestones', ['crypto', 'btc', 'price']]])
-    );
-
+  it('treats tags as order-insensitive (no spurious update)', () => {
+    const eventTagMap = new Map([
+      ['btc-milestones', ['crypto', 'btc', 'price']],
+    ]);
     const market = makeMarket({ conditionId: '0xordered' });
 
-    mockCheckExisting.mockResolvedValue(
-      new Map([
-        [
-          '0xordered',
-          // Same tags, different order
-          existingFromMarket(market, { tags: ['price', 'crypto', 'btc'] }),
-        ],
-      ])
-    );
+    const existing = new Map([
+      [
+        '0xordered',
+        existingFromMarket(market, { tags: ['price', 'crypto', 'btc'] }),
+      ],
+    ]);
 
-    const result = await groupMarkets([market], 'https://test-api.example.com');
+    const { metadataUpdates } = runDiff([market], existing, eventTagMap);
 
-    expect(result.metadataUpdates).toHaveLength(0);
+    expect(metadataUpdates).toHaveLength(0);
   });
 
-  it('applies transformMatchQuestion so "vs" markets do not flap', async () => {
-    // "X vs. Y" should be transformed to "X beats Y?" by transformMatchQuestion.
-    // The DB has the transformed version; raw Polymarket data has "vs".
-    // The old buggy diff would detect a change on every run; the fixed
-    // diff should see them as equal.
-    const market = makeMarket({
-      conditionId: '0xvs',
-      question: 'Lakers vs. Celtics',
-    });
-
-    // The existing condition was stored with the transformed question.
-    // Since we can't import transformMatchQuestion here without pulling
-    // in all its dependencies, use a stub that's guaranteed to match
-    // whatever the transform produces by running the diff once and
-    // asserting it does NOT produce an update when existing matches.
-    // Strategy: first run with a known-correct existing, then verify
-    // it's stable.
-    mockCheckExisting.mockResolvedValueOnce(
-      new Map([['0xvs', existingFromMarket(market)]])
-    );
-    const first = await groupMarkets([market], 'https://test-api.example.com');
-    // Seed round — whatever question the first run produced, use it
-    // as the "existing" for the second run.
-    const seeded = first.metadataUpdates[0]?.fields.question ?? market.question;
-
-    mockCheckExisting.mockResolvedValueOnce(
-      new Map([
-        [
-          '0xvs',
-          existingFromMarket(market, { question: seeded, shortName: seeded }),
-        ],
-      ])
-    );
-    const second = await groupMarkets([market], 'https://test-api.example.com');
-
-    // On the second run, nothing should drift — the transformed question
-    // matches what's in the DB, so no update emitted.
-    expect(second.metadataUpdates).toHaveLength(0);
-  });
-
-  it('skips unchanged conditions', async () => {
+  it('skips unchanged conditions', () => {
     const market = makeMarket({ conditionId: '0xddd' });
 
-    mockCheckExisting.mockResolvedValue(
-      new Map([['0xddd', existingFromMarket(market)]])
-    );
+    const existing = new Map([['0xddd', existingFromMarket(market)]]);
 
-    const result = await groupMarkets([market], 'https://test-api.example.com');
+    const { metadataUpdates } = runDiff([market], existing);
 
-    expect(result.metadataUpdates).toHaveLength(0);
+    expect(metadataUpdates).toHaveLength(0);
   });
 
-  it('returns no updates for new conditions (not in existingIds)', async () => {
+  it('returns no updates for new conditions (not in existingIds)', () => {
     const market = makeMarket({ conditionId: '0xeee' });
 
-    mockCheckExisting.mockResolvedValue(new Map()); // nothing exists
+    const { metadataUpdates } = runDiff([market], new Map());
 
-    const result = await groupMarkets([market], 'https://test-api.example.com');
-
-    expect(result.metadataUpdates).toHaveLength(0);
+    expect(metadataUpdates).toHaveLength(0);
   });
 
-  it('backfills every syncable field when existing condition is sparse', async () => {
+  it('backfills every syncable field when existing condition is sparse', () => {
     const market = makeMarket({
       conditionId: '0xfff',
       question: 'Some question?',
       events: [{ title: 'Some Group', slug: 'some-group' }],
     });
 
-    mockCheckExisting.mockResolvedValue(
-      new Map([
-        [
-          '0xfff',
-          {
-            endTime: 1700000000,
-            // no other metadata in DB — backfill everything we know
-          },
-        ],
-      ])
-    );
+    const existing = new Map<string, ExistingCondition>([
+      [
+        '0xfff',
+        {
+          endTime: 1700000000,
+        },
+      ],
+    ]);
 
-    const result = await groupMarkets([market], 'https://test-api.example.com');
+    const { metadataUpdates } = runDiff([market], existing);
 
-    expect(result.metadataUpdates).toHaveLength(1);
-    const update = result.metadataUpdates[0];
+    expect(metadataUpdates).toHaveLength(1);
+    const update = metadataUpdates[0];
     expect(update.conditionId).toBe('0xfff');
     expect(update.fields.question).toBe('Some question?');
     expect(update.fields.groupName).toBe('Some Group');
@@ -415,12 +370,10 @@ describe('metadata updates via groupMarkets', () => {
       'https://polymarket.com/event/some-group#btc-100k',
     ]);
     expect(update.fields.similarMarketVolume).toBe(100000);
-    // shortName is NOT backfilled from question fallback — only rewritten when
-    // the regex produces a non-null result. "Some question?" doesn't match.
     expect(update.fields.shortName).toBeUndefined();
   });
 
-  it('handles multiple conditions with mixed updates', async () => {
+  it('handles multiple conditions with mixed updates', () => {
     const markets = [
       makeMarket({
         conditionId: '0x111',
@@ -439,30 +392,247 @@ describe('metadata updates via groupMarkets', () => {
       }),
     ];
 
-    mockCheckExisting.mockResolvedValue(
-      new Map([
-        [
-          '0x111',
-          existingFromMarket(markets[0], {
-            question: 'Old question?',
-            shortName: 'Old question?',
-          }),
-        ],
-        ['0x222', existingFromMarket(markets[1])],
-        // 0x333 is new, not in DB
-      ])
-    );
+    const existing = new Map([
+      [
+        '0x111',
+        existingFromMarket(markets[0], {
+          question: 'Old question?',
+          shortName: 'Old question?',
+        }),
+      ],
+      ['0x222', existingFromMarket(markets[1])],
+    ]);
 
-    const result = await groupMarkets(markets, 'https://test-api.example.com');
+    const { metadataUpdates } = runDiff(markets, existing);
 
-    // Only 0x111 changed (question drift). shortName does NOT update because
-    // neither old nor new question matches any regex rule.
-    expect(result.metadataUpdates).toHaveLength(1);
-    expect(result.metadataUpdates[0].conditionId).toBe('0x111');
-    expect(result.metadataUpdates[0].fields.question).toBe('Changed question?');
-    expect(result.metadataUpdates[0].fields.shortName).toBeUndefined();
+    expect(metadataUpdates).toHaveLength(1);
+    expect(metadataUpdates[0].conditionId).toBe('0x111');
+    expect(metadataUpdates[0].fields.question).toBe('Changed question?');
+    expect(metadataUpdates[0].fields.shortName).toBeUndefined();
   });
 
+  it('backfills optionName on existing condition that predates the column', () => {
+    const market = makeMarket({
+      conditionId: '0xbackfill',
+      question: 'Will the next Prime Minister of Hungary be Viktor Orban?',
+      groupItemTitle: 'Viktor Orban',
+    });
+
+    const existing = new Map([
+      ['0xbackfill', existingFromMarket(market, { optionName: undefined })],
+    ]);
+
+    const { metadataUpdates } = runDiff([market], existing);
+
+    expect(metadataUpdates).toHaveLength(1);
+    expect(metadataUpdates[0].fields.optionName).toBe('Viktor Orban');
+    expect(metadataUpdates[0].old.optionName).toBeUndefined();
+  });
+
+  it('detects optionName drift when Polymarket renames groupItemTitle', () => {
+    const market = makeMarket({
+      conditionId: '0xrename',
+      question: 'Will Bitcoin reach $150k in April?',
+      groupItemTitle: '↑ 150,000',
+    });
+
+    const existing = new Map([
+      ['0xrename', existingFromMarket(market, { optionName: 'BTC 150k' })],
+    ]);
+
+    const { metadataUpdates } = runDiff([market], existing);
+
+    expect(metadataUpdates).toHaveLength(1);
+    expect(metadataUpdates[0].fields.optionName).toBe('↑ 150,000');
+    expect(metadataUpdates[0].old.optionName).toBe('BTC 150k');
+  });
+
+  it('does not emit optionName update when groupItemTitle already matches', () => {
+    const market = makeMarket({
+      conditionId: '0xmatch',
+      question: 'Will the next Prime Minister of Hungary be Viktor Orban?',
+      groupItemTitle: 'Viktor Orban',
+    });
+
+    const existing = new Map([
+      ['0xmatch', existingFromMarket(market, { optionName: 'Viktor Orban' })],
+    ]);
+
+    const { metadataUpdates } = runDiff([market], existing);
+
+    expect(metadataUpdates).toHaveLength(0);
+  });
+
+  it('does not clear optionName when Polymarket drops groupItemTitle', () => {
+    const market = makeMarket({
+      conditionId: '0xdrop',
+      groupItemTitle: undefined,
+    });
+
+    const existing = new Map([
+      ['0xdrop', existingFromMarket(market, { optionName: 'Viktor Orban' })],
+    ]);
+
+    const { metadataUpdates } = runDiff([market], existing);
+
+    expect(metadataUpdates).toHaveLength(0);
+  });
+
+  it('does not clear a field when fresh Polymarket value is missing', () => {
+    const market = makeMarket({ conditionId: '0xnoimg', image: undefined });
+
+    const existing = new Map([
+      [
+        '0xnoimg',
+        existingFromMarket(market, {
+          similarMarketImage: 'https://existing-image.png',
+        }),
+      ],
+    ]);
+
+    const { metadataUpdates } = runDiff([market], existing);
+
+    expect(metadataUpdates).toHaveLength(0);
+  });
+});
+
+describe('computeGroupMetadataUpdates', () => {
+  it('detects stored group URL using the broken polymarket.com#slug format', () => {
+    const market = makeMarket({
+      conditionId: '0xfmt',
+      slug: 'btc-100k',
+      events: [{ title: 'Bitcoin Milestones', slug: 'btc-milestones' }],
+    });
+
+    const existing = new Map([
+      [
+        '0xfmt',
+        existingFromMarket(market, {
+          conditionGroupId: 42,
+          conditionGroupSimilarMarkets: [
+            'https://polymarket.com#btc-milestones',
+          ],
+        }),
+      ],
+    ]);
+
+    const { groupMetadataUpdates } = runDiff([market], existing);
+
+    expect(groupMetadataUpdates).toHaveLength(1);
+    expect(groupMetadataUpdates[0].groupId).toBe(42);
+    expect(groupMetadataUpdates[0].fields.similarMarkets).toEqual([
+      'https://polymarket.com/event/btc-milestones#btc-100k',
+    ]);
+    expect(groupMetadataUpdates[0].old.similarMarkets).toEqual([
+      'https://polymarket.com#btc-milestones',
+    ]);
+  });
+
+  it('detects stored group URL when Polymarket renames the event slug', () => {
+    const market = makeMarket({
+      conditionId: '0xrenamed',
+      slug: 'btc-100k',
+      events: [{ title: 'Bitcoin Milestones', slug: 'btc-milestones-v2' }],
+    });
+
+    const existing = new Map([
+      [
+        '0xrenamed',
+        existingFromMarket(market, {
+          conditionGroupId: 100,
+          conditionGroupSimilarMarkets: [
+            'https://polymarket.com/event/btc-milestones#btc-100k',
+          ],
+        }),
+      ],
+    ]);
+
+    const { groupMetadataUpdates } = runDiff([market], existing);
+
+    expect(groupMetadataUpdates).toHaveLength(1);
+    expect(groupMetadataUpdates[0].groupId).toBe(100);
+    expect(groupMetadataUpdates[0].fields.similarMarkets).toEqual([
+      'https://polymarket.com/event/btc-milestones-v2#btc-100k',
+    ]);
+  });
+
+  it('emits no update when group similarMarkets is already current', () => {
+    const market = makeMarket({
+      conditionId: '0xcurrent',
+      slug: 'btc-100k',
+      events: [{ title: 'Bitcoin Milestones', slug: 'btc-milestones' }],
+    });
+
+    const existing = new Map([
+      [
+        '0xcurrent',
+        existingFromMarket(market, {
+          conditionGroupId: 7,
+          conditionGroupSimilarMarkets: [
+            'https://polymarket.com/event/btc-milestones#btc-100k',
+          ],
+        }),
+      ],
+    ]);
+
+    const { groupMetadataUpdates } = runDiff([market], existing);
+
+    expect(groupMetadataUpdates).toHaveLength(0);
+  });
+
+  it('emits no group update when the condition is not yet linked to a group', () => {
+    const market = makeMarket({
+      conditionId: '0xnogroup',
+      events: [{ title: 'Bitcoin Milestones', slug: 'btc-milestones' }],
+    });
+
+    const existing = new Map([
+      [
+        '0xnogroup',
+        existingFromMarket(market, {
+          conditionGroupId: undefined,
+          conditionGroupSimilarMarkets: undefined,
+        }),
+      ],
+    ]);
+
+    const { groupMetadataUpdates } = runDiff([market], existing);
+
+    expect(groupMetadataUpdates).toHaveLength(0);
+  });
+
+  it('emits no group update for a brand new condition', () => {
+    const market = makeMarket({ conditionId: '0xnew' });
+
+    const { groupMetadataUpdates } = runDiff([market], new Map());
+
+    expect(groupMetadataUpdates).toHaveLength(0);
+  });
+
+  it('does not clear an existing group URL when Polymarket returns no event slug', () => {
+    const market = makeMarket({ conditionId: '0xnoevent', events: undefined });
+
+    const existing = new Map([
+      [
+        '0xnoevent',
+        existingFromMarket(market, {
+          conditionGroupId: 55,
+          conditionGroupSimilarMarkets: [
+            'https://polymarket.com/event/something-old#something-old',
+          ],
+        }),
+      ],
+    ]);
+
+    const { groupMetadataUpdates } = runDiff([market], existing);
+
+    expect(groupMetadataUpdates).toHaveLength(0);
+  });
+});
+
+// `groupMarkets` itself still owns transformToSapienceCondition routing for
+// new conditions. These cases test the create path, not the diff helpers.
+describe('groupMarkets new-condition routing', () => {
   it('routes groupItemTitle into optionName (not shortName) for new conditions', async () => {
     const market = makeMarket({
       conditionId: '0xgit',
@@ -472,13 +642,10 @@ describe('metadata updates via groupMarkets', () => {
 
     mockCheckExisting.mockResolvedValue(new Map());
 
-    const result = await groupMarkets([market], 'https://test-api.example.com');
-
+    const result = await groupMarkets([market], API_URL);
     const condition = result.groups[0]?.conditions[0];
     expect(condition).toBeDefined();
     expect(condition.optionName).toBe('Viktor Orban');
-    // shortName is independent — no regex match, falls back to question
-    // (no LLM in tests)
     expect(condition.shortName).toBe(
       'Will the next Prime Minister of Hungary be Viktor Orban?'
     );
@@ -493,268 +660,11 @@ describe('metadata updates via groupMarkets', () => {
 
     mockCheckExisting.mockResolvedValue(new Map());
 
-    const result = await groupMarkets([market], 'https://test-api.example.com');
-
+    const result = await groupMarkets([market], API_URL);
     const condition = result.groups[0]?.conditions[0];
     expect(condition).toBeDefined();
     expect(condition.optionName).toBe('BTC 200k');
     expect(condition.shortName).not.toBe('BTC 200k');
     expect(condition.shortName).toBe('Bitcoin above $200k?');
-  });
-
-  it('backfills optionName on existing condition that predates the column', async () => {
-    const market = makeMarket({
-      conditionId: '0xbackfill',
-      question: 'Will the next Prime Minister of Hungary be Viktor Orban?',
-      groupItemTitle: 'Viktor Orban',
-    });
-
-    mockCheckExisting.mockResolvedValue(
-      new Map([
-        ['0xbackfill', existingFromMarket(market, { optionName: undefined })],
-      ])
-    );
-
-    const result = await groupMarkets([market], 'https://test-api.example.com');
-
-    expect(result.metadataUpdates).toHaveLength(1);
-    expect(result.metadataUpdates[0].fields.optionName).toBe('Viktor Orban');
-    expect(result.metadataUpdates[0].old.optionName).toBeUndefined();
-  });
-
-  it('detects optionName drift when Polymarket renames groupItemTitle', async () => {
-    const market = makeMarket({
-      conditionId: '0xrename',
-      question: 'Will Bitcoin reach $150k in April?',
-      groupItemTitle: '↑ 150,000',
-    });
-
-    mockCheckExisting.mockResolvedValue(
-      new Map([
-        ['0xrename', existingFromMarket(market, { optionName: 'BTC 150k' })],
-      ])
-    );
-
-    const result = await groupMarkets([market], 'https://test-api.example.com');
-
-    expect(result.metadataUpdates).toHaveLength(1);
-    expect(result.metadataUpdates[0].fields.optionName).toBe('↑ 150,000');
-    expect(result.metadataUpdates[0].old.optionName).toBe('BTC 150k');
-  });
-
-  it('does not emit optionName update when groupItemTitle already matches', async () => {
-    const market = makeMarket({
-      conditionId: '0xmatch',
-      question: 'Will the next Prime Minister of Hungary be Viktor Orban?',
-      groupItemTitle: 'Viktor Orban',
-    });
-
-    mockCheckExisting.mockResolvedValue(
-      new Map([
-        ['0xmatch', existingFromMarket(market, { optionName: 'Viktor Orban' })],
-      ])
-    );
-
-    const result = await groupMarkets([market], 'https://test-api.example.com');
-
-    expect(result.metadataUpdates).toHaveLength(0);
-  });
-
-  it('does not clear optionName when Polymarket drops groupItemTitle', async () => {
-    const market = makeMarket({
-      conditionId: '0xdrop',
-      groupItemTitle: undefined,
-    });
-
-    mockCheckExisting.mockResolvedValue(
-      new Map([
-        ['0xdrop', existingFromMarket(market, { optionName: 'Viktor Orban' })],
-      ])
-    );
-
-    const result = await groupMarkets([market], 'https://test-api.example.com');
-
-    expect(result.metadataUpdates).toHaveLength(0);
-  });
-
-  it('does not clear a field when fresh Polymarket value is missing', async () => {
-    // similarMarketImage is optional on the PolymarketMarket type.
-    // If the market comes back without an image, we should NOT clear
-    // the existing image in the DB — just leave it alone.
-    const market = makeMarket({ conditionId: '0xnoimg', image: undefined });
-
-    mockCheckExisting.mockResolvedValue(
-      new Map([
-        [
-          '0xnoimg',
-          existingFromMarket(market, {
-            similarMarketImage: 'https://existing-image.png',
-          }),
-        ],
-      ])
-    );
-
-    const result = await groupMarkets([market], 'https://test-api.example.com');
-
-    // No updates — we don't own a fresh value, so we don't touch it.
-    expect(result.metadataUpdates).toHaveLength(0);
-  });
-});
-
-describe('group metadata updates via groupMarkets', () => {
-  it('detects stored group URL using the broken polymarket.com#slug format', async () => {
-    // Real prod bug: groups were written with `polymarket.com#<slug>` instead
-    // of `polymarket.com/event/<slug>#<market>`. Fresh Polymarket data should
-    // drive the group row back to the correct URL.
-    const market = makeMarket({
-      conditionId: '0xfmt',
-      slug: 'btc-100k',
-      events: [{ title: 'Bitcoin Milestones', slug: 'btc-milestones' }],
-    });
-
-    mockCheckExisting.mockResolvedValue(
-      new Map([
-        [
-          '0xfmt',
-          existingFromMarket(market, {
-            conditionGroupId: 42,
-            conditionGroupSimilarMarkets: [
-              'https://polymarket.com#btc-milestones', // broken legacy format
-            ],
-          }),
-        ],
-      ])
-    );
-
-    const result = await groupMarkets([market], 'https://test-api.example.com');
-
-    expect(result.groupMetadataUpdates).toHaveLength(1);
-    expect(result.groupMetadataUpdates[0].groupId).toBe(42);
-    expect(result.groupMetadataUpdates[0].fields.similarMarkets).toEqual([
-      'https://polymarket.com/event/btc-milestones#btc-100k',
-    ]);
-    expect(result.groupMetadataUpdates[0].old.similarMarkets).toEqual([
-      'https://polymarket.com#btc-milestones',
-    ]);
-  });
-
-  it('detects stored group URL when Polymarket renames the event slug', async () => {
-    const market = makeMarket({
-      conditionId: '0xrenamed',
-      slug: 'btc-100k',
-      events: [{ title: 'Bitcoin Milestones', slug: 'btc-milestones-v2' }],
-    });
-
-    mockCheckExisting.mockResolvedValue(
-      new Map([
-        [
-          '0xrenamed',
-          existingFromMarket(market, {
-            conditionGroupId: 100,
-            conditionGroupSimilarMarkets: [
-              'https://polymarket.com/event/btc-milestones#btc-100k',
-            ],
-          }),
-        ],
-      ])
-    );
-
-    const result = await groupMarkets([market], 'https://test-api.example.com');
-
-    expect(result.groupMetadataUpdates).toHaveLength(1);
-    expect(result.groupMetadataUpdates[0].groupId).toBe(100);
-    expect(result.groupMetadataUpdates[0].fields.similarMarkets).toEqual([
-      'https://polymarket.com/event/btc-milestones-v2#btc-100k',
-    ]);
-  });
-
-  it('emits no update when group similarMarkets is already current', async () => {
-    const market = makeMarket({
-      conditionId: '0xcurrent',
-      slug: 'btc-100k',
-      events: [{ title: 'Bitcoin Milestones', slug: 'btc-milestones' }],
-    });
-
-    mockCheckExisting.mockResolvedValue(
-      new Map([
-        [
-          '0xcurrent',
-          existingFromMarket(market, {
-            conditionGroupId: 7,
-            conditionGroupSimilarMarkets: [
-              'https://polymarket.com/event/btc-milestones#btc-100k',
-            ],
-          }),
-        ],
-      ])
-    );
-
-    const result = await groupMarkets([market], 'https://test-api.example.com');
-
-    expect(result.groupMetadataUpdates).toHaveLength(0);
-  });
-
-  it('emits no group update when the condition is not yet linked to a group', async () => {
-    // Condition exists but has no conditionGroupId (e.g. ungrouped). Nothing
-    // to update on the group side — skip without error.
-    const market = makeMarket({
-      conditionId: '0xnogroup',
-      events: [{ title: 'Bitcoin Milestones', slug: 'btc-milestones' }],
-    });
-
-    mockCheckExisting.mockResolvedValue(
-      new Map([
-        [
-          '0xnogroup',
-          existingFromMarket(market, {
-            conditionGroupId: undefined,
-            conditionGroupSimilarMarkets: undefined,
-          }),
-        ],
-      ])
-    );
-
-    const result = await groupMarkets([market], 'https://test-api.example.com');
-
-    expect(result.groupMetadataUpdates).toHaveLength(0);
-  });
-
-  it('emits no group update for a brand new condition', async () => {
-    const market = makeMarket({ conditionId: '0xnew' });
-
-    mockCheckExisting.mockResolvedValue(new Map()); // nothing exists
-
-    const result = await groupMarkets([market], 'https://test-api.example.com');
-
-    expect(result.groupMetadataUpdates).toHaveLength(0);
-  });
-
-  it('does not clear an existing group URL when Polymarket returns no event slug', async () => {
-    // Regression guard: if the upstream market comes back without an event
-    // (CLOB fallback, stale cache, etc.) we have no way to build a correct
-    // fresh URL. Leaving the stored value alone is better than overwriting
-    // with a broken one or clearing to [].
-    const market = makeMarket({
-      conditionId: '0xnoevent',
-      events: undefined,
-    });
-
-    mockCheckExisting.mockResolvedValue(
-      new Map([
-        [
-          '0xnoevent',
-          existingFromMarket(market, {
-            conditionGroupId: 55,
-            conditionGroupSimilarMarkets: [
-              'https://polymarket.com/event/something-old#something-old',
-            ],
-          }),
-        ],
-      ])
-    );
-
-    const result = await groupMarkets([market], 'https://test-api.example.com');
-
-    expect(result.groupMetadataUpdates).toHaveLength(0);
   });
 });

--- a/packages/market-keeper/src/__tests__/metadata-updates.test.ts
+++ b/packages/market-keeper/src/__tests__/metadata-updates.test.ts
@@ -667,4 +667,69 @@ describe('groupMarkets new-condition routing', () => {
     expect(condition.shortName).not.toBe('BTC 200k');
     expect(condition.shortName).toBe('Bitcoin above $200k?');
   });
+
+  it('forces sibling conditions sharing an event title onto the majority category', async () => {
+    // Three sibling markets in "Champions League QF" — two LLM-classified as
+    // sports, one as culture. Expected outcome: all three (and all three
+    // single-market groups) end up tagged sports after the uniformity pass.
+    // Without that pass the DB ConditionGroup gets whichever sibling submits
+    // first as its category, and the other siblings disagree.
+    const markets = [
+      makeMarket({
+        conditionId: '0xa',
+        question: 'Will Real Madrid beat Arsenal?',
+        events: [{ title: 'Champions League QF', slug: 'ucl-qf' }],
+      }),
+      makeMarket({
+        conditionId: '0xb',
+        question: 'Will Barcelona beat PSG?',
+        events: [{ title: 'Champions League QF', slug: 'ucl-qf' }],
+      }),
+      makeMarket({
+        conditionId: '0xc',
+        question: 'Will the halftime musician forget the lyrics?',
+        events: [{ title: 'Champions League QF', slug: 'ucl-qf' }],
+      }),
+    ];
+
+    mockCheckExisting.mockResolvedValue(new Map());
+
+    const result = await groupMarkets(markets, API_URL);
+
+    // All three should land in three keeper-side groups sharing the title.
+    const titleGroups = result.groups.filter(
+      (g) => g.title === 'Champions League QF'
+    );
+    expect(titleGroups).toHaveLength(3);
+
+    // Two markets have sports-style questions, one has a culture-style
+    // question. inferSapienceCategorySlug (the LLM-disabled fallback used
+    // here) returns 'sports' for the first two and 'culture' for the third,
+    // so the majority is sports. After the uniformity pass, all three
+    // groups + their conditions agree on sports.
+    const categories = titleGroups.map((g) => g.categorySlug);
+    expect(new Set(categories).size).toBe(1);
+
+    const conditionCategories = titleGroups.flatMap((g) =>
+      g.conditions.map((c) => c.categorySlug)
+    );
+    expect(new Set(conditionCategories).size).toBe(1);
+    expect(conditionCategories[0]).toBe(categories[0]);
+  });
+
+  it('leaves a single-condition group alone (no siblings to vote against)', async () => {
+    const market = makeMarket({
+      conditionId: '0xsolo',
+      question: 'Will the halftime musician forget the lyrics?',
+      events: [{ title: 'Some Solo Event', slug: 'solo' }],
+    });
+
+    mockCheckExisting.mockResolvedValue(new Map());
+
+    const result = await groupMarkets([market], API_URL);
+    const group = result.groups[0];
+    expect(group).toBeDefined();
+    // Single-condition bucket — vote returns that one condition's category.
+    expect(group.categorySlug).toBe(group.conditions[0].categorySlug);
+  });
 });

--- a/packages/market-keeper/src/__tests__/refresh-metadata.test.ts
+++ b/packages/market-keeper/src/__tests__/refresh-metadata.test.ts
@@ -1,0 +1,367 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PolymarketMarket } from '../types';
+
+// Lock LLM and constants to test-safe values; refresh-metadata pulls these
+// transitively via grouping.ts → llm imports.
+vi.mock('../constants', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    CHAIN_ID: 5064014,
+    LLM_ENRICHMENT_ENABLED: false,
+    LLM_ENDTIME_SEARCH_ENABLED: false,
+    OPENROUTER_API_KEY: '',
+    LLM_MODEL: '',
+    LLM_ENDTIME_MODEL: '',
+    DEFAULT_SAPIENCE_API_URL: 'https://test-api.example.com',
+  };
+});
+
+// Mock fetchWithRetry at the source — both fetch.ts (refresh-metadata) and
+// tags.ts (event tag fetch) read it from utils. A single recorded array of
+// (url, init) calls plus a queue of canned responses lets each test wire
+// exactly the GraphQL + Gamma traffic it cares about.
+type FetchCall = { url: string; init?: RequestInit };
+const fetchCalls: FetchCall[] = [];
+const fetchQueue: Array<() => Response> = [];
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+vi.mock('../utils/fetch', () => ({
+  fetchWithRetry: vi.fn(async (url: string, init?: RequestInit) => {
+    fetchCalls.push({ url, init });
+    const next = fetchQueue.shift();
+    if (!next) throw new Error(`No queued response for ${url}`);
+    return next();
+  }),
+}));
+
+import {
+  fetchAllExistingConditions,
+  fetchMarketsByConditionIds,
+  fetchEventTagsByIds,
+} from '../refresh-metadata/fetch';
+
+beforeEach(() => {
+  fetchCalls.length = 0;
+  fetchQueue.length = 0;
+  vi.clearAllMocks();
+});
+
+function makeMarket(
+  overrides: Partial<PolymarketMarket> = {}
+): PolymarketMarket {
+  return {
+    id: 'test',
+    question: 'Q',
+    conditionId: '0x123',
+    outcomes: ['Yes', 'No'],
+    volume: '0',
+    liquidity: '0',
+    endDate: '2030-01-01T00:00:00Z',
+    description: '',
+    slug: 'btc-100k',
+    active: true,
+    closed: false,
+    events: [{ title: 'Bitcoin Milestones', slug: 'btc-milestones' }],
+    ...overrides,
+  };
+}
+
+describe('fetchAllExistingConditions', () => {
+  it('sends a where clause that filters to public + unsettled + non-empty similarMarkets', async () => {
+    fetchQueue.push(() => jsonResponse({ data: { conditions: [] } }));
+
+    await fetchAllExistingConditions('https://api.example.com');
+
+    expect(fetchCalls).toHaveLength(1);
+    const body = JSON.parse(fetchCalls[0].init!.body as string);
+    expect(body.variables.where).toEqual({
+      public: { equals: true },
+      settled: { equals: false },
+      similarMarkets: { isEmpty: false },
+    });
+    expect(body.variables.orderBy).toEqual([{ id: 'asc' }]);
+    expect(fetchCalls[0].url.endsWith('/graphql')).toBe(true);
+  });
+
+  it('paginates with deterministic orderBy until a page returns < pageSize', async () => {
+    // Two full pages of 100 then an empty short page — same shape
+    // refresh-volume's fetchActiveConditionIds uses.
+    const page1 = Array.from({ length: 100 }, (_, i) => ({
+      id: `0x${(i + 1).toString().padStart(3, '0')}`,
+      endTime: 1700000000,
+      similarMarkets: ['https://polymarket.com/event/x#y'],
+    }));
+    const page2 = Array.from({ length: 100 }, (_, i) => ({
+      id: `0x${(i + 101).toString().padStart(3, '0')}`,
+      endTime: 1700000000,
+      similarMarkets: ['https://polymarket.com/event/x#y'],
+    }));
+    const page3 = [
+      {
+        id: '0x999',
+        endTime: 1700000000,
+        similarMarkets: ['https://polymarket.com/event/x#y'],
+      },
+    ];
+
+    fetchQueue.push(() => jsonResponse({ data: { conditions: page1 } }));
+    fetchQueue.push(() => jsonResponse({ data: { conditions: page2 } }));
+    fetchQueue.push(() => jsonResponse({ data: { conditions: page3 } }));
+
+    const result = await fetchAllExistingConditions('https://api.example.com');
+
+    expect(result.size).toBe(201);
+    expect(fetchCalls).toHaveLength(3);
+    expect(JSON.parse(fetchCalls[0].init!.body as string).variables.skip).toBe(
+      0
+    );
+    expect(JSON.parse(fetchCalls[1].init!.body as string).variables.skip).toBe(
+      100
+    );
+    expect(JSON.parse(fetchCalls[2].init!.body as string).variables.skip).toBe(
+      200
+    );
+  });
+
+  it('maps GraphQL fields onto the ExistingCondition shape', async () => {
+    fetchQueue.push(() =>
+      jsonResponse({
+        data: {
+          conditions: [
+            {
+              id: '0xabc',
+              endTime: 1700000000,
+              question: 'Will X happen?',
+              shortName: 'X?',
+              optionName: 'Yes side',
+              description: 'A description',
+              similarMarkets: ['https://polymarket.com/event/foo#bar'],
+              tags: ['crypto', 'btc'],
+              similarMarketVolume: 1234,
+              similarMarketImage: 'https://img.example/x.png',
+              conditionGroup: {
+                id: 7,
+                name: 'Group Name',
+                similarMarkets: ['https://polymarket.com/event/foo#bar'],
+              },
+            },
+          ],
+        },
+      })
+    );
+
+    const result = await fetchAllExistingConditions('https://api.example.com');
+    const row = result.get('0xabc');
+
+    expect(row).toEqual({
+      endTime: 1700000000,
+      question: 'Will X happen?',
+      shortName: 'X?',
+      optionName: 'Yes side',
+      description: 'A description',
+      similarMarkets: ['https://polymarket.com/event/foo#bar'],
+      tags: ['crypto', 'btc'],
+      similarMarketVolume: 1234,
+      similarMarketImage: 'https://img.example/x.png',
+      groupName: 'Group Name',
+      conditionGroupId: 7,
+      conditionGroupSimilarMarkets: ['https://polymarket.com/event/foo#bar'],
+    });
+  });
+
+  it('throws when the GraphQL endpoint returns a non-2xx', async () => {
+    fetchQueue.push(
+      () =>
+        new Response('boom', {
+          status: 500,
+          statusText: 'Internal Server Error',
+        })
+    );
+
+    await expect(
+      fetchAllExistingConditions('https://api.example.com')
+    ).rejects.toThrow(/HTTP 500/);
+  });
+});
+
+describe('fetchMarketsByConditionIds', () => {
+  it('returns an empty Map immediately for an empty input list', async () => {
+    const result = await fetchMarketsByConditionIds([]);
+    expect(result.size).toBe(0);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it('builds Gamma URLs with repeated condition_ids params', async () => {
+    fetchQueue.push(() =>
+      jsonResponse([
+        makeMarket({ conditionId: '0x1' }),
+        makeMarket({ conditionId: '0x2' }),
+      ])
+    );
+
+    await fetchMarketsByConditionIds(['0x1', '0x2']);
+
+    expect(fetchCalls).toHaveLength(1);
+    const url = fetchCalls[0].url;
+    expect(url).toMatch(/^https:\/\/gamma-api\.polymarket\.com\/markets\?/);
+    expect(url).toContain('condition_ids=0x1');
+    expect(url).toContain('condition_ids=0x2');
+    // Plural-param style (not condition_id=, not a CSV)
+    expect(url).not.toContain('condition_id=');
+    expect(url).not.toContain('0x1%2C0x2');
+  });
+
+  it('batches input into Gamma calls of at most 50 IDs', async () => {
+    const ids = Array.from({ length: 75 }, (_, i) => `0x${i + 1}`);
+    fetchQueue.push(() => jsonResponse([])); // batch 1: 50 IDs
+    fetchQueue.push(() => jsonResponse([])); // batch 2: 25 IDs
+
+    await fetchMarketsByConditionIds(ids);
+
+    expect(fetchCalls).toHaveLength(2);
+    const batch1Count = (fetchCalls[0].url.match(/condition_ids=/g) || [])
+      .length;
+    const batch2Count = (fetchCalls[1].url.match(/condition_ids=/g) || [])
+      .length;
+    expect(batch1Count).toBe(50);
+    expect(batch2Count).toBe(25);
+  });
+
+  it('keys the returned Map by conditionId regardless of response order', async () => {
+    fetchQueue.push(() =>
+      jsonResponse([
+        makeMarket({ conditionId: '0xb' }),
+        makeMarket({ conditionId: '0xa' }),
+      ])
+    );
+
+    const result = await fetchMarketsByConditionIds(['0xa', '0xb']);
+    expect([...result.keys()].sort()).toEqual(['0xa', '0xb']);
+  });
+
+  it('skips missing conditionIds (delisted) without including them in the result', async () => {
+    // Caller asks for 3 IDs; Gamma only returns 2.
+    fetchQueue.push(() =>
+      jsonResponse([
+        makeMarket({ conditionId: '0xa' }),
+        makeMarket({ conditionId: '0xc' }),
+      ])
+    );
+
+    const result = await fetchMarketsByConditionIds(['0xa', '0xb', '0xc']);
+    expect(result.has('0xa')).toBe(true);
+    expect(result.has('0xb')).toBe(false);
+    expect(result.has('0xc')).toBe(true);
+  });
+
+  it('continues batching even if one batch errors', async () => {
+    const ids = Array.from({ length: 60 }, (_, i) => `0x${i + 1}`);
+    fetchQueue.push(
+      () => new Response('oops', { status: 502, statusText: 'Bad Gateway' })
+    );
+    fetchQueue.push(() => jsonResponse([makeMarket({ conditionId: '0x55' })]));
+
+    const result = await fetchMarketsByConditionIds(ids);
+    expect(result.has('0x55')).toBe(true);
+  });
+});
+
+describe('fetchEventTagsByIds', () => {
+  it('returns an empty Map immediately for an empty / all-falsy input', async () => {
+    expect((await fetchEventTagsByIds([])).size).toBe(0);
+    expect(
+      (await fetchEventTagsByIds(['', undefined as unknown as string])).size
+    ).toBe(0);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it('batches up to 50 unique IDs per /events request with repeated id= params and limit=50', async () => {
+    fetchQueue.push(() =>
+      jsonResponse([
+        { id: '1', slug: 'a', tags: [{ label: 'Politics' }] },
+        { id: '2', slug: 'b', tags: [{ label: 'Sports' }] },
+      ])
+    );
+
+    const result = await fetchEventTagsByIds(['1', '2', '1']); // '1' duplicated
+
+    expect(fetchCalls).toHaveLength(1);
+    const url = fetchCalls[0].url;
+    expect(url).toMatch(/^https:\/\/gamma-api\.polymarket\.com\/events\?/);
+    expect(url).toContain('limit=50');
+    expect(url).toContain('id=1');
+    expect(url).toContain('id=2');
+    // Plural-param style — not CSV, not single-id
+    expect(url).not.toContain('ids=');
+    expect(url).not.toContain('1%2C2');
+    expect(result.get('a')).toEqual(['Politics']);
+    expect(result.get('b')).toEqual(['Sports']);
+  });
+
+  it('keys the result Map by event slug (not by ID)', async () => {
+    fetchQueue.push(() =>
+      jsonResponse([
+        { id: '42', slug: 'my-event', tags: [{ label: 'Crypto' }] },
+      ])
+    );
+
+    const result = await fetchEventTagsByIds(['42']);
+    expect(result.has('42')).toBe(false);
+    expect(result.get('my-event')).toEqual(['Crypto']);
+  });
+
+  it('drops the generic "All" tag and dedupes labels', async () => {
+    fetchQueue.push(() =>
+      jsonResponse([
+        {
+          id: '1',
+          slug: 'foo',
+          tags: [
+            { label: 'All' },
+            { label: 'Politics' },
+            { label: 'Politics' }, // duplicate
+            { label: 'US' },
+          ],
+        },
+      ])
+    );
+
+    const result = await fetchEventTagsByIds(['1']);
+    expect(result.get('foo')).toEqual(['Politics', 'US']);
+  });
+
+  it('skips a batch whose response is non-2xx without aborting the rest', async () => {
+    // 75 IDs = two batches (50 + 25). First fails, second succeeds.
+    const ids = Array.from({ length: 75 }, (_, i) => `${i}`);
+    fetchQueue.push(
+      () => new Response('nope', { status: 502, statusText: 'Bad Gateway' })
+    );
+    fetchQueue.push(() =>
+      jsonResponse([{ id: '70', slug: 'good', tags: [{ label: 'Crypto' }] }])
+    );
+
+    const result = await fetchEventTagsByIds(ids);
+    expect(fetchCalls).toHaveLength(2);
+    expect(result.get('good')).toEqual(['Crypto']);
+  });
+
+  it('chunks 175 unique IDs into four batches (50 + 50 + 50 + 25)', async () => {
+    const ids = Array.from({ length: 175 }, (_, i) => `${i}`);
+    for (let i = 0; i < 4; i++) fetchQueue.push(() => jsonResponse([]));
+
+    await fetchEventTagsByIds(ids);
+
+    expect(fetchCalls).toHaveLength(4);
+    const idCounts = fetchCalls.map(
+      (c) => (c.url.match(/(?<=^|&)id=/g) || []).length
+    );
+    expect(idCounts).toEqual([50, 50, 50, 25]);
+  });
+});

--- a/packages/market-keeper/src/__tests__/refresh-metadata.test.ts
+++ b/packages/market-keeper/src/__tests__/refresh-metadata.test.ts
@@ -198,62 +198,63 @@ describe('fetchMarketsByConditionIds', () => {
     expect(fetchCalls).toHaveLength(0);
   });
 
-  it('builds Gamma URLs with repeated condition_ids params', async () => {
-    fetchQueue.push(() =>
-      jsonResponse([
-        makeMarket({ conditionId: '0x1' }),
-        makeMarket({ conditionId: '0x2' }),
-      ])
-    );
+  it('issues paired closed=false / closed=true requests with repeated condition_ids params', async () => {
+    // Each batch fires two requests (closed=false then closed=true) so we
+    // pick up both open and resolved-but-not-yet-Sapience-settled markets.
+    fetchQueue.push(() => jsonResponse([makeMarket({ conditionId: '0x1' })]));
+    fetchQueue.push(() => jsonResponse([makeMarket({ conditionId: '0x2' })]));
 
     await fetchMarketsByConditionIds(['0x1', '0x2']);
 
-    expect(fetchCalls).toHaveLength(1);
-    const url = fetchCalls[0].url;
-    expect(url).toMatch(/^https:\/\/gamma-api\.polymarket\.com\/markets\?/);
-    expect(url).toContain('condition_ids=0x1');
-    expect(url).toContain('condition_ids=0x2');
-    // Plural-param style (not condition_id=, not a CSV)
-    expect(url).not.toContain('condition_id=');
-    expect(url).not.toContain('0x1%2C0x2');
+    expect(fetchCalls).toHaveLength(2);
+    const sides = fetchCalls.map((c) => {
+      const m = c.url.match(/[?&]closed=(true|false)/);
+      return m ? m[1] : null;
+    });
+    expect(new Set(sides)).toEqual(new Set(['true', 'false']));
+
+    for (const c of fetchCalls) {
+      expect(c.url).toMatch(/^https:\/\/gamma-api\.polymarket\.com\/markets\?/);
+      expect(c.url).toContain('condition_ids=0x1');
+      expect(c.url).toContain('condition_ids=0x2');
+      expect(c.url).not.toContain('condition_id=');
+      expect(c.url).not.toContain('0x1%2C0x2');
+    }
   });
 
-  it('batches input into Gamma calls of at most 50 IDs', async () => {
+  it('batches input into Gamma calls of at most 50 IDs (each batch = 2 requests)', async () => {
     const ids = Array.from({ length: 75 }, (_, i) => `0x${i + 1}`);
-    fetchQueue.push(() => jsonResponse([])); // batch 1: 50 IDs
-    fetchQueue.push(() => jsonResponse([])); // batch 2: 25 IDs
+    // 2 batches × 2 sides = 4 requests
+    fetchQueue.push(() => jsonResponse([])); // batch 1, closed=false
+    fetchQueue.push(() => jsonResponse([])); // batch 1, closed=true
+    fetchQueue.push(() => jsonResponse([])); // batch 2, closed=false
+    fetchQueue.push(() => jsonResponse([])); // batch 2, closed=true
 
     await fetchMarketsByConditionIds(ids);
 
-    expect(fetchCalls).toHaveLength(2);
-    const batch1Count = (fetchCalls[0].url.match(/condition_ids=/g) || [])
-      .length;
-    const batch2Count = (fetchCalls[1].url.match(/condition_ids=/g) || [])
-      .length;
-    expect(batch1Count).toBe(50);
-    expect(batch2Count).toBe(25);
+    expect(fetchCalls).toHaveLength(4);
+    const idCounts = fetchCalls.map(
+      (c) => (c.url.match(/condition_ids=/g) || []).length
+    );
+    // First two requests are batch 1 (50 IDs each), second two are batch 2 (25 IDs each)
+    expect(idCounts.slice(0, 2).every((n) => n === 50)).toBe(true);
+    expect(idCounts.slice(2, 4).every((n) => n === 25)).toBe(true);
   });
 
-  it('keys the returned Map by conditionId regardless of response order', async () => {
-    fetchQueue.push(() =>
-      jsonResponse([
-        makeMarket({ conditionId: '0xb' }),
-        makeMarket({ conditionId: '0xa' }),
-      ])
-    );
+  it('keys the returned Map by conditionId and merges open + closed markets', async () => {
+    // Open side returns 0xa, closed side returns 0xb — both should land
+    // in the result Map.
+    fetchQueue.push(() => jsonResponse([makeMarket({ conditionId: '0xa' })]));
+    fetchQueue.push(() => jsonResponse([makeMarket({ conditionId: '0xb' })]));
 
     const result = await fetchMarketsByConditionIds(['0xa', '0xb']);
     expect([...result.keys()].sort()).toEqual(['0xa', '0xb']);
   });
 
-  it('skips missing conditionIds (delisted) without including them in the result', async () => {
-    // Caller asks for 3 IDs; Gamma only returns 2.
-    fetchQueue.push(() =>
-      jsonResponse([
-        makeMarket({ conditionId: '0xa' }),
-        makeMarket({ conditionId: '0xc' }),
-      ])
-    );
+  it('skips missing conditionIds (delisted on both sides) without including them', async () => {
+    // Caller asks for 3 IDs; open returns 0xa, closed returns 0xc, 0xb is gone.
+    fetchQueue.push(() => jsonResponse([makeMarket({ conditionId: '0xa' })]));
+    fetchQueue.push(() => jsonResponse([makeMarket({ conditionId: '0xc' })]));
 
     const result = await fetchMarketsByConditionIds(['0xa', '0xb', '0xc']);
     expect(result.has('0xa')).toBe(true);
@@ -261,8 +262,10 @@ describe('fetchMarketsByConditionIds', () => {
     expect(result.has('0xc')).toBe(true);
   });
 
-  it('continues batching even if one batch errors', async () => {
-    const ids = Array.from({ length: 60 }, (_, i) => `0x${i + 1}`);
+  it('continues batching even if one side of one batch errors', async () => {
+    // Single batch (60 IDs, but limited to 1 batch worth = 50). Open side
+    // errors; closed side succeeds and contributes one market.
+    const ids = Array.from({ length: 50 }, (_, i) => `0x${i + 1}`);
     fetchQueue.push(
       () => new Response('oops', { status: 502, statusText: 'Bad Gateway' })
     );
@@ -282,7 +285,7 @@ describe('fetchEventTagsByIds', () => {
     expect(fetchCalls).toHaveLength(0);
   });
 
-  it('batches up to 50 unique IDs per /events request with repeated id= params and limit=50', async () => {
+  it('batches up to 50 unique IDs per /events request with repeated id= params and a generous limit', async () => {
     fetchQueue.push(() =>
       jsonResponse([
         { id: '1', slug: 'a', tags: [{ label: 'Politics' }] },
@@ -295,7 +298,12 @@ describe('fetchEventTagsByIds', () => {
     expect(fetchCalls).toHaveLength(1);
     const url = fetchCalls[0].url;
     expect(url).toMatch(/^https:\/\/gamma-api\.polymarket\.com\/events\?/);
-    expect(url).toContain('limit=50');
+    // Limit must exceed the batch size (defensive headroom — Polymarket's
+    // default limit is 20, so passing a too-small value would silently
+    // truncate). 50 batch × 4 = 200 today.
+    const limitMatch = url.match(/[?&]limit=(\d+)/);
+    expect(limitMatch).not.toBeNull();
+    expect(Number(limitMatch![1])).toBeGreaterThanOrEqual(50);
     expect(url).toContain('id=1');
     expect(url).toContain('id=2');
     // Plural-param style — not CSV, not single-id

--- a/packages/market-keeper/src/__tests__/relist.test.ts
+++ b/packages/market-keeper/src/__tests__/relist.test.ts
@@ -72,8 +72,6 @@ const emptySapienceOutput: SapienceOutput = {
   },
   groups: [],
   ungroupedConditions: [],
-  metadataUpdates: [],
-  groupMetadataUpdates: [],
 };
 
 beforeEach(() => {

--- a/packages/market-keeper/src/generate/grouping.ts
+++ b/packages/market-keeper/src/generate/grouping.ts
@@ -172,19 +172,6 @@ export async function groupMarkets(
   const allConditionIds = allFilteredMarkets.map((m) => m.conditionId);
   const existingIds = await checkExistingConditions(apiUrl, allConditionIds);
 
-  // Compute metadata updates for existing conditions by diffing against fresh Polymarket data
-  const metadataUpdates = computeMetadataUpdates(
-    allFilteredMarkets,
-    filteredGroups,
-    existingIds,
-    eventTagMap
-  );
-
-  const groupMetadataUpdates = computeGroupMetadataUpdates(
-    filteredGroups,
-    existingIds
-  );
-
   // Apply LLM pre-filter pipeline to separate new vs existing markets
   const { output: newMarkets, stats: llmFilterStats } = runPipeline(
     allFilteredMarkets,
@@ -277,8 +264,6 @@ export async function groupMarkets(
     },
     groups: conditionGroups,
     ungroupedConditions,
-    metadataUpdates,
-    groupMetadataUpdates,
   };
 }
 
@@ -287,7 +272,7 @@ export async function groupMarkets(
  * of the fields that transformToSapienceCondition writes on initial create.
  * Kept as a single source of truth so the diff and the create paths agree.
  */
-function freshMetadataFor(
+export function freshMetadataFor(
   market: PolymarketMarket,
   groupTitle: string | undefined,
   tags: string[]
@@ -313,7 +298,7 @@ function freshMetadataFor(
  * as sets since Polymarket can reshuffle tag/similarMarkets ordering
  * without any semantic change.
  */
-function fieldsEqual(a: unknown, b: unknown): boolean {
+export function fieldsEqual(a: unknown, b: unknown): boolean {
   if (Array.isArray(a) && Array.isArray(b)) {
     if (a.length !== b.length) return false;
     const sa = [...a].map(String).sort();
@@ -330,7 +315,7 @@ function fieldsEqual(a: unknown, b: unknown): boolean {
  * SyncableFields is re-derived from the current Polymarket market and
  * pushed back if it differs from what we have stored.
  */
-function computeMetadataUpdates(
+export function computeMetadataUpdates(
   markets: PolymarketMarket[],
   groups: Array<{
     title: string;
@@ -433,7 +418,7 @@ function computeMetadataUpdates(
  * up via the group's first market, so we can't double-emit even if future
  * changes allow multi-market groups.
  */
-function computeGroupMetadataUpdates(
+export function computeGroupMetadataUpdates(
   groups: Array<{
     title: string;
     markets: PolymarketMarket[];

--- a/packages/market-keeper/src/generate/grouping.ts
+++ b/packages/market-keeper/src/generate/grouping.ts
@@ -249,6 +249,29 @@ export async function groupMarkets(
     );
   });
 
+  // Enforce category uniformity within each event-title bucket. The DB's
+  // ConditionGroup is keyed by name (find-or-create), so multiple keeper
+  // groups sharing a title collapse onto a single row server-side. Without
+  // this pass, sibling conditions can carry per-market LLM categories that
+  // disagree with each other AND with the group's stored category (which
+  // gets stamped by whichever sibling submits first). Vote once per title
+  // and rewrite both the group payload and every condition under it.
+  const titleBuckets = new Map<string, SapienceConditionGroup[]>();
+  for (const group of conditionGroups) {
+    const bucket = titleBuckets.get(group.title) ?? [];
+    bucket.push(group);
+    titleBuckets.set(group.title, bucket);
+  }
+  for (const bucket of titleBuckets.values()) {
+    const allConditions = bucket.flatMap((g) => g.conditions);
+    if (allConditions.length === 0) continue;
+    const voted = computeGroupCategory(allConditions);
+    for (const g of bucket) {
+      g.categorySlug = voted;
+      for (const c of g.conditions) c.categorySlug = voted;
+    }
+  }
+
   // Count total conditions after filtering
   const totalConditions =
     conditionGroups.reduce((sum, g) => sum + g.conditions.length, 0) +

--- a/packages/market-keeper/src/generate/index.ts
+++ b/packages/market-keeper/src/generate/index.ts
@@ -7,12 +7,7 @@ import { DEFAULT_SAPIENCE_API_URL } from '../constants';
 import { validatePrivateKey, confirmProductionAccess } from '../utils';
 import { fetchEndingSoonestMarkets } from './market';
 import { groupMarkets, exportJSON } from './grouping';
-import {
-  printDryRun,
-  submitToAPI,
-  submitMetadataUpdates,
-  submitGroupMetadataUpdates,
-} from './api';
+import { printDryRun, submitToAPI } from './api';
 
 // ============ CLI Arguments ============
 
@@ -99,63 +94,12 @@ export async function main() {
     // Dry run mode - just print what would be submitted
     if (options.dryRun) {
       printDryRun(sapienceData);
-      if (sapienceData.metadataUpdates.length > 0) {
-        console.log(
-          `\nWould update metadata for ${sapienceData.metadataUpdates.length} existing conditions:`
-        );
-        for (const u of sapienceData.metadataUpdates) {
-          const changedKeys = Object.keys(u.fields);
-          console.log(
-            `  ${u.conditionId.slice(0, 10)}... → ${changedKeys.join(', ')}`
-          );
-          const oldRec = u.old as Record<string, unknown>;
-          const newRec = u.fields as Record<string, unknown>;
-          for (const key of changedKeys) {
-            console.log(
-              `    ${key}: ${JSON.stringify(oldRec[key])} → ${JSON.stringify(newRec[key])}`
-            );
-          }
-        }
-      }
-      if (sapienceData.groupMetadataUpdates.length > 0) {
-        console.log(
-          `\nWould update metadata for ${sapienceData.groupMetadataUpdates.length} existing condition groups:`
-        );
-        for (const u of sapienceData.groupMetadataUpdates) {
-          const changedKeys = Object.keys(u.fields);
-          console.log(`  group ${u.groupId} → ${changedKeys.join(', ')}`);
-          const oldRec = u.old as Record<string, unknown>;
-          const newRec = u.fields as Record<string, unknown>;
-          for (const key of changedKeys) {
-            console.log(
-              `    ${key}: ${JSON.stringify(oldRec[key])} → ${JSON.stringify(newRec[key])}`
-            );
-          }
-        }
-      }
       return;
     }
 
     // Submit to API if credentials are available
     if (hasAPICredentials && apiUrl && privateKey) {
       await submitToAPI(apiUrl, privateKey, sapienceData);
-
-      // Submit metadata updates for existing conditions that changed on Polymarket
-      if (sapienceData.metadataUpdates.length > 0) {
-        await submitMetadataUpdates(
-          apiUrl,
-          privateKey,
-          sapienceData.metadataUpdates
-        );
-      }
-
-      if (sapienceData.groupMetadataUpdates.length > 0) {
-        await submitGroupMetadataUpdates(
-          apiUrl,
-          privateKey,
-          sapienceData.groupMetadataUpdates
-        );
-      }
     }
   } catch (error) {
     console.error('Error:', error);

--- a/packages/market-keeper/src/llm/prompts.ts
+++ b/packages/market-keeper/src/llm/prompts.ts
@@ -295,6 +295,8 @@ TODAY'S DATE: ${new Date().toISOString().split('T')[0]}
 
 IMPORTANT CONTEXT: These are prediction markets with YES/NO outcomes. You do NOT need to predict the answer — you only need to determine WHEN the answer will become available. For example, "Will X be the next PM of Y?" does not require knowing who will be PM — it requires knowing when the PM will be announced (e.g. after coalition talks conclude). Similarly, "Will X happen between March 17-23?" just needs the end of that date range, not whether X actually happened.
 
+OPTIMISTIC RESOLUTION PRINCIPLE: Most events resolve on their scheduled / announced date. Default to that date. Only deviate when there is positive evidence of postponement, cancellation, or unusual delay (an explicit news article, a "rescheduled to" note in the description, etc.). Do NOT pad scheduled dates with speculative buffers in case of "what if it slips" — return the actual scheduled resolution time. Fallback dates (constitutional deadlines, end-of-quarter, etc.) are a last resort, not a hedge.
+
 STEP 1 — CHECK DATES IN THE QUESTION: If the question contains a date or date range, check whether it is before today (${new Date().toISOString().split('T')[0]}).
 - If the date/range is entirely in the past (e.g. "between March 17-23" and today is March 27): the outcome is ALREADY knowable. Return the end of that date range (e.g. March 23 end-of-day in the relevant timezone). Do NOT add extra days for "data reporting" — prediction markets resolve based on the stated date.
 - If the date is in the future: proceed to Step 2.
@@ -306,13 +308,15 @@ STEP 2 — CHECK IF THE EVENT ALREADY HAPPENED: Search for whether the event has
 - Any event: search "[event] results" or "[event] outcome" first.
 If the event already happened and the outcome is known, return the date/time when the outcome became known (e.g. when results were announced, when the game ended, when the vote was counted). Do NOT return a future date for an event that already occurred.
 
-STEP 3 — SEARCH FOR SCHEDULED TIME (only if the event has NOT happened yet): Construct a targeted search query from the question text to find the exact scheduled time. Examples:
+STEP 3 — SEARCH FOR SCHEDULED TIME (only if the event has NOT happened yet): Construct a targeted search query from the question text to find the exact scheduled time. Exhaust search BEFORE falling back — a discoverable scheduled date always beats a generic deadline. Examples:
 - Sports: search "[team1] vs [team2] [date] start time"
 - Esports: search "[team1] vs [team2] [tournament] schedule"
 - Financial: search "[company] earnings date Q[N] [year]" or "Fed meeting [month] [year] announcement time"
 - If description says the event was "postponed" or "rescheduled to [new date]": search for the new date; if not found, use the date directly
 - If description contains a resolution source URL (e.g. vlr.gg, hltv.org, flashscore.com): search that site directly for the match schedule
 - Elections without a specific date in the question: search "[country/region] [year] election date" to find the actual scheduled date
+
+When you find a scheduled date, trust it. Do not silently substitute a more conservative date "in case the event slips" — the OPTIMISTIC RESOLUTION PRINCIPLE applies.
 
 STEP 4 — COMPUTE END TIME: Return when the outcome will be KNOWN, not the start time.
 - If the question contains a past date/range (from Step 1): return end of that date/range
@@ -328,9 +332,12 @@ STEP 4 — COMPUTE END TIME: Return when the outcome will be KNOWN, not the star
 - Elections already held but leader not yet chosen (e.g. coalition talks): estimate when the new government will be formed — search for "[country] coalition talks timeline" and give a realistic near-term estimate, NOT a constitutional maximum deadline
 - If there is a deadline in the question/description (e.g. "Will X happen by Y?"): use Y directly
 
-STEP 5 — FALLBACK: Only if start time cannot be found after searching, use end of day (23:59:59) in the event's local timezone. NEVER return UNKNOWN just because a specific time is missing — if the date is known, end-of-day is always an acceptable fallback.
+STEP 5 — FALLBACK (last resort, after exhausting search):
+- If you found the date but not the exact time: use end of day (23:59:59) in the event's local timezone. This is an acceptable fallback for the *time*, not for the *date*.
+- If you cannot find any scheduled date AND no deadline is stated in the question: only then may you fall back to a constitutional / end-of-period deadline. Make this the genuine outer bound — not a "safe" guess when an actual date probably exists but you didn't search hard enough.
+- NEVER return UNKNOWN just because a specific time is missing — if the date is known, end-of-day is always an acceptable fallback.
 
-CRITICAL: The returned date must be the EARLIEST time the outcome can be known. Never return a "must be held by" constitutional deadline when the actual event date is known. Never return a future date for an event that search results confirm has already happened.
+CRITICAL: The returned date must be the EARLIEST time the outcome can be known. Never return a "must be held by" constitutional deadline when the actual event date is known. Never return a future date for an event that search results confirm has already happened. Default to optimism — assume the scheduled date holds unless evidence says otherwise.
 
 OTHER RULES:
 - Always output UTC (convert from local timezone)

--- a/packages/market-keeper/src/refresh-metadata/fetch.ts
+++ b/packages/market-keeper/src/refresh-metadata/fetch.ts
@@ -22,6 +22,15 @@ const GAMMA_CONCURRENCY = 10;
 const EVENT_TAGS_BATCH_SIZE = 50;
 const EVENT_TAGS_CONCURRENCY = 10;
 
+// Polymarket's default `limit` is 20 (verified empirically) — passing limit
+// is load-bearing, not optional. We size it well above each request's batch
+// so the response is bounded by the `id=`/`condition_ids=` filter, not by
+// the page cap. Headroom is intentional: even if the API ever returned more
+// rows than expected per ID (related-events, soft match, etc.), we still
+// wouldn't silently truncate.
+const GAMMA_RESPONSE_LIMIT = GAMMA_BATCH_SIZE * 4;
+const EVENT_TAGS_RESPONSE_LIMIT = EVENT_TAGS_BATCH_SIZE * 4;
+
 /**
  * Paginate Sapience GraphQL conditions to collect every refreshable row.
  * Filters: public=true, settled=false, similarMarkets non-empty.
@@ -162,30 +171,48 @@ export async function fetchMarketsByConditionIds(
   }
   const totalBatches = batches.length;
 
-  const fetchBatch = async (
+  // Polymarket /markets defaults to `closed=false` — markets that have
+  // resolved on Polymarket but are still `settled=false` on Sapience would
+  // silently fall out of the result set. Query both states and merge.
+  const fetchOneSide = async (
     batch: string[],
-    batchIdx: number
-  ): Promise<void> => {
+    closed: boolean
+  ): Promise<PolymarketMarket[]> => {
     const params = batch
       .map((id) => `condition_ids=${encodeURIComponent(id)}`)
       .join('&');
-    const url = `https://gamma-api.polymarket.com/markets?${params}&limit=${GAMMA_BATCH_SIZE}`;
-    const batchStart = Date.now();
+    const url = `https://gamma-api.polymarket.com/markets?${params}&closed=${closed}&limit=${GAMMA_RESPONSE_LIMIT}`;
     const response = await fetchWithRetry(url, {
       headers: { Accept: 'application/json' },
     });
     if (!response.ok) {
       console.warn(
-        `[RefreshMetadata]   Gamma batch ${batchIdx}/${totalBatches} failed: HTTP ${response.status}`
+        `[RefreshMetadata]   Gamma fetch (closed=${closed}) failed: HTTP ${response.status}`
       );
-      return;
+      return [];
     }
-    const markets = (await response.json()) as PolymarketMarket[];
-    for (const m of markets) {
-      if (m.conditionId) out.set(m.conditionId, m);
+    return (await response.json()) as PolymarketMarket[];
+  };
+
+  const fetchBatch = async (
+    batch: string[],
+    batchIdx: number
+  ): Promise<void> => {
+    const batchStart = Date.now();
+    const [open, closed] = await Promise.all([
+      fetchOneSide(batch, false),
+      fetchOneSide(batch, true),
+    ]);
+    const seen = new Set<string>();
+    for (const m of [...open, ...closed]) {
+      if (m.conditionId && !seen.has(m.conditionId)) {
+        seen.add(m.conditionId);
+        out.set(m.conditionId, m);
+      }
     }
+    const matched = open.length + closed.length;
     console.log(
-      `[RefreshMetadata]   Gamma batch ${batchIdx}/${totalBatches}: ${markets.length}/${batch.length} markets (cumulative ${out.size}, ${Date.now() - batchStart}ms)`
+      `[RefreshMetadata]   Gamma batch ${batchIdx}/${totalBatches}: ${matched}/${batch.length} markets (open ${open.length} + closed ${closed.length}, cumulative ${out.size}, ${Date.now() - batchStart}ms)`
     );
   };
 
@@ -232,7 +259,7 @@ export async function fetchEventTagsByIds(
     totalBatches: number
   ): Promise<void> => {
     const params = batch.map((id) => `id=${encodeURIComponent(id)}`).join('&');
-    const url = `https://gamma-api.polymarket.com/events?limit=${EVENT_TAGS_BATCH_SIZE}&${params}`;
+    const url = `https://gamma-api.polymarket.com/events?limit=${EVENT_TAGS_RESPONSE_LIMIT}&${params}`;
     const batchStart = Date.now();
     const response = await fetchWithRetry(url, {
       headers: { Accept: 'application/json' },

--- a/packages/market-keeper/src/refresh-metadata/fetch.ts
+++ b/packages/market-keeper/src/refresh-metadata/fetch.ts
@@ -1,0 +1,279 @@
+/**
+ * Fetch helpers for refresh-metadata.
+ *
+ * Splits cleanly in two:
+ *   - fetchAllExistingConditions: paginated GraphQL walk over Sapience for
+ *     every public + unsettled condition that has at least one similarMarkets
+ *     entry. Mirrors the projection of checkExistingConditions so the diff
+ *     helpers it feeds (computeMetadataUpdates / computeGroupMetadataUpdates)
+ *     work unchanged.
+ *   - fetchMarketsByConditionIds: batched Polymarket Gamma /markets call by
+ *     condition_ids (plural per-param), returns Map keyed by conditionId.
+ */
+
+import type { PolymarketMarket } from '../types';
+import { fetchWithRetry } from '../utils';
+import { normalizeTagLabel } from '../generate/tags';
+import type { ExistingCondition } from '../generate/pipeline';
+
+const SAPIENCE_PAGE_SIZE = 100;
+const GAMMA_BATCH_SIZE = 50;
+const GAMMA_CONCURRENCY = 10;
+const EVENT_TAGS_BATCH_SIZE = 50;
+const EVENT_TAGS_CONCURRENCY = 10;
+
+/**
+ * Paginate Sapience GraphQL conditions to collect every refreshable row.
+ * Filters: public=true, settled=false, similarMarkets non-empty.
+ * Pagination: orderBy id asc, take/skip — deterministic to avoid skipping
+ * rows that share a timestamp (same approach as fetchActiveConditionIds in
+ * refresh-volume).
+ */
+export async function fetchAllExistingConditions(
+  apiUrl: string
+): Promise<Map<string, ExistingCondition>> {
+  const graphqlUrl = apiUrl.replace(/\/+$/, '') + '/graphql';
+
+  const query = `
+    query RefreshMetadataConditions($where: ConditionWhereInput!, $take: Int!, $skip: Int!, $orderBy: [ConditionOrderByWithRelationInput!]) {
+      conditions(where: $where, take: $take, skip: $skip, orderBy: $orderBy) {
+        id
+        endTime
+        question
+        shortName
+        optionName
+        description
+        similarMarkets
+        tags
+        similarMarketVolume
+        similarMarketImage
+        conditionGroup {
+          id
+          name
+          similarMarkets
+        }
+      }
+    }
+  `;
+
+  const existing = new Map<string, ExistingCondition>();
+  let skip = 0;
+  let pageCount = 0;
+
+  while (true) {
+    pageCount++;
+    const pageStart = Date.now();
+    const response = await fetchWithRetry(graphqlUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query,
+        variables: {
+          where: {
+            public: { equals: true },
+            settled: { equals: false },
+            similarMarkets: { isEmpty: false },
+          },
+          take: SAPIENCE_PAGE_SIZE,
+          skip,
+          orderBy: [{ id: 'asc' }],
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `[RefreshMetadata] GraphQL query failed: HTTP ${response.status} ${response.statusText}`
+      );
+    }
+
+    const result = (await response.json()) as {
+      data?: {
+        conditions?: Array<{
+          id: string;
+          endTime: number;
+          question?: string | null;
+          shortName?: string | null;
+          optionName?: string | null;
+          description?: string | null;
+          similarMarkets?: string[] | null;
+          tags?: string[] | null;
+          similarMarketVolume?: number | null;
+          similarMarketImage?: string | null;
+          conditionGroup?: {
+            id?: number | null;
+            name?: string | null;
+            similarMarkets?: string[] | null;
+          } | null;
+        }>;
+      };
+    };
+
+    const conditions = result.data?.conditions ?? [];
+
+    for (const c of conditions) {
+      existing.set(c.id, {
+        endTime: c.endTime,
+        question: c.question ?? undefined,
+        shortName: c.shortName ?? undefined,
+        optionName: c.optionName ?? undefined,
+        description: c.description ?? undefined,
+        similarMarkets: c.similarMarkets ?? undefined,
+        tags: c.tags ?? undefined,
+        similarMarketVolume: c.similarMarketVolume ?? undefined,
+        similarMarketImage: c.similarMarketImage ?? undefined,
+        groupName: c.conditionGroup?.name ?? undefined,
+        conditionGroupId: c.conditionGroup?.id ?? undefined,
+        conditionGroupSimilarMarkets:
+          c.conditionGroup?.similarMarkets ?? undefined,
+      });
+    }
+
+    console.log(
+      `[RefreshMetadata]   GraphQL page ${pageCount}: fetched ${conditions.length} (cumulative ${existing.size}, ${Date.now() - pageStart}ms)`
+    );
+
+    if (conditions.length < SAPIENCE_PAGE_SIZE) break;
+    skip += SAPIENCE_PAGE_SIZE;
+  }
+
+  return existing;
+}
+
+/**
+ * Fetch Polymarket markets by condition_id, batched and parallelized.
+ * Gamma accepts repeated `condition_ids=` query params; the response order
+ * is not guaranteed so the result Map is keyed by conditionId. Missing IDs
+ * (delisted markets) don't appear in the Map; callers skip those rather
+ * than emitting clobbering updates.
+ *
+ * Batches of GAMMA_BATCH_SIZE IDs run in concurrent waves of GAMMA_CONCURRENCY.
+ * Per-batch failures are logged and skipped; the rest of the wave completes.
+ */
+export async function fetchMarketsByConditionIds(
+  conditionIds: string[]
+): Promise<Map<string, PolymarketMarket>> {
+  const out = new Map<string, PolymarketMarket>();
+  if (conditionIds.length === 0) return out;
+
+  const batches: string[][] = [];
+  for (let i = 0; i < conditionIds.length; i += GAMMA_BATCH_SIZE) {
+    batches.push(conditionIds.slice(i, i + GAMMA_BATCH_SIZE));
+  }
+  const totalBatches = batches.length;
+
+  const fetchBatch = async (
+    batch: string[],
+    batchIdx: number
+  ): Promise<void> => {
+    const params = batch
+      .map((id) => `condition_ids=${encodeURIComponent(id)}`)
+      .join('&');
+    const url = `https://gamma-api.polymarket.com/markets?${params}&limit=${GAMMA_BATCH_SIZE}`;
+    const batchStart = Date.now();
+    const response = await fetchWithRetry(url, {
+      headers: { Accept: 'application/json' },
+    });
+    if (!response.ok) {
+      console.warn(
+        `[RefreshMetadata]   Gamma batch ${batchIdx}/${totalBatches} failed: HTTP ${response.status}`
+      );
+      return;
+    }
+    const markets = (await response.json()) as PolymarketMarket[];
+    for (const m of markets) {
+      if (m.conditionId) out.set(m.conditionId, m);
+    }
+    console.log(
+      `[RefreshMetadata]   Gamma batch ${batchIdx}/${totalBatches}: ${markets.length}/${batch.length} markets (cumulative ${out.size}, ${Date.now() - batchStart}ms)`
+    );
+  };
+
+  for (let i = 0; i < batches.length; i += GAMMA_CONCURRENCY) {
+    const wave = batches.slice(i, i + GAMMA_CONCURRENCY);
+    await Promise.allSettled(
+      wave.map((batch, j) => fetchBatch(batch, i + j + 1))
+    );
+  }
+
+  return out;
+}
+
+/**
+ * Fetch event tags for a specific set of event IDs.
+ *
+ * The original `fetchEventTags` walks every event in a date window — fine for
+ * the generate cron's 7-day cohort, but for refresh-metadata the date window
+ * spans every public + unsettled condition (often a year+) and pulling all
+ * ~50k events for a few thousand needed events is the dominant cost in the
+ * pipeline.
+ *
+ * Polymarket's Gamma `/events` endpoint accepts repeated `id=` query params
+ * (verified empirically — docs only mention single-slug lookup). With
+ * `?limit=N&id=<a>&id=<b>...` we batch up to 50 IDs per request, then
+ * parallelize in waves of EVENT_TAGS_CONCURRENCY. Failures inside a batch
+ * are logged; the caller falls back to existing stored tags for any event
+ * not in the result Map (same "don't clobber with worse data" stance the
+ * rest of the script uses).
+ *
+ * Returns a map keyed by event SLUG (not ID), because the diff helpers look
+ * up tags via `event.slug`.
+ */
+export async function fetchEventTagsByIds(
+  eventIds: string[]
+): Promise<Map<string, string[]>> {
+  const out = new Map<string, string[]>();
+  const unique = [...new Set(eventIds.filter((id): id is string => !!id))];
+  if (unique.length === 0) return out;
+
+  const fetchBatch = async (
+    batch: string[],
+    batchIdx: number,
+    totalBatches: number
+  ): Promise<void> => {
+    const params = batch.map((id) => `id=${encodeURIComponent(id)}`).join('&');
+    const url = `https://gamma-api.polymarket.com/events?limit=${EVENT_TAGS_BATCH_SIZE}&${params}`;
+    const batchStart = Date.now();
+    const response = await fetchWithRetry(url, {
+      headers: { Accept: 'application/json' },
+    });
+    if (!response.ok) {
+      console.warn(
+        `[RefreshMetadata]   Event tags batch ${batchIdx}/${totalBatches} failed: HTTP ${response.status}`
+      );
+      return;
+    }
+    const events = (await response.json()) as Array<{
+      slug?: string;
+      tags?: Array<{ label?: string; slug?: string }>;
+    }>;
+    let mapped = 0;
+    for (const event of events) {
+      if (!event.slug) continue;
+      const labels = (event.tags ?? [])
+        .map((t) => t.label)
+        .filter((label): label is string => !!label && label !== 'All')
+        .map(normalizeTagLabel);
+      out.set(event.slug, [...new Set(labels)]);
+      mapped++;
+    }
+    console.log(
+      `[RefreshMetadata]   Event tags batch ${batchIdx}/${totalBatches}: ${mapped}/${batch.length} mapped (cumulative ${out.size}, ${Date.now() - batchStart}ms)`
+    );
+  };
+
+  // Pre-compute all batches, then run them in concurrency-limited waves.
+  const batches: string[][] = [];
+  for (let i = 0; i < unique.length; i += EVENT_TAGS_BATCH_SIZE) {
+    batches.push(unique.slice(i, i + EVENT_TAGS_BATCH_SIZE));
+  }
+
+  for (let i = 0; i < batches.length; i += EVENT_TAGS_CONCURRENCY) {
+    const wave = batches.slice(i, i + EVENT_TAGS_CONCURRENCY);
+    await Promise.allSettled(
+      wave.map((batch, j) => fetchBatch(batch, i + j + 1, batches.length))
+    );
+  }
+
+  return out;
+}

--- a/packages/market-keeper/src/refresh-metadata/index.ts
+++ b/packages/market-keeper/src/refresh-metadata/index.ts
@@ -1,0 +1,265 @@
+/**
+ * Refresh metadata (similarMarkets, tags, question, description, etc.) for
+ * every public + unsettled Sapience condition by re-fetching its market
+ * from Polymarket Gamma.
+ *
+ * Solves the coverage gap where the generate cron only refreshes metadata
+ * for markets in the ending-soonest fetch window. Anything that's still
+ * public + unsettled but past that window goes stale, including the
+ * `similarMarkets` URL fragment used by downstream consumers to look up
+ * the canonical Polymarket slug.
+ */
+
+import 'dotenv/config';
+import { DEFAULT_SAPIENCE_API_URL } from '../constants';
+import {
+  validatePrivateKey,
+  confirmProductionAccess,
+  log,
+  logError,
+} from '../utils';
+import {
+  computeMetadataUpdates,
+  computeGroupMetadataUpdates,
+} from '../generate/grouping';
+import {
+  submitMetadataUpdates,
+  submitGroupMetadataUpdates,
+} from '../generate/api';
+import type { PolymarketMarket } from '../types';
+import {
+  fetchAllExistingConditions,
+  fetchMarketsByConditionIds,
+  fetchEventTagsByIds,
+} from './fetch';
+
+interface RefreshMetadataCLIOptions {
+  dryRun: boolean;
+  help: boolean;
+}
+
+function parseArgs(): RefreshMetadataCLIOptions {
+  const args = process.argv.slice(2);
+  return {
+    dryRun: args.includes('--dry-run'),
+    help: args.includes('--help') || args.includes('-h'),
+  };
+}
+
+function showHelp(): void {
+  console.log(`
+Usage: tsx scripts/refresh-metadata.ts [options]
+
+Walks every public + unsettled Sapience condition, re-fetches its market from
+Polymarket Gamma, and submits metadata updates for any drifted Polymarket-owned
+field (similarMarkets, tags, question, description, etc.). Settled / private
+conditions are not touched.
+
+Options:
+  --dry-run      Show what would be updated without submitting
+  --help, -h     Show this help message
+
+Environment Variables (required for API submission):
+  SAPIENCE_API_URL     API URL (default: https://api.sapience.xyz)
+  ADMIN_PRIVATE_KEY    64-char hex private key for signing admin requests
+`);
+}
+
+/**
+ * Synthesize the `groups[]` argument shape that computeMetadataUpdates and
+ * computeGroupMetadataUpdates expect. Each market becomes its own one-market
+ * group keyed off its parent event — same shape groupMarkets() builds in
+ * the generate path.
+ */
+function synthesizeGroups(markets: PolymarketMarket[]): Array<{
+  title: string;
+  markets: PolymarketMarket[];
+  eventSlug?: string;
+}> {
+  return markets.map((market) => ({
+    title: market.events?.[0]?.title ?? '',
+    markets: [market],
+    eventSlug: market.events?.[0]?.slug,
+  }));
+}
+
+/**
+ * Print dry-run output in the same format generate's old metadata dry-run
+ * used (so existing operator muscle memory carries over).
+ */
+function printDryRun(
+  metadataUpdates: ReturnType<typeof computeMetadataUpdates>,
+  groupMetadataUpdates: ReturnType<typeof computeGroupMetadataUpdates>
+): void {
+  log('\n========== DRY RUN: Metadata Refresh ==========\n');
+  if (metadataUpdates.length > 0) {
+    log(
+      `Would update metadata for ${metadataUpdates.length} existing conditions:`
+    );
+    for (const u of metadataUpdates) {
+      const changedKeys = Object.keys(u.fields);
+      log(`  ${u.conditionId.slice(0, 10)}... → ${changedKeys.join(', ')}`);
+      const oldRec = u.old as Record<string, unknown>;
+      const newRec = u.fields as Record<string, unknown>;
+      for (const key of changedKeys) {
+        log(
+          `    ${key}: ${JSON.stringify(oldRec[key])} → ${JSON.stringify(newRec[key])}`
+        );
+      }
+    }
+  } else {
+    log('No condition metadata drift.');
+  }
+  if (groupMetadataUpdates.length > 0) {
+    log(
+      `\nWould update metadata for ${groupMetadataUpdates.length} existing condition groups:`
+    );
+    for (const u of groupMetadataUpdates) {
+      const changedKeys = Object.keys(u.fields);
+      log(`  group ${u.groupId} → ${changedKeys.join(', ')}`);
+      const oldRec = u.old as Record<string, unknown>;
+      const newRec = u.fields as Record<string, unknown>;
+      for (const key of changedKeys) {
+        log(
+          `    ${key}: ${JSON.stringify(oldRec[key])} → ${JSON.stringify(newRec[key])}`
+        );
+      }
+    }
+  } else {
+    log('No group metadata drift.');
+  }
+  log('\n========== END DRY RUN ==========\n');
+}
+
+export async function main() {
+  const options = parseArgs();
+
+  if (options.help) {
+    showHelp();
+    process.exit(0);
+  }
+
+  const apiUrl = process.env.SAPIENCE_API_URL || DEFAULT_SAPIENCE_API_URL;
+  const rawPrivateKey = process.env.ADMIN_PRIVATE_KEY;
+
+  let privateKey: `0x${string}` | undefined;
+  try {
+    privateKey = validatePrivateKey(rawPrivateKey);
+  } catch (error) {
+    logError(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+
+  const hasAPICredentials = apiUrl && privateKey;
+
+  if (hasAPICredentials && !options.dryRun) {
+    await confirmProductionAccess(apiUrl);
+  }
+
+  try {
+    const totalStart = performance.now();
+
+    log(
+      '[RefreshMetadata] Fetching public + unsettled conditions from Sapience...'
+    );
+    const sapienceStart = performance.now();
+    const existing = await fetchAllExistingConditions(apiUrl);
+    log(
+      `[RefreshMetadata] Found ${existing.size} conditions (${((performance.now() - sapienceStart) / 1000).toFixed(1)}s)`
+    );
+
+    if (existing.size === 0) {
+      log('[RefreshMetadata] No conditions to refresh');
+      return;
+    }
+
+    const conditionIds = [...existing.keys()];
+
+    log(
+      `[RefreshMetadata] Fetching ${conditionIds.length} markets from Polymarket Gamma...`
+    );
+    const gammaStart = performance.now();
+    const marketMap = await fetchMarketsByConditionIds(conditionIds);
+    log(
+      `[RefreshMetadata] Got ${marketMap.size}/${conditionIds.length} markets back (${((performance.now() - gammaStart) / 1000).toFixed(1)}s)`
+    );
+
+    const markets = [...marketMap.values()];
+    const missing = conditionIds.length - marketMap.size;
+    if (missing > 0) {
+      log(
+        `[RefreshMetadata] ${missing} conditions had no Gamma response (delisted or condition_id unknown) — leaving stored values alone`
+      );
+    }
+
+    if (markets.length === 0) {
+      log('[RefreshMetadata] No markets returned by Gamma; nothing to diff');
+      return;
+    }
+
+    // Build the inputs computeMetadataUpdates / computeGroupMetadataUpdates
+    // already expect — so we get exactly the same diff semantics that the
+    // generate path used for the ending-soonest cohort.
+    const groups = synthesizeGroups(markets);
+
+    // Targeted tag fetch: batch /events?id=<a>&id=<b>... for only the events
+    // we actually need (one per market), 50 IDs per request, parallelized.
+    // Avoids the 50k-event date-window walk that fetchEventTags does in
+    // generate. Map is keyed by event SLUG to match what computeMetadataUpdates
+    // looks up.
+    const eventIds = markets
+      .map((m) => m.events?.[0]?.id)
+      .filter((id): id is string => !!id);
+    log(
+      `[RefreshMetadata] Fetching event tags for ${new Set(eventIds).size} unique event IDs...`
+    );
+    const tagsStart = performance.now();
+    const eventTagMap = await fetchEventTagsByIds(eventIds);
+    log(
+      `[RefreshMetadata] Got ${eventTagMap.size} event tag mappings (${((performance.now() - tagsStart) / 1000).toFixed(1)}s)`
+    );
+
+    log('[RefreshMetadata] Computing diffs...');
+    const diffStart = performance.now();
+    const metadataUpdates = computeMetadataUpdates(
+      markets,
+      groups,
+      existing,
+      eventTagMap
+    );
+    const groupMetadataUpdates = computeGroupMetadataUpdates(groups, existing);
+    log(
+      `[RefreshMetadata] Diff complete: ${metadataUpdates.length} condition updates, ${groupMetadataUpdates.length} group updates (${((performance.now() - diffStart) / 1000).toFixed(1)}s)`
+    );
+
+    if (options.dryRun) {
+      printDryRun(metadataUpdates, groupMetadataUpdates);
+      const totalSec = ((performance.now() - totalStart) / 1000).toFixed(1);
+      log(`[RefreshMetadata] Total runtime: ${totalSec}s`);
+      return;
+    }
+
+    if (hasAPICredentials && apiUrl && privateKey) {
+      if (metadataUpdates.length > 0) {
+        await submitMetadataUpdates(apiUrl, privateKey, metadataUpdates);
+      } else {
+        log('[RefreshMetadata] No condition metadata drift; skipping submit');
+      }
+      if (groupMetadataUpdates.length > 0) {
+        await submitGroupMetadataUpdates(
+          apiUrl,
+          privateKey,
+          groupMetadataUpdates
+        );
+      } else {
+        log('[RefreshMetadata] No group metadata drift; skipping submit');
+      }
+    }
+
+    const totalSec = ((performance.now() - totalStart) / 1000).toFixed(1);
+    log(`[RefreshMetadata] Total runtime: ${totalSec}s`);
+  } catch (error) {
+    logError('Error:', error);
+    process.exit(1);
+  }
+}

--- a/packages/market-keeper/src/types/sapience.ts
+++ b/packages/market-keeper/src/types/sapience.ts
@@ -91,6 +91,4 @@ export interface SapienceOutput {
   };
   groups: SapienceConditionGroup[];
   ungroupedConditions: SapienceCondition[];
-  metadataUpdates: MetadataUpdate[];
-  groupMetadataUpdates: GroupMetadataUpdate[];
 }


### PR DESCRIPTION
Walks every public + unsettled Sapience condition, re-fetches its market from Polymarket Gamma, and submits drift updates for similarMarkets, tags, question, description, etc. Closes the coverage gap where the generate cron only refreshed metadata for markets in the 7-day ending-soonest window — settled-but-still-public conditions kept stale slugs that no longer resolved on Gamma.

Strips metadata-update concerns out of generate (now create-only) so there's a single owner for this work.