### PR TITLE
secondary: warmup install of kernel session before sudo-mode trade userOp

### DIFF
--- a/packages/app/src/hooks/blockchain/useSapienceWriteContract.ts
+++ b/packages/app/src/hooks/blockchain/useSapienceWriteContract.ts
@@ -38,6 +38,7 @@ import { useSession } from '~/lib/context/SessionContext';
 import {
   ethereal,
   executeSudoTransaction,
+  markSessionInstalledOnChain,
   type OwnerSigner,
 } from '~/lib/session/sessionKeyManager';
 
@@ -132,6 +133,7 @@ export function useSapienceWriteContract({
     isUsingSession,
     isUsingSmartAccount,
     smartAccountAddress,
+    sessionKeyAddress,
     chainClients,
     sessionConfig,
     hasArbitrumSession,
@@ -388,9 +390,22 @@ export function useSapienceWriteContract({
         }
       );
       console.log(`[SessionTx] Total: ${Date.now() - startTime}ms`);
+      // A successful session userOp installs the kernel permission validator
+      // (ENABLE mode the first time, USE mode thereafter). Mark it so flows
+      // that use sudo-mode userOps + ERC-1271 (e.g. secondary trade accept)
+      // can skip a redundant warmup.
+      if (sessionKeyAddress) {
+        markSessionInstalledOnChain(_chainId, sessionKeyAddress);
+      }
       return hash;
     },
-    [sessionConfig, onTxSending, onTxSent, onReceiptConfirmed]
+    [
+      sessionConfig,
+      onTxSending,
+      onTxSent,
+      onReceiptConfirmed,
+      sessionKeyAddress,
+    ]
   );
 
   // Wrapper for Arbitrum session creation that provides user-friendly error messages.

--- a/packages/app/src/hooks/secondary/__tests__/useSecondaryAccept.test.ts
+++ b/packages/app/src/hooks/secondary/__tests__/useSecondaryAccept.test.ts
@@ -25,6 +25,18 @@ vi.mock('@sapience/sdk/contracts', () => ({
   collateralToken: { 5064014: { address: '0xCollateral' } },
 }));
 
+vi.mock('@sapience/sdk/abis', () => ({
+  secondaryMarketEscrowAbi: [
+    {
+      type: 'function',
+      name: 'revokeSessionKey',
+      inputs: [{ name: 'sessionKey', type: 'address' }],
+      outputs: [],
+      stateMutability: 'nonpayable',
+    },
+  ],
+}));
+
 vi.mock('@sapience/sdk/auction/secondarySigning', () => ({
   buildSellerTradeApproval: vi.fn().mockReturnValue({
     domain: { name: 'SecondaryMarketEscrow', version: '1', chainId: 5064014n },
@@ -43,20 +55,45 @@ vi.mock('@sapience/sdk/onchain/secondaryTrade', () => ({
 }));
 
 const mockAddBreadcrumb = vi.fn();
+const mockCaptureException = vi.fn();
 vi.mock('@sentry/nextjs', () => ({
   addBreadcrumb: (...args: unknown[]) => mockAddBreadcrumb(...args),
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
 }));
 
 const mockSessionSignTypedData = vi
   .fn()
   .mockResolvedValue('0xKernelWrappedSig');
 let isUsingSession = true;
+const mockSendUserOperation = vi.fn().mockResolvedValue('0xWarmupUserOpHash');
+const mockWaitForUserOperationReceipt = vi.fn().mockResolvedValue({
+  success: true,
+  receipt: { transactionHash: '0xWarmupTxHash' },
+});
+let etherealClient: {
+  sendUserOperation: typeof mockSendUserOperation;
+  waitForUserOperationReceipt: typeof mockWaitForUserOperationReceipt;
+} | null = {
+  sendUserOperation: mockSendUserOperation,
+  waitForUserOperationReceipt: mockWaitForUserOperationReceipt,
+};
 vi.mock('~/lib/context/SessionContext', () => ({
   useSession: () => ({
     effectiveAddress: '0xSmartAccount',
     isUsingSession,
     signTypedData: mockSessionSignTypedData,
+    sessionKeyAddress: '0xSessionKey',
+    chainClients: { ethereal: etherealClient, arbitrum: null },
   }),
+}));
+
+const mockIsSessionInstalledOnChain = vi.fn().mockReturnValue(false);
+const mockMarkSessionInstalledOnChain = vi.fn();
+vi.mock('~/lib/session/sessionKeyManager', () => ({
+  isSessionInstalledOnChain: (...args: unknown[]) =>
+    mockIsSessionInstalledOnChain(...args),
+  markSessionInstalledOnChain: (...args: unknown[]) =>
+    mockMarkSessionInstalledOnChain(...args),
 }));
 
 const mockReadContract = vi.fn().mockResolvedValue(0n);
@@ -89,9 +126,18 @@ describe('useSecondaryAccept', () => {
   beforeEach(() => {
     mockPrepareCalls.mockClear();
     mockAddBreadcrumb.mockClear();
+    mockCaptureException.mockClear();
     mockSessionSignTypedData.mockClear();
     mockSignTypedDataAsync.mockClear();
+    mockSendUserOperation.mockClear();
+    mockWaitForUserOperationReceipt.mockClear();
+    mockIsSessionInstalledOnChain.mockReset().mockReturnValue(true);
+    mockMarkSessionInstalledOnChain.mockClear();
     isUsingSession = true;
+    etherealClient = {
+      sendUserOperation: mockSendUserOperation,
+      waitForUserOperationReceipt: mockWaitForUserOperationReceipt,
+    };
   });
 
   it('builds trade params with sellerSessionKeyData=0x when session active', async () => {
@@ -142,5 +188,104 @@ describe('useSecondaryAccept', () => {
       trade: { buyerSessionKeyData: string };
     };
     expect(callArgs.trade.buyerSessionKeyData).toBe('0xdeadbeef');
+  });
+
+  // ── Session install warmup ─────────────────────────────────────────────
+
+  it('skips warmup when session is already installed on this chain', async () => {
+    mockIsSessionInstalledOnChain.mockReturnValue(true);
+    const { result } = renderHook(() => useSecondaryAccept());
+
+    await act(async () => {
+      await result.current.acceptBid({
+        token: '0xToken',
+        tokenAmount: 50n,
+        bid: baseBid,
+      });
+    });
+
+    expect(mockSendUserOperation).not.toHaveBeenCalled();
+    expect(mockMarkSessionInstalledOnChain).not.toHaveBeenCalled();
+    // Trade still goes through.
+    expect(mockSessionSignTypedData).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs a no-op revokeSessionKey warmup when session is not installed', async () => {
+    mockIsSessionInstalledOnChain.mockReturnValue(false);
+    const { result } = renderHook(() => useSecondaryAccept());
+
+    await act(async () => {
+      await result.current.acceptBid({
+        token: '0xToken',
+        tokenAmount: 50n,
+        bid: baseBid,
+      });
+    });
+
+    expect(mockSendUserOperation).toHaveBeenCalledTimes(1);
+    const sentCalls = (
+      mockSendUserOperation.mock.calls[0][0] as {
+        calls: Array<{ to: string; data: string; value: bigint }>;
+      }
+    ).calls;
+    expect(sentCalls).toHaveLength(1);
+    expect(sentCalls[0].to).toBe('0xSecondaryEscrow');
+    expect(sentCalls[0].value).toBe(0n);
+    // First 4 bytes of revokeSessionKey(address) calldata, then padded zero
+    // address as the only argument.
+    expect(sentCalls[0].data.startsWith('0x')).toBe(true);
+
+    expect(mockWaitForUserOperationReceipt).toHaveBeenCalledWith({
+      hash: '0xWarmupUserOpHash',
+    });
+    expect(mockMarkSessionInstalledOnChain).toHaveBeenCalledWith(
+      5064014,
+      '0xSessionKey'
+    );
+    // Trade proceeds after the warmup.
+    expect(mockSessionSignTypedData).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips warmup in EOA mode (no session)', async () => {
+    isUsingSession = false;
+    mockIsSessionInstalledOnChain.mockReturnValue(false);
+    const { result } = renderHook(() => useSecondaryAccept());
+
+    await act(async () => {
+      await result.current.acceptBid({
+        token: '0xToken',
+        tokenAmount: 50n,
+        bid: baseBid,
+      });
+    });
+
+    expect(mockSendUserOperation).not.toHaveBeenCalled();
+    expect(mockMarkSessionInstalledOnChain).not.toHaveBeenCalled();
+    expect(mockSignTypedDataAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts the trade when the warmup userOp reverts', async () => {
+    mockIsSessionInstalledOnChain.mockReturnValue(false);
+    mockWaitForUserOperationReceipt.mockResolvedValueOnce({
+      success: false,
+      receipt: { transactionHash: '0xrevertedHash' },
+    });
+
+    const { result } = renderHook(() => useSecondaryAccept());
+
+    let resp: { success: boolean; error?: string } = { success: false };
+    await act(async () => {
+      resp = await result.current.acceptBid({
+        token: '0xToken',
+        tokenAmount: 50n,
+        bid: baseBid,
+      });
+    });
+
+    expect(resp.success).toBe(false);
+    expect(resp.error).toMatch(/Could not prepare session/);
+    expect(mockSessionSignTypedData).not.toHaveBeenCalled();
+    expect(mockMarkSessionInstalledOnChain).not.toHaveBeenCalled();
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/hooks/secondary/useSecondaryAccept.ts
+++ b/packages/app/src/hooks/secondary/useSecondaryAccept.ts
@@ -3,7 +3,13 @@
 import { useCallback, useMemo, useState } from 'react';
 import * as Sentry from '@sentry/nextjs';
 import { useAccount, useChainId, useSignTypedData } from 'wagmi';
-import { erc20Abi, type Address, type Hex } from 'viem';
+import {
+  encodeFunctionData,
+  erc20Abi,
+  zeroAddress,
+  type Address,
+  type Hex,
+} from 'viem';
 import { buildSellerTradeApproval } from '@sapience/sdk/auction/secondarySigning';
 import {
   prepareExecuteTradeCalls,
@@ -13,11 +19,16 @@ import {
   secondaryMarketEscrow,
   collateralToken,
 } from '@sapience/sdk/contracts';
+import { secondaryMarketEscrowAbi } from '@sapience/sdk/abis';
 import { generateRandomNonce } from '@sapience/sdk';
 import type { SecondaryValidatedBid } from '@sapience/sdk/types/secondary';
 import { useSession } from '~/lib/context/SessionContext';
 import { useSapienceWriteContract } from '~/hooks/blockchain/useSapienceWriteContract';
 import { getPublicClientForChainId } from '~/lib/utils/util';
+import {
+  isSessionInstalledOnChain,
+  markSessionInstalledOnChain,
+} from '~/lib/session/sessionKeyManager';
 
 export interface AcceptBidParams {
   /** Position token address */
@@ -69,6 +80,8 @@ export function useSecondaryAccept(options: UseSecondaryAcceptOptions = {}) {
     effectiveAddress,
     signTypedData: sessionSignTypedData,
     isUsingSession,
+    sessionKeyAddress,
+    chainClients,
   } = useSession();
 
   const [isAccepting, setIsAccepting] = useState(false);
@@ -128,6 +141,59 @@ export function useSecondaryAccept(options: UseSecondaryAcceptOptions = {}) {
       setIsAccepting(true);
 
       try {
+        // 0. Install the kernel permission validator if it has not been
+        //    activated on this chain yet. The trade userOp itself is sent in
+        //    sudo mode (owner-signed) to bypass the ZeroDev paymaster
+        //    CallPolicy on `executeTrade`, but sudo userOps DO NOT install
+        //    the validator. If no prior session-signed userOp has run, the
+        //    contract's `isValidSignature` call against the seller will
+        //    revert with `InvalidValidator()` and the trade fails. Send a
+        //    no-op session-signed warmup (`revokeSessionKey(0x0)`) to force
+        //    ENABLE-mode validator install.
+        if (
+          isUsingSession &&
+          sessionKeyAddress &&
+          chainClients.ethereal &&
+          !isSessionInstalledOnChain(chainId, sessionKeyAddress)
+        ) {
+          try {
+            const warmupHash = await chainClients.ethereal.sendUserOperation({
+              calls: [
+                {
+                  to: escrowAddress,
+                  data: encodeFunctionData({
+                    abi: secondaryMarketEscrowAbi,
+                    functionName: 'revokeSessionKey',
+                    args: [zeroAddress],
+                  }),
+                  value: 0n,
+                },
+              ],
+            });
+            const warmupReceipt =
+              await chainClients.ethereal.waitForUserOperationReceipt({
+                hash: warmupHash,
+              });
+            if (!warmupReceipt.success) {
+              throw new Error('Session install warmup userOp reverted');
+            }
+            markSessionInstalledOnChain(chainId, sessionKeyAddress);
+          } catch (warmErr: unknown) {
+            const error =
+              warmErr instanceof Error ? warmErr : new Error(String(warmErr));
+            Sentry.captureException(error, {
+              tags: { component: 'secondary.session-warmup' },
+              extra: { chainId, sessionKeyAddress },
+            });
+            setIsAccepting(false);
+            onError?.(error);
+            return {
+              success: false,
+              error: `Could not prepare session for trade: ${error.message}`,
+            };
+          }
+        }
+
         // 1. Seller signs TradeApproval
         const sellerNonce = generateRandomNonce();
         const nowSec = Math.floor(Date.now() / 1000);
@@ -266,6 +332,8 @@ export function useSecondaryAccept(options: UseSecondaryAcceptOptions = {}) {
       signTypedDataAsync,
       sessionSignTypedData,
       isUsingSession,
+      sessionKeyAddress,
+      chainClients.ethereal,
       sendCalls,
       onError,
       onSignatureRejected,

--- a/packages/app/src/lib/session/sessionKeyManager.ts
+++ b/packages/app/src/lib/session/sessionKeyManager.ts
@@ -1374,6 +1374,52 @@ function createChainClient(
  */
 export const SESSION_STORAGE_KEY = 'sapience:session';
 
+// ─── Session install tracking ────────────────────────────────────────────────
+//
+// A Kernel V3 permission validator is installed on the smart account the
+// first time a session-signed userOp uses ENABLE mode (0x02). After that,
+// subsequent session signatures use USE mode (0x01) cheaply. Owner-signed
+// userOps (sudo mode) DO NOT install the permission validator. So a flow
+// that signs a TradeApproval with the session key and submits the userOp
+// in sudo mode (e.g. `useSecondaryAccept`) reverts with `InvalidValidator()`
+// when the contract calls `isValidSignature` — unless some prior session
+// userOp already installed the validator.
+//
+// Track install state in-memory per page load. Any successful session
+// userOp marks the (chainId, sessionKey) pair installed; consumers can
+// run a warmup before a sudo-mode flow if not yet marked. Lost on reload,
+// which only costs a one-time redundant warmup userOp.
+
+const sessionInstalledOnChain = new Set<string>();
+
+function sessionInstallKey(
+  chainId: number,
+  sessionKeyAddress: Address
+): string {
+  return `${chainId}:${sessionKeyAddress.toLowerCase()}`;
+}
+
+export function markSessionInstalledOnChain(
+  chainId: number,
+  sessionKeyAddress: Address
+): void {
+  sessionInstalledOnChain.add(sessionInstallKey(chainId, sessionKeyAddress));
+}
+
+export function isSessionInstalledOnChain(
+  chainId: number,
+  sessionKeyAddress: Address
+): boolean {
+  return sessionInstalledOnChain.has(
+    sessionInstallKey(chainId, sessionKeyAddress)
+  );
+}
+
+/** @internal — for tests only. */
+export function _resetSessionInstallTracking(): void {
+  sessionInstalledOnChain.clear();
+}
+
 /**
  * Save session to localStorage.
  */


### PR DESCRIPTION
## Summary

The secondary trade accept flow signs the seller's TradeApproval with a Kernel V3 session key (kernel-wrapped, validated on-chain via ERC-1271), but submits the actual `executeTrade` userOp in **sudo mode** (owner-signed) to bypass the ZeroDev paymaster's CallPolicy on `executeTrade`.

The catch: a sudo-mode userOp does NOT install the kernel permission validator. If a fresh session has had no prior session-signed userOp, the validator is never registered on-chain. When the contract calls `seller.isValidSignature(...)` during `executeTrade`, the kernel reverts with `InvalidValidator()` (selector `0x682a6e7c`) and the trade fails.

This PR fixes that by sending a **no-op session-signed warmup userOp** (`secondaryMarketEscrow.revokeSessionKey(0x0)`) before the trade flow when the session is not yet installed on-chain. The warmup uses ENABLE mode (0x02) on first run, which installs the validator. After that, `isValidSignature` works and the sudo-mode trade userOp succeeds.

To avoid redundant warmups, install state is tracked in-memory per `(chainId, sessionKey)`. Any successful session-signed userOp (mint, vault deposit, etc.) marks the pair as installed via `markSessionInstalledOnChain`, wired through `executeViaSessionKeyDefault`. The flag is process-local — cleared on page reload, which costs at most one redundant warmup per session.

## What's in
- `sessionKeyManager.ts`: `markSessionInstalledOnChain(chainId, sessionKey)` and `isSessionInstalledOnChain(chainId, sessionKey)` helpers backed by a module-level `Set`.
- `useSapienceWriteContract.ts`: marks the session installed after every successful session-signed userOp, so flows that mint first don't pay the warmup cost on subsequent secondary trades.
- `useSecondaryAccept.ts`: runs the warmup userOp before signing the TradeApproval if `isUsingSession && !isSessionInstalledOnChain(...)`. Reverts surface as a clean error and abort the trade.

## Test plan
- [x] `pnpm --filter @sapience/app test -- --run src/hooks/secondary/__tests__/useSecondaryAccept.test.ts` — 6/6 pass
- [x] Four new test cases covering: warmup runs on first trade, warmup skipped when already installed, no warmup in EOA mode, trade aborts cleanly on warmup revert
- [x] `pnpm --filter @sapience/app run type-check` clean
- [ ] Manual: on testnet, clear localStorage, create a fresh session, attempt a secondary trade WITHOUT minting first. Expect 1 gasless paymaster-sponsored warmup userOp, then trade goes through. Mint flow first → no warmup, trade goes through.

## Discovered during

End-to-end testnet testing of #1673 (post-1673 follow-up A in the working memory). Independent of #1673 — staging already has the ERC-1271 session-signed TradeApproval flow from #1671.