### PR TITLE
fix(api): roll vaultUnredeemedClaim into the vault PnL chart

### DIFF
--- a/packages/api/src/graphql/sdl/resolvers/queries/analytics.test.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/analytics.test.ts
@@ -18,9 +18,10 @@ vi.mock('../../../../services/protocolStats', () => ({
   sumEscrowBalancesAtBlock: vi.fn(),
 }));
 
+const mockQueryRaw = vi.fn();
 vi.mock('../../../../core/db', () => ({
   default: {
-    $queryRaw: vi.fn(),
+    $queryRaw: mockQueryRaw,
   },
 }));
 
@@ -63,5 +64,85 @@ describe('Query.protocolStats', () => {
 
     expect(result).toEqual([]);
     expect(mockGetProtocolStatsTimeSeries).not.toHaveBeenCalled();
+  });
+
+  it('rolls vaultUnredeemedClaim into vaultCumulativePnL for snapshots and the live candle', async () => {
+    // A snapshot captured the instant a chunk of the vault's positions
+    // resolved but before the keeper's redeem tx was indexed: realized PnL is
+    // deeply negative (cost recognized, payout not), yet the wUSDe is already
+    // earmarked for the vault in `vaultUnredeemedClaim`. The chart must net the
+    // two so the line doesn't show a phantom loss.
+    const baseSnapshot = {
+      vaultAddress: '0xprotocol',
+      vaultBalance: '0',
+      vaultAvailableAssets: '0',
+      vaultDeployed: '0',
+      escrowBalance: '0',
+      vaultPositionsWon: 0,
+      vaultPositionsLost: 0,
+      vaultDeposits: '0',
+      vaultWithdrawals: '0',
+      vaultAirdropGains: '0',
+    };
+    mockGetProtocolStatsTimeSeries.mockResolvedValue([
+      {
+        ...baseSnapshot,
+        timestamp: 1_000_000,
+        vaultRealizedPnL: '100',
+        vaultUnredeemedClaim: '0',
+        vaultSecondaryBought: '0',
+        vaultSecondarySold: '0',
+      },
+      {
+        ...baseSnapshot,
+        timestamp: 1_000_000 + 86_400,
+        vaultRealizedPnL: '-970', // cost booked at resolution
+        vaultUnredeemedClaim: '988', // payout earmarked, redeem not yet indexed
+        vaultSecondaryBought: '5',
+        vaultSecondarySold: '7',
+      },
+    ]);
+    mockQueryRaw.mockResolvedValue([]);
+
+    const svc = await import('../../../../services/protocolStats');
+    vi.mocked(svc.fetchVaultTVL).mockResolvedValue(0n);
+    vi.mocked(svc.fetchVaultAvailableAssets).mockResolvedValue(0n);
+    vi.mocked(svc.fetchVaultDeployed).mockResolvedValue(0n);
+    vi.mocked(svc.sumEscrowBalancesAtBlock).mockResolvedValue(0n);
+    vi.mocked(svc.calculateVaultPnL).mockResolvedValue({
+      realizedPnL: -970n,
+      positionsWon: 0,
+      positionsLost: 0,
+      totalCollateralWon: 0n,
+      totalCollateralLost: 970n,
+    });
+    vi.mocked(svc.calculateVaultFlows).mockResolvedValue({
+      totalDeposits: 0n,
+      totalWithdrawals: 0n,
+    });
+    vi.mocked(svc.calculateVaultSecondaryFlows).mockResolvedValue({
+      bought: 5n,
+      sold: 7n,
+    });
+    vi.mocked(svc.calculateVaultAirdrops).mockResolvedValue(0n);
+    vi.mocked(svc.calculateVaultUnredeemedClaim).mockResolvedValue(988n);
+
+    const result = (await protocolStatsFn(
+      {} as never,
+      { vaultAddress: null },
+      {} as never,
+      {} as never
+    )) as Array<{ vaultCumulativePnL: string; periodPnL: string }>;
+
+    // 2 persisted snapshots + 1 live candle.
+    expect(result).toHaveLength(3);
+    // Snapshot 0: 100 + 0 + 0 - 0
+    expect(result[0].vaultCumulativePnL).toBe('100');
+    // Snapshot 1: -970 + 988 + 7 - 5 = 20
+    expect(result[1].vaultCumulativePnL).toBe('20');
+    // Period PnL between the two snapshots: 20 - 100 = -80
+    expect(result[1].periodPnL).toBe('-80');
+    // Live candle: realizedPnL(-970) + unredeemed(988) + sold(7) - bought(5) = 20
+    expect(result[2].vaultCumulativePnL).toBe('20');
   });
 });

--- a/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
@@ -228,11 +228,23 @@ export const protocolStats: NonNullable<
   const interval = resolveSnapshotIntervalSeconds();
 
   // Cumulative PnL surfaced to the chart rolls up trading activity:
-  // settlement PnL plus net secondary-market trade flow. Airdrops are
-  // tracked separately so they can be reported alongside without
-  // distorting the trading return shown in the PnL chart.
+  // settlement PnL, plus wUSDe already earmarked for the vault from
+  // resolved-but-not-yet-redeemed wins, plus net secondary-market trade flow.
+  //
+  // `vaultRealizedPnL` is `grossPayouts(Claim ∪ Close) − primaryCollateral`:
+  // the cost basis (`primaryCollateral`) is recognized the moment a pickConfig
+  // resolves, but the payout only lands once the holder's `redeem()`/`burn()`
+  // is indexed. Between those two events a winning position contributes
+  // `−stake` instead of `+profit` — a transient phantom loss that crashed the
+  // PnL chart on days when a chunk of the vault's positions resolved before the
+  // keeper's `redeemFromEscrow` tx was indexed. `vaultUnredeemedClaim` (= total
+  // collateral owed on the vault's winning sides, net of what it's already
+  // claimed) exactly cancels that gap, so the line stays stable across the
+  // resolve → redeem → index cycle. Airdrops are tracked separately so they can
+  // be reported alongside without distorting the trading return shown here.
   const cumulativePnL = (s: (typeof protocolSnapshots)[number]): bigint =>
     BigInt(s.vaultRealizedPnL) +
+    BigInt(s.vaultUnredeemedClaim) +
     BigInt(s.vaultSecondarySold) -
     BigInt(s.vaultSecondaryBought);
 
@@ -322,6 +334,7 @@ export const protocolStats: NonNullable<
 
     const liveCumulativePnL =
       livePnlResult.realizedPnL +
+      liveUnredeemedClaim +
       liveSecondaryFlows.sold -
       liveSecondaryFlows.bought;
     const livePeriodPnL = (

--- a/packages/api/src/services/protocolStats/vaultAggregator.ts
+++ b/packages/api/src/services/protocolStats/vaultAggregator.ts
@@ -103,6 +103,7 @@ export async function buildVaultAggregator(
         },
         select: {
           burnedAt: true,
+          pickConfigId: true,
           predictorHolder: true,
           counterpartyHolder: true,
           predictorPayout: true,
@@ -286,31 +287,40 @@ export async function buildVaultAggregator(
   // regardless of which sibling triggered the on-chain resolution.
   const unredeemedClaimAt = (t: number, vaultAddress: string): bigint => {
     let owed = 0n;
+    const winningPickConfigIds = new Set<string>();
     for (const p of predictions) {
       const pc = p.pickConfiguration;
       if (!pc || !pc.resolved) continue;
       if (pc.resolvedAt === null || pc.resolvedAt > t) continue;
       const counterpartyIsVault = p.counterparty.toLowerCase() === vaultAddress;
       const predictorIsVault = p.predictor.toLowerCase() === vaultAddress;
-      if (
-        counterpartyIsVault &&
-        pc.result === SettlementResult.COUNTERPARTY_WINS
-      ) {
-        owed +=
-          BigInt(p.predictorCollateral) + BigInt(p.counterpartyCollateral);
-      } else if (
-        predictorIsVault &&
-        pc.result === SettlementResult.PREDICTOR_WINS
-      ) {
-        owed +=
-          BigInt(p.predictorCollateral) + BigInt(p.counterpartyCollateral);
-      }
+      const vaultWon =
+        (counterpartyIsVault &&
+          pc.result === SettlementResult.COUNTERPARTY_WINS) ||
+        (predictorIsVault && pc.result === SettlementResult.PREDICTOR_WINS);
+      if (!vaultWon) continue;
+      owed += BigInt(p.predictorCollateral) + BigInt(p.counterpartyCollateral);
+      if (p.pickConfigId) winningPickConfigIds.add(p.pickConfigId);
     }
     let claimed = 0n;
     for (const c of claims) {
       if (c.holder.toLowerCase() !== vaultAddress) continue;
       if (c.redeemedAt > t) continue;
       claimed += BigInt(c.collateralPaid);
+    }
+    // Wins settled via the bilateral burn path (`Close`) are already in
+    // `pnlAt`'s gross payouts — net their vault-side legs out of the residual
+    // too. Scoped to resolved-winning pickConfigs so a pre-resolution burn
+    // can't over-subtract. Mirrors `calculateVaultUnredeemedClaim`.
+    for (const c of closes) {
+      if (c.burnedAt > t) continue;
+      if (!winningPickConfigIds.has(c.pickConfigId)) continue;
+      if (c.predictorHolder.toLowerCase() === vaultAddress) {
+        claimed += BigInt(c.predictorPayout);
+      }
+      if (c.counterpartyHolder.toLowerCase() === vaultAddress) {
+        claimed += BigInt(c.counterpartyPayout);
+      }
     }
     const remainder = owed - claimed;
     return remainder > 0n ? remainder : 0n;

--- a/packages/api/src/services/protocolStats/vaultUnredeemed.test.ts
+++ b/packages/api/src/services/protocolStats/vaultUnredeemed.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    prediction: { findMany: vi.fn() },
+    claim: { findMany: vi.fn() },
+    close: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock('../../core/db', () => ({ default: mockPrisma }));
+
+vi.mock('../../../generated/prisma', () => ({
+  SettlementResult: {
+    UNRESOLVED: 'UNRESOLVED',
+    PREDICTOR_WINS: 'PREDICTOR_WINS',
+    COUNTERPARTY_WINS: 'COUNTERPARTY_WINS',
+    NON_DECISIVE: 'NON_DECISIVE',
+  },
+}));
+
+const VAULT = '0xvault';
+vi.mock('./vaultConfig', () => ({
+  resolveVaultAddress: (_chainId: number, arg?: string) =>
+    (arg ?? VAULT).toLowerCase(),
+}));
+
+const { calculateVaultUnredeemedClaim } = await import('./vaultUnredeemed');
+
+describe('calculateVaultUnredeemedClaim', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.close.findMany.mockResolvedValue([]);
+  });
+
+  it('counts total collateral on the winning side, net of Claim redemptions', async () => {
+    // counterparty win: predictor 1.75 + counterparty 97.45 → owed 99.2
+    mockPrisma.prediction.findMany
+      .mockResolvedValueOnce([
+        {
+          predictorCollateral: '1750000000000000000',
+          counterpartyCollateral: '97450000000000000000',
+          pickConfigId: '0xpc1',
+        },
+      ]) // counterpartyWins
+      .mockResolvedValueOnce([]); // predictorWins
+    mockPrisma.claim.findMany.mockResolvedValue([]);
+
+    expect(await calculateVaultUnredeemedClaim(1)).toBe(
+      99_200_000_000_000_000_000n
+    );
+
+    // Now the vault has redeemed it via redeem() → Claim of 99.2.
+    mockPrisma.prediction.findMany
+      .mockResolvedValueOnce([
+        {
+          predictorCollateral: '1750000000000000000',
+          counterpartyCollateral: '97450000000000000000',
+          pickConfigId: '0xpc1',
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    mockPrisma.claim.findMany.mockResolvedValue([
+      { collateralPaid: '99200000000000000000' },
+    ]);
+
+    expect(await calculateVaultUnredeemedClaim(1)).toBe(0n);
+  });
+
+  it('also nets out wins settled via the bilateral burn path (Close), not just Claim', async () => {
+    // Vault won pickConfig 0xpc1 (owed 99.2) but exited via burn() → Close,
+    // whose counterpartyPayout (99.2, vault is the counterparty holder) is
+    // already in vaultRealizedPnL. Without netting it here it'd double-count.
+    mockPrisma.prediction.findMany
+      .mockResolvedValueOnce([
+        {
+          predictorCollateral: '1750000000000000000',
+          counterpartyCollateral: '97450000000000000000',
+          pickConfigId: '0xpc1',
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    mockPrisma.claim.findMany.mockResolvedValue([]);
+    mockPrisma.close.findMany.mockResolvedValue([
+      {
+        predictorHolder: '0xsomeoneelse',
+        counterpartyHolder: VAULT,
+        predictorPayout: '0',
+        counterpartyPayout: '99200000000000000000',
+      },
+    ]);
+
+    expect(await calculateVaultUnredeemedClaim(1)).toBe(0n);
+  });
+
+  it('clamps at 0n when redemptions exceed the owed amount', async () => {
+    mockPrisma.prediction.findMany
+      .mockResolvedValueOnce([]) // counterpartyWins
+      .mockResolvedValueOnce([]); // predictorWins
+    mockPrisma.claim.findMany.mockResolvedValue([
+      { collateralPaid: '5000000000000000000' },
+    ]);
+    expect(await calculateVaultUnredeemedClaim(1)).toBe(0n);
+  });
+});

--- a/packages/api/src/services/protocolStats/vaultUnredeemed.ts
+++ b/packages/api/src/services/protocolStats/vaultUnredeemed.ts
@@ -22,6 +22,13 @@ import { resolveVaultAddress } from './vaultConfig';
  * (Picks.resolved = true, which is what gates `redeem()` on-chain), the vault's
  * counterparty stake AND prize are sitting in escrow earmarked for it.
  *
+ * The vault is normally redeemed via `redeem()` (→ `Claim`), but a win can also
+ * be settled via the bilateral burn path (`burn()` → `Close`). `calculateVaultPnL`
+ * counts BOTH event streams in its gross payouts, so we net BOTH out here — Claim
+ * rows whose holder is the vault, plus the vault's payout legs on `Close` rows
+ * for the same resolved-winning pickConfigs — otherwise a win exited via `burn()`
+ * would be double-counted (once in `vaultRealizedPnL`, once in this residual).
+ *
  * Clamped at 0n. The `Claim.predictionId` column actually stores the on-chain
  * pickConfigId (known indexer misnomer); we don't join through it — we just sum
  * Claim rows whose holder is the vault.
@@ -47,7 +54,11 @@ export async function calculateVaultUnredeemedClaim(
           ...(resolvedFilter ? { resolvedAt: resolvedFilter } : {}),
         },
       },
-      select: { predictorCollateral: true, counterpartyCollateral: true },
+      select: {
+        predictorCollateral: true,
+        counterpartyCollateral: true,
+        pickConfigId: true,
+      },
     }),
     prisma.prediction.findMany({
       where: {
@@ -59,7 +70,11 @@ export async function calculateVaultUnredeemedClaim(
           ...(resolvedFilter ? { resolvedAt: resolvedFilter } : {}),
         },
       },
-      select: { predictorCollateral: true, counterpartyCollateral: true },
+      select: {
+        predictorCollateral: true,
+        counterpartyCollateral: true,
+        pickConfigId: true,
+      },
     }),
     prisma.claim.findMany({
       where: {
@@ -72,15 +87,47 @@ export async function calculateVaultUnredeemedClaim(
   ]);
 
   let owed = 0n;
-  for (const p of counterpartyWins) {
+  const winningPickConfigIds = new Set<string>();
+  for (const p of [...counterpartyWins, ...predictorWins]) {
     owed += BigInt(p.predictorCollateral) + BigInt(p.counterpartyCollateral);
-  }
-  for (const p of predictorWins) {
-    owed += BigInt(p.predictorCollateral) + BigInt(p.counterpartyCollateral);
+    if (p.pickConfigId) winningPickConfigIds.add(p.pickConfigId);
   }
 
   let claimed = 0n;
   for (const c of claims) claimed += BigInt(c.collateralPaid);
+
+  // Wins settled through the bilateral burn path show up as `Close` rows
+  // rather than `Claim` rows; their payout legs are already in
+  // `vaultRealizedPnL`, so subtract them from the owed residual too. Scoped to
+  // the resolved-winning pickConfigs so a pre-resolution burn (where the
+  // prediction isn't in `owed` at all) can't over-subtract.
+  if (winningPickConfigIds.size > 0) {
+    const closes = await prisma.close.findMany({
+      where: {
+        chainId,
+        pickConfigId: { in: [...winningPickConfigIds] },
+        OR: [
+          { predictorHolder: vaultAddress },
+          { counterpartyHolder: vaultAddress },
+        ],
+        ...(beforeTimestamp ? { burnedAt: { lte: beforeTimestamp } } : {}),
+      },
+      select: {
+        predictorHolder: true,
+        counterpartyHolder: true,
+        predictorPayout: true,
+        counterpartyPayout: true,
+      },
+    });
+    for (const c of closes) {
+      if (c.predictorHolder.toLowerCase() === vaultAddress) {
+        claimed += BigInt(c.predictorPayout);
+      }
+      if (c.counterpartyHolder.toLowerCase() === vaultAddress) {
+        claimed += BigInt(c.counterpartyPayout);
+      }
+    }
+  }
 
   const remainder = owed - claimed;
   return remainder > 0n ? remainder : 0n;

--- a/packages/docs/docs/pages/builder-guide/reference/contracts-and-addresses.mdx
+++ b/packages/docs/docs/pages/builder-guide/reference/contracts-and-addresses.mdx
@@ -107,11 +107,11 @@ Replaced by the addresses above. Indexers and historical readers may still need 
 
 | Contract                       | Address                                                                                                                                    | SDK key                                    |
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
-| PredictionMarketEscrow         | [`0xD2C147f9294b13FF3Cf1a0b3b52C54969AdBb2Ca`](https://testnet-explorer.ethereal.trade/address/0xD2C147f9294b13FF3Cf1a0b3b52C54969AdBb2Ca) | `contracts.predictionMarketEscrow`         |
+| PredictionMarketEscrow         | [`0x72bAf4704650CA327d22BFc84ed1E45a0fB4fd14`](https://testnet-explorer.ethereal.trade/address/0x72bAf4704650CA327d22BFc84ed1E45a0fB4fd14) | `contracts.predictionMarketEscrow`         |
 | PredictionMarketVault          | [`0xD2b8da7b659A8273d36bc6A28c3c2521c5f9113F`](https://testnet-explorer.ethereal.trade/address/0xD2b8da7b659A8273d36bc6A28c3c2521c5f9113F) | `contracts.predictionMarketVault`          |
 | PythPredictionMarketVault      | [`0x41eE785175C836F9F342B787a818a9B8B02bd8c8`](https://testnet-explorer.ethereal.trade/address/0x41eE785175C836F9F342B787a818a9B8B02bd8c8) | `contracts.pythPredictionMarketVault`      |
 | PredictionMarketVaultStrategyB | [`0x78fFD04e61A0E405F3A04ddD8a39A01f8fAB00b3`](https://testnet-explorer.ethereal.trade/address/0x78fFD04e61A0E405F3A04ddD8a39A01f8fAB00b3) | `contracts.predictionMarketVaultStrategyB` |
-| SecondaryMarketEscrow          | [`0x2877B0b65f0BB7F1e93681B7EE6646f568A23972`](https://testnet-explorer.ethereal.trade/address/0x2877B0b65f0BB7F1e93681B7EE6646f568A23972) | `contracts.secondaryMarketEscrow`          |
+| SecondaryMarketEscrow          | [`0x86746772F119f0f0925dd1a715F7A1528CC2482a`](https://testnet-explorer.ethereal.trade/address/0x86746772F119f0f0925dd1a715F7A1528CC2482a) | `contracts.secondaryMarketEscrow`          |
 | OnboardingSponsor              | [`0xa0b2fa0284273A4d6BA1C76521757F520c84f58a`](https://testnet-explorer.ethereal.trade/address/0xa0b2fa0284273A4d6BA1C76521757F520c84f58a) | `contracts.onboardingSponsor`              |
 | Collateral (wUSDe)             | [`0xb7ae43711d85c23dc862c85b9c95a64dc6351f90`](https://testnet-explorer.ethereal.trade/address/0xb7ae43711d85c23dc862c85b9c95a64dc6351f90) | `collateralToken`                          |
 
@@ -126,8 +126,8 @@ Replaced by the addresses above. Indexers and historical readers may still need 
 
 | Contract                     | Address                                                                                                                                    | SDK key                                  |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
-| PredictionMarketBridge       | [`0x57a56aEE60C5C411517bD5575709cc898DAbf1Fa`](https://testnet-explorer.ethereal.trade/address/0x57a56aEE60C5C411517bD5575709cc898DAbf1Fa) | `contracts.predictionMarketBridge`       |
-| PredictionMarketTokenFactory | [`0xfbC42AeB29bb2eEeDCD7431Ad5c2F18cB3016772`](https://testnet-explorer.ethereal.trade/address/0xfbC42AeB29bb2eEeDCD7431Ad5c2F18cB3016772) | `contracts.predictionMarketTokenFactory` |
+| PredictionMarketBridge       | [`0xa3a266CbC9E7dbf358A70Ffe21d3d6C929913329`](https://testnet-explorer.ethereal.trade/address/0xa3a266CbC9E7dbf358A70Ffe21d3d6C929913329) | `contracts.predictionMarketBridge`       |
+| PredictionMarketTokenFactory | [`0xda16846B0F1A0C5292ed0177B343470E364C27F3`](https://testnet-explorer.ethereal.trade/address/0xda16846B0F1A0C5292ed0177B343470E364C27F3) | `contracts.predictionMarketTokenFactory` |
 | EAS                          | [`0x680022513d33306E47441FB622D2E5CECCc089AC`](https://testnet-explorer.ethereal.trade/address/0x680022513d33306E47441FB622D2E5CECCc089AC) | `eas`                                    |
 
 ### Legacy deployments
@@ -136,6 +136,7 @@ Replaced by the addresses above. Indexers and historical readers may still need 
 
 | Contract                     | Legacy address                                                                                                                             | Created at block |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| PredictionMarketEscrow       | [`0xD2C147f9294b13FF3Cf1a0b3b52C54969AdBb2Ca`](https://testnet-explorer.ethereal.trade/address/0xD2C147f9294b13FF3Cf1a0b3b52C54969AdBb2Ca) | 2857000          |
 | PredictionMarketEscrow       | [`0x9afaAAda6dc3a5013ef6fbaab203A55102E329eb`](https://testnet-explorer.ethereal.trade/address/0x9afaAAda6dc3a5013ef6fbaab203A55102E329eb) | 2585864          |
 | PredictionMarketEscrow       | [`0x3B680e06B9A384179644C1bC7842Db67Df5Fb5f0`](https://testnet-explorer.ethereal.trade/address/0x3B680e06B9A384179644C1bC7842Db67Df5Fb5f0) | 2294248          |
 | PredictionMarketEscrow       | [`0x3025C4E3087f33Ac04D78eE34f35D4d003c2D642`](https://testnet-explorer.ethereal.trade/address/0x3025C4E3087f33Ac04D78eE34f35D4d003c2D642) | 2294248          |
@@ -144,6 +145,7 @@ Replaced by the addresses above. Indexers and historical readers may still need 
 | PredictionMarketEscrow       | [`0xb5d2E6B148eBdFB02a3456F0Af021FAe81356511`](https://testnet-explorer.ethereal.trade/address/0xb5d2E6B148eBdFB02a3456F0Af021FAe81356511) | 2264547          |
 | PredictionMarketEscrow       | [`0x8730eE1194Cd03A14deA9975e2bafD4C8b6019F1`](https://testnet-explorer.ethereal.trade/address/0x8730eE1194Cd03A14deA9975e2bafD4C8b6019F1) | 2107812          |
 | PredictionMarketVault        | [`0xADf3C8D4B159FdA439E3C0e519DEc3C93DE0a4c3`](https://testnet-explorer.ethereal.trade/address/0xADf3C8D4B159FdA439E3C0e519DEc3C93DE0a4c3) | 2265901          |
+| SecondaryMarketEscrow        | [`0x2877B0b65f0BB7F1e93681B7EE6646f568A23972`](https://testnet-explorer.ethereal.trade/address/0x2877B0b65f0BB7F1e93681B7EE6646f568A23972) | 2857000          |
 | SecondaryMarketEscrow        | [`0x3c2783afA444c157eE3689E6306cFC0f2FbD231B`](https://testnet-explorer.ethereal.trade/address/0x3c2783afA444c157eE3689E6306cFC0f2FbD231B) | 2585868          |
 | SecondaryMarketEscrow        | [`0x16222940184Aad2E806529C963531e36c13875cF`](https://testnet-explorer.ethereal.trade/address/0x16222940184Aad2E806529C963531e36c13875cF) | 2266775          |
 | SecondaryMarketEscrow        | [`0x0c12a974E7741135a8431458705Ae16dDa41aA85`](https://testnet-explorer.ethereal.trade/address/0x0c12a974E7741135a8431458705Ae16dDa41aA85) | 2266775          |
@@ -158,6 +160,7 @@ Replaced by the addresses above. Indexers and historical readers may still need 
 | ManualConditionResolver      | [`0xAE41b42dC5d9a98C53c7A91c44523173300c1f31`](https://testnet-explorer.ethereal.trade/address/0xAE41b42dC5d9a98C53c7A91c44523173300c1f31) | 2293991          |
 | ManualConditionResolver      | [`0x9938583eA9a6450Cc64502bDcBF76f4EEa2F9560`](https://testnet-explorer.ethereal.trade/address/0x9938583eA9a6450Cc64502bDcBF76f4EEa2F9560) | 2264546          |
 | ManualConditionResolver      | [`0x514A4321d89Aa47D1b1Dd9E0a3226249E6ef896A`](https://testnet-explorer.ethereal.trade/address/0x514A4321d89Aa47D1b1Dd9E0a3226249E6ef896A) | 2107805          |
+| PredictionMarketBridge       | [`0x57a56aEE60C5C411517bD5575709cc898DAbf1Fa`](https://testnet-explorer.ethereal.trade/address/0x57a56aEE60C5C411517bD5575709cc898DAbf1Fa) | 2857000          |
 | PredictionMarketBridge       | [`0x8Bd3E6d81A55ba2A658666f470bFb8a40CF8F71F`](https://testnet-explorer.ethereal.trade/address/0x8Bd3E6d81A55ba2A658666f470bFb8a40CF8F71F) | 2585866          |
 | PredictionMarketBridge       | [`0xd45D795A3eB5890ad3Ff127C29b3A191D8A06F44`](https://testnet-explorer.ethereal.trade/address/0xd45D795A3eB5890ad3Ff127C29b3A191D8A06F44) | 2294253          |
 | PredictionMarketBridge       | [`0xAf0c78547018F9e2e515e6Fc0064DD091f3dDE38`](https://testnet-explorer.ethereal.trade/address/0xAf0c78547018F9e2e515e6Fc0064DD091f3dDE38) | 2294253          |
@@ -165,6 +168,7 @@ Replaced by the addresses above. Indexers and historical readers may still need 
 | PredictionMarketBridge       | [`0xAE32505E17Ff704df7Cd22E99916360328915BEb`](https://testnet-explorer.ethereal.trade/address/0xAE32505E17Ff704df7Cd22E99916360328915BEb) | 2293995          |
 | PredictionMarketBridge       | [`0xAe66B4DED22bED7bE9385c29ADEc7AC9e1B97700`](https://testnet-explorer.ethereal.trade/address/0xAe66B4DED22bED7bE9385c29ADEc7AC9e1B97700) | 2264550          |
 | PredictionMarketBridge       | [`0x275Ba9B8DB207afb33022043848216BB7195eDb5`](https://testnet-explorer.ethereal.trade/address/0x275Ba9B8DB207afb33022043848216BB7195eDb5) | 2107823          |
+| PredictionMarketTokenFactory | [`0xfbC42AeB29bb2eEeDCD7431Ad5c2F18cB3016772`](https://testnet-explorer.ethereal.trade/address/0xfbC42AeB29bb2eEeDCD7431Ad5c2F18cB3016772) | 2857000          |
 | PredictionMarketTokenFactory | [`0xbD8bB933ae35D15Ef6DC9Bd82daEDA09B139d28C`](https://testnet-explorer.ethereal.trade/address/0xbD8bB933ae35D15Ef6DC9Bd82daEDA09B139d28C) | 2585863          |
 | PredictionMarketTokenFactory | [`0x5B9f2cb9c822899A0F824eEb039B628A4d13d7AD`](https://testnet-explorer.ethereal.trade/address/0x5B9f2cb9c822899A0F824eEb039B628A4d13d7AD) | 2294247          |
 | PredictionMarketTokenFactory | [`0x9924518205391c0443fA565327108afB3E100b51`](https://testnet-explorer.ethereal.trade/address/0x9924518205391c0443fA565327108afB3E100b51) | 2294247          |
@@ -211,8 +215,8 @@ Replaced by the addresses above. Indexers and historical readers may still need 
 
 | Contract                     | Address                                                                                                                        | SDK key                                  |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
-| PredictionMarketBridgeRemote | [`0xC80f317d26151C3093429c178d5f1ED4A64feF71`](https://sepolia.arbiscan.io/address/0xC80f317d26151C3093429c178d5f1ED4A64feF71) | `contracts.predictionMarketBridgeRemote` |
-| PredictionMarketTokenFactory | [`0xfbC42AeB29bb2eEeDCD7431Ad5c2F18cB3016772`](https://sepolia.arbiscan.io/address/0xfbC42AeB29bb2eEeDCD7431Ad5c2F18cB3016772) | `contracts.predictionMarketTokenFactory` |
+| PredictionMarketBridgeRemote | [`0x4EFA05Fc64505587D7F2612aDcb25e5D88619B72`](https://sepolia.arbiscan.io/address/0x4EFA05Fc64505587D7F2612aDcb25e5D88619B72) | `contracts.predictionMarketBridgeRemote` |
+| PredictionMarketTokenFactory | [`0xda16846B0F1A0C5292ed0177B343470E364C27F3`](https://sepolia.arbiscan.io/address/0xda16846B0F1A0C5292ed0177B343470E364C27F3) | `contracts.predictionMarketTokenFactory` |
 
 ### Legacy deployments
 
@@ -220,6 +224,7 @@ Replaced by the addresses above. Indexers and historical readers may still need 
 
 | Contract                     | Legacy address                                                                                                                 | Created at block |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| PredictionMarketBridgeRemote | [`0xC80f317d26151C3093429c178d5f1ED4A64feF71`](https://sepolia.arbiscan.io/address/0xC80f317d26151C3093429c178d5f1ED4A64feF71) | 253300000        |
 | PredictionMarketBridgeRemote | [`0xb18b50A19040fC88b02082e869127935CA1df5aA`](https://sepolia.arbiscan.io/address/0xb18b50A19040fC88b02082e869127935CA1df5aA) | 253273957        |
 | PredictionMarketBridgeRemote | [`0x11B74d5a4aF9c83FF6610C0FaA8EC5378077Eb16`](https://sepolia.arbiscan.io/address/0x11B74d5a4aF9c83FF6610C0FaA8EC5378077Eb16) | 252903704        |
 | PredictionMarketBridgeRemote | [`0x4e52A5D1FaCcd4ebb97cEf22E91760662C7eDb54`](https://sepolia.arbiscan.io/address/0x4e52A5D1FaCcd4ebb97cEf22E91760662C7eDb54) | 252903704        |
@@ -227,6 +232,7 @@ Replaced by the addresses above. Indexers and historical readers may still need 
 | PredictionMarketBridgeRemote | [`0x888e445F96515186B7b262d959FFF4AF14151ca9`](https://sepolia.arbiscan.io/address/0x888e445F96515186B7b262d959FFF4AF14151ca9) | 252901943        |
 | PredictionMarketBridgeRemote | [`0xE64ca8f0533422BCb6d48dCF11DB2fF3FA26B7Fb`](https://sepolia.arbiscan.io/address/0xE64ca8f0533422BCb6d48dCF11DB2fF3FA26B7Fb) | 252904306        |
 | PredictionMarketBridgeRemote | [`0x1a7F19Ee50FBCa9a4d195E4a3737e7737b252b4c`](https://sepolia.arbiscan.io/address/0x1a7F19Ee50FBCa9a4d195E4a3737e7737b252b4c) | 252901832        |
+| PredictionMarketTokenFactory | [`0xfbC42AeB29bb2eEeDCD7431Ad5c2F18cB3016772`](https://sepolia.arbiscan.io/address/0xfbC42AeB29bb2eEeDCD7431Ad5c2F18cB3016772) | 253300000        |
 | PredictionMarketTokenFactory | [`0xbD8bB933ae35D15Ef6DC9Bd82daEDA09B139d28C`](https://sepolia.arbiscan.io/address/0xbD8bB933ae35D15Ef6DC9Bd82daEDA09B139d28C) | 253273877        |
 | PredictionMarketTokenFactory | [`0x5B9f2cb9c822899A0F824eEb039B628A4d13d7AD`](https://sepolia.arbiscan.io/address/0x5B9f2cb9c822899A0F824eEb039B628A4d13d7AD) | 252904693        |
 | PredictionMarketTokenFactory | [`0x9924518205391c0443fA565327108afB3E100b51`](https://sepolia.arbiscan.io/address/0x9924518205391c0443fA565327108afB3E100b51) | 252904693        |


### PR DESCRIPTION
## Problem

The `/vaults` Profit/Loss chart shows a **phantom loss** whenever a chunk of the vault's positions resolve before the keeper's `redeemFromEscrow` tx is indexed. `calculateVaultPnL` computes:

```
vaultRealizedPnL = grossPayouts(Claim ∪ Close) − primaryCollateral(resolved predictions)
```

The cost basis (`primaryCollateral`) is recognized the instant a `pickConfig` flips `resolved = true`, but the payout only enters `grossPayouts` once the `Claim` (`TokensRedeemed`) / `Close` (`PositionsBurned`) row exists. In that window a winning position contributes `−stake` instead of `+profit`.

Concretely, on **2026-05-12** pickConfig `0x29813a6b…` (10 predictions, all Core-Vault-as-counterparty) resolved `COUNTERPARTY_WINS`. `primaryCollateral` immediately picked up the vault's ≈970 USDe of counterparty stake; the offsetting +988 USDe redemption (tx `0xb8db67c0…`) only landed when its `Claim` was indexed. Between the two, `vaultCumulativePnL` dropped ≈970 USDe (≈−11% of TVL) — the off-the-bottom crater on the chart — then snapped back to +1235 once indexed.

`vaultUnredeemedClaim` (total collateral owed on the vault's winning sides, net of what it has already claimed) is computed and stored on every snapshot **for exactly this reason** — but the resolver's rollup never added it.

## Fix

- Roll `vaultUnredeemedClaim` into the cumulative PnL in `analytics.ts`, for both persisted snapshots and the live candle:
  ```
  vaultCumulativePnL = vaultRealizedPnL + vaultUnredeemedClaim + vaultSecondarySold − vaultSecondaryBought
  ```
  During the resolve→redeem→index gap the unredeemed term equals the not-yet-received payout, so it cancels the prematurely-booked cost; once the `Claim` is indexed, `realizedPnL` rises and `unredeemedClaim` falls by the same amount — the sum is stable throughout.
- Net `Close` (bilateral burn) payouts out of `calculateVaultUnredeemedClaim` and the in-memory aggregator's `unredeemedClaimAt`, scoped to the resolved-winning pickConfigs. A win exited via `burn()` is already in `grossPayouts`, so without this it would be double-counted in the rollup. (Scoping to winning pickConfigs prevents a pre-resolution burn from over-subtracting.)

No schema/migration changes — `vaultUnredeemedClaim` is already a stored column; this only changes how the resolver rolls components up. The backfill path (`vaultAggregator`) is kept in lockstep.

## Tests

- `analytics.test.ts`: new case asserting `vaultCumulativePnL` (and `periodPnL`) include the unredeemed term for both snapshots and the live candle.
- `vaultUnredeemed.test.ts` (new): unit tests for the Claim netting and the Close netting (double-count guard).
- Full `@sapience/api` suite green (445 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)