### PR TITLE
feat(app): skip invite-code requirement on staging

### DIFF
--- a/packages/app/src/components/layout/ConnectDialog.tsx
+++ b/packages/app/src/components/layout/ConnectDialog.tsx
@@ -11,13 +11,20 @@ import {
 } from '@sapience/ui/components/ui/dialog';
 import { Button } from '@sapience/ui/components/ui/button';
 import { Wallet } from 'lucide-react';
+import {
+  CHAIN_ID_ETHEREAL_TESTNET,
+  DEFAULT_CHAIN_ID,
+} from '@sapience/sdk/constants';
+import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
 import { useAuth } from '~/lib/context/AuthContext';
 import { useSession } from '~/lib/context/SessionContext';
 import {
   useSettings,
   DEFAULT_CONNECTION_DURATION_HOURS,
 } from '~/lib/context/SettingsContext';
-import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
+
+// On staging (Ethereal Testnet) we don't gate access behind an invite code.
+const IS_STAGING = DEFAULT_CHAIN_ID === CHAIN_ID_ETHEREAL_TESTNET;
 
 const USER_REFERRAL_STATUS_QUERY = `
   query UserReferralStatus($wallet: String!) {
@@ -243,44 +250,47 @@ export default function ConnectDialog({
       const createSessionAsync = async () => {
         try {
           const currentAddress = address.toLowerCase();
-          let hasReferral = false;
+          // Staging skips the invite-code gate entirely.
+          let hasReferral = IS_STAGING;
 
-          try {
-            const data = await graphqlRequest<{
-              user: {
-                address: string;
-                refCodeHash?: string | null;
-                referredBy?: { id: number } | null;
-                referredByCode?: { id: number } | null;
-              } | null;
-            }>(USER_REFERRAL_STATUS_QUERY, { wallet: currentAddress });
-
-            const user = data?.user;
-            hasReferral = !!(
-              user &&
-              (user.refCodeHash || user.referredBy || user.referredByCode)
-            );
-
-            console.debug('[ConnectDialog] Referral check:', {
-              currentAddress,
-              hasReferral,
-              refCodeHash: user?.refCodeHash,
-              referredBy: user?.referredBy,
-              referredByCode: user?.referredByCode,
-            });
-          } catch (error) {
-            console.error(
-              '[ConnectDialog] Failed to check referral status:',
-              error
-            );
-            // On error, check localStorage fallback (same logic as Header)
+          if (!IS_STAGING) {
             try {
-              const key = `sapience:referralCode:${currentAddress}`;
-              const existing = window.localStorage.getItem(key);
-              hasReferral = !!existing;
-            } catch {
-              // If localStorage fails, assume no referral
-              hasReferral = false;
+              const data = await graphqlRequest<{
+                user: {
+                  address: string;
+                  refCodeHash?: string | null;
+                  referredBy?: { id: number } | null;
+                  referredByCode?: { id: number } | null;
+                } | null;
+              }>(USER_REFERRAL_STATUS_QUERY, { wallet: currentAddress });
+
+              const user = data?.user;
+              hasReferral = !!(
+                user &&
+                (user.refCodeHash || user.referredBy || user.referredByCode)
+              );
+
+              console.debug('[ConnectDialog] Referral check:', {
+                currentAddress,
+                hasReferral,
+                refCodeHash: user?.refCodeHash,
+                referredBy: user?.referredBy,
+                referredByCode: user?.referredByCode,
+              });
+            } catch (error) {
+              console.error(
+                '[ConnectDialog] Failed to check referral status:',
+                error
+              );
+              // On error, check localStorage fallback (same logic as Header)
+              try {
+                const key = `sapience:referralCode:${currentAddress}`;
+                const existing = window.localStorage.getItem(key);
+                hasReferral = !!existing;
+              } catch {
+                // If localStorage fails, assume no referral
+                hasReferral = false;
+              }
             }
           }
 

--- a/packages/app/src/components/layout/Header.tsx
+++ b/packages/app/src/components/layout/Header.tsx
@@ -40,6 +40,10 @@ import { SiSubstack } from 'react-icons/si';
 
 import { useEffect, useRef, useState } from 'react';
 import { useDisconnect } from 'wagmi';
+import {
+  CHAIN_ID_ETHEREAL_TESTNET,
+  DEFAULT_CHAIN_ID,
+} from '@sapience/sdk/constants';
 import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
 import CollateralBalanceButton from './CollateralBalanceButton';
 import { useConnectedWallet } from '~/hooks/useConnectedWallet';
@@ -70,6 +74,9 @@ const USER_REFERRAL_STATUS_QUERY = `
     }
   }
 `;
+
+// On staging (Ethereal Testnet) we don't gate access behind an invite code.
+const IS_STAGING = DEFAULT_CHAIN_ID === CHAIN_ID_ETHEREAL_TESTNET;
 
 const isActive = (path: string, pathname: string) => {
   if (path === '/') {
@@ -320,6 +327,12 @@ const Header = () => {
     let cancelled = false;
 
     const run = async () => {
+      // Staging skips the invite-code gate entirely.
+      if (IS_STAGING) {
+        setIsReferralRequiredOpen(false);
+        return;
+      }
+
       if (!ready || !hasConnectedWallet || !connectedWallet?.address) {
         setIsReferralRequiredOpen(false);
         lastWalletAddressRef.current = null;


### PR DESCRIPTION
## What

On the **staging** environment (Ethereal Testnet), the app now bypasses the invite/referral-code gate so testers don't need a code to use the app.

## How

Staging is detected the same way `SettingsContext` already does it: `DEFAULT_CHAIN_ID === CHAIN_ID_ETHEREAL_TESTNET` (both from `@sapience/sdk/constants`), which is driven by `NEXT_PUBLIC_DEFAULT_CHAIN_ID`.

- `Header.tsx` — the blocking `RequiredReferralCodeDialog` is never opened on staging.
- `ConnectDialog.tsx` — the auto session-creation flow treats the wallet as having a referral on staging, so it proceeds straight to `startSession()` instead of deferring to the refcode dialog.

Non-staging behavior is unchanged.

## Notes

This is a frontend-only bypass. If the API independently enforces a referral on testnet, that would need a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)