### PR TITLE
app: fall back to sequential eth_sendTransaction for EOA sendCalls on Ethereal

### DIFF
--- a/packages/app/src/hooks/blockchain/transactionExecutor.test.ts
+++ b/packages/app/src/hooks/blockchain/transactionExecutor.test.ts
@@ -533,7 +533,10 @@ describe('executeTransaction', () => {
       expect(result.path).toBe('eoa');
     });
 
-    it('uses sendCalls for Ethereal writeContract with value (wrapping)', async () => {
+    it('runs Ethereal writeContract-with-value sequentially via sendTransactionAsync (wrap + call)', async () => {
+      // MetaMask routes EOA wallet_sendCalls through EIP-7702, which Ethereal
+      // does not support. The executor falls back to sequential
+      // eth_sendTransaction calls instead.
       const callsWithValue: TransactionCall[] = [
         {
           to: '0x1111111111111111111111111111111111111111',
@@ -541,22 +544,60 @@ describe('executeTransaction', () => {
           value: 100n,
         },
       ];
-      const sendCallsAsync = vi.fn().mockResolvedValue({
-        receipts: [{ transactionHash: '0xwrapped' }],
-      });
+      const hashes: string[] = ['0xwrap', '0xcall'];
+      const sendTransactionAsync = vi
+        .fn()
+        .mockImplementation(async () => hashes.shift());
+      const sendCallsAsync = vi.fn();
 
       const result = await executeTransaction(
         callsWithValue,
         CHAIN_ID_ETHEREAL,
         'eoa',
-        { sendCallsAsync, writeContractAsync: vi.fn() },
+        { sendCallsAsync, sendTransactionAsync, writeContractAsync: vi.fn() },
         'writeContract'
       );
 
-      expect(sendCallsAsync).toHaveBeenCalled();
-      const sentCalls = sendCallsAsync.mock.calls[0][0].calls;
-      expect(sentCalls).toHaveLength(2);
-      expect(result.hash).toBe('0xwrapped');
+      expect(sendCallsAsync).not.toHaveBeenCalled();
+      // 2 calls: deposit (wrap) + the original write
+      expect(sendTransactionAsync).toHaveBeenCalledTimes(2);
+      // Hash of the LAST tx is what's surfaced
+      expect(result.hash).toBe('0xcall');
+      expect(result.path).toBe('eoa');
+    });
+
+    it('runs Ethereal sendCalls batch sequentially via sendTransactionAsync', async () => {
+      // Same fallback applies for plain sendCalls mode (no wrapping).
+      const calls: TransactionCall[] = [
+        {
+          to: '0x1111111111111111111111111111111111111111',
+          data: '0xaa',
+          value: 0n,
+        },
+        {
+          to: '0x2222222222222222222222222222222222222222',
+          data: '0xbb',
+          value: 0n,
+        },
+      ];
+      const hashes: string[] = ['0xfirst', '0xsecond'];
+      const sendTransactionAsync = vi
+        .fn()
+        .mockImplementation(async () => hashes.shift());
+      const sendCallsAsync = vi.fn();
+
+      const result = await executeTransaction(
+        calls,
+        CHAIN_ID_ETHEREAL,
+        'eoa',
+        { sendCallsAsync, sendTransactionAsync },
+        'sendCalls'
+      );
+
+      expect(sendCallsAsync).not.toHaveBeenCalled();
+      expect(sendTransactionAsync).toHaveBeenCalledTimes(2);
+      expect(result.hash).toBe('0xsecond');
+      expect(result.path).toBe('eoa');
     });
   });
 });

--- a/packages/app/src/hooks/blockchain/transactionExecutor.ts
+++ b/packages/app/src/hooks/blockchain/transactionExecutor.ts
@@ -93,6 +93,13 @@ export interface ExecutionDeps {
   writeContractAsync?: (...args: any[]) => Promise<Hash>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- wagmi hook return types use complex generics
   sendCallsAsync?: (params: any) => Promise<SendCallsResult>;
+  // Fallback for EOAs on Ethereal: MetaMask's `wallet_sendCalls` routes EOA
+  // batches through EIP-7702, which Ethereal does not support. wagmi's
+  // `experimental_fallback` does not catch that case (returns success
+  // without executing), so we run calls sequentially via plain
+  // `eth_sendTransaction` instead.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- wagmi hook return types use complex generics
+  sendTransactionAsync?: (params: any) => Promise<Hash>;
   validateAndSwitchChain?: (chainId: number) => Promise<void>;
 
   // Lifecycle callbacks
@@ -402,20 +409,14 @@ export async function executeTransaction(
 
   if (mode === 'writeContract' && deps.writeContractAsync) {
     // Single-call writeContract path
-    // If Ethereal with value, needs wrapping via sendCalls batch
+    // If Ethereal with value, needs wrapping (USDe → wUSDe) before the call.
     if (isEtherealChain(chainId) && calls.length === 1 && calls[0].value > 0n) {
-      if (!deps.sendCallsAsync) {
-        throw new Error(
-          'sendCallsAsync required for Ethereal wrapping in EOA mode'
-        );
-      }
-      const result = await deps.sendCallsAsync({
+      const lastHash = await sendCallsEoaSequential(
+        wrappedCalls,
         chainId,
-        calls: wrappedCalls,
-        experimental_fallback: true,
-      });
-      const txHash = pickFinalTransactionHash(result);
-      return { hash: txHash as Hash | undefined, data: result, path: 'eoa' };
+        deps
+      );
+      return { hash: lastHash, path: 'eoa' };
     }
 
     // Simple single call - use writeContractAsync directly
@@ -424,6 +425,16 @@ export async function executeTransaction(
   }
 
   // Batch sendCalls path
+  if (isEtherealChain(chainId)) {
+    // MetaMask routes EOA `wallet_sendCalls` through EIP-7702, which
+    // Ethereal does not support. wagmi's `experimental_fallback` does not
+    // catch that case (returns success without executing), so we send calls
+    // sequentially via `eth_sendTransaction` instead. The user pays gas per
+    // tx — acceptable since the chain does not offer batched EOA execution.
+    const lastHash = await sendCallsEoaSequential(calls, chainId, deps);
+    return { hash: lastHash, path: 'eoa' };
+  }
+
   if (!deps.sendCallsAsync) {
     throw new Error('sendCallsAsync not available');
   }
@@ -434,4 +445,31 @@ export async function executeTransaction(
   });
 
   return { data, path: 'eoa' };
+}
+
+/**
+ * Run `calls` sequentially via `eth_sendTransaction`. Used in EOA mode on
+ * chains that lack EIP-5792 / EIP-7702 support (Ethereal). Returns the hash
+ * of the final tx, or `undefined` if no calls were sent.
+ */
+async function sendCallsEoaSequential(
+  calls: TransactionCall[],
+  chainId: number,
+  deps: ExecutionDeps
+): Promise<Hash | undefined> {
+  if (!deps.sendTransactionAsync) {
+    throw new Error(
+      'sendTransactionAsync required for EOA sequential sendCalls fallback'
+    );
+  }
+  let lastHash: Hash | undefined;
+  for (const call of calls) {
+    lastHash = await deps.sendTransactionAsync({
+      chainId,
+      to: call.to,
+      data: call.data,
+      value: call.value ?? 0n,
+    });
+  }
+  return lastHash;
 }

--- a/packages/app/src/hooks/blockchain/useSapienceWriteContract.ts
+++ b/packages/app/src/hooks/blockchain/useSapienceWriteContract.ts
@@ -5,6 +5,7 @@ import type { useTransactionReceipt } from 'wagmi';
 import {
   useWriteContract,
   useSendCalls,
+  useSendTransaction,
   useConnectorClient,
   useAccount,
 } from 'wagmi';
@@ -368,6 +369,11 @@ export function useSapienceWriteContract({
     reset: resetCalls,
   } = useSendCalls();
 
+  // Sequential fallback for EOAs on Ethereal: MetaMask routes
+  // wallet_sendCalls through EIP-7702 which Ethereal does not support, so
+  // the executor falls back to plain eth_sendTransaction in a loop.
+  const { sendTransactionAsync } = useSendTransaction();
+
   // Helper to execute transaction via session key (shared by writeContract and sendCalls)
   const executeViaSessionKey = useCallback(
     async (
@@ -499,6 +505,7 @@ export function useSapienceWriteContract({
             executeViaOwnerSigning,
             writeContractAsync,
             sendCallsAsync,
+            sendTransactionAsync,
             validateAndSwitchChain,
           },
           'writeContract',
@@ -518,6 +525,7 @@ export function useSapienceWriteContract({
       validateAndSwitchChain,
       writeContractAsync,
       sendCallsAsync,
+      sendTransactionAsync,
       completeTransaction,
       getExecutionPathForChain,
       getSessionClient,
@@ -588,6 +596,7 @@ export function useSapienceWriteContract({
             executeViaSessionKey,
             executeViaOwnerSigning,
             sendCallsAsync,
+            sendTransactionAsync,
             validateAndSwitchChain,
           },
           'sendCalls',
@@ -613,6 +622,7 @@ export function useSapienceWriteContract({
       resetCalls,
       validateAndSwitchChain,
       sendCallsAsync,
+      sendTransactionAsync,
       client,
       getExecutionPathForChain,
       getSessionClient,


### PR DESCRIPTION
## Summary

MetaMask routes EOA `wallet_sendCalls` (EIP-5792) through EIP-7702. Ethereal does not support EIP-7702 and returns RPC error code 5710. wagmi's `experimental_fallback: true` does not detect this case — it returns successfully without executing any tx, leaving the user staring at an unupdated UI.

This PR fixes the issue at the centralized `transactionExecutor.ts` so all `sendCalls` callers (`useSubmitPosition`, `useEscrowWrite`, `usePassiveLiquidityVault`, anything else routed through `useSapienceWriteContract`) inherit the fix without local changes.

When `mode='sendCalls'` (or `mode='writeContract'` with value > 0 that requires a wrap on Ethereal) is invoked in EOA mode on an Ethereal chain, the executor now runs the calls sequentially via `sendTransactionAsync` (`eth_sendTransaction`). The user signs once per call (acceptable since the chain offers no batched EOA execution anyway). The hash returned is the last tx in the batch.

Smart-account paths (session / owner) are unchanged — they go through the bundler and don't touch this fallback.

## Test plan

- [x] `pnpm --filter @sapience/app test -- --run src/hooks/blockchain/transactionExecutor.test.ts` — 39/39 pass
- [x] Two new test cases:
  - `runs Ethereal writeContract-with-value sequentially via sendTransactionAsync (wrap + call)`
  - `runs Ethereal sendCalls batch sequentially via sendTransactionAsync`
- [x] `pnpm --filter @sapience/app run type-check` — clean
- [ ] Manual: on Ethereal in EOA mode, attempt a mint and a vault deposit. MetaMask should prompt twice (wrap + actual call) instead of silently no-oping.

## Discovered during

End-to-end testnet testing of PR #1673 ([memory](https://github.com/sapiencexyz/sapience/blob/main/.) post-1673 follow-up B). Same root cause as the `ApprovalDialog.tsx` fix landing in #1673 — this PR consolidates the strategy at the executor layer.