### PR TITLE
feat(keeper): admit negRisk Polymarket baskets atomically

### DIFF
--- a/packages/market-keeper/src/__tests__/neg-risk-basket.test.ts
+++ b/packages/market-keeper/src/__tests__/neg-risk-basket.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest';
+import type { PolymarketMarket } from '../types';
+import {
+  GROUP_FILTERS,
+  runPipeline,
+  type MarketGroup,
+} from '../generate/pipeline';
+
+function makeMarket(
+  overrides: Partial<PolymarketMarket> = {}
+): PolymarketMarket {
+  return {
+    id: 'm-id',
+    question: 'Will X win?',
+    conditionId: '0xabc',
+    outcomes: ['Yes', 'No'],
+    volume: '0',
+    liquidity: '0',
+    endDate: '2026-12-31T00:00:00Z',
+    description: '',
+    slug: 'x',
+    active: true,
+    closed: false,
+    ...overrides,
+  };
+}
+
+function makeGroup(
+  market: PolymarketMarket,
+  eventTitle: string,
+  eventId: string
+): MarketGroup {
+  market.events = [{ id: eventId, title: eventTitle, slug: eventTitle }];
+  return {
+    title: eventTitle,
+    markets: [market],
+    eventSlug: eventTitle,
+  };
+}
+
+describe('GROUP_FILTERS — negRisk basket admission', () => {
+  it('rescues low-volume negRisk siblings when one sibling passes volume+liquidity', () => {
+    const passing = makeGroup(
+      makeMarket({
+        conditionId: '0x01',
+        question: 'Will Hovland win?',
+        volume: '50000',
+        liquidity: '50000',
+        negRisk: true,
+      }),
+      'us-open-winner',
+      'event-1'
+    );
+    const longTail = makeGroup(
+      makeMarket({
+        conditionId: '0x02',
+        question: 'Will Player B win?',
+        volume: '5',
+        liquidity: '5',
+        negRisk: true,
+      }),
+      'us-open-winner',
+      'event-1'
+    );
+
+    const { output } = runPipeline([passing, longTail], GROUP_FILTERS);
+
+    expect(output).toHaveLength(2);
+    expect(output.map((g) => g.markets[0].conditionId).sort()).toEqual([
+      '0x01',
+      '0x02',
+    ]);
+  });
+
+  it('does not rescue negRisk siblings when no sibling passes thresholds', () => {
+    const a = makeGroup(
+      makeMarket({
+        conditionId: '0xa',
+        question: 'Will A win?',
+        volume: '10',
+        liquidity: '10',
+        negRisk: true,
+      }),
+      'cold-event',
+      'event-2'
+    );
+    const b = makeGroup(
+      makeMarket({
+        conditionId: '0xb',
+        question: 'Will B win?',
+        volume: '20',
+        liquidity: '20',
+        negRisk: true,
+      }),
+      'cold-event',
+      'event-2'
+    );
+
+    const { output } = runPipeline([a, b], GROUP_FILTERS);
+
+    expect(output).toHaveLength(0);
+  });
+
+  it('still removes low-volume non-negRisk groups (regression check)', () => {
+    const lowVol = makeGroup(
+      makeMarket({
+        conditionId: '0xc',
+        question: 'Will it rain?',
+        volume: '5',
+        liquidity: '5',
+        // explicitly no negRisk
+      }),
+      'standalone',
+      'event-3'
+    );
+
+    const { output } = runPipeline([lowVol], GROUP_FILTERS);
+
+    expect(output).toHaveLength(0);
+  });
+
+  it('keeps non-negRisk groups that pass volume+liquidity (regression check)', () => {
+    const passing = makeGroup(
+      makeMarket({
+        conditionId: '0xd',
+        question: 'Will it rain?',
+        volume: '5000',
+        liquidity: '5000',
+      }),
+      'standalone',
+      'event-4'
+    );
+
+    const { output } = runPipeline([passing], GROUP_FILTERS);
+
+    expect(output).toHaveLength(1);
+  });
+
+  it('does not rescue a negRisk market that lacks an event id', () => {
+    // Defensive: the rescue keys off Polymarket event id. A negRisk market
+    // arriving without one (malformed feed, supplementary fetch path that
+    // strips parent metadata) cannot be associated with a basket, so it must
+    // fall back to standard volume+liquidity rules.
+    const orphan = makeGroup(
+      makeMarket({
+        conditionId: '0xorphan',
+        question: 'Will orphan win?',
+        volume: '5',
+        liquidity: '5',
+        negRisk: true,
+      }),
+      'orphan-event',
+      'event-orphan'
+    );
+    // Strip the event id to simulate the malformed payload.
+    orphan.markets[0].events = [
+      { title: 'orphan-event', slug: 'orphan-event' },
+    ];
+
+    const passingElsewhere = makeGroup(
+      makeMarket({
+        conditionId: '0xother',
+        question: 'Will Other win?',
+        volume: '50000',
+        liquidity: '50000',
+        negRisk: true,
+      }),
+      'other-event',
+      'event-other'
+    );
+
+    const { output } = runPipeline([orphan, passingElsewhere], GROUP_FILTERS);
+
+    expect(output.map((g) => g.markets[0].conditionId).sort()).toEqual([
+      '0xother',
+    ]);
+  });
+
+  it('does not rescue negRisk children across different events', () => {
+    // Two separate negRisk events that happen to share a title (rare but
+    // possible). Rescue must key off event id, not title — otherwise a
+    // passing child of event-A would drag along low-volume children of
+    // event-B.
+    const passingInA = makeGroup(
+      makeMarket({
+        conditionId: '0xe1',
+        question: 'Will X win?',
+        volume: '50000',
+        liquidity: '50000',
+        negRisk: true,
+      }),
+      'shared-title',
+      'event-A'
+    );
+    const lowInB = makeGroup(
+      makeMarket({
+        conditionId: '0xe2',
+        question: 'Will Y win?',
+        volume: '5',
+        liquidity: '5',
+        negRisk: true,
+      }),
+      'shared-title',
+      'event-B'
+    );
+
+    const { output } = runPipeline([passingInA, lowInB], GROUP_FILTERS);
+
+    expect(output).toHaveLength(1);
+    expect(output[0].markets[0].conditionId).toBe('0xe1');
+  });
+});

--- a/packages/market-keeper/src/__tests__/pipeline.test.ts
+++ b/packages/market-keeper/src/__tests__/pipeline.test.ts
@@ -7,6 +7,8 @@ import {
   type ExistingCondition,
 } from '../generate/pipeline/filters/exclude-existing';
 import { runPipeline } from '../generate/pipeline';
+import { UnionFilter } from '../generate/pipeline/combinators';
+import type { Filter, FilterResult } from '../generate/pipeline/types';
 
 // ============ Test Helpers ============
 
@@ -132,6 +134,115 @@ describe('ExcludeExistingMarketsFilter', () => {
     const markets = [makeMarket({ conditionId: '0xabc' })];
     const { kept } = filter.apply(markets);
     expect(kept).toHaveLength(1);
+  });
+});
+
+// ============ UnionFilter ============
+
+describe('UnionFilter', () => {
+  // A trivial item-local filter: keeps items whose `tag` is in `tags`.
+  class TagFilter implements Filter<{ id: string; tag: string }> {
+    name: string;
+    description = 'tag filter';
+    constructor(
+      private tags: string[],
+      name = 'tag-filter'
+    ) {
+      this.name = name;
+    }
+    apply(items: { id: string; tag: string }[]): FilterResult<{
+      id: string;
+      tag: string;
+    }> {
+      const kept = items.filter((i) => this.tags.includes(i.tag));
+      const removed = items.filter((i) => !this.tags.includes(i.tag));
+      return { kept, removed };
+    }
+  }
+
+  it('keeps items kept by ANY sub-filter (per-item OR semantics, backward compat)', () => {
+    const items = [
+      { id: '1', tag: 'a' },
+      { id: '2', tag: 'b' },
+      { id: '3', tag: 'c' },
+    ];
+    const filter = new UnionFilter<{ id: string; tag: string }>([
+      new TagFilter(['a'], 'keeps-a'),
+      new TagFilter(['b'], 'keeps-b'),
+    ]);
+
+    const { kept, removed } = filter.apply(items);
+
+    expect(kept.map((i) => i.id).sort()).toEqual(['1', '2']);
+    expect(removed.map((i) => i.id)).toEqual(['3']);
+  });
+
+  it('preserves input order and identity (no duplicates) when sub-filters overlap', () => {
+    const items = [
+      { id: '1', tag: 'a' },
+      { id: '2', tag: 'a' },
+    ];
+    // Two sub-filters that both keep tag=a → an item could be double-counted
+    // if the implementation simply concatenates kept sets.
+    const filter = new UnionFilter<{ id: string; tag: string }>([
+      new TagFilter(['a'], 'first'),
+      new TagFilter(['a'], 'second'),
+    ]);
+
+    const { kept } = filter.apply(items);
+
+    expect(kept).toHaveLength(2);
+    expect(kept[0]).toBe(items[0]);
+    expect(kept[1]).toBe(items[1]);
+  });
+
+  it('lets sibling-aware sub-filters use cross-item state', () => {
+    // A stateful sub-filter that needs to see ALL items: keeps every item
+    // that shares a `groupId` with at least one item whose `volume >= 100`.
+    // This relies on UnionFilter passing the full input list, not [item].
+    class GroupRescueFilter
+      implements Filter<{ id: string; groupId: string; volume: number }>
+    {
+      name = 'group-rescue';
+      description = 'rescue siblings of high-volume members';
+      apply(
+        items: { id: string; groupId: string; volume: number }[]
+      ): FilterResult<{ id: string; groupId: string; volume: number }> {
+        const passingGroups = new Set(
+          items.filter((i) => i.volume >= 100).map((i) => i.groupId)
+        );
+        const kept = items.filter((i) => passingGroups.has(i.groupId));
+        const removed = items.filter((i) => !passingGroups.has(i.groupId));
+        return { kept, removed };
+      }
+    }
+    // A stateless never-keep filter to guarantee the rescue branch is the
+    // only thing keeping low-volume items.
+    class NeverKeepFilter
+      implements Filter<{ id: string; groupId: string; volume: number }>
+    {
+      name = 'never';
+      description = 'never';
+      apply(
+        items: { id: string; groupId: string; volume: number }[]
+      ): FilterResult<{ id: string; groupId: string; volume: number }> {
+        return { kept: [], removed: items };
+      }
+    }
+
+    const items = [
+      { id: 'big-A', groupId: 'A', volume: 500 },
+      { id: 'small-A', groupId: 'A', volume: 1 }, // rescued via sibling
+      { id: 'small-B', groupId: 'B', volume: 1 }, // not rescued, B has nothing big
+    ];
+    const filter = new UnionFilter([
+      new NeverKeepFilter(),
+      new GroupRescueFilter(),
+    ]);
+
+    const { kept } = filter.apply(items);
+
+    expect(kept.map((i) => i.id).sort()).toEqual(['big-A', 'small-A']);
   });
 });
 

--- a/packages/market-keeper/src/generate/pipeline/combinators.ts
+++ b/packages/market-keeper/src/generate/pipeline/combinators.ts
@@ -7,8 +7,11 @@ import type { Filter, FilterResult } from './types';
 /**
  * UnionFilter: Keep items that pass ANY of the sub-filters (OR logic)
  *
- * Use this when you want to keep items that match at least one condition.
- * Each sub-filter can be tested and reused independently.
+ * Each sub-filter is invoked once on the full input, and an item is kept
+ * if any sub-filter's `kept` set contains it. Passing the whole list (not
+ * one item at a time) is what lets sibling-aware sub-filters work — e.g. a
+ * negRisk basket rescue that keeps low-volume children when at least one of
+ * their event-siblings has high volume.
  */
 export class UnionFilter<T> implements Filter<T> {
   name: string;
@@ -20,15 +23,17 @@ export class UnionFilter<T> implements Filter<T> {
   }
 
   apply(items: T[]): FilterResult<T> {
+    const keptSet = new Set<T>();
+    for (const f of this.filters) {
+      for (const item of f.apply(items).kept) {
+        keptSet.add(item);
+      }
+    }
+
     const kept: T[] = [];
     const removed: T[] = [];
-
     for (const item of items) {
-      // Keep if ANY filter would keep this item
-      const wouldKeep = this.filters.some(
-        (f) => f.apply([item]).kept.length > 0
-      );
-      if (wouldKeep) {
+      if (keptSet.has(item)) {
         kept.push(item);
       } else {
         removed.push(item);

--- a/packages/market-keeper/src/generate/pipeline/filters/neg-risk-basket.ts
+++ b/packages/market-keeper/src/generate/pipeline/filters/neg-risk-basket.ts
@@ -1,0 +1,77 @@
+/**
+ * Filter: rescue low-volume children of a Polymarket negRisk basket when at
+ * least one sibling in the same event passes the standard volume+liquidity
+ * thresholds. A negRisk event is a set of mutually-exclusive binary markets
+ * where exactly one resolves YES — admitting only the high-volume legs would
+ * leave the basket incomplete and break the conversion identity
+ * NO_i ≡ Σ YES_j (j ≠ i) on our side.
+ */
+
+import type { Filter, FilterResult } from '../types';
+import {
+  MIN_VOLUME_THRESHOLD,
+  MIN_LIQUIDITY_THRESHOLD,
+} from '../../../constants';
+import type { MarketGroup } from './volume-threshold';
+
+export class NegRiskBasketRescueFilter implements Filter<MarketGroup> {
+  name = 'neg-risk-basket-rescue';
+  description =
+    'Keep negRisk children whose event has at least one sibling passing volume+liquidity';
+
+  apply(groups: MarketGroup[]): FilterResult<MarketGroup> {
+    // Identify negRisk events with at least one child that already clears
+    // both thresholds on its own. Keying off the Polymarket event id (not
+    // title) is deliberate — different events can share a title.
+    const eventsWithPassingChild = new Set<string>();
+    for (const group of groups) {
+      for (const market of group.markets) {
+        if (!market.negRisk) continue;
+        const eventId = market.events?.[0]?.id;
+        if (!eventId) continue;
+        const volume = parseFloat(market.volume || '0');
+        const liquidity = parseFloat(market.liquidity || '0');
+        if (
+          volume >= MIN_VOLUME_THRESHOLD &&
+          liquidity >= MIN_LIQUIDITY_THRESHOLD
+        ) {
+          eventsWithPassingChild.add(eventId);
+        }
+      }
+    }
+
+    const kept: MarketGroup[] = [];
+    const removed: MarketGroup[] = [];
+    // Marginal rescues = groups this branch keeps that the volume+liquidity
+    // branch would have dropped. Total kept also counts siblings that pass on
+    // their own — those would survive without us, so they don't count as
+    // "rescued."
+    let marginalRescued = 0;
+    for (const group of groups) {
+      const isRescuedSibling = group.markets.some((m) => {
+        if (!m.negRisk) return false;
+        const eventId = m.events?.[0]?.id;
+        return !!eventId && eventsWithPassingChild.has(eventId);
+      });
+      if (isRescuedSibling) {
+        kept.push(group);
+        const failsOnOwn = group.markets.every((m) => {
+          const v = parseFloat(m.volume || '0');
+          const l = parseFloat(m.liquidity || '0');
+          return v < MIN_VOLUME_THRESHOLD || l < MIN_LIQUIDITY_THRESHOLD;
+        });
+        if (failsOnOwn) marginalRescued++;
+      } else {
+        removed.push(group);
+      }
+    }
+
+    console.log(
+      `[neg-risk-basket-rescue] baskets=${eventsWithPassingChild.size} ` +
+        `kept=${kept.length} marginal=${marginalRescued} ` +
+        `(marginal = legs that would have failed volume+liquidity on their own)`
+    );
+
+    return { kept, removed };
+  }
+}

--- a/packages/market-keeper/src/generate/pipeline/index.ts
+++ b/packages/market-keeper/src/generate/pipeline/index.ts
@@ -37,6 +37,7 @@ import {
   AlwaysIncludeConditionFilter,
   AlwaysIncludeConditionGroupFilter,
 } from './filters/always-include';
+import { NegRiskBasketRescueFilter } from './filters/neg-risk-basket';
 import {
   NonCryptoMarketFilter,
   NonCryptoConditionFilter,
@@ -86,6 +87,10 @@ export const GROUP_FILTERS: Filter<MarketGroup>[] = [
       new LiquidityThresholdFilter(),
     ]),
     new AlwaysIncludeGroupFilter(),
+    // Mutually-exclusive Polymarket baskets must be ingested whole; this
+    // branch rescues low-volume siblings whenever any leg of the same
+    // negRisk event already clears volume+liquidity.
+    new NegRiskBasketRescueFilter(),
   ]),
 ];
 

--- a/packages/market-keeper/src/types/polymarket.ts
+++ b/packages/market-keeper/src/types/polymarket.ts
@@ -34,6 +34,11 @@ export interface PolymarketMarket {
     }>;
   }>;
   outcomePrices?: string | number[];
+  // True on every child of a Polymarket "negative risk" basket — a set of
+  // mutually-exclusive binary markets where exactly one resolves YES and the
+  // rest resolve NO. The basket is one logical question, so admission
+  // decisions must apply to every sibling together, not per child.
+  negRisk?: boolean;
   active: boolean;
   closed: boolean;
   archived?: boolean;


### PR DESCRIPTION
## Summary

Polymarket "negative risk" events are mutually-exclusive baskets — exactly one of the N child markets resolves YES, the rest resolve NO. Until now, the keeper applied per-child volume + liquidity thresholds independently, so long-tail legs of a basket were dropped while the favorite was admitted. That leaves the basket incomplete on our side and breaks the on-chain conversion identity `NO_i ≡ Σ YES_j (j ≠ i)`.

This PR makes basket admission atomic: when at least one child of a negRisk event clears the standard thresholds, every sibling of that event is admitted regardless of its own volume / liquidity. Non-negRisk groups behave exactly as before.

### What changed

- **`PolymarketMarket.negRisk?: boolean`** — new field. Reliable on every child of a negRisk basket on both fetch paths (`/markets` and the supplementary `/events?tag_slug=...`).
- **New `NegRiskBasketRescueFilter`** — added as a third branch of `GROUP_FILTERS`'s `UnionFilter`, alongside the existing volume+liquidity intersection and always-include patterns. Keys off Polymarket `event.id`, not title, so two unrelated events sharing a title don't pollute each other's baskets. Defensive on missing event id (orphan negRisk markets fall back to standard rules).
- **`UnionFilter.apply()` now invokes each sub-filter on the full input list** (rather than per-item) and unions the kept sets. For stateless sub-filters this is identical to the previous per-item OR; the change unblocks sibling-aware sub-filters like the rescue.
- **Per-run log line** so operators can see the rescue's effect:
  ```
  [neg-risk-basket-rescue] baskets=N kept=K marginal=M
  ```
  where `marginal` is the count of legs the rescue admitted that volume+liquidity alone would have dropped.

### Tests added

- 6 cases covering the rescue filter directly: rescue, no-rescue when no sibling passes, low-volume non-negRisk regression, high-volume non-negRisk regression, missing-event-id defensive fallback, and cross-event isolation under shared title.
- 3 cases locking in the `UnionFilter` contract: per-item OR backward compat, no double-counting on overlapping branches, and the new sibling-aware behavior with a stateful sub-filter.

### Observed impact (live dry-run)

```
[neg-risk-basket-rescue] baskets=291 kept=2312 marginal=1009
[Volume Filter] ... Kept 3374/28329
```

291 negRisk baskets fired the rescue, contributing 1009 long-tail legs that previously would have been filtered out — roughly 30% of the total admitted groups.

## Test plan

- [x] `pnpm --filter @sapience/market-keeper run test` — 319/319 pass
- [x] `pnpm --filter @sapience/market-keeper run type-check` clean
- [x] `pnpm --filter @sapience/market-keeper run build` clean
- [x] ESLint clean on every file in the diff (pre-existing `src/resolver.ts` lint error on this branch is unrelated)
- [x] Live `generate:dry-run` against Gamma API verified rescue counters and basket completeness in the JSON output