### PR TITLE
fix(api): release GraphQL concurrency slots on close

### DIFF
--- a/packages/api/src/core/server.hardening.test.ts
+++ b/packages/api/src/core/server.hardening.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import request from 'supertest';
 import express, { type Request, type Response } from 'express';
@@ -157,6 +158,65 @@ describe('per-IP concurrency limit on /graphql', () => {
       .set('Content-Type', 'application/json')
       .send(JSON.stringify({ query: '{ __typename }' }));
     expect(res2.status).toBe(200);
+  });
+
+  it('releases global and per-IP slots when a client connection closes before finish', () => {
+    const { concurrencyMiddleware } = createConcurrencyLimiter({
+      maxConcurrent: 1,
+      maxConcurrentPerIp: 1,
+      requestTimeoutMs: 15000,
+    });
+
+    function createMockResponse() {
+      const res = new EventEmitter() as Response & {
+        statusCode?: number;
+        headersSent: boolean;
+        setTimeout: () => void;
+        set: () => Response;
+        status: (statusCode: number) => Response;
+        json: (body: unknown) => Response;
+      };
+      res.headersSent = false;
+      res.setTimeout = vi.fn();
+      res.set = vi.fn(() => res);
+      res.status = vi.fn((statusCode: number) => {
+        res.statusCode = statusCode;
+        return res;
+      });
+      res.json = vi.fn(() => res);
+      return res;
+    }
+
+    const req = {
+      headers: { 'x-forwarded-for': '1.2.3.4' },
+      socket: {},
+      path: '/graphql',
+      method: 'POST',
+      query: {},
+    } as unknown as Request;
+
+    const firstRes = createMockResponse();
+    const firstNext = vi.fn();
+    concurrencyMiddleware(req, firstRes, firstNext);
+    expect(firstNext).toHaveBeenCalledOnce();
+
+    firstRes.emit('close');
+
+    const secondRes = createMockResponse();
+    const secondNext = vi.fn();
+    concurrencyMiddleware(req, secondRes, secondNext);
+
+    expect(secondNext).toHaveBeenCalledOnce();
+    expect(secondRes.status).not.toHaveBeenCalledWith(429);
+
+    firstRes.emit('finish');
+
+    const thirdRes = createMockResponse();
+    const thirdNext = vi.fn();
+    concurrencyMiddleware(req, thirdRes, thirdNext);
+
+    expect(thirdNext).not.toHaveBeenCalled();
+    expect(thirdRes.status).toHaveBeenCalledWith(429);
   });
 
   it('429 response includes per-IP indicator and Retry-After header', async () => {

--- a/packages/api/src/runtime/concurrencyLimiter.ts
+++ b/packages/api/src/runtime/concurrencyLimiter.ts
@@ -10,6 +10,7 @@
  */
 
 import type { Request, Response, NextFunction } from 'express';
+import { createHash } from 'node:crypto';
 import { createLogger } from '../core/logger';
 
 const log = createLogger('concurrency-limiter');
@@ -40,6 +41,47 @@ export function createConcurrencyLimiter(opts: ConcurrencyLimiterOptions) {
     );
   }
 
+  function getRequestId(req: Request): string | undefined {
+    const requestId = req.headers['x-request-id'];
+    return typeof requestId === 'string' && requestId ? requestId : undefined;
+  }
+
+  function getOperationName(req: Request): string | undefined {
+    const queryOperationName = req.query.operationName;
+    if (typeof queryOperationName === 'string' && queryOperationName) {
+      return queryOperationName;
+    }
+
+    const body = req.body as { operationName?: unknown } | undefined;
+    return typeof body?.operationName === 'string' && body.operationName
+      ? body.operationName
+      : undefined;
+  }
+
+  function getQueryHash(req: Request): string | undefined {
+    const query = req.query.query;
+    const body = req.body as { query?: unknown } | undefined;
+    const rawQuery = typeof query === 'string' ? query : body?.query;
+    return typeof rawQuery === 'string' && rawQuery
+      ? createHash('sha256').update(rawQuery).digest('hex').slice(0, 12)
+      : undefined;
+  }
+
+  function getRequestLogContext(req: Request, ip: string) {
+    return {
+      ip,
+      path: req.path,
+      method: req.method,
+      requestId: getRequestId(req),
+      operationName: getOperationName(req),
+      queryHash: getQueryHash(req),
+      userAgent: req.headers['user-agent'],
+      origin: req.headers.origin,
+      referer: req.headers.referer,
+      xForwardedFor: req.headers['x-forwarded-for'],
+    };
+  }
+
   // Middleware 1: Request timeout — runs before body parsing (slowloris defense)
   function timeoutMiddleware(
     _req: Request,
@@ -63,15 +105,15 @@ export function createConcurrencyLimiter(opts: ConcurrencyLimiterOptions) {
     next: NextFunction
   ): void {
     const ip = getIp(req);
+    const requestContext = getRequestLogContext(req, ip);
 
     // Global limit
     if (activeOperations >= maxConcurrent) {
       log.warn(
         {
+          ...requestContext,
           activeOperations,
           maxConcurrent,
-          ip,
-          path: req.path,
         },
         '429 load shed (global)'
       );
@@ -94,7 +136,7 @@ export function createConcurrencyLimiter(opts: ConcurrencyLimiterOptions) {
     const ipOps = activePerIp.get(ip) ?? 0;
     if (ipOps >= maxConcurrentPerIp) {
       log.warn(
-        { ipOps, maxConcurrentPerIp, ip },
+        { ...requestContext, ipOps, maxConcurrentPerIp, activeOperations },
         '429 per-IP concurrency limit'
       );
       res
@@ -114,15 +156,46 @@ export function createConcurrencyLimiter(opts: ConcurrencyLimiterOptions) {
 
     activeOperations++;
     activePerIp.set(ip, ipOps + 1);
-    res.on('finish', () => {
-      activeOperations--;
-      const current = activePerIp.get(ip) ?? 1;
-      if (current <= 1) {
+
+    const activeAtStart = activeOperations;
+    let cleanedUp = false;
+    const cleanup = (reason: 'finish' | 'close') => {
+      if (cleanedUp) {
+        return;
+      }
+      cleanedUp = true;
+
+      activeOperations = Math.max(0, activeOperations - 1);
+      const current = activePerIp.get(ip) ?? 0;
+      const ipOperations = Math.max(0, current - 1);
+      if (ipOperations === 0) {
         activePerIp.delete(ip);
       } else {
-        activePerIp.set(ip, current - 1);
+        activePerIp.set(ip, ipOperations);
       }
-    });
+
+      const logContext = {
+        ...requestContext,
+        cleanupReason: reason,
+        statusCode: res.statusCode,
+        activeOperations,
+        activeAtStart,
+        ipOperations,
+        completed: res.writableEnded,
+      };
+
+      if (reason === 'close' && !res.writableEnded) {
+        log.warn(
+          logContext,
+          'GraphQL concurrency slot released on closed connection'
+        );
+      } else {
+        log.debug(logContext, 'GraphQL concurrency slot released');
+      }
+    };
+
+    res.on('finish', () => cleanup('finish'));
+    res.on('close', () => cleanup('close'));
     next();
   }
 


### PR DESCRIPTION
## Summary
- release GraphQL concurrency slots on `res.close` as well as `res.finish`, with idempotent cleanup so close/finish double-events cannot undercount
- add structured limiter diagnostics for global/per-IP shedding and close-based cleanup: active counts, request id, operation name/query hash when available, user-agent/origin/referer, and forwarded IP context
- add a regression test proving a closed client connection frees the global/per-IP slot before `finish`, and that a later `finish` does not double-decrement

## Why this is appropriate
The incident cleared after restart, which matches an in-memory limiter counter being pinned. The existing limiter only released slots from `res.finish`; Node/Express can emit `close` when the connection terminates before the response finishes, so aborted clients can hold slots forever unless `close` also runs cleanup. The cleanup in this PR is deliberately idempotent because normal completed responses can involve both events.

## Test plan
- `pnpm --filter @sapience/api exec vitest run src/core/server.hardening.test.ts -t 'releases global and per-IP slots when a client connection closes before finish'`
- `pnpm --filter @sapience/api exec vitest run src/core/server.hardening.test.ts`
- `pnpm --filter @sapience/api run lint`
- `pnpm --filter @sapience/api run type-check`
- `pnpm --filter @sapience/api run test`
