### PR TITLE
fix(protocol): format ERC1271 test

### DIFF
--- a/packages/protocol/test/PredictionMarketEscrowERC1271.t.sol
+++ b/packages/protocol/test/PredictionMarketEscrowERC1271.t.sol
@@ -50,8 +50,7 @@ contract MockSmartAccount is IERC1271 {
 /// @notice Non-EIP1271 contract (no isValidSignature function)
 contract NonEIP1271Contract {
     // Intentionally empty - does not implement IERC1271
-
-    }
+}
 
 /// @notice Contract that reverts on isValidSignature
 contract RevertingEIP1271Contract is IERC1271 {


### PR DESCRIPTION
## Summary

Fixes the stale Forge formatting drift that made the staging promotion PR's `test-protocol` job fail.

The failing CI diff was in `packages/protocol/test/PredictionMarketEscrowERC1271.t.sol`: `NonEIP1271Contract` had an over-indented closing brace.

## Validation

- `git diff --check`
- Attempted `forge fmt --check`, but `forge` is not installed in this agent runtime. The patch is the exact formatting change reported by GitHub Actions in `test-protocol`.
