### PR TITLE
fix(api): map GraphQL VolumeWindow enum values in questions sort

### DIFF
--- a/packages/api/src/graphql/sdl/resolvers/queries/questions.test.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/questions.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../../core/db', () => ({
+  default: {
+    $queryRaw: vi.fn(),
+  },
+}));
+
+const { resolveVolumeKey } = await import('./questions');
+
+describe('resolveVolumeKey', () => {
+  it('maps GraphQL VolumeWindow enum values to internal volume keys', () => {
+    expect(resolveVolumeKey('oneHour')).toBe('volume1h');
+    expect(resolveVolumeKey('fourHours')).toBe('volume4h');
+    expect(resolveVolumeKey('twentyFourHours')).toBe('volume24h');
+    expect(resolveVolumeKey('sevenDays')).toBe('volume7d');
+    expect(resolveVolumeKey('oneHourFiltered')).toBe('volumeFiltered1h');
+    expect(resolveVolumeKey('fourHoursFiltered')).toBe('volumeFiltered4h');
+    expect(resolveVolumeKey('twentyFourHoursFiltered')).toBe(
+      'volumeFiltered24h'
+    );
+    expect(resolveVolumeKey('sevenDaysFiltered')).toBe('volumeFiltered7d');
+  });
+
+  it('falls back to volume24h when the window is null/undefined', () => {
+    expect(resolveVolumeKey(null)).toBe('volume24h');
+    expect(resolveVolumeKey(undefined)).toBe('volume24h');
+  });
+
+  it('falls back to volume24h for unrecognized window values', () => {
+    expect(resolveVolumeKey('1hFiltered')).toBe('volume24h');
+    expect(resolveVolumeKey('bogus')).toBe('volume24h');
+  });
+});

--- a/packages/api/src/graphql/sdl/resolvers/queries/questions.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/questions.ts
@@ -90,16 +90,27 @@ const volumeColumnFragments = {
 
 type VolumeKey = keyof typeof volumeColumnFragments;
 
+// Keys are the GraphQL `VolumeWindow` enum values exactly as they arrive in
+// the resolver (the SDK maps its friendly "1hFiltered"-style names to these
+// before sending the query). Anything unrecognized — including a missing
+// window — falls back to the all-time 24h column via `resolveVolumeKey`.
 const volumeWindowToKey: Record<string, VolumeKey> = {
-  '1h': 'volume1h',
-  '4h': 'volume4h',
-  '24h': 'volume24h',
-  '7d': 'volume7d',
-  '1hFiltered': 'volumeFiltered1h',
-  '4hFiltered': 'volumeFiltered4h',
-  '24hFiltered': 'volumeFiltered24h',
-  '7dFiltered': 'volumeFiltered7d',
+  oneHour: 'volume1h',
+  fourHours: 'volume4h',
+  twentyFourHours: 'volume24h',
+  sevenDays: 'volume7d',
+  oneHourFiltered: 'volumeFiltered1h',
+  fourHoursFiltered: 'volumeFiltered4h',
+  twentyFourHoursFiltered: 'volumeFiltered24h',
+  sevenDaysFiltered: 'volumeFiltered7d',
 };
+
+export const resolveVolumeKey = (
+  similarMarketVolumeWindow: string | null | undefined
+): VolumeKey =>
+  (similarMarketVolumeWindow != null
+    ? volumeWindowToKey[similarMarketVolumeWindow]
+    : undefined) ?? 'volume24h';
 
 const fieldByResolvedVolumeKey: Record<VolumeKey, string> = {
   volume1h: 'similarMarketVolume1h',
@@ -180,10 +191,9 @@ export const questions: NonNullable<QueryResolvers['questions']> = async (
     minSimilarMarketVolume != null ||
     maxSimilarMarketVolume != null;
 
-  const resolvedVolumeKey: VolumeKey =
-    (similarMarketVolumeWindow &&
-      volumeWindowToKey[similarMarketVolumeWindow]) ??
-    'volume24h';
+  const resolvedVolumeKey: VolumeKey = resolveVolumeKey(
+    similarMarketVolumeWindow
+  );
   const volumeFragments = volumeColumnFragments[resolvedVolumeKey];
   const useWindowedSimilarMarketVolume = similarMarketVolumeWindow != null;
 


### PR DESCRIPTION
Cherry-picks 2cb93266e (merged to main in #1703) onto staging.

The questions resolver's window->column lookup was keyed on the SDK's friendly names ("1hFiltered" etc.), but the resolver actually receives the GraphQL VolumeWindow enum values ("oneHourFiltered" etc.) — the SDK rewrites the friendly names to enum values before sending. Every lookup missed and fell back to the all-time volume24h column, so `questions(sortField: similarMarketVolume, similarMarketVolumeWindow: ...)` was always sorted/filtered by raw 24h volume regardless of the requested window.

Re-keys the map on the actual enum values and extracts `resolveVolumeKey` (now unit-tested, including the fallback path).