### PR TITLE
fix(api): add indexer identity to watermark logs

### DIFF
--- a/packages/api/src/workers/indexers/conditionSettledIndexer.ts
+++ b/packages/api/src/workers/indexers/conditionSettledIndexer.ts
@@ -83,7 +83,7 @@ class ConditionSettledIndexer implements IIndexer {
 
   private async persistIndexerState(blockNumber: number): Promise<void> {
     logger.info(
-      `[ConditionSettledIndexer:${this.chainId}] Persisting watermark block=${blockNumber}`
+      `[ConditionSettledIndexer:${this.chainId}] Persisting watermark block=${blockNumber} contract=${this.contractAddress} legacy=${this.isLegacy}`
     );
     await prisma.indexerState.upsert({
       where: {

--- a/packages/api/src/workers/indexers/positionTokenTransferIndexer.ts
+++ b/packages/api/src/workers/indexers/positionTokenTransferIndexer.ts
@@ -406,7 +406,7 @@ class PositionTokenTransferIndexer implements IIndexer {
 
   private async setLastIndexedBlock(block: number): Promise<void> {
     logger.info(
-      `[TransferIndexer:${this.chainId}${this.indexerStateKeySuffix}] Persisting watermark block=${block}`
+      `[TransferIndexer:${this.chainId}${this.indexerStateKeySuffix}] Persisting watermark block=${block} escrow=${this.escrowAddress ?? 'current'} legacy=${this.isLegacy}`
     );
     const key = `${INDEXER_STATE_KEY}:${this.chainId}${this.indexerStateKeySuffix}`;
     await prisma.keyValueStore.upsert({

--- a/packages/api/src/workers/indexers/predictionMarketEscrowIndexer.ts
+++ b/packages/api/src/workers/indexers/predictionMarketEscrowIndexer.ts
@@ -255,7 +255,7 @@ class PredictionMarketEscrowIndexer implements IIndexer {
 
       // Update indexer state
       logger.info(
-        `[PredictionMarketEscrowIndexer:${this.chainId}] Persisting watermark block=${endBlockNumber}`
+        `[PredictionMarketEscrowIndexer:${this.chainId}] Persisting watermark block=${endBlockNumber} contract=${this.contractAddress} legacy=${this.isLegacy}`
       );
       await prisma.indexerState.upsert({
         where: {
@@ -432,7 +432,7 @@ class PredictionMarketEscrowIndexer implements IIndexer {
 
           // Persist indexer state for resume on restart
           logger.info(
-            `[PredictionMarketEscrowIndexer:${this.chainId}] Persisting watermark block=${currentBlock}`
+            `[PredictionMarketEscrowIndexer:${this.chainId}] Persisting watermark block=${currentBlock} contract=${this.contractAddress} legacy=${this.isLegacy}`
           );
           await prisma.indexerState.upsert({
             where: {

--- a/packages/api/src/workers/indexers/secondaryMarketIndexer.ts
+++ b/packages/api/src/workers/indexers/secondaryMarketIndexer.ts
@@ -107,7 +107,7 @@ class SecondaryMarketIndexer implements IIndexer {
       }
 
       logger.info(
-        `[SecondaryMarketIndexer:${this.chainId}] Persisting watermark block=${endBlockNumber}`
+        `[SecondaryMarketIndexer:${this.chainId}] Persisting watermark block=${endBlockNumber} contract=${this.contractAddress} legacy=${this.isLegacy}`
       );
       await prisma.secondaryIndexerState.upsert({
         where: { chainId: this.chainId },
@@ -267,7 +267,7 @@ class SecondaryMarketIndexer implements IIndexer {
           this.lastProcessedBlock = currentBlock;
 
           logger.info(
-            `[SecondaryMarketIndexer:${this.chainId}] Persisting watermark block=${currentBlock}`
+            `[SecondaryMarketIndexer:${this.chainId}] Persisting watermark block=${currentBlock} contract=${this.contractAddress} legacy=${this.isLegacy}`
           );
           await prisma.secondaryIndexerState.upsert({
             where: { chainId: this.chainId },


### PR DESCRIPTION
## Summary
- Adds contract/escrow address and legacy status to background indexer watermark logs
- Makes repeated `Persisting watermark block=...` messages distinguishable across current and legacy indexer instances

## Test Plan
- `git diff --check`
- Attempted `pnpm --filter @sapience/api run type-check`, but this fresh worktree had no `node_modules`; `pnpm install --frozen-lockfile` repeatedly failed in this environment with `ERR_WORKER_INIT_FAILED EAGAIN` before dependencies were linked
