### PR TITLE
fix: make Railway Reconciler build use backend prerequisites

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "main": "index.js",
   "scripts": {
-    "build": "pnpm --filter protocol run build && pnpm --filter app run build && pnpm --filter docs run build",
+    "build": "pnpm run build:backend",
+    "build:backend": "pnpm --filter @sapience/sdk run build:lib && pnpm --filter @sapience/api run prisma:generate",
+    "build:web": "pnpm --filter @sapience/app run build && pnpm --filter docs run build",
     "test": "pnpm run test --recursive",
     "dev:app": "pnpm --filter @sapience/app run dev",
     "dev:docs": "pnpm --filter docs run dev",


### PR DESCRIPTION
## Summary
- Makes the root `build` script an explicit alias for `build:backend`.
- Adds `build:backend` for Railway/Nixpacks API services: build the SDK and generate the API Prisma client.
- Adds `build:web` as the separate app/docs aggregate, without the invalid protocol build step.

## Why
The Reconciler deploy was failing before startup because Railway ran root `pnpm run build`, which expanded to a web/protocol aggregate containing:

```sh
pnpm --filter protocol run build
```

`@sapience/protocol` does not have a `build` script, so pnpm exited with `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT` before the Reconciler service could start.

Keeping backend and web builds separate avoids letting frontend/docs/protocol build assumptions block backend worker deploys.

## Validation
- `pnpm install --frozen-lockfile --prefer-offline`
- `pnpm run build`
