### PR TITLE
feat(analytics): add trade count metrics

### DIFF
--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -1435,6 +1435,9 @@ type ProtocolStat {
   """Realized PnL delta over the snapshot interval"""
   periodPnL: String!
 
+  """Trade-count delta over the snapshot interval"""
+  periodTradeCount: Int!
+
   """Cumulative-volume delta over the snapshot interval"""
   periodVolume: String!
 
@@ -1442,6 +1445,9 @@ type ProtocolStat {
   Unix epoch timestamp (seconds) aligned to the snapshot interval boundary
   """
   timestamp: Int!
+
+  """Cumulative count of predictions and secondary trades/sales"""
+  totalTradeCount: Int!
   vaultAirdropGains: String!
   vaultAvailableAssets: String!
   vaultBalance: String!

--- a/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
@@ -43,6 +43,11 @@ interface CumulativeVolumeRow {
   cumulative_volume: string | null;
 }
 
+interface CumulativeTradeCountRow {
+  timestamp: bigint;
+  cumulative_trade_count: bigint | number | string | null;
+}
+
 interface DailyOIRow {
   timestamp: bigint;
   open_interest: string | null;
@@ -147,8 +152,9 @@ export const protocolStats: NonNullable<
   const nowTimestamp = Math.floor(Date.now() / 1000);
   const queryTimestamps = [...snapshotTimestamps, nowTimestamp];
 
-  const [cumulativeVolumes, openInterests] = await Promise.all([
-    prisma.$queryRaw<CumulativeVolumeRow[]>`
+  const [cumulativeVolumes, cumulativeTradeCounts, openInterests] =
+    await Promise.all([
+      prisma.$queryRaw<CumulativeVolumeRow[]>`
       SELECT
         ts.timestamp,
         COALESCE(SUM(vol), 0)::TEXT as cumulative_volume
@@ -172,7 +178,24 @@ export const protocolStats: NonNullable<
       GROUP BY ts.timestamp
       ORDER BY ts.timestamp
     `,
-    prisma.$queryRaw<DailyOIRow[]>`
+      prisma.$queryRaw<CumulativeTradeCountRow[]>`
+      SELECT
+        ts.timestamp,
+        COALESCE(COUNT(combined.created_ts), 0) as cumulative_trade_count
+      FROM UNNEST(${queryTimestamps}::BIGINT[]) AS ts(timestamp)
+      LEFT JOIN (
+        SELECT "onChainCreatedAt" AS created_ts, "chainId"
+        FROM "Prediction"
+        UNION ALL
+        SELECT "executedAt" AS created_ts, "chainId"
+        FROM secondary_trade
+      ) combined ON
+        combined.created_ts <= ts.timestamp
+        AND combined."chainId" = ${chainId}
+      GROUP BY ts.timestamp
+      ORDER BY ts.timestamp
+    `,
+      prisma.$queryRaw<DailyOIRow[]>`
       SELECT
         ts.timestamp,
         COALESCE(SUM(vol), 0)::TEXT as open_interest
@@ -195,9 +218,13 @@ export const protocolStats: NonNullable<
       GROUP BY ts.timestamp
       ORDER BY ts.timestamp
     `,
-  ]);
+    ]);
 
   const volumeMap = buildTimestampMap(cumulativeVolumes, 'cumulative_volume');
+  const tradeCountMap = buildTimestampMap(
+    cumulativeTradeCounts,
+    'cumulative_trade_count'
+  );
   const oiMap = buildTimestampMap(openInterests, 'open_interest');
 
   // Display each bar one interval *before* the snapshot's capture timestamp
@@ -220,6 +247,13 @@ export const protocolStats: NonNullable<
       i > 0 ? volumeMap.get(protocolSnapshots[i - 1].timestamp) || '0' : '0';
     const periodVolume = (BigInt(cumVol) - BigInt(prevCumVol)).toString();
 
+    const cumTradeCount = Number(tradeCountMap.get(snapshot.timestamp) || '0');
+    const prevCumTradeCount =
+      i > 0
+        ? Number(tradeCountMap.get(protocolSnapshots[i - 1].timestamp) || '0')
+        : 0;
+    const periodTradeCount = cumTradeCount - prevCumTradeCount;
+
     const cumPnL = cumulativePnL(snapshot);
     const prevCumPnL = i > 0 ? cumulativePnL(protocolSnapshots[i - 1]) : 0n;
     const periodPnL = (cumPnL - prevCumPnL).toString();
@@ -227,6 +261,8 @@ export const protocolStats: NonNullable<
     return {
       timestamp: snapshot.timestamp - interval,
       cumulativeVolume: cumVol,
+      totalTradeCount: cumTradeCount,
+      periodTradeCount,
       openInterest: oiMap.get(snapshot.timestamp) || '0',
       vaultBalance: snapshot.vaultBalance,
       vaultAvailableAssets: snapshot.vaultAvailableAssets,
@@ -253,6 +289,13 @@ export const protocolStats: NonNullable<
     const livePeriodVolume = (
       BigInt(liveCumVol) - BigInt(lastCumVol)
     ).toString();
+    const lastTradeCount = Number(
+      tradeCountMap.get(lastSnapshot.timestamp) || '0'
+    );
+    const liveTradeCount = Number(
+      tradeCountMap.get(nowTimestamp) || lastTradeCount
+    );
+    const livePeriodTradeCount = liveTradeCount - lastTradeCount;
 
     // Scope all per-vault helpers to the SELECTED vault category. Without this
     // the live candle on the Pyth/SingleLeg/StrategyB tabs would silently render
@@ -297,6 +340,8 @@ export const protocolStats: NonNullable<
     results.push({
       timestamp: currentBoundary,
       cumulativeVolume: liveCumVol,
+      totalTradeCount: liveTradeCount,
+      periodTradeCount: livePeriodTradeCount,
       openInterest: oiMap.get(nowTimestamp) || '0',
       vaultBalance: liveVaultBalance.toString(),
       vaultAvailableAssets: liveVaultAvailableAssets.toString(),

--- a/packages/api/src/graphql/sdl/schema/schema.graphql
+++ b/packages/api/src/graphql/sdl/schema/schema.graphql
@@ -1447,6 +1447,12 @@ deltas over that interval.
 type ProtocolStat {
   cumulativeVolume: String!
 
+  """Cumulative count of predictions and secondary trades/sales"""
+  totalTradeCount: Int!
+
+  """Trade-count delta over the snapshot interval"""
+  periodTradeCount: Int!
+
   """Realized PnL delta over the snapshot interval"""
   periodPnL: String!
 

--- a/packages/api/test/contract/operations/protocolStats.test.ts
+++ b/packages/api/test/contract/operations/protocolStats.test.ts
@@ -18,6 +18,8 @@ const VOLATILE_LIVE_FIELDS = new Set([
   'vaultWithdrawals',
   'periodPnL',
   'periodVolume',
+  'totalTradeCount',
+  'periodTradeCount',
   'cumulativeVolume',
   'openInterest',
   'vaultPositionsWon',

--- a/packages/app/src/components/analytics/pages/AnalyticsPageContent.tsx
+++ b/packages/app/src/components/analytics/pages/AnalyticsPageContent.tsx
@@ -60,6 +60,14 @@ function formatChartValue(value: number): string {
   return formatLargeNumber(value, 1, false);
 }
 
+function formatCount(value: number): string {
+  return Math.round(value).toLocaleString();
+}
+
+function formatCountChartValue(value: number): string {
+  return formatLargeNumber(value, 1, false);
+}
+
 type AnimatedCursorProps = {
   top?: number;
   height?: number;
@@ -91,7 +99,8 @@ type ChartTooltipProps = {
   }>;
   label?: string;
   dataKey: string;
-  collateralSymbol: string;
+  collateralSymbol?: string;
+  valueFormatter?: (value: number) => string;
 };
 
 function ChartTooltip({
@@ -100,6 +109,7 @@ function ChartTooltip({
   label,
   dataKey,
   collateralSymbol,
+  valueFormatter,
 }: ChartTooltipProps): React.ReactNode {
   if (!active || !payload?.length) return null;
 
@@ -107,10 +117,12 @@ function ChartTooltip({
   if (!dataPoint || dataPoint.value == null) return null;
 
   const value = Number(dataPoint.value);
-  const formattedValue = value.toLocaleString(undefined, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  });
+  const formattedValue = valueFormatter
+    ? valueFormatter(value)
+    : value.toLocaleString(undefined, {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      });
 
   let dateLabel = '';
   if (label != null) {
@@ -138,7 +150,8 @@ function ChartTooltip({
         {dateLabel}
       </div>
       <div className="text-sm font-mono text-ethena">
-        {formattedValue} {collateralSymbol}
+        {formattedValue}
+        {collateralSymbol ? ` ${collateralSymbol}` : ''}
       </div>
     </div>
   );
@@ -188,6 +201,7 @@ function AnalyticsPageContent(): React.ReactElement {
 
   // Period states for each chart
   const [volumePeriod, setVolumePeriod] = useState<Period>('1M');
+  const [tradeCountPeriod, setTradeCountPeriod] = useState<Period>('1M');
   const [oiPeriod, setOiPeriod] = useState<Period>('1M');
   const [tvlPeriod, setTvlPeriod] = useState<Period>('1M');
 
@@ -226,6 +240,14 @@ function AnalyticsPageContent(): React.ReactElement {
     }));
   }, [protocolStats]);
 
+  const tradeCountChartData = useMemo(() => {
+    if (!protocolStats) return [];
+    return protocolStats.map((point) => ({
+      timestamp: point.timestamp,
+      tradeCount: point.periodTradeCount,
+    }));
+  }, [protocolStats]);
+
   // Aggregate sub-daily snapshots into UTC-day buckets. The cron interval is
   // configurable and often runs multiple times per day, so without this the
   // "Daily Volume" bar chart shows N bars per day instead of one.
@@ -240,6 +262,18 @@ function AnalyticsPageContent(): React.ReactElement {
       .sort(([a], [b]) => a - b)
       .map(([timestamp, volume]) => ({ timestamp, volume }));
   }, [volumeChartData, volumePeriod]);
+
+  const filteredTradeCountData = useMemo(() => {
+    const filtered = filterDataByPeriod(tradeCountChartData, tradeCountPeriod);
+    const byDay = new Map<number, number>();
+    for (const point of filtered) {
+      const dayStart = Math.floor(point.timestamp / 86400) * 86400;
+      byDay.set(dayStart, (byDay.get(dayStart) ?? 0) + point.tradeCount);
+    }
+    return [...byDay.entries()]
+      .sort(([a], [b]) => a - b)
+      .map(([timestamp, tradeCount]) => ({ timestamp, tradeCount }));
+  }, [tradeCountChartData, tradeCountPeriod]);
 
   // Bucket sub-daily snapshots into UTC days, keeping the last snapshot of
   // each day (closing value) so OI/TVL line charts render one point per day
@@ -268,7 +302,7 @@ function AnalyticsPageContent(): React.ReactElement {
         </div>
 
         {/* Summary Cards */}
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 lg:gap-8 mb-4 lg:mb-8">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-4 lg:mb-8">
           <Card className="bg-brand-black border border-brand-white/10">
             <CardContent className="p-6">
               <div className="sc-heading text-foreground mb-2 flex items-center gap-1.5">
@@ -361,6 +395,25 @@ function AnalyticsPageContent(): React.ReactElement {
               </div>
             </CardContent>
           </Card>
+
+          <Card className="bg-brand-black border border-brand-white/10">
+            <CardContent className="p-6">
+              <div className="sc-heading text-foreground mb-2">
+                Total Trades
+              </div>
+              <div className="text-2xl md:text-3xl font-mono h-9 flex items-center">
+                {isLoading ? (
+                  <div className="w-full flex justify-center pt-3">
+                    <Loader className="w-6 h-6" />
+                  </div>
+                ) : (
+                  <span className="transition-opacity duration-300">
+                    {formatCount(summary?.totalTradeCount ?? 0)}
+                  </span>
+                )}
+              </div>
+            </CardContent>
+          </Card>
         </div>
 
         {/* Charts */}
@@ -423,6 +476,71 @@ function AnalyticsPageContent(): React.ReactElement {
                           dataKey="volume"
                           fill="hsl(var(--ethena) / 0.6)"
                           name="volume"
+                        />
+                      </ComposedChart>
+                    </ResponsiveContainer>
+                  </div>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="bg-brand-black border border-brand-white/10">
+            <CardContent className="p-6">
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="sc-heading text-foreground flex items-center gap-1.5">
+                  Daily Trades
+                </h3>
+                <PeriodFilter
+                  value={tradeCountPeriod}
+                  onChange={setTradeCountPeriod}
+                />
+              </div>
+              <div className="h-[300px]">
+                {isLoading ? (
+                  <div className="flex items-center justify-center h-full">
+                    <Loader className="w-8 h-8" />
+                  </div>
+                ) : filteredTradeCountData.length === 0 ? (
+                  <div className="flex items-center justify-center h-full text-muted-foreground">
+                    No data available
+                  </div>
+                ) : (
+                  <div className="w-full h-full transition-opacity duration-300">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <ComposedChart
+                        data={filteredTradeCountData}
+                        margin={CHART_MARGIN}
+                      >
+                        <CartesianGrid
+                          strokeDasharray="3 3"
+                          stroke="hsl(var(--brand-white) / 0.1)"
+                        />
+                        <XAxis
+                          dataKey="timestamp"
+                          {...CHART_AXIS_STYLE}
+                          tickFormatter={formatTimestampTick}
+                        />
+                        <YAxis
+                          {...CHART_AXIS_STYLE}
+                          tickFormatter={formatCountChartValue}
+                          width={44}
+                          allowDecimals={false}
+                        />
+                        <Tooltip
+                          cursor={<AnimatedCursor />}
+                          content={(props) => (
+                            <ChartTooltip
+                              {...props}
+                              dataKey="tradeCount"
+                              valueFormatter={formatCount}
+                            />
+                          )}
+                        />
+                        <Bar
+                          dataKey="tradeCount"
+                          fill="hsl(var(--accent-gold) / 0.6)"
+                          name="trades"
                         />
                       </ComposedChart>
                     </ResponsiveContainer>

--- a/packages/app/src/components/analytics/pages/AnalyticsPageContent.tsx
+++ b/packages/app/src/components/analytics/pages/AnalyticsPageContent.tsx
@@ -302,10 +302,10 @@ function AnalyticsPageContent(): React.ReactElement {
         </div>
 
         {/* Summary Cards */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-4 lg:mb-8">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-4">
           <Card className="bg-brand-black border border-brand-white/10">
-            <CardContent className="p-6">
-              <div className="sc-heading text-foreground mb-2 flex items-center gap-1.5">
+            <CardContent className="px-6 py-5">
+              <div className="sc-heading text-foreground mb-1 flex items-center gap-1.5">
                 Protocol TVL
                 <Popover>
                   <PopoverTrigger asChild>
@@ -341,9 +341,9 @@ function AnalyticsPageContent(): React.ReactElement {
                   </PopoverContent>
                 </Popover>
               </div>
-              <div className="text-2xl md:text-3xl font-mono h-9 flex items-center">
+              <div className="text-xl md:text-2xl font-mono leading-tight flex items-center h-8">
                 {isLoading ? (
-                  <div className="w-full flex justify-center pt-3">
+                  <div className="w-full flex justify-center">
                     <Loader className="w-6 h-6" />
                   </div>
                 ) : (
@@ -357,13 +357,13 @@ function AnalyticsPageContent(): React.ReactElement {
           </Card>
 
           <Card className="bg-brand-black border border-brand-white/10">
-            <CardContent className="p-6">
-              <div className="sc-heading text-foreground mb-2">
+            <CardContent className="px-6 py-5">
+              <div className="sc-heading text-foreground mb-1">
                 Open Interest
               </div>
-              <div className="text-2xl md:text-3xl font-mono h-9 flex items-center">
+              <div className="text-xl md:text-2xl font-mono leading-tight flex items-center h-8">
                 {isLoading ? (
-                  <div className="w-full flex justify-center pt-3">
+                  <div className="w-full flex justify-center">
                     <Loader className="w-6 h-6" />
                   </div>
                 ) : (
@@ -377,13 +377,13 @@ function AnalyticsPageContent(): React.ReactElement {
           </Card>
 
           <Card className="bg-brand-black border border-brand-white/10">
-            <CardContent className="p-6">
-              <div className="sc-heading text-foreground mb-2">
+            <CardContent className="px-6 py-5">
+              <div className="sc-heading text-foreground mb-1">
                 Cumulative Volume
               </div>
-              <div className="text-2xl md:text-3xl font-mono h-9 flex items-center">
+              <div className="text-xl md:text-2xl font-mono leading-tight flex items-center h-8">
                 {isLoading ? (
-                  <div className="w-full flex justify-center pt-3">
+                  <div className="w-full flex justify-center">
                     <Loader className="w-6 h-6" />
                   </div>
                 ) : (
@@ -397,13 +397,13 @@ function AnalyticsPageContent(): React.ReactElement {
           </Card>
 
           <Card className="bg-brand-black border border-brand-white/10">
-            <CardContent className="p-6">
-              <div className="sc-heading text-foreground mb-2">
+            <CardContent className="px-6 py-5">
+              <div className="sc-heading text-foreground mb-1">
                 Total Trades
               </div>
-              <div className="text-2xl md:text-3xl font-mono h-9 flex items-center">
+              <div className="text-xl md:text-2xl font-mono leading-tight flex items-center h-8">
                 {isLoading ? (
-                  <div className="w-full flex justify-center pt-3">
+                  <div className="w-full flex justify-center">
                     <Loader className="w-6 h-6" />
                   </div>
                 ) : (
@@ -417,9 +417,9 @@ function AnalyticsPageContent(): React.ReactElement {
         </div>
 
         {/* Charts */}
-        <div className="space-y-4 md:space-y-8">
+        <div className="space-y-4">
           {/* Open Interest distribution: by category + by time-to-resolution */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 lg:gap-8">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
             <OpenInterestByCategoryChart />
             <OpenInterestByTimeToResolutionChart />
           </div>

--- a/packages/sdk/queries/analytics.ts
+++ b/packages/sdk/queries/analytics.ts
@@ -3,6 +3,8 @@ import { graphqlRequest } from './client/graphqlClient';
 export interface ProtocolStat {
   timestamp: number;
   cumulativeVolume: string;
+  totalTradeCount: number;
+  periodTradeCount: number;
   openInterest: string;
   vaultBalance: string;
   vaultAvailableAssets: string;
@@ -25,6 +27,8 @@ export const GET_PROTOCOL_STATS = /* GraphQL */ `
     protocolStats(vaultAddress: $vaultAddress) {
       timestamp
       cumulativeVolume
+      totalTradeCount
+      periodTradeCount
       openInterest
       vaultBalance
       vaultAvailableAssets

--- a/packages/sdk/types/graphql.ts
+++ b/packages/sdk/types/graphql.ts
@@ -1569,10 +1569,14 @@ export type ProtocolStat = {
   openInterest: Scalars['String']['output'];
   /** Realized PnL delta over the snapshot interval */
   periodPnL: Scalars['String']['output'];
+  /** Trade-count delta over the snapshot interval */
+  periodTradeCount: Scalars['Int']['output'];
   /** Cumulative-volume delta over the snapshot interval */
   periodVolume: Scalars['String']['output'];
   /** Unix epoch timestamp (seconds) aligned to the snapshot interval boundary */
   timestamp: Scalars['Int']['output'];
+  /** Cumulative count of predictions and secondary trades/sales */
+  totalTradeCount: Scalars['Int']['output'];
   vaultAirdropGains: Scalars['String']['output'];
   vaultAvailableAssets: Scalars['String']['output'];
   vaultBalance: Scalars['String']['output'];


### PR DESCRIPTION
## Summary
- add `protocolStats.totalTradeCount` and `protocolStats.periodTradeCount`
- count trades as `Prediction` rows plus `secondary_trade` executions
- add Total Trades summary card and Daily Trades chart on the analytics page

## Verification
- `pnpm --filter @sapience/api run generate-types`
- `pnpm --filter @sapience/sdk run build:lib`
- `pnpm --filter @sapience/api run lint`
- `pnpm --filter @sapience/api run type-check`
- `pnpm --filter @sapience/app run lint`
- `pnpm --filter @sapience/app run type-check`
- `pnpm --filter @sapience/sdk run lint`
- `pnpm --filter @sapience/sdk run type-check`
- `pnpm --filter @sapience/api run test -- src/graphql/sdl/resolvers/queries/analytics.test.ts test/contract/operations/protocolStats.test.ts`
- `pnpm --filter @sapience/app run test`
