### PR TITLE
fix(app): mobile activity filters, OpenClaw bg, profile breakpoints

### DIFF
--- a/packages/app/src/components/bots/ForecastingBotSection.tsx
+++ b/packages/app/src/components/bots/ForecastingBotSection.tsx
@@ -58,7 +58,7 @@ export default function ForecastingBotSection() {
             <img
               src="/openclaw-bg.svg"
               alt="OpenClaw Agent"
-              className="w-full rounded-lg"
+              className="w-full rounded-lg bg-black"
             />
           </div>
         </div>

--- a/packages/app/src/components/positions/ActivityTable.tsx
+++ b/packages/app/src/components/positions/ActivityTable.tsx
@@ -741,7 +741,7 @@ export default function ActivityTable({
   // ── Render ───────────────────────────────────────────────────────────────
   const headerContent =
     hideFilters && !leftSlot ? null : (
-      <div className="px-4 py-4 border-b border-border/60 flex flex-col sm:flex-row sm:items-center gap-4 bg-white/[0.03]">
+      <div className="px-4 py-4 border-b border-border/60 flex flex-col xl:flex-row xl:items-center gap-4 bg-white/[0.03]">
         {leftSlot && leftSlot}
         {!hideFilters && (
           <div className="flex-1">

--- a/packages/app/src/components/positions/ActivityTableFilters.tsx
+++ b/packages/app/src/components/positions/ActivityTableFilters.tsx
@@ -92,6 +92,11 @@ export function ActivityTableFilters(props: {
         onFiltersChange={handleBaseChange}
         config={ACTIVITY_CONFIG}
         inline
+        searchClassName={
+          showTypeFilter
+            ? 'order-first md:order-none col-span-2 md:col-span-1'
+            : undefined
+        }
       />
     </div>
   );

--- a/packages/app/src/components/profile/pages/ProfilePageContent.tsx
+++ b/packages/app/src/components/profile/pages/ProfilePageContent.tsx
@@ -120,7 +120,7 @@ const ProfilePageContent = ({
     // (ContentArea is itself a flex column under the layout root).
     <div className="mx-auto px-3 md:px-6 lg:px-8 w-full pt-4 md:pt-0 flex-1 flex flex-col">
       <ShareAfterRedirect address={address} />
-      <div className="mb-6 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+      <div className="mb-6 flex flex-col min-[1900px]:flex-row min-[1900px]:items-center min-[1900px]:justify-between gap-4">
         <ProfileHeader address={address} className="mb-0" />
         {hasLoadedOnce ? (
           <ProfileQuickMetrics

--- a/packages/app/src/components/shared/TableFilters.tsx
+++ b/packages/app/src/components/shared/TableFilters.tsx
@@ -48,6 +48,7 @@ export function TableFilters<TStatus extends string>({
   config,
   className,
   inline,
+  searchClassName,
 }: {
   filters: TableFilterState<TStatus>;
   onFiltersChange: (filters: TableFilterState<TStatus>) => void;
@@ -55,6 +56,8 @@ export function TableFilters<TStatus extends string>({
   className?: string;
   /** When true, renders filter elements without a wrapping grid container (for embedding in a parent grid). */
   inline?: boolean;
+  /** Extra classes applied to the search input wrapper (useful for grid placement when inline). */
+  searchClassName?: string;
 }) {
   const isMobile = useIsMobile();
   const dateMin = config.dateRange.min ?? DEFAULT_DATE_MIN;
@@ -106,7 +109,7 @@ export function TableFilters<TStatus extends string>({
 
   const content = (
     <>
-      <div className="relative flex items-center">
+      <div className={cn('relative flex items-center', searchClassName)}>
         <Search className="hidden md:block absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 opacity-50 pointer-events-none z-10" />
         <input
           type="text"


### PR DESCRIPTION
## Summary
- Activity filters on mobile: Search becomes full-width on row 1, then a 2x2 of All activity / Any status / Any payout / Any date.
- OpenClaw hero image now sits on a black background so the artwork's corner blends with the page.
- Profile address/stats and activity tab+filter rows now stack at narrower viewports — tabs+filters stack until xl (1280px) and the address/stats group stacks until 1900px — eliminating cramped/overflowing filter rows at intermediate widths.

## Test plan
- [ ] Mobile (~420px): Activity table shows Search full-width on row 1, then 2x2 filter grid.
- [ ] Tablet/medium desktop (1100–1700px): Activity table tab switcher and filter row stack vertically.
- [ ] Profile page at 1764px: address sits on its own row above the stat tiles; tab+filter row laid out cleanly below.
- [ ] Wide desktop (≥1900px): address and stats sit side-by-side as before.
- [ ] Bots page: OpenClaw hero image has a black background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)