### PR TITLE
feat(app): close market-request dialog on submit, confirm via toast

### DIFF
--- a/packages/app/src/components/shared/RequestMarketPanel.tsx
+++ b/packages/app/src/components/shared/RequestMarketPanel.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { useAccount } from 'wagmi';
-import { Loader2, Check, AlertCircle } from 'lucide-react';
+import { Loader2, AlertCircle } from 'lucide-react';
 import { Button } from '@sapience/ui/components/ui/button';
 import { Input } from '@sapience/ui/components/ui/input';
 import { Label } from '@sapience/ui/components/ui/label';
@@ -14,6 +14,7 @@ import {
   DialogDescription,
   DialogFooter,
 } from '@sapience/ui/components/ui/dialog';
+import { useToast } from '@sapience/ui/hooks/use-toast';
 import { useRequestMarket } from '~/hooks/markets/useRequestMarket';
 
 function looksLikePolymarketUrl(value: string): boolean {
@@ -32,10 +33,12 @@ function looksLikePolymarketUrl(value: string): boolean {
  * Shown in the questions-table empty state: a short "we haven't listed this yet"
  * message plus a button that opens a dialog where the user can name the market
  * (prefilled with their search) and optionally attach a Polymarket link.
- * Submitting pings the team via Discord (handled API-side).
+ * Submitting pings the team via Discord (handled API-side); on success the
+ * dialog closes and a toast confirms the request.
  */
 export default function RequestMarketPanel({ ticker }: { ticker: string }) {
   const { address } = useAccount();
+  const { toast } = useToast();
   const { mutate, status, reset } = useRequestMarket();
   const [open, setOpen] = React.useState(false);
   const [market, setMarket] = React.useState(ticker);
@@ -44,7 +47,7 @@ export default function RequestMarketPanel({ ticker }: { ticker: string }) {
   const trimmedTicker = ticker.trim();
 
   // Reset the dialog state whenever the user opens it (so a fresh search term
-  // prefills the field and any previous result/error is cleared).
+  // prefills the field and any previous error is cleared).
   React.useEffect(() => {
     if (open) {
       reset();
@@ -57,6 +60,28 @@ export default function RequestMarketPanel({ ticker }: { ticker: string }) {
   const urlValid = looksLikePolymarketUrl(polymarketUrl);
   const isSubmitting = status === 'pending';
   const canSubmit = !!trimmedMarket && urlValid && !isSubmitting;
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    const requested = trimmedMarket;
+    mutate(
+      {
+        ticker: requested,
+        polymarketUrl: polymarketUrl.trim() || undefined,
+        walletAddress: address,
+      },
+      {
+        onSuccess: () => {
+          setOpen(false);
+          toast({
+            title: 'Request received',
+            description: `Thanks — we'll take a look at ${requested}.`,
+            duration: 5000,
+          });
+        },
+      }
+    );
+  };
 
   return (
     <>
@@ -81,107 +106,75 @@ export default function RequestMarketPanel({ ticker }: { ticker: string }) {
 
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent className="sm:max-w-[420px]">
-          {status === 'success' ? (
-            <div className="flex flex-col items-center gap-3 py-6 text-center">
-              <Check className="h-6 w-6 text-emerald-500" />
-              <p className="text-sm text-muted-foreground">
-                Thanks — we&apos;ll take a look at{' '}
-                <span className="font-mono text-brand-white">
-                  {trimmedMarket}
-                </span>
-                .
-              </p>
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => setOpen(false)}
-              >
-                Close
-              </Button>
+          <DialogHeader>
+            <DialogTitle>Request a Market</DialogTitle>
+            <DialogDescription>
+              Tell us what you&apos;d like to predict on and we&apos;ll take a
+              look.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-4 py-2">
+            <div className="flex flex-col gap-1.5 pb-2">
+              <Label htmlFor="request-market-name">Market</Label>
+              <Input
+                id="request-market-name"
+                autoFocus
+                value={market}
+                onChange={(e) => setMarket(e.target.value)}
+                placeholder="e.g. BTC above $150k by end of year"
+              />
             </div>
-          ) : (
-            <>
-              <DialogHeader>
-                <DialogTitle>Request a Market</DialogTitle>
-                <DialogDescription>
-                  Tell us what you&apos;d like to predict on and we&apos;ll take
-                  a look.
-                </DialogDescription>
-              </DialogHeader>
 
-              <div className="flex flex-col gap-4 py-2">
-                <div className="flex flex-col gap-1.5 pb-2">
-                  <Label htmlFor="request-market-name">Market</Label>
-                  <Input
-                    id="request-market-name"
-                    autoFocus
-                    value={market}
-                    onChange={(e) => setMarket(e.target.value)}
-                    placeholder="e.g. BTC above $150k by end of year"
-                  />
-                </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="request-market-link">
+                Polymarket Link{' '}
+                <span className="font-normal text-muted-foreground">
+                  (optional)
+                </span>
+              </Label>
+              <Input
+                id="request-market-link"
+                value={polymarketUrl}
+                onChange={(e) => setPolymarketUrl(e.target.value)}
+                placeholder="https://polymarket.com/event/..."
+                aria-invalid={!urlValid}
+              />
+              {!urlValid && (
+                <span className="text-xs text-destructive">
+                  Enter a valid polymarket.com link, or leave it blank.
+                </span>
+              )}
+            </div>
 
-                <div className="flex flex-col gap-1.5">
-                  <Label htmlFor="request-market-link">
-                    Polymarket Link{' '}
-                    <span className="font-normal text-muted-foreground">
-                      (optional)
-                    </span>
-                  </Label>
-                  <Input
-                    id="request-market-link"
-                    value={polymarketUrl}
-                    onChange={(e) => setPolymarketUrl(e.target.value)}
-                    placeholder="https://polymarket.com/event/..."
-                    aria-invalid={!urlValid}
-                  />
-                  {!urlValid && (
-                    <span className="text-xs text-destructive">
-                      Enter a valid polymarket.com link, or leave it blank.
-                    </span>
-                  )}
-                </div>
+            {status === 'error' && (
+              <span className="inline-flex items-center gap-1 text-xs text-destructive">
+                <AlertCircle className="h-3 w-3" />
+                Something went wrong. Try again.
+              </span>
+            )}
+          </div>
 
-                {status === 'error' && (
-                  <span className="inline-flex items-center gap-1 text-xs text-destructive">
-                    <AlertCircle className="h-3 w-3" />
-                    Something went wrong. Try again.
-                  </span>
-                )}
-              </div>
-
-              <DialogFooter>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setOpen(false)}
-                  disabled={isSubmitting}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  size="sm"
-                  disabled={!canSubmit}
-                  onClick={() =>
-                    mutate({
-                      ticker: trimmedMarket,
-                      polymarketUrl: polymarketUrl.trim() || undefined,
-                      walletAddress: address,
-                    })
-                  }
-                >
-                  {isSubmitting ? (
-                    <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Requesting…
-                    </>
-                  ) : (
-                    'Submit Request'
-                  )}
-                </Button>
-              </DialogFooter>
-            </>
-          )}
+          <DialogFooter>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setOpen(false)}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button size="sm" disabled={!canSubmit} onClick={handleSubmit}>
+              {isSubmitting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Requesting…
+                </>
+              ) : (
+                'Submit Request'
+              )}
+            </Button>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </>


### PR DESCRIPTION
Follow-up to #1707.

On a successful market request the dialog now **closes** and a toast confirms it ("Request received — Thanks, we'll take a look at <market>."), instead of swapping the dialog contents to an in-place success pane. Error handling is unchanged (inline message in the dialog so the user can retry).

Net diff: only `RequestMarketPanel.tsx`.