### PR TITLE
feat(app): let users request unlisted markets from the markets table

### DIFF
--- a/packages/api/.env.sample
+++ b/packages/api/.env.sample
@@ -3,6 +3,9 @@ DATABASE_URL=postgresql://user:password@localhost:5432/development
 INFURA_API_KEY=
 ALLOWED_ADDRESSES=
 DISCORD_WEBHOOK_URLS=
+# Optional: dedicated webhook for user market requests. Falls back to the first
+# DISCORD_WEBHOOK_URLS entry when unset.
+DISCORD_MARKET_REQUEST_WEBHOOK_URL=
 SENTRY_AUTH_TOKEN=
 IPINFO_TOKEN=
 API_ACCESS_TOKEN=

--- a/packages/api/src/routes/index.ts
+++ b/packages/api/src/routes/index.ts
@@ -5,6 +5,7 @@ import { router as conditionsRoutes } from './conditions';
 import { router as conditionGroupsRoutes } from './conditionGroups';
 import { router as referralsRoutes } from './referrals';
 import { router as tokenlistRoutes } from './tokenlist';
+import { router as marketRequestsRoutes } from './marketRequests';
 
 const router = Router();
 const adminRouter = Router();
@@ -14,6 +15,7 @@ adminRouter.use(adminAuth);
 
 router.use('/', tokenlistRoutes);
 router.use('/referrals', referralsRoutes);
+router.use('/market-requests', marketRequestsRoutes);
 
 adminRouter.use('/reindex', reindexRoutes);
 adminRouter.use('/conditions', conditionsRoutes);

--- a/packages/api/src/routes/marketRequests.test.ts
+++ b/packages/api/src/routes/marketRequests.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before the router import
+// ---------------------------------------------------------------------------
+
+const mockSendMarketRequestAlert = vi.fn();
+const mockHasMarketRequestWebhook = vi.fn();
+
+vi.mock('../services/marketRequestAlert', () => ({
+  sendMarketRequestAlert: (...args: unknown[]) =>
+    mockSendMarketRequestAlert(...args),
+  hasMarketRequestWebhook: () => mockHasMarketRequestWebhook(),
+  MAX_TICKER_LENGTH: 64,
+  MAX_NOTE_LENGTH: 280,
+}));
+
+vi.mock('../core/logger', () => ({
+  createLogger: () => ({
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import { router } from './marketRequests';
+
+const app = express();
+app.use(express.json());
+app.use('/market-requests', router);
+
+describe('POST /market-requests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHasMarketRequestWebhook.mockReturnValue(true);
+    mockSendMarketRequestAlert.mockReturnValue(true);
+  });
+
+  it('rejects a request without a ticker', async () => {
+    const res = await request(app).post('/market-requests').send({});
+    expect(res.status).toBe(400);
+    expect(mockSendMarketRequestAlert).not.toHaveBeenCalled();
+  });
+
+  it('rejects an over-long ticker', async () => {
+    const res = await request(app)
+      .post('/market-requests')
+      .send({ ticker: 'X'.repeat(65) });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a non-polymarket URL', async () => {
+    const res = await request(app)
+      .post('/market-requests')
+      .send({ ticker: 'SUGAR', polymarketUrl: 'https://evil.example.com/x' });
+    expect(res.status).toBe(400);
+    expect(mockSendMarketRequestAlert).not.toHaveBeenCalled();
+  });
+
+  it('accepts a valid request and forwards it to the alert service', async () => {
+    const res = await request(app).post('/market-requests').send({
+      ticker: '  SUGAR  ',
+      polymarketUrl: 'https://polymarket.com/event/sugar-price',
+      walletAddress: '0x1111111111111111111111111111111111111111',
+      note: 'please list this',
+    });
+
+    expect(res.status).toBe(202);
+    expect(res.body).toEqual({ delivered: true });
+    expect(mockSendMarketRequestAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ticker: 'SUGAR',
+        polymarketUrl: 'https://polymarket.com/event/sugar-price',
+        walletAddress: '0x1111111111111111111111111111111111111111',
+        note: 'please list this',
+      })
+    );
+  });
+
+  it('drops a bad wallet address but still accepts the request', async () => {
+    const res = await request(app)
+      .post('/market-requests')
+      .send({ ticker: 'SUGAR', walletAddress: 'not-an-address' });
+
+    expect(res.status).toBe(202);
+    expect(mockSendMarketRequestAlert).toHaveBeenCalledWith(
+      expect.objectContaining({ ticker: 'SUGAR', walletAddress: null })
+    );
+  });
+
+  it('returns 202 delivered:false when no webhook is configured', async () => {
+    mockHasMarketRequestWebhook.mockReturnValue(false);
+    const res = await request(app)
+      .post('/market-requests')
+      .send({ ticker: 'SUGAR' });
+
+    expect(res.status).toBe(202);
+    expect(res.body).toEqual({ delivered: false });
+    expect(mockSendMarketRequestAlert).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/routes/marketRequests.ts
+++ b/packages/api/src/routes/marketRequests.ts
@@ -1,0 +1,97 @@
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { isAddress } from 'viem';
+import { createLogger } from '../core/logger';
+import {
+  hasMarketRequestWebhook,
+  sendMarketRequestAlert,
+  MAX_TICKER_LENGTH,
+  MAX_NOTE_LENGTH,
+} from '../services/marketRequestAlert';
+
+const log = createLogger('routes.marketRequests');
+
+const router = Router();
+
+type MarketRequestBody = {
+  ticker?: string;
+  polymarketUrl?: string;
+  note?: string;
+  walletAddress?: string;
+};
+
+/** Accept polymarket.com (and its subdomains) links only. */
+function normalizePolymarketUrl(raw: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw.trim());
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return null;
+  const host = parsed.hostname.toLowerCase();
+  if (host !== 'polymarket.com' && !host.endsWith('.polymarket.com')) {
+    return null;
+  }
+  return parsed.toString();
+}
+
+// POST /market-requests - user requests a market/ticker that isn't listed yet
+router.post('/', async (req: Request, res: Response) => {
+  const body = (req.body ?? {}) as MarketRequestBody;
+
+  const ticker = typeof body.ticker === 'string' ? body.ticker.trim() : '';
+  if (!ticker) {
+    return res.status(400).json({ message: 'ticker is required' });
+  }
+  if (ticker.length > MAX_TICKER_LENGTH) {
+    return res
+      .status(400)
+      .json({ message: `ticker must be ${MAX_TICKER_LENGTH} chars or fewer` });
+  }
+
+  let polymarketUrl: string | null = null;
+  if (typeof body.polymarketUrl === 'string' && body.polymarketUrl.trim()) {
+    polymarketUrl = normalizePolymarketUrl(body.polymarketUrl);
+    if (!polymarketUrl) {
+      return res
+        .status(400)
+        .json({ message: 'polymarketUrl must be a valid polymarket.com link' });
+    }
+  }
+
+  let note: string | null = null;
+  if (typeof body.note === 'string' && body.note.trim()) {
+    note = body.note.trim().slice(0, MAX_NOTE_LENGTH);
+  }
+
+  let walletAddress: string | null = null;
+  if (typeof body.walletAddress === 'string' && body.walletAddress.trim()) {
+    walletAddress = isAddress(body.walletAddress.trim())
+      ? body.walletAddress.trim()
+      : null;
+  }
+
+  if (!hasMarketRequestWebhook()) {
+    // Not configured — accept silently so the client UX still works in dev.
+    log.warn(
+      '[marketRequests] No Discord webhook configured; dropping request'
+    );
+    return res.status(202).json({ delivered: false });
+  }
+
+  try {
+    const delivered = sendMarketRequestAlert({
+      ticker,
+      polymarketUrl,
+      note,
+      walletAddress,
+    });
+    return res.status(202).json({ delivered });
+  } catch (e) {
+    log.error({ err: e }, 'Error sending market request alert');
+    return res.status(500).json({ message: 'Internal Server Error' });
+  }
+});
+
+export { router };

--- a/packages/api/src/services/marketRequestAlert.test.ts
+++ b/packages/api/src/services/marketRequestAlert.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildMarketRequestEmbed,
+  sendMarketRequestAlert,
+  hasMarketRequestWebhook,
+} from './marketRequestAlert';
+
+describe('marketRequestAlert', () => {
+  describe('buildMarketRequestEmbed', () => {
+    it('puts the ticker in the description', () => {
+      const embed = buildMarketRequestEmbed({ ticker: 'SUGAR' }) as {
+        description: string;
+        fields: unknown[];
+      };
+      expect(embed.description).toContain('SUGAR');
+      expect(embed.fields).toEqual([]);
+    });
+
+    it('includes optional polymarket link, note and wallet as fields', () => {
+      const embed = buildMarketRequestEmbed({
+        ticker: 'SUGAR',
+        polymarketUrl: 'https://polymarket.com/event/sugar',
+        note: 'pls',
+        walletAddress: '0xabc',
+      }) as { fields: Array<{ name: string; value: string }> };
+
+      const values = embed.fields.map((f) => f.value);
+      expect(values).toContain('https://polymarket.com/event/sugar');
+      expect(values).toContain('pls');
+      expect(values.some((v) => v.includes('0xabc'))).toBe(true);
+    });
+  });
+
+  describe('sendMarketRequestAlert', () => {
+    it('returns false when no webhook is configured (test env)', () => {
+      // No DISCORD_* env vars set in the test environment.
+      expect(hasMarketRequestWebhook()).toBe(false);
+      expect(sendMarketRequestAlert({ ticker: 'SUGAR' })).toBe(false);
+    });
+  });
+});

--- a/packages/api/src/services/marketRequestAlert.ts
+++ b/packages/api/src/services/marketRequestAlert.ts
@@ -1,0 +1,165 @@
+/**
+ * Discord webhook notifications for user-submitted market requests.
+ *
+ * When a user searches for a ticker/market that isn't listed yet, the app lets
+ * them request it. Each request is posted to a Discord channel so the team can
+ * triage and list it.
+ *
+ * Design constraints (mirrors `discordAlert`):
+ * - Fire-and-forget: never blocks the request handler
+ * - 5s timeout per webhook call
+ * - Rate limited: max 20 requests per 60s window (global, best-effort)
+ */
+import { createLogger } from '../core/logger';
+
+const log = createLogger('services.marketRequestAlert');
+
+const WEBHOOK_PREFIX = 'https://discord.com/api/webhooks/';
+
+/**
+ * Dedicated webhook for market requests. Falls back to the first configured
+ * position-alert webhook so a single env var is enough in simple deployments.
+ */
+const MARKET_REQUEST_WEBHOOK_URLS: string[] = (
+  process.env.DISCORD_MARKET_REQUEST_WEBHOOK_URL ||
+  process.env.DISCORD_WEBHOOK_URLS ||
+  ''
+)
+  .split(',')
+  .map((u) => u.trim())
+  .filter((u) => {
+    if (!u) return false;
+    if (!u.startsWith(WEBHOOK_PREFIX)) {
+      log.warn(
+        `[marketRequestAlert] Ignoring invalid webhook URL (must start with ${WEBHOOK_PREFIX})`
+      );
+      return false;
+    }
+    return true;
+  });
+
+// Rate limiting state (best-effort, per-process)
+const requestTimestamps: number[] = [];
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 20;
+
+export const MAX_TICKER_LENGTH = 64;
+export const MAX_NOTE_LENGTH = 280;
+
+export interface MarketRequestData {
+  /** Free-text ticker / market name the user searched for */
+  ticker: string;
+  /** Optional Polymarket URL the user supplied so we can mirror the exact market */
+  polymarketUrl?: string | null;
+  /** Optional note from the user */
+  note?: string | null;
+  /** Optional wallet address of the requester */
+  walletAddress?: string | null;
+}
+
+function isRateLimited(): boolean {
+  const now = Date.now();
+  while (
+    requestTimestamps.length > 0 &&
+    requestTimestamps[0] < now - RATE_LIMIT_WINDOW_MS
+  ) {
+    requestTimestamps.shift();
+  }
+  return requestTimestamps.length >= RATE_LIMIT_MAX;
+}
+
+function recordRequest(): void {
+  requestTimestamps.push(Date.now());
+}
+
+/** Reset rate limiter state (for testing only). */
+export function _resetRateLimiter(): void {
+  requestTimestamps.length = 0;
+}
+
+/** True when at least one valid webhook URL is configured. */
+export function hasMarketRequestWebhook(): boolean {
+  return MARKET_REQUEST_WEBHOOK_URLS.length > 0;
+}
+
+/**
+ * Build the Discord embed payload for a market request.
+ * Exported for testing.
+ */
+export function buildMarketRequestEmbed(data: MarketRequestData): object {
+  const fields: Array<{ name: string; value: string; inline: boolean }> = [];
+
+  if (data.polymarketUrl) {
+    fields.push({
+      name: '🔗 Polymarket',
+      value: data.polymarketUrl,
+      inline: false,
+    });
+  }
+  if (data.note) {
+    fields.push({ name: '📝 Note', value: data.note, inline: false });
+  }
+  if (data.walletAddress) {
+    fields.push({
+      name: '👤 Requested by',
+      value: `\`${data.walletAddress}\``,
+      inline: false,
+    });
+  }
+
+  return {
+    title: '🆕 Market Request',
+    description: `**${data.ticker}**`,
+    color: 0x7c3aed,
+    fields,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+/**
+ * Send a market request notification to Discord. Fire-and-forget.
+ * Returns `true` if the request was accepted for delivery, `false` if it was
+ * dropped (no webhook configured or rate limited).
+ */
+export function sendMarketRequestAlert(data: MarketRequestData): boolean {
+  if (MARKET_REQUEST_WEBHOOK_URLS.length === 0) return false;
+
+  if (isRateLimited()) {
+    log.warn('[marketRequestAlert] Rate limited, dropping market request');
+    return false;
+  }
+
+  recordRequest();
+
+  const embed = buildMarketRequestEmbed(data);
+  const payload = JSON.stringify({ embeds: [embed] });
+
+  for (const url of MARKET_REQUEST_WEBHOOK_URLS) {
+    fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: payload,
+      signal: AbortSignal.timeout(5000),
+    })
+      .then((res) => {
+        if (!res.ok) {
+          res
+            .text()
+            .then((body) => {
+              log.error(
+                `[marketRequestAlert] Webhook HTTP ${res.status}: ${body.slice(0, 200)}`
+              );
+            })
+            .catch(() => {});
+        }
+      })
+      .catch((err) => {
+        log.error(
+          `[marketRequestAlert] Webhook failed (network):`,
+          err?.message || err
+        );
+      });
+  }
+
+  return true;
+}

--- a/packages/app/src/components/markets/MarketsPage.tsx
+++ b/packages/app/src/components/markets/MarketsPage.tsx
@@ -437,6 +437,7 @@ const MarketsPage = () => {
                     onVolumeWindowChange={setVolumeWindow}
                     filterVolume={filterVolume}
                     onFilterVolumeChange={setFilterVolume}
+                    searchTerm={searchTerm}
                   />
                 </div>
               )}

--- a/packages/app/src/components/markets/QuestionsTable.tsx
+++ b/packages/app/src/components/markets/QuestionsTable.tsx
@@ -40,6 +40,7 @@ import {
 import { cn } from '@sapience/ui/lib/utils';
 import Loader from '../shared/Loader';
 import { PythMarketBadge } from '../shared/PythMarketBadge';
+import RequestMarketPanel from '../shared/RequestMarketPanel';
 import ConditionTitleLink from './ConditionTitleLink';
 import MarketBadge from './MarketBadge';
 import TableFilters, {
@@ -95,6 +96,10 @@ interface QuestionsTableProps {
   // Filter volume toggle (excludes extreme-odds trades from sorted volume)
   filterVolume: boolean;
   onFilterVolumeChange: (v: boolean) => void;
+
+  // Current text search — used to offer a "request this market" prompt in the
+  // empty state when nothing matches.
+  searchTerm?: string;
 }
 
 // Class name maps for table headers and cells
@@ -777,6 +782,7 @@ export default function QuestionsTable({
   onVolumeWindowChange,
   filterVolume,
   onFilterVolumeChange,
+  searchTerm,
 }: QuestionsTableProps) {
   // Derive volume metric from the persisted sortField so the dropdown and
   // column header stay in sync with the actual sort on reload.
@@ -1053,9 +1059,9 @@ export default function QuestionsTable({
               <TableRow className="hover:bg-transparent">
                 <TableCell
                   colSpan={columns.length}
-                  className="h-24 text-center text-muted-foreground"
+                  className="text-center text-muted-foreground"
                 >
-                  No results found.
+                  <RequestMarketPanel ticker={searchTerm ?? ''} />
                 </TableCell>
               </TableRow>
             )}

--- a/packages/app/src/components/shared/RequestMarketPanel.tsx
+++ b/packages/app/src/components/shared/RequestMarketPanel.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import * as React from 'react';
+import { useAccount } from 'wagmi';
+import { Loader2, Check, AlertCircle } from 'lucide-react';
+import { Button } from '@sapience/ui/components/ui/button';
+import { Input } from '@sapience/ui/components/ui/input';
+import { Label } from '@sapience/ui/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@sapience/ui/components/ui/dialog';
+import { useRequestMarket } from '~/hooks/markets/useRequestMarket';
+
+function looksLikePolymarketUrl(value: string): boolean {
+  const v = value.trim();
+  if (!v) return true; // empty is fine (optional)
+  try {
+    const url = new URL(v);
+    const host = url.hostname.toLowerCase();
+    return host === 'polymarket.com' || host.endsWith('.polymarket.com');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Shown in the questions-table empty state: a short "we haven't listed this yet"
+ * message plus a button that opens a dialog where the user can name the market
+ * (prefilled with their search) and optionally attach a Polymarket link.
+ * Submitting pings the team via Discord (handled API-side).
+ */
+export default function RequestMarketPanel({ ticker }: { ticker: string }) {
+  const { address } = useAccount();
+  const { mutate, status, reset } = useRequestMarket();
+  const [open, setOpen] = React.useState(false);
+  const [market, setMarket] = React.useState(ticker);
+  const [polymarketUrl, setPolymarketUrl] = React.useState('');
+
+  const trimmedTicker = ticker.trim();
+
+  // Reset the dialog state whenever the user opens it (so a fresh search term
+  // prefills the field and any previous result/error is cleared).
+  React.useEffect(() => {
+    if (open) {
+      reset();
+      setMarket(ticker);
+      setPolymarketUrl('');
+    }
+  }, [open, ticker, reset]);
+
+  const trimmedMarket = market.trim();
+  const urlValid = looksLikePolymarketUrl(polymarketUrl);
+  const isSubmitting = status === 'pending';
+  const canSubmit = !!trimmedMarket && urlValid && !isSubmitting;
+
+  return (
+    <>
+      <div className="flex flex-col items-center gap-3 px-4 py-12 text-center">
+        <p className="text-sm text-muted-foreground">
+          {trimmedTicker ? (
+            <>
+              Oops, looks like we haven&apos;t listed{' '}
+              <span className="font-mono text-brand-white">
+                {trimmedTicker}
+              </span>{' '}
+              yet.
+            </>
+          ) : (
+            <>No results found.</>
+          )}
+        </p>
+        <Button size="sm" onClick={() => setOpen(true)}>
+          Request {trimmedTicker || 'a market'}
+        </Button>
+      </div>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-[420px]">
+          {status === 'success' ? (
+            <div className="flex flex-col items-center gap-3 py-6 text-center">
+              <Check className="h-6 w-6 text-emerald-500" />
+              <p className="text-sm text-muted-foreground">
+                Thanks — we&apos;ll take a look at{' '}
+                <span className="font-mono text-brand-white">
+                  {trimmedMarket}
+                </span>
+                .
+              </p>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setOpen(false)}
+              >
+                Close
+              </Button>
+            </div>
+          ) : (
+            <>
+              <DialogHeader>
+                <DialogTitle>Request a Market</DialogTitle>
+                <DialogDescription>
+                  Tell us what you&apos;d like to predict on and we&apos;ll take
+                  a look.
+                </DialogDescription>
+              </DialogHeader>
+
+              <div className="flex flex-col gap-4 py-2">
+                <div className="flex flex-col gap-1.5 pb-2">
+                  <Label htmlFor="request-market-name">Market</Label>
+                  <Input
+                    id="request-market-name"
+                    autoFocus
+                    value={market}
+                    onChange={(e) => setMarket(e.target.value)}
+                    placeholder="e.g. BTC above $150k by end of year"
+                  />
+                </div>
+
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="request-market-link">
+                    Polymarket Link{' '}
+                    <span className="font-normal text-muted-foreground">
+                      (optional)
+                    </span>
+                  </Label>
+                  <Input
+                    id="request-market-link"
+                    value={polymarketUrl}
+                    onChange={(e) => setPolymarketUrl(e.target.value)}
+                    placeholder="https://polymarket.com/event/..."
+                    aria-invalid={!urlValid}
+                  />
+                  {!urlValid && (
+                    <span className="text-xs text-destructive">
+                      Enter a valid polymarket.com link, or leave it blank.
+                    </span>
+                  )}
+                </div>
+
+                {status === 'error' && (
+                  <span className="inline-flex items-center gap-1 text-xs text-destructive">
+                    <AlertCircle className="h-3 w-3" />
+                    Something went wrong. Try again.
+                  </span>
+                )}
+              </div>
+
+              <DialogFooter>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setOpen(false)}
+                  disabled={isSubmitting}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  size="sm"
+                  disabled={!canSubmit}
+                  onClick={() =>
+                    mutate({
+                      ticker: trimmedMarket,
+                      polymarketUrl: polymarketUrl.trim() || undefined,
+                      walletAddress: address,
+                    })
+                  }
+                >
+                  {isSubmitting ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Requesting…
+                    </>
+                  ) : (
+                    'Submit Request'
+                  )}
+                </Button>
+              </DialogFooter>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/packages/app/src/hooks/markets/useRequestMarket.ts
+++ b/packages/app/src/hooks/markets/useRequestMarket.ts
@@ -1,0 +1,70 @@
+'use client';
+
+import { useMutation, type UseMutationResult } from '@tanstack/react-query';
+
+function getPublicApiBaseUrl(): string {
+  return process.env.NEXT_PUBLIC_FOIL_API_URL || 'https://api.sapience.xyz';
+}
+
+export class MarketRequestApiError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'MarketRequestApiError';
+    this.status = status;
+  }
+}
+
+export type RequestMarketInput = {
+  /** The ticker / market name the user searched for */
+  ticker: string;
+  /** Optional Polymarket URL so the team can mirror the exact market */
+  polymarketUrl?: string;
+  /** Optional free-text note */
+  note?: string;
+  /** Optional connected wallet address */
+  walletAddress?: string;
+};
+
+export type RequestMarketResponse = {
+  delivered: boolean;
+};
+
+export function useRequestMarket(): UseMutationResult<
+  RequestMarketResponse,
+  Error,
+  RequestMarketInput
+> {
+  return useMutation<RequestMarketResponse, Error, RequestMarketInput>({
+    mutationFn: async (input) => {
+      const res = await fetch(`${getPublicApiBaseUrl()}/market-requests`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ticker: input.ticker,
+          ...(input.polymarketUrl
+            ? { polymarketUrl: input.polymarketUrl }
+            : {}),
+          ...(input.note ? { note: input.note } : {}),
+          ...(input.walletAddress
+            ? { walletAddress: input.walletAddress }
+            : {}),
+        }),
+      });
+
+      if (!res.ok) {
+        let message = 'Failed to submit market request';
+        try {
+          const data = (await res.json()) as { message?: string };
+          if (data?.message) message = data.message;
+        } catch {
+          /* ignore parse errors */
+        }
+        throw new MarketRequestApiError(res.status, message);
+      }
+
+      return (await res.json()) as RequestMarketResponse;
+    },
+  });
+}


### PR DESCRIPTION
## What

Adds a **Request a Market** flow surfaced in the questions-table empty state.

- When a search returns no markets, the empty state offers a `Request <query>` button.
- Clicking it opens a dialog with:
  - **Market** — pre-filled with the search term, editable
  - **Polymarket Link** — optional, validated against `polymarket.com`
- Submitting POSTs to a new `/market-requests` API route, which validates input, rate-limits (20/min, best-effort), and forwards a Discord embed.

## Discord webhook

The alert is sent via `DISCORD_MARKET_REQUEST_WEBHOOK_URL`. If that's unset it falls back to the first entry in `DISCORD_WEBHOOK_URLS` — i.e. it lands in the same channel as new-prediction alerts with zero extra config. Added to `.env.sample`.

## Notes

- The CommandMenu empty state is unchanged (`No results found.`).
- One commit, based on latest `staging`.