### PR TITLE
refactor(api): positionsPage with lazy totalCount + synthesis cache

### DIFF
--- a/packages/api/MIGRATION.md
+++ b/packages/api/MIGRATION.md
@@ -1,0 +1,150 @@
+# Sapience GraphQL API — migration guide
+
+A running log of API changes that downstream services should adopt. Entries are reverse-chronological; the section header is the canonical name a downstream LLM/engineer should grep for.
+
+---
+
+## `positionsPage` — paginated V2 holdings, replaces `positions`
+
+### TL;DR
+
+Three additive changes:
+
+1. **`positionsPage`** is the canonical query for V2 position holdings. The bare `positions` query is now `@deprecated`. Migrate at your convenience; `positions` continues to work and returns identical data.
+2. **`PositionsPage.totalCount: Int`** is new and lazy. Selecting it issues a single `COUNT(*)` server-side; not selecting it costs nothing. Use this instead of `positionCount`.
+3. V1 (NFT-based) **`LegacyPosition.predictions`, `LegacyPrediction.position`, `LegacyPrediction.limitOrder`, `LimitOrder.predictions`** are now `@deprecated`. Use `positionsPage` for holdings.
+
+One server-side behavior change:
+
+- **`positionsPage(skip: $skip)` is now clamped at 10_000** (was unbounded). Larger values are silently truncated. At default `take: 50` that's 200 pages deep — well past any realistic FE use case.
+
+Nothing breaks today. The bare `positions`, `positionCount`, and V1 fields all continue to work; introspection emits deprecation notices.
+
+---
+
+### Migration: `positions` → `positionsPage`
+
+**Before**
+
+```graphql
+query MyHoldings($holder: String!) {
+  positions(holder: $holder, take: 50, skip: 0) {
+    id
+    balance
+    userCollateral
+    pickConfig {
+      id
+      resolved
+    }
+  }
+}
+```
+
+**After**
+
+```graphql
+query MyHoldings($holder: String!) {
+  positionsPage(holder: $holder, take: 50, skip: 0) {
+    hasMore
+    items {
+      id
+      balance
+      userCollateral
+      pickConfig {
+        id
+        resolved
+      }
+    }
+  }
+}
+```
+
+Two changes:
+
+- The result is wrapped: `items: [Position!]!` plus `hasMore: Boolean!`.
+- **Use `hasMore` as the pagination stop signal, not `items.length === 0`.** The resolver synthesizes one synthetic "Closed" row per secondary sell (in addition to the open balance row), and a zero-balance unresolved position with no sells emits zero rows. So a page can legitimately come back empty while there are still rows beyond. The `hasMore` flag is server-truth — it's `true` iff the next page exists.
+
+---
+
+### Migration: `positionCount` → `positionsPage(...).totalCount`
+
+**Before**
+
+```graphql
+query MyHoldingsCount($holder: String!) {
+  positionCount(holder: $holder)
+}
+```
+
+**After**
+
+```graphql
+query MyHoldingsCount($holder: String!) {
+  positionsPage(holder: $holder, take: 1) {
+    totalCount
+  }
+}
+```
+
+Notes:
+
+- `totalCount` is **lazy** — the server only runs `COUNT(*)` when the field is selected. Pages that don't ask for it pay zero count cost.
+- You still pass `take` (use `take: 1` if you want only the count); the page query needs a take/skip pair.
+- `totalCount` is the count of **underlying Position rows** matching the filters, **not** the count of rendered event-stream rows. The two differ because each secondary sell becomes its own synthetic row. If your UI shows a count of "rows visible to the user", `items.length` after pagination is what you want; if it shows "positions held", `totalCount` is correct.
+
+---
+
+### V1 (LegacyPosition) deprecations
+
+The V1 NFT-based holdings surface is being phased out. The following fields are now `@deprecated`:
+
+| Field                         | Reason               | Replacement               |
+| ----------------------------- | -------------------- | ------------------------- |
+| `LegacyPosition.predictions`  | V1 holdings model    | `positionsPage`           |
+| `LegacyPrediction.position`   | V1 holdings model    | `positionsPage`           |
+| `LegacyPrediction.limitOrder` | LimitOrder phase-out | none — feature deprecated |
+| `LimitOrder.predictions`      | LimitOrder phase-out | none — feature deprecated |
+
+If your operations select any of these, the GraphQL introspection result includes a deprecation notice.
+
+---
+
+### `Page` interface
+
+All `*Page` wrappers in the API implement a shared interface:
+
+```graphql
+interface Page {
+  hasMore: Boolean!
+  totalCount: Int
+}
+```
+
+You can fragment on `Page` to read `hasMore` / `totalCount` generically (useful when you have a generic pagination wrapper component), and on the concrete type (`PositionsPage`, etc.) for the typed `items` list. `items` is intentionally not on the interface because each concrete page exposes a different row type.
+
+---
+
+### Behavior change: `skip` cap
+
+`positionsPage(skip: $skip)` now applies a server-side ceiling of `skip ≤ 10_000`. Values above the cap are silently truncated to 10_000.
+
+Why: previously unbounded, so a client passing `skip: 5_000_000` would force Postgres to scan and discard 5M rows on every call. The 10_000 cap is a defensive safety net — at `take: 50` that's 200 pages of holdings, well past any realistic FE pagination depth.
+
+If your service genuinely needs deeper pagination, file a ticket so we can add cursor-based pagination on a stable `(createdAt, id)` key instead — offset pagination beyond a few thousand rows is expensive regardless of cap.
+
+---
+
+### Staleness note
+
+`positionsPage` results may include cost-basis fields (`userCollateral`, `realizedPnL`) that are up to **30 seconds stale**. This only happens when a `secondaryTrade` lands between requests without bumping the underlying `Position.updatedAt`. Balance / settlement / resolved flags are always live.
+
+If you need strictly real-time trade data, prefer the trade- or activity-specific endpoints (e.g. `accountActivity`, `trades`). The synthesis-derived cost-basis view is the only thing affected.
+
+---
+
+### Reference
+
+- Resolver source: [`packages/api/src/graphql/sdl/resolvers/queries/escrow.ts`](src/graphql/sdl/resolvers/queries/escrow.ts) (`runPositions`)
+- SDL: [`packages/api/src/graphql/sdl/schema/schema.graphql`](src/graphql/sdl/schema/schema.graphql) (search for `positionsPage`, `PositionsPage`, `Page`)
+- Generated schema: [`packages/api/schema.graphql`](schema.graphql)
+- Tests: [`packages/api/src/graphql/sdl/resolvers/queries/escrow.test.ts`](src/graphql/sdl/resolvers/queries/escrow.test.ts), [`packages/api/src/graphql/sdl/resolvers/PositionsPage.test.ts`](src/graphql/sdl/resolvers/PositionsPage.test.ts)

--- a/packages/api/prisma/migrations/20260511000000_add_questions_sort_indexes/migration.sql
+++ b/packages/api/prisma/migrations/20260511000000_add_questions_sort_indexes/migration.sql
@@ -1,0 +1,27 @@
+-- Adds partial indexes on `condition` for sort fields exposed via
+-- QuestionSortField that previously fell back to sequential scan when
+-- the ungrouped-condition branch of the questionsPage UNION sorted on
+-- them. The matching condition_group aggregate columns already had
+-- indexes; this closes the gap on the per-condition side.
+--
+-- Production note: CREATE INDEX without CONCURRENTLY takes a brief
+-- write lock on the condition table. Run during a low-traffic window,
+-- or rewrite each to `CREATE INDEX CONCURRENTLY` outside a transaction
+-- if running against a busy prod database.
+
+-- Sort by createdAt (QuestionSortField.createdAt)
+CREATE INDEX IF NOT EXISTS "IDX_condition_public_createdat"
+ON "condition" ("createdAt" DESC)
+WHERE "public" = true;
+
+-- Sort by similarMarketVolume with the 24h window (default volumeKey
+-- when no similarMarketVolumeWindow arg is supplied).
+CREATE INDEX IF NOT EXISTS "IDX_condition_public_volume24h"
+ON "condition" ("volume24h" DESC)
+WHERE "public" = true;
+
+-- Sort by similarMarketVolume with the 7d window (the longest common
+-- discovery window in the FE).
+CREATE INDEX IF NOT EXISTS "IDX_condition_public_volume7d"
+ON "condition" ("volume7d" DESC)
+WHERE "public" = true;

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -224,6 +224,9 @@ model Condition {
   // - IDX_condition_oi_numeric: ("openInterest"::numeric) DESC WHERE public = true
   // - IDX_condition_public_endtime: "endTime" DESC WHERE public = true
   // - IDX_condition_prediction_count: "predictionCount" DESC WHERE public = true
+  // - IDX_condition_public_createdat: "createdAt" DESC WHERE public = true
+  // - IDX_condition_public_volume24h: "volume24h" DESC WHERE public = true
+  // - IDX_condition_public_volume7d: "volume7d" DESC WHERE public = true
   // Trigger: trg_prediction_count maintains predictionCount on prediction INSERT/DELETE
   @@map("condition")
 }

--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -877,7 +877,7 @@ type LegacyPosition {
   id: Int!
   marketAddress: String!
   mintedAt: Int!
-  predictions(cursor: LegacyPredictionWhereUniqueInput, distinct: [LegacyPredictionScalarFieldEnum!], orderBy: [LegacyPredictionOrderByWithRelationInput!], skip: Int, take: Int, where: LegacyPredictionWhereInput): [LegacyPrediction!]!
+  predictions(cursor: LegacyPredictionWhereUniqueInput, distinct: [LegacyPredictionScalarFieldEnum!], orderBy: [LegacyPredictionOrderByWithRelationInput!], skip: Int, take: Int, where: LegacyPredictionWhereInput): [LegacyPrediction!]! @deprecated(reason: "LegacyPosition is the V1 (NFT-based) holdings model and is being phased out. Use `positionsPage` instead.")
   predictor: String!
   predictorCollateral: String
   predictorNftTokenId: String!
@@ -958,10 +958,10 @@ type LegacyPrediction {
   conditionId: String!
   createdAt: DateTimeISO!
   id: Int!
-  limitOrder(where: LimitOrderWhereInput): LimitOrder
+  limitOrder(where: LimitOrderWhereInput): LimitOrder @deprecated(reason: "LimitOrder is deprecated and being phased out.")
   limitOrderId: Int
   outcomeYes: Boolean!
-  position(where: LegacyPositionWhereInput): LegacyPosition
+  position(where: LegacyPositionWhereInput): LegacyPosition @deprecated(reason: "LegacyPosition is the V1 (NFT-based) holdings model and is being phased out. Use `positionsPage` instead.")
   positionId: Int
 }
 
@@ -1057,7 +1057,7 @@ type LimitOrder {
   orderId: String!
   placedAt: Int!
   placedTxHash: String!
-  predictions(cursor: LegacyPredictionWhereUniqueInput, distinct: [LegacyPredictionScalarFieldEnum!], orderBy: [LegacyPredictionOrderByWithRelationInput!], skip: Int, take: Int, where: LegacyPredictionWhereInput): [LegacyPrediction!]!
+  predictions(cursor: LegacyPredictionWhereUniqueInput, distinct: [LegacyPredictionScalarFieldEnum!], orderBy: [LegacyPredictionOrderByWithRelationInput!], skip: Int, take: Int, where: LegacyPredictionWhereInput): [LegacyPrediction!]! @deprecated(reason: "LimitOrder is deprecated and being phased out.")
   predictor: String!
   predictorCollateral: String!
   refCode: String
@@ -1272,6 +1272,24 @@ enum NullsOrder {
   last
 }
 
+"""
+Common shape implemented by every `*Page` type. `items` is intentionally
+not declared on the interface because each page exposes a different
+concrete row type; clients can fragment on the interface to read
+`hasMore` / `totalCount` generically and on the concrete type to read
+the typed `items` list.
+"""
+interface Page {
+  """Server-truth signal that another page exists after this one."""
+  hasMore: Boolean!
+
+  """
+  Total rows matching the filters. May be null when the count is not
+  computed for this resolver (e.g. complex unioned feeds).
+  """
+  totalCount: Int
+}
+
 """Individual outcome pick within a pick configuration"""
 type Pick {
   """
@@ -1343,11 +1361,21 @@ enum PositionSortField {
 }
 
 """
-Paginated wrapper around Position rows with a server-truth hasMore flag
+Paginated wrapper around Position rows with a server-truth hasMore flag.
+`totalCount` is the count of underlying Position rows that match the filters
+(not the count of rendered event-stream rows, which can be larger due to
+per-sell synthetic expansion).
 """
-type PositionsPage {
+type PositionsPage implements Page {
   hasMore: Boolean!
   items: [Position!]!
+
+  """
+  Total Position rows matching the filters. Computed lazily — the count
+  query only fires when this field is selected in the operation, so
+  pagination requests that don't need a total don't pay for one.
+  """
+  totalCount: Int
 }
 
 """
@@ -1556,12 +1584,12 @@ type Query {
   popularTags: [String!]!
 
   """Count of token positions for a given holder"""
-  positionCount(chainId: Int, holder: String!, settled: Boolean): Int!
+  positionCount(chainId: Int, holder: String!, settled: Boolean): Int! @deprecated(reason: "Use `positionsPage(...).totalCount` — same number, available alongside the page payload, no extra query needed.")
 
   """
   Paginated list of token position balances, filterable by holder, condition, chain, pick config, settlement, date range, collateral range, and won/lost status
   """
-  positions(chainId: Int, collateralMax: String, collateralMin: String, conditionId: String, endsAtMax: Int, endsAtMin: Int, holder: String, holderWon: Boolean, orderBy: PositionSortField, orderDirection: SortOrder, pickConfigId: String, result: SettlementResult, settled: Boolean, skip: Int! = 0, take: Int! = 50): [Position!]!
+  positions(chainId: Int, collateralMax: String, collateralMin: String, conditionId: String, endsAtMax: Int, endsAtMin: Int, holder: String, holderWon: Boolean, orderBy: PositionSortField, orderDirection: SortOrder, pickConfigId: String, result: SettlementResult, settled: Boolean, skip: Int! = 0, take: Int! = 50): [Position!]! @deprecated(reason: "Use `positionsPage` — same data with a server-truth `hasMore` stop signal. The bare-array form can return empty pages mid-stream (synthesized sell rows for zero-balance unresolved positions), so `length === 0` is not a reliable end-of-pagination check.")
 
   """
   Same as `positions`, but wraps the result in a `PositionsPage` with a server-truth `hasMore` flag. Use this for infinite scroll: synthesized rows can be empty for some raw pages (zero-balance unresolved positions with no sells), so client-side `lastPage.length === 0` is not a reliable stop signal.

--- a/packages/api/src/graphql/sdl/resolvers/PositionsPage.test.ts
+++ b/packages/api/src/graphql/sdl/resolvers/PositionsPage.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockPrisma = vi.hoisted(() => ({
+  position: { count: vi.fn() },
+}));
+
+vi.mock('../../../core/db', () => ({ default: mockPrisma }));
+
+import { PositionsPage } from './PositionsPage';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const callTotal = (resolver: typeof PositionsPage.totalCount, parent: object) =>
+  (resolver as unknown as (p: unknown) => Promise<number | null>)(parent);
+
+describe('PositionsPage.totalCount', () => {
+  it('returns the eager value when present (early-return paths set it)', async () => {
+    const out = await callTotal(PositionsPage.totalCount, { totalCount: 0 });
+    expect(out).toBe(0);
+    expect(mockPrisma.position.count).not.toHaveBeenCalled();
+  });
+
+  it('returns null when no eager value and no _countWhere is provided', async () => {
+    const out = await callTotal(PositionsPage.totalCount, {
+      totalCount: null,
+    });
+    expect(out).toBeNull();
+    expect(mockPrisma.position.count).not.toHaveBeenCalled();
+  });
+
+  it('issues prisma.position.count(_countWhere) when selected', async () => {
+    mockPrisma.position.count.mockResolvedValue(42);
+    const where = { holder: '0xabc' };
+    const out = await callTotal(PositionsPage.totalCount, {
+      totalCount: null,
+      _countWhere: where,
+    });
+    expect(out).toBe(42);
+    expect(mockPrisma.position.count).toHaveBeenCalledWith({ where });
+  });
+});

--- a/packages/api/src/graphql/sdl/resolvers/PositionsPage.ts
+++ b/packages/api/src/graphql/sdl/resolvers/PositionsPage.ts
@@ -1,0 +1,33 @@
+/**
+ * PositionsPage field resolvers.
+ *
+ * `totalCount` is lazy: `runPositions` returns the matching where
+ * clause as `_countWhere` rather than running an eager count, so the
+ * `prisma.position.count(...)` query only fires when the client
+ * actually selects `totalCount`. The deprecated bare-array `positions`
+ * wrapper discards the envelope's totalCount and never reaches this
+ * resolver, so it gets the count-skip for free.
+ *
+ * The count is the number of underlying Position rows matching the
+ * filters (not the count of rendered event-stream rows, which can be
+ * larger after per-sell synthetic expansion).
+ */
+
+import type { PositionsPageResolvers } from '../__generated__/resolvers';
+import prisma from '../../../core/db';
+
+type PositionsPageParent = {
+  totalCount?: number | null;
+  _countWhere?: NonNullable<
+    Parameters<typeof prisma.position.count>[0]
+  >['where'];
+};
+
+export const PositionsPage: PositionsPageResolvers = {
+  totalCount: async (parent: unknown) => {
+    const p = parent as PositionsPageParent;
+    if (typeof p.totalCount === 'number') return p.totalCount;
+    if (!p._countWhere) return null;
+    return prisma.position.count({ where: p._countWhere });
+  },
+};

--- a/packages/api/src/graphql/sdl/resolvers/index.ts
+++ b/packages/api/src/graphql/sdl/resolvers/index.ts
@@ -29,6 +29,7 @@ import { LegacyPosition } from './LegacyPosition';
 import { LegacyPrediction } from './LegacyPrediction';
 import { LimitOrder } from './LimitOrder';
 import { Pick } from './Pick';
+import { PositionsPage } from './PositionsPage';
 import { ReferralCode } from './ReferralCode';
 import { User } from './User';
 
@@ -59,12 +60,12 @@ import {
   pickConfiguration,
   pickConfigurations,
   positionCount,
-  positions,
   positionsPage,
   prediction,
   predictionCount,
   predictions,
 } from './queries/escrow';
+import { positions } from './queries/deprecated/escrow';
 import { accountProfitRank, profitLeaderboard } from './queries/pnl';
 import { questions } from './queries/questions';
 import {
@@ -150,6 +151,7 @@ export const resolvers: Resolvers = {
   LegacyPrediction,
   LimitOrder,
   Pick,
+  PositionsPage,
   ReferralCode,
   User,
 };

--- a/packages/api/src/graphql/sdl/resolvers/queries/deprecated/escrow.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/deprecated/escrow.ts
@@ -1,0 +1,20 @@
+/**
+ * Deprecated escrow-system queries:
+ *
+ *   - positions — replaced by `positionsPage` (server-truth `hasMore`
+ *     + lazy `totalCount`). Logic lives in `runPositions` in the live
+ *     `../escrow.ts`; this wrapper just discards the envelope and
+ *     returns the items array for backwards compatibility.
+ */
+
+import type { QueryResolvers } from '../../../__generated__/resolvers';
+import { runPositions } from '../escrow';
+
+export const positions: NonNullable<QueryResolvers['positions']> = async (
+  _parent,
+  args,
+  ctx
+) => {
+  const { items } = await runPositions(args, ctx);
+  return items;
+};

--- a/packages/api/src/graphql/sdl/resolvers/queries/escrow.test.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/escrow.test.ts
@@ -13,26 +13,35 @@ import type {
   QueryPositionsArgs,
   QueryPositionCountArgs,
 } from '../../__generated__/resolvers';
-import { positions, positionCount, positionsPage } from './escrow';
+import {
+  __clearPositionSynthesisCache,
+  positionCount,
+  positionsPage,
+} from './escrow';
 
 // Resolvers in the generated module are typed as the
 // `ResolverFn | ResolverWithResolve` union, which TypeScript can't narrow
 // to a callable from outside Apollo. The implementations are plain async
 // functions, so we cast to the function shape for direct invocation in
 // tests.
-type PositionsFn = (
+type PositionsPageFn = (
   parent: unknown,
   args: QueryPositionsArgs,
   ctx: unknown,
   info: unknown
-) => Promise<unknown[]>;
+) => Promise<{
+  items: unknown[];
+  hasMore: boolean;
+  totalCount: number | null;
+  _countWhere?: unknown;
+}>;
 type PositionCountFn = (
   parent: unknown,
   args: QueryPositionCountArgs,
   ctx: unknown,
   info: unknown
 ) => Promise<number>;
-const positionsFn = positions as unknown as PositionsFn;
+const positionsPageFn = positionsPage as unknown as PositionsPageFn;
 const positionCountFn = positionCount as unknown as PositionCountFn;
 
 const ALICE = '0xalice';
@@ -144,20 +153,34 @@ type PositionRowShape = {
   totalPayout: string | null;
 };
 
-const callPositions = (
+// Wrap positionsPage so the existing assertions (which check the row
+// array directly) keep working — the synthetic-row + WAC logic is the
+// same regardless of which Page/non-Page entry point is used.
+const callPositions = async (
   args: Partial<QueryPositionsArgs> = {}
 ): Promise<PositionRowShape[]> => {
-  return positionsFn(
+  const result = await positionsPageFn(
     undefined,
     { take: 50, skip: 0, holder: ALICE, ...args },
     undefined,
     undefined
-  ) as Promise<PositionRowShape[]>;
+  );
+  return result.items as PositionRowShape[];
 };
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Clear the synthesis cache between tests so per-test fixtures don't
+  // accidentally hit a previous test's synthesized rows (the cache key
+  // is `(chainId, token, holder, updatedAt)` and fixtures reuse those
+  // values).
+  __clearPositionSynthesisCache();
   mockPrisma.secondaryTrade.findMany.mockResolvedValue([]);
+  // totalCount is now lazy — runPositions returns `_countWhere` and the
+  // PositionsPage.totalCount field resolver issues the count query only
+  // when the field is actually selected. The default mock here just
+  // covers tests that do exercise the totalCount path.
+  mockPrisma.position.count.mockResolvedValue(0);
 });
 
 describe('positions resolver — synthetic row emission', () => {
@@ -325,6 +348,132 @@ describe('positions resolver — synthetic row emission', () => {
     });
   });
 
+  it('two sells with a buy between them: each sell sees the WAC at its own moment', async () => {
+    // Timeline (alice is the predictor; the predictor mint hits the pool at TS_MINT):
+    //   t=MINT      mint 200 shares for cost 100   pool=(100, 200)  WAC=0.5
+    //   t=MINT+1    sell 100 @ proceeds 80         allocated = 100*100/200 = 50
+    //                                              pool=(50, 100)   WAC=0.5
+    //   t=BUY       buy 100 @ cost 90              pool=(140, 200)  WAC=0.7
+    //   t=SELL      sell 200 @ proceeds 200        allocated = 140*200/200 = 140
+    //                                              pool=(0, 0)
+    // Final balance is 0 and the pickConfig is unresolved, so the open row is
+    // dropped — we expect exactly two SOLD rows with distinct cost bases.
+    const TS_SELL_1 = TS_MINT + 1;
+    mockPrisma.position.findMany.mockResolvedValue([
+      makePosition({
+        balance: '0',
+        pickConfiguration: makePickConfig({
+          predictions: [makePrediction()], // cost=100, shares=200
+        }),
+      }),
+    ]);
+    mockPrisma.secondaryTrade.findMany.mockResolvedValue([
+      makeTrade({
+        seller: ALICE,
+        buyer: '0xcarol',
+        price: '80',
+        tokenAmount: '100',
+        executedAt: TS_SELL_1,
+        tradeHash: '0xsellA',
+      }),
+      makeTrade({
+        seller: '0xcarol',
+        buyer: ALICE,
+        price: '90',
+        tokenAmount: '100',
+        executedAt: TS_BUY,
+        tradeHash: '0xbuyB',
+      }),
+      makeTrade({
+        seller: ALICE,
+        buyer: '0xdave',
+        price: '200',
+        tokenAmount: '200',
+        executedAt: TS_SELL,
+        tradeHash: '0xsellC',
+      }),
+    ]);
+
+    const result = await callPositions();
+
+    const sells = result.filter((r) => r.id.includes('-sell-'));
+    const opens = result.filter((r) => !r.id.includes('-sell-'));
+    expect(opens).toHaveLength(0);
+    expect(sells).toHaveLength(2);
+
+    const sellA = sells.find((r) => r.id.endsWith('0xsellA'));
+    const sellC = sells.find((r) => r.id.endsWith('0xsellC'));
+    expect(sellA).toMatchObject({
+      userCollateral: '50',
+      realizedPnL: '30', // 80 - 50
+      balance: '0',
+    });
+    expect(sellC).toMatchObject({
+      userCollateral: '140',
+      realizedPnL: '60', // 200 - 140
+      balance: '0',
+    });
+  });
+
+  it('two sells back-to-back (no buys between): WAC stays constant; pool drains proportionally', async () => {
+    // Timeline:
+    //   t=MINT      mint 300 shares for cost 150   pool=(150, 300)  WAC=0.5
+    //   t=BUY       sell 100 @ proceeds 70         allocated = 150*100/300 = 50
+    //                                              pool=(100, 200)  WAC=0.5
+    //   t=SELL      sell 100 @ proceeds 80         allocated = 100*100/200 = 50
+    //                                              pool=(50, 100)   WAC=0.5
+    // Balance is 100 remaining and unresolved — expect 2 SOLD rows
+    // (each with cost 50) plus 1 open row carrying the remaining 50.
+    mockPrisma.position.findMany.mockResolvedValue([
+      makePosition({
+        balance: '100',
+        pickConfiguration: makePickConfig({
+          predictions: [
+            makePrediction({
+              predictorCollateral: '150',
+              counterpartyCollateral: '150',
+            }),
+          ],
+        }),
+      }),
+    ]);
+    mockPrisma.secondaryTrade.findMany.mockResolvedValue([
+      makeTrade({
+        seller: ALICE,
+        buyer: '0xcarol',
+        price: '70',
+        tokenAmount: '100',
+        executedAt: TS_BUY,
+        tradeHash: '0xsellA',
+      }),
+      makeTrade({
+        seller: ALICE,
+        buyer: '0xdave',
+        price: '80',
+        tokenAmount: '100',
+        executedAt: TS_SELL,
+        tradeHash: '0xsellB',
+      }),
+    ]);
+
+    const result = await callPositions();
+
+    const sells = result.filter((r) => r.id.includes('-sell-'));
+    const opens = result.filter((r) => !r.id.includes('-sell-'));
+    expect(sells).toHaveLength(2);
+    expect(opens).toHaveLength(1);
+
+    const sellA = sells.find((r) => r.id.endsWith('0xsellA'));
+    const sellB = sells.find((r) => r.id.endsWith('0xsellB'));
+    expect(sellA).toMatchObject({ userCollateral: '50', realizedPnL: '20' });
+    expect(sellB).toMatchObject({ userCollateral: '50', realizedPnL: '30' });
+    expect(opens[0]).toMatchObject({
+      id: '1',
+      balance: '100',
+      userCollateral: '50', // remaining cost basis
+    });
+  });
+
   it('zero balance, unresolved, no sells (transferred away): emits no rows', async () => {
     mockPrisma.position.findMany.mockResolvedValue([
       makePosition({
@@ -482,10 +631,10 @@ describe('positions resolver — query shape', () => {
     );
   });
 
-  it('runs preloadPickConditions and secondaryTrade.findMany in parallel after position.findMany', async () => {
-    // We can't observe scheduling directly, but we can confirm both
-    // dependent fetches were issued from the resolver. The Promise.all
-    // wrapper means neither blocks the other.
+  it('issues secondaryTrade.findMany once after position.findMany returns rows', async () => {
+    // The synthesis pipeline fans out to the trades fetch after raw
+    // positions land. We're asserting the trade-fetch shape so
+    // regressions on the position → trade pipeline still surface here.
     mockPrisma.position.findMany.mockResolvedValue([
       makePosition({ balance: '100' }),
     ]);
@@ -493,9 +642,6 @@ describe('positions resolver — query shape', () => {
     await callPositions({ holder: ALICE });
 
     expect(mockPrisma.secondaryTrade.findMany).toHaveBeenCalledTimes(1);
-    // preloadPickConditions issues a condition.findMany when ctx is provided.
-    // We don't pass ctx in this suite, so it's a no-op — but the trades
-    // call is the smoking gun that the parallel branch ran.
     const tradesArgs = mockPrisma.secondaryTrade.findMany.mock.calls[0][0];
     expect(tradesArgs.where).toMatchObject({
       OR: [{ seller: { in: [ALICE] } }, { buyer: { in: [ALICE] } }],
@@ -520,15 +666,7 @@ describe('positions resolver — query shape', () => {
   });
 });
 
-describe('positionsPage resolver', () => {
-  type PositionsPageFn = (
-    parent: unknown,
-    args: QueryPositionsArgs,
-    ctx: unknown,
-    info: unknown
-  ) => Promise<{ items: unknown[]; hasMore: boolean }>;
-  const positionsPageFn = positionsPage as unknown as PositionsPageFn;
-
+describe('positionsPage resolver — page envelope', () => {
   const callPositionsPage = (args: Partial<QueryPositionsArgs> = {}) =>
     positionsPageFn(
       undefined,
@@ -589,6 +727,65 @@ describe('positionsPage resolver', () => {
 
     expect(result.items.length).toBe(0);
     expect(result.hasMore).toBe(true);
+  });
+
+  it('runPositions does not issue a count query — totalCount is lazy', async () => {
+    mockPrisma.position.findMany.mockResolvedValue([]);
+
+    const result = await callPositionsPage({ take: 10, holder: ALICE });
+
+    // The envelope carries `_countWhere` matching the findMany where, but
+    // the count query itself is deferred to the PositionsPage.totalCount
+    // field resolver (which only runs when the client selects totalCount).
+    expect(result.totalCount).toBeNull();
+    expect(mockPrisma.position.count).not.toHaveBeenCalled();
+    const findManyWhere = mockPrisma.position.findMany.mock.calls[0][0].where;
+    expect(result._countWhere).toEqual(findManyWhere);
+  });
+
+  it('synthesis cache: second request with same Position.updatedAt skips the trades fetch', async () => {
+    const positionRow = makePosition({
+      balance: '200',
+      pickConfiguration: makePickConfig({
+        predictions: [makePrediction()],
+      }),
+    });
+    mockPrisma.position.findMany.mockResolvedValue([positionRow]);
+
+    // First call: cache miss → trades fetch fires.
+    const first = await callPositionsPage({ take: 10, holder: ALICE });
+    expect(first.items.length).toBeGreaterThan(0);
+    expect(mockPrisma.secondaryTrade.findMany).toHaveBeenCalledTimes(1);
+
+    // Second call (same Position.updatedAt): cache hit → no trades fetch.
+    const second = await callPositionsPage({ take: 10, holder: ALICE });
+    expect(second.items.length).toBe(first.items.length);
+    expect(mockPrisma.secondaryTrade.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('synthesis cache: bumping Position.updatedAt invalidates the entry', async () => {
+    const v1 = makePosition({
+      balance: '200',
+      updatedAt: new Date(1_000_000_000_000),
+      pickConfiguration: makePickConfig({
+        predictions: [makePrediction()],
+      }),
+    });
+    mockPrisma.position.findMany.mockResolvedValue([v1]);
+    await callPositionsPage({ take: 10, holder: ALICE });
+    expect(mockPrisma.secondaryTrade.findMany).toHaveBeenCalledTimes(1);
+
+    const v2 = makePosition({
+      balance: '200',
+      updatedAt: new Date(1_000_000_001_000),
+      pickConfiguration: makePickConfig({
+        predictions: [makePrediction()],
+      }),
+    });
+    mockPrisma.position.findMany.mockResolvedValue([v2]);
+    await callPositionsPage({ take: 10, holder: ALICE });
+    // Different updatedAt → cache miss → another trades fetch.
+    expect(mockPrisma.secondaryTrade.findMany).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
@@ -7,7 +7,8 @@
  *   prediction           — single lookup by predictionId
  *   pickConfigurations   — paginated picks config list
  *   pickConfiguration    — single lookup by id
- *   positions            — paginated token-balance list with many filters
+ *   positions            — paginated token-balance list with many filters (deprecated; see `queries/deprecated/escrow.ts`)
+ *   positionsPage        — same data, server-truth `hasMore` + lazy `totalCount`
  *   closes               — paginated burn records
  *   claims               — paginated redemption records
  *
@@ -15,6 +16,19 @@
  * `Close`, and `Claim` are all custom object types (NOT direct Prisma
  * models); every resolver below hand-maps the Prisma row to the SDL
  * shape. `mapPickConfig` lives in the shared `pickConfigHelpers.ts`.
+ *
+ * `runPositions` is the most involved resolver — it builds a Prisma
+ * where, runs an optional collateral-range pre-query, fetches a page of
+ * Positions, then synthesizes a per-position event stream (mints +
+ * trades, walked with running WAC) into one or more output rows. It is
+ * decomposed into focused helpers so each step is inspectable in
+ * isolation:
+ *
+ *   normalizePositionsArgs   → clamp + lowercase
+ *   buildPositionsWhere      → conditionId pre-resolve + filter merge
+ *   applyCollateralRange     → raw-SQL UNION of in-range pickConfigIds
+ *   synthesizePositionsPage  → cache split + trade fetch + WAC walk
+ *   sortSynthesizedRows      → final interleaved sort
  */
 
 import type {
@@ -28,6 +42,8 @@ import { Prisma } from '../../../../../generated/prisma';
 import prisma from '../../../../core/db';
 import { mapPickConfig } from '../pickConfigHelpers';
 import { preloadPickConditions } from '../preloadPickConditions';
+import { TtlCache } from '../../../../lib/ttlCache';
+import { clampSkip, clampTake } from './pagination';
 
 type PredictionWithPickConfig = Prisma.PredictionGetPayload<{
   include: { pickConfiguration: { include: { picks: true } } };
@@ -222,57 +238,147 @@ type PositionShape = ResolversParentTypes['Position'] & {
   pickConfig: ReturnType<typeof mapPickConfig> | null;
 };
 
-const runPositions = async (
-  {
-    holder,
+/**
+ * Per-position synthesis cache. The synthesized event-stream rows for
+ * a Position depend on its trade history + the pickConfiguration's
+ * predictions; both are append-only and overlap heavily across page
+ * requests. Keying on `Position.updatedAt.getTime()` invalidates
+ * automatically when the indexer touches the row (mint, burn, balance
+ * change). The 30s TTL bounds staleness for the indirect path where a
+ * fresh secondaryTrade lands without bumping Position.updatedAt — the
+ * trade itself surfaces on accountActivityPage immediately; only the
+ * derived cost-basis view here lags briefly.
+ *
+ * maxSize bounds memory: each entry is 1-2 small objects per held
+ * position. 10_000 covers ~all active holders across both chains.
+ */
+const positionSynthesisCache = new TtlCache<string, PositionShape[]>({
+  ttlMs: 30_000,
+  maxSize: 10_000,
+});
+
+const positionSynthesisCacheKey = (r: {
+  chainId: number;
+  tokenAddress: string;
+  holder: string;
+  updatedAt: Date;
+}) => `${r.chainId}:${r.tokenAddress}:${r.holder}:${r.updatedAt.getTime()}`;
+
+/** Test-only: clear synthesis cache between test cases. */
+export const __clearPositionSynthesisCache = () =>
+  positionSynthesisCache.clear();
+
+export type PositionsPageEnvelope = {
+  items: PositionShape[];
+  hasMore: boolean;
+  totalCount: number | null;
+  _countWhere?: Prisma.PositionWhereInput;
+};
+
+type NormalizedPositionsArgs = {
+  cappedTake: number;
+  skipVal: number;
+  holderLower?: string;
+  pickConfigIdLower?: string;
+  conditionId: string | null;
+  chainId: number | null | undefined;
+  settled: boolean | null | undefined;
+  result: QueryPositionsArgs['result'];
+  endsAtMin: number | null | undefined;
+  endsAtMax: number | null | undefined;
+  holderWon: boolean | null | undefined;
+  collateralMin: string | null | undefined;
+  collateralMax: string | null | undefined;
+  orderField: 'createdAt' | 'updatedAt';
+  orderDirection: 'asc' | 'desc';
+};
+
+const normalizePositionsArgs = (
+  args: QueryPositionsArgs
+): NormalizedPositionsArgs => ({
+  cappedTake: clampTake(args.take, { defaultTake: 50, maxTake: 100 }),
+  // Positions uses a 10_000 ceiling rather than the shared
+  // `MAX_SKIP = 1_000` default in `./pagination.ts`. Staging was
+  // unbounded, so this is purely a defensive safety net: nobody
+  // realistically pages past row ~5_000 of their own positions, but
+  // an accidental `skip: 5_000_000` would otherwise force Postgres to
+  // scan and discard millions of rows. The broader `*Page` refactor
+  // will land the uniform 1_000 policy across all paginated queries;
+  // we keep positions at 10_000 here so this slice stays close to the
+  // previous open-ended behavior.
+  skipVal: clampSkip(args.skip, { maxSkip: 10_000 }),
+  holderLower: args.holder?.toLowerCase(),
+  pickConfigIdLower: args.pickConfigId?.toLowerCase(),
+  conditionId: args.conditionId ?? null,
+  chainId: args.chainId,
+  settled: args.settled,
+  result: args.result,
+  endsAtMin: args.endsAtMin,
+  endsAtMax: args.endsAtMax,
+  holderWon: args.holderWon,
+  collateralMin: args.collateralMin,
+  collateralMax: args.collateralMax,
+  // PositionSortField SDL enum values are CREATED_AT / UPDATED_AT; map
+  // to the Prisma column name for orderBy.
+  orderField: args.orderBy === 'CREATED_AT' ? 'createdAt' : 'updatedAt',
+  orderDirection: args.orderDirection === 'asc' ? 'asc' : 'desc',
+});
+
+/**
+ * Resolve `conditionId` to the matching pickConfigIds via the join
+ * table. Returns null when no pickConfigs match — caller must early-
+ * return an empty page (a `pickConfigId IN ()` would match no rows
+ * but pay for a useless query).
+ */
+const resolveConditionPickConfigIds = async (
+  conditionId: string
+): Promise<string[] | null> => {
+  const matchingPicks = await prisma.pick.findMany({
+    where: {
+      conditionId: { equals: conditionId.toLowerCase(), mode: 'insensitive' },
+    },
+    select: { pickConfigId: true },
+    distinct: ['pickConfigId'],
+  });
+  if (matchingPicks.length === 0) return null;
+  return matchingPicks.map((p) => p.pickConfigId);
+};
+
+/**
+ * Build the Prisma where for `positions`. Returns `null` when the
+ * filter set is empty (no holder / conditionId / pickConfigId) — the
+ * resolver requires at least one to avoid unbounded scans.
+ *
+ * `conditionPickConfigIds` is the optional pre-resolved set from
+ * resolveConditionPickConfigIds; when present it scopes pickConfigId
+ * to just those ids.
+ */
+const buildPositionsWhere = (
+  args: NormalizedPositionsArgs,
+  conditionPickConfigIds: string[] | null
+): Prisma.PositionWhereInput | null => {
+  const {
+    holderLower,
+    pickConfigIdLower,
     conditionId,
-    take,
-    skip,
     chainId,
-    pickConfigId,
     settled,
     result,
     endsAtMin,
     endsAtMax,
     holderWon,
-    collateralMin,
-    collateralMax,
-    orderBy,
-    orderDirection,
-  }: QueryPositionsArgs,
-  ctx: ApolloContext | undefined
-): Promise<{
-  items: PositionShape[];
-  hasMore: boolean;
-}> => {
-  const cappedTake = Math.max(1, Math.min(take ?? 50, 100));
-  const skipVal = skip ?? 0;
-  const holderLower = holder?.toLowerCase();
-  const pickConfigIdLower = pickConfigId?.toLowerCase();
+  } = args;
+
+  if (!holderLower && !conditionId && !pickConfigIdLower) return null;
 
   const where: Prisma.PositionWhereInput = {};
 
   if (holderLower) where.holder = holderLower;
-
-  if (conditionId) {
-    const matchingPicks = await prisma.pick.findMany({
-      where: {
-        conditionId: { equals: conditionId.toLowerCase(), mode: 'insensitive' },
-      },
-      select: { pickConfigId: true },
-      distinct: ['pickConfigId'],
-    });
-    const pickConfigIds = matchingPicks.map((p) => p.pickConfigId);
-    if (pickConfigIds.length === 0) return { items: [], hasMore: false };
-    where.pickConfigId = { in: pickConfigIds };
-  }
-
-  // Require at least one filter — prevents accidentally-unbounded queries.
-  if (!holderLower && !conditionId && !pickConfigIdLower)
-    return { items: [], hasMore: false };
-
+  if (conditionPickConfigIds)
+    where.pickConfigId = { in: conditionPickConfigIds };
   if (chainId !== undefined && chainId !== null) where.chainId = chainId;
   if (pickConfigIdLower && !conditionId) where.pickConfigId = pickConfigIdLower;
+
   if (settled !== undefined && settled !== null) {
     where.pickConfiguration = {
       ...((where.pickConfiguration as Prisma.PicksWhereInput) ?? {}),
@@ -326,127 +432,268 @@ const runPositions = async (
     ];
   }
 
-  // Collateral range: pre-query pickConfigIds where holder's collateral is
-  // in range via a raw UNION grouped by side (predictor vs counterparty).
-  if (holderLower && (collateralMin || collateralMax)) {
-    const minVal = collateralMin ? BigInt(collateralMin) : 0n;
-    const maxVal = collateralMax ? BigInt(collateralMax) : null;
-    interface PickConfigRow {
-      pickConfigId: string;
-      is_predictor: boolean;
-    }
-    const matchingConfigs = await prisma.$queryRaw<PickConfigRow[]>`
-      SELECT "pickConfigId", true AS is_predictor
-      FROM "Prediction"
-      WHERE predictor = ${holderLower} AND "pickConfigId" IS NOT NULL
-      GROUP BY "pickConfigId"
-      HAVING SUM(CAST("predictorCollateral" AS DECIMAL)) >= ${minVal.toString()}::DECIMAL
-        ${maxVal !== null ? Prisma.sql`AND SUM(CAST("predictorCollateral" AS DECIMAL)) <= ${maxVal.toString()}::DECIMAL` : Prisma.empty}
-      UNION
-      SELECT "pickConfigId", false AS is_predictor
-      FROM "Prediction"
-      WHERE counterparty = ${holderLower} AND "pickConfigId" IS NOT NULL
-      GROUP BY "pickConfigId"
-      HAVING SUM(CAST("counterpartyCollateral" AS DECIMAL)) >= ${minVal.toString()}::DECIMAL
-        ${maxVal !== null ? Prisma.sql`AND SUM(CAST("counterpartyCollateral" AS DECIMAL)) <= ${maxVal.toString()}::DECIMAL` : Prisma.empty}
-    `;
-    if (matchingConfigs.length === 0) return { items: [], hasMore: false };
-    const validPickConfigIds = matchingConfigs.map((r) => r.pickConfigId);
-    if (
-      where.pickConfigId &&
-      typeof where.pickConfigId === 'object' &&
-      'in' in where.pickConfigId
-    ) {
-      const existing = where.pickConfigId.in as string[];
-      where.pickConfigId = {
-        in: existing.filter((id) => validPickConfigIds.includes(id)),
-      };
-    } else if (where.pickConfigId && typeof where.pickConfigId === 'string') {
-      if (!validPickConfigIds.includes(where.pickConfigId))
-        return { items: [], hasMore: false };
-    } else {
-      where.pickConfigId = { in: validPickConfigIds };
+  return where;
+};
+
+/**
+ * Pre-query pickConfigIds where the holder's collateral is in
+ * [collateralMin, collateralMax] via a raw UNION grouped by side
+ * (predictor vs counterparty). Returns the intersected pickConfigId
+ * filter to merge into the where, or `null` to signal "no matching
+ * configs — return empty page".
+ */
+const applyCollateralRangeFilter = async (
+  where: Prisma.PositionWhereInput,
+  holderLower: string,
+  collateralMin: string | null | undefined,
+  collateralMax: string | null | undefined
+): Promise<Prisma.PositionWhereInput | null> => {
+  if (!collateralMin && !collateralMax) return where;
+  const minVal = collateralMin ? BigInt(collateralMin) : 0n;
+  const maxVal = collateralMax ? BigInt(collateralMax) : null;
+  interface PickConfigRow {
+    pickConfigId: string;
+    is_predictor: boolean;
+  }
+  const matchingConfigs = await prisma.$queryRaw<PickConfigRow[]>`
+    SELECT "pickConfigId", true AS is_predictor
+    FROM "Prediction"
+    WHERE predictor = ${holderLower} AND "pickConfigId" IS NOT NULL
+    GROUP BY "pickConfigId"
+    HAVING SUM(CAST("predictorCollateral" AS DECIMAL)) >= ${minVal.toString()}::DECIMAL
+      ${maxVal !== null ? Prisma.sql`AND SUM(CAST("predictorCollateral" AS DECIMAL)) <= ${maxVal.toString()}::DECIMAL` : Prisma.empty}
+    UNION
+    SELECT "pickConfigId", false AS is_predictor
+    FROM "Prediction"
+    WHERE counterparty = ${holderLower} AND "pickConfigId" IS NOT NULL
+    GROUP BY "pickConfigId"
+    HAVING SUM(CAST("counterpartyCollateral" AS DECIMAL)) >= ${minVal.toString()}::DECIMAL
+      ${maxVal !== null ? Prisma.sql`AND SUM(CAST("counterpartyCollateral" AS DECIMAL)) <= ${maxVal.toString()}::DECIMAL` : Prisma.empty}
+  `;
+  if (matchingConfigs.length === 0) return null;
+  const validPickConfigIds = matchingConfigs.map((r) => r.pickConfigId);
+  if (
+    where.pickConfigId &&
+    typeof where.pickConfigId === 'object' &&
+    'in' in where.pickConfigId
+  ) {
+    const existing = where.pickConfigId.in as string[];
+    where.pickConfigId = {
+      in: existing.filter((id) => validPickConfigIds.includes(id)),
+    };
+  } else if (where.pickConfigId && typeof where.pickConfigId === 'string') {
+    if (!validPickConfigIds.includes(where.pickConfigId)) return null;
+  } else {
+    where.pickConfigId = { in: validPickConfigIds };
+  }
+  return where;
+};
+
+type PositionRow = Prisma.PositionGetPayload<{
+  include: {
+    pickConfiguration: {
+      include: { picks: true; predictions: true };
+    };
+  };
+}>;
+type TradeRow = {
+  chainId: number;
+  token: string;
+  seller: string;
+  buyer: string;
+  price: string;
+  tokenAmount: string;
+  executedAt: number;
+  tradeHash: string;
+};
+
+const positionKey = (chainId: number, token: string, holder: string) =>
+  `${chainId}:${token}:${holder}`;
+
+/**
+ * Walk a single Position's mint + trade history with running WAC,
+ * emitting one synthetic Closed row per sell (when unresolved) and an
+ * Open row carrying remaining cost basis. Claims are intentionally
+ * excluded — the contract reverts redeem() unless the pickConfig is
+ * resolved, so any Claim is post-settlement and the existing
+ * settlement-PnL flow on a resolved Position already covers it.
+ */
+const synthesizePositionRow = (
+  r: PositionRow,
+  trades: readonly TradeRow[]
+): PositionShape[] => {
+  const pc = r.pickConfiguration;
+  let totalPayout = 0n;
+  let predictionId: string | null = null;
+
+  type Acquire = { ts: number; cost: bigint; shares: bigint };
+  type Disposal = {
+    tradeHash: string;
+    ts: number;
+    proceeds: bigint;
+    shares: bigint;
+  };
+  const acquires: Acquire[] = [];
+  const disposals: Disposal[] = [];
+
+  if (pc) {
+    for (const pred of pc.predictions) {
+      const predCollateral = BigInt(pred.predictorCollateral);
+      const cpCollateral = BigInt(pred.counterpartyCollateral);
+      const predictionTotal = predCollateral + cpCollateral;
+      const isHolderSide =
+        (r.isPredictorToken && pred.predictor === r.holder) ||
+        (!r.isPredictorToken && pred.counterparty === r.holder);
+      if (!isHolderSide) continue;
+      predictionId ??= pred.predictionId;
+      totalPayout += predictionTotal;
+      // Mint amount on both sides equals total collateral pool (see
+      // PredictionMarketEscrow.sol). Cost is just the holder's share.
+      const cost = r.isPredictorToken ? predCollateral : cpCollateral;
+      acquires.push({
+        ts: pred.createdAt.getTime() / 1000,
+        cost,
+        shares: predictionTotal,
+      });
     }
   }
 
-  // PositionSortField SDL enum values are CREATED_AT / UPDATED_AT; map
-  // to the Prisma column name for orderBy.
-  const posOrderDirection = orderDirection === 'asc' ? 'asc' : 'desc';
-  const posOrderField = orderBy === 'CREATED_AT' ? 'createdAt' : 'updatedAt';
-  const orderByClause: Prisma.PositionOrderByWithRelationInput = {
-    [posOrderField]: posOrderDirection,
-  };
+  for (const t of trades) {
+    const price = BigInt(t.price);
+    const shares = BigInt(t.tokenAmount);
+    if (t.buyer === r.holder) {
+      acquires.push({ ts: t.executedAt, cost: price, shares });
+    }
+    if (t.seller === r.holder) {
+      disposals.push({
+        tradeHash: t.tradeHash,
+        ts: t.executedAt,
+        proceeds: price,
+        shares,
+      });
+    }
+  }
 
-  // The PickConfiguration → Prediction relation is many-to-many in spirit:
-  // any user who has predicted on this market shows up here. We only need
-  // the rows where the holder is a counterparty to compute their cost
-  // basis, so push the filter into the include and avoid pulling every
-  // other user's prediction back over the wire. When `holder` isn't
-  // pinned (conditionId / pickConfigId path), keep the full set.
-  const predictionsInclude: Prisma.Picks$predictionsArgs | true = holderLower
-    ? {
-        where: {
-          OR: [{ predictor: holderLower }, { counterparty: holderLower }],
-        },
-      }
-    : true;
+  const acquiresSorted = [...acquires].sort((a, b) => a.ts - b.ts);
+  const disposalsSorted = [...disposals].sort((a, b) => a.ts - b.ts);
 
-  // Fetch take+1 to detect a `hasMore`-style next page without a count
-  // query. Synthesized event-stream rows from raw positions can be
-  // empty (zero-balance unresolved with no sells), so client-side
-  // `lastPage.length === 0` is unreliable as a stop signal — we need
-  // server-truth pagination.
-  const rawRows = await prisma.position.findMany({
-    where,
-    orderBy: orderByClause,
-    take: cappedTake + 1,
-    skip: skipVal,
-    include: {
-      pickConfiguration: {
-        include: { picks: true, predictions: predictionsInclude },
-      },
-    },
-  });
-  const hasMore = rawRows.length > cappedTake;
-  const rows = rawRows.slice(0, cappedTake);
+  // Walk acquires + disposals in chronological order, maintaining running
+  // WAC. Each disposal records the cost basis allocated to its shares
+  // using the WAC at that moment.
+  let costPool = 0n;
+  let sharesPool = 0n;
+  let acqIdx = 0;
+  type DisposalWithCostBasis = Disposal & { costBasis: bigint };
+  const disposalRows: DisposalWithCostBasis[] = [];
+  for (const d of disposalsSorted) {
+    while (
+      acqIdx < acquiresSorted.length &&
+      acquiresSorted[acqIdx].ts <= d.ts
+    ) {
+      costPool += acquiresSorted[acqIdx].cost;
+      sharesPool += acquiresSorted[acqIdx].shares;
+      acqIdx += 1;
+    }
+    const allocated = sharesPool > 0n ? (costPool * d.shares) / sharesPool : 0n;
+    disposalRows.push({ ...d, costBasis: allocated });
+    costPool -= allocated;
+    sharesPool -= d.shares;
+    if (sharesPool < 0n) sharesPool = 0n;
+    if (costPool < 0n) costPool = 0n;
+  }
+  while (acqIdx < acquiresSorted.length) {
+    costPool += acquiresSorted[acqIdx].cost;
+    sharesPool += acquiresSorted[acqIdx].shares;
+    acqIdx += 1;
+  }
 
-  // For each Position row we build a chronological event stream of primary
-  // mints (Predictions) and secondary trades (buys + sells matching
-  // token+holder), then walk it with running WAC. Each sell produces a
-  // synthetic Closed row; if balance > 0 at the end, we also emit an Open
-  // row carrying the remaining cost basis. Claims are intentionally excluded
-  // — the contract reverts redeem() unless the pickConfig is resolved, so
-  // any Claim is post-settlement and the existing settlement-PnL flow on a
-  // resolved Position already covers it.
-  const chainIds = Array.from(new Set(rows.map((r) => r.chainId)));
-  const tokenAddresses = Array.from(new Set(rows.map((r) => r.tokenAddress)));
-  const holders = Array.from(new Set(rows.map((r) => r.holder)));
+  const totalUserCollateral = acquires.reduce((s, a) => s + a.cost, 0n);
+  const totalPayoutStr = totalPayout > 0n ? totalPayout.toString() : null;
+  const mappedPickConfig = pc ? mapPickConfig(pc, { predictionId }) : null;
+  const balanceBn = BigInt(r.balance);
+  const isResolved = pc?.resolved ?? false;
 
-  type TradeRow = {
-    chainId: number;
-    token: string;
-    seller: string;
-    buyer: string;
-    price: string;
-    tokenAmount: string;
-    executedAt: number;
-    tradeHash: string;
-  };
+  const out: PositionShape[] = [];
 
-  // preloadPickConditions and the trades fetch are independent — both only
-  // need `rows`. Run them in parallel to overlap their network round trips.
-  const [, trades] = await Promise.all([
-    preloadPickConditions(
-      ctx,
-      rows.map((r) => r.pickConfiguration)
-    ),
-    rows.length === 0
-      ? Promise.resolve([] as TradeRow[])
-      : prisma.secondaryTrade.findMany({
+  // Emit one synthetic row per sell (only meaningful for unresolved
+  // pickConfigs — once settled, the existing PnL flow takes over).
+  if (!isResolved) {
+    for (const d of disposalRows) {
+      out.push({
+        id: `${r.id}-sell-${d.tradeHash}`,
+        chainId: r.chainId,
+        tokenAddress: r.tokenAddress,
+        pickConfigId: r.pickConfigId,
+        isPredictorToken: r.isPredictorToken,
+        holder: r.holder,
+        balance: '0',
+        userCollateral: d.costBasis.toString(),
+        totalPayout: totalPayoutStr,
+        realizedPnL: (d.proceeds - d.costBasis).toString(),
+        createdAt: r.createdAt,
+        updatedAt: new Date(d.ts * 1000),
+        pickConfig: mappedPickConfig,
+      });
+    }
+  }
+
+  // Open / parent row: keep when there's still balance, or when the
+  // position is settled (existing settlement-PnL flow handles it). A
+  // zero-balance unresolved row with no sells means the holder transferred
+  // or burned the tokens off-platform — drop it, matching prior behavior.
+  if (balanceBn > 0n || isResolved) {
+    const remainingCost =
+      !isResolved && disposalRows.length > 0 ? costPool : totalUserCollateral;
+    out.push({
+      id: String(r.id),
+      chainId: r.chainId,
+      tokenAddress: r.tokenAddress,
+      pickConfigId: r.pickConfigId,
+      isPredictorToken: r.isPredictorToken,
+      holder: r.holder,
+      balance: r.balance,
+      userCollateral: remainingCost > 0n ? remainingCost.toString() : null,
+      totalPayout: totalPayoutStr,
+      realizedPnL: null,
+      createdAt: r.createdAt,
+      updatedAt: r.updatedAt,
+      pickConfig: mappedPickConfig,
+    });
+  }
+
+  return out;
+};
+
+/**
+ * Synthesize a page of Position rows: split into cache hits/misses,
+ * fetch trades only for the misses, then run the WAC walk per row.
+ * Hits skip both the trades fetch and the synthesis loop entirely.
+ */
+const synthesizePositionsPage = async (
+  rows: PositionRow[]
+): Promise<PositionShape[]> => {
+  const cachedByRow = new Map<PositionRow, PositionShape[]>();
+  const missedRows: PositionRow[] = [];
+  for (const r of rows) {
+    const cached = positionSynthesisCache.get(positionSynthesisCacheKey(r));
+    if (cached) cachedByRow.set(r, cached);
+    else missedRows.push(r);
+  }
+
+  const missChainIds = Array.from(new Set(missedRows.map((r) => r.chainId)));
+  const missTokens = Array.from(new Set(missedRows.map((r) => r.tokenAddress)));
+  const missHolders = Array.from(new Set(missedRows.map((r) => r.holder)));
+  const trades: TradeRow[] =
+    missedRows.length === 0
+      ? []
+      : await prisma.secondaryTrade.findMany({
           where: {
-            chainId: { in: chainIds },
-            token: { in: tokenAddresses },
-            OR: [{ seller: { in: holders } }, { buyer: { in: holders } }],
+            chainId: { in: missChainIds },
+            token: { in: missTokens },
+            OR: [
+              { seller: { in: missHolders } },
+              { buyer: { in: missHolders } },
+            ],
           },
           select: {
             chainId: true,
@@ -458,12 +705,9 @@ const runPositions = async (
             executedAt: true,
             tradeHash: true,
           },
-        }),
-  ]);
+        });
 
-  const positionKey = (chainId: number, token: string, holder: string) =>
-    `${chainId}:${token}:${holder}`;
-  const tradesByPos = new Map<string, typeof trades>();
+  const tradesByPos = new Map<string, TradeRow[]>();
   for (const t of trades) {
     for (const role of [t.seller, t.buyer] as const) {
       const k = positionKey(t.chainId, t.token, role);
@@ -473,174 +717,132 @@ const runPositions = async (
     }
   }
 
-  const synthesized: PositionShape[] = [];
+  const out: PositionShape[] = [];
   for (const r of rows) {
-    const pc = r.pickConfiguration;
-    let totalPayout = 0n;
-    let predictionId: string | null = null;
-
-    // Primary-mint events from Predictions tied to this position
-    type Acquire = { ts: number; cost: bigint; shares: bigint };
-    type Disposal = {
-      tradeHash: string;
-      ts: number;
-      proceeds: bigint;
-      shares: bigint;
-    };
-    const acquires: Acquire[] = [];
-    const disposals: Disposal[] = [];
-
-    if (pc) {
-      for (const pred of pc.predictions) {
-        const predCollateral = BigInt(pred.predictorCollateral);
-        const cpCollateral = BigInt(pred.counterpartyCollateral);
-        const predictionTotal = predCollateral + cpCollateral;
-        const isHolderSide =
-          (r.isPredictorToken && pred.predictor === r.holder) ||
-          (!r.isPredictorToken && pred.counterparty === r.holder);
-        if (!isHolderSide) continue;
-        predictionId ??= pred.predictionId;
-        totalPayout += predictionTotal;
-        // Mint amount on both sides equals total collateral pool (see
-        // PredictionMarketEscrow.sol). Cost is just the holder's share.
-        const cost = r.isPredictorToken ? predCollateral : cpCollateral;
-        acquires.push({
-          ts: pred.createdAt.getTime() / 1000,
-          cost,
-          shares: predictionTotal,
-        });
-      }
+    const cached = cachedByRow.get(r);
+    if (cached) {
+      out.push(...cached);
+      continue;
     }
-
     const k = positionKey(r.chainId, r.tokenAddress, r.holder);
-    for (const t of tradesByPos.get(k) ?? []) {
-      const price = BigInt(t.price);
-      const shares = BigInt(t.tokenAmount);
-      if (t.buyer === r.holder) {
-        acquires.push({ ts: t.executedAt, cost: price, shares });
-      }
-      if (t.seller === r.holder) {
-        disposals.push({
-          tradeHash: t.tradeHash,
-          ts: t.executedAt,
-          proceeds: price,
-          shares,
-        });
-      }
-    }
-
-    const acquiresSorted = [...acquires].sort((a, b) => a.ts - b.ts);
-    const disposalsSorted = [...disposals].sort((a, b) => a.ts - b.ts);
-
-    // Walk acquires + disposals in chronological order, maintaining running
-    // WAC. Each disposal records the cost basis allocated to its shares
-    // using the WAC at that moment.
-    let costPool = 0n;
-    let sharesPool = 0n;
-    let acqIdx = 0;
-    type DisposalRow = {
-      tradeHash: string;
-      ts: number;
-      proceeds: bigint;
-      shares: bigint;
-      costBasis: bigint;
-    };
-    const disposalRows: DisposalRow[] = [];
-    for (const d of disposalsSorted) {
-      while (
-        acqIdx < acquiresSorted.length &&
-        acquiresSorted[acqIdx].ts <= d.ts
-      ) {
-        costPool += acquiresSorted[acqIdx].cost;
-        sharesPool += acquiresSorted[acqIdx].shares;
-        acqIdx += 1;
-      }
-      const allocated =
-        sharesPool > 0n ? (costPool * d.shares) / sharesPool : 0n;
-      disposalRows.push({ ...d, costBasis: allocated });
-      costPool -= allocated;
-      sharesPool -= d.shares;
-      if (sharesPool < 0n) sharesPool = 0n;
-      if (costPool < 0n) costPool = 0n;
-    }
-    while (acqIdx < acquiresSorted.length) {
-      costPool += acquiresSorted[acqIdx].cost;
-      sharesPool += acquiresSorted[acqIdx].shares;
-      acqIdx += 1;
-    }
-
-    const totalUserCollateral = acquires.reduce((s, a) => s + a.cost, 0n);
-    const totalPayoutStr = totalPayout > 0n ? totalPayout.toString() : null;
-    const mappedPickConfig = pc ? mapPickConfig(pc, { predictionId }) : null;
-    const balanceBn = BigInt(r.balance);
-    const isResolved = pc?.resolved ?? false;
-
-    // Emit one synthetic row per sell (only meaningful for unresolved
-    // pickConfigs — once settled, the existing PnL flow takes over).
-    if (!isResolved) {
-      for (const d of disposalRows) {
-        synthesized.push({
-          id: `${r.id}-sell-${d.tradeHash}`,
-          chainId: r.chainId,
-          tokenAddress: r.tokenAddress,
-          pickConfigId: r.pickConfigId,
-          isPredictorToken: r.isPredictorToken,
-          holder: r.holder,
-          balance: '0',
-          userCollateral: d.costBasis.toString(),
-          totalPayout: totalPayoutStr,
-          realizedPnL: (d.proceeds - d.costBasis).toString(),
-          createdAt: r.createdAt,
-          updatedAt: new Date(d.ts * 1000),
-          pickConfig: mappedPickConfig,
-        });
-      }
-    }
-
-    // Open / parent row: keep when there's still balance, or when the
-    // position is settled (existing settlement-PnL flow handles it). A
-    // zero-balance unresolved row with no sells means the holder transferred
-    // or burned the tokens off-platform — drop it, matching prior behavior.
-    if (balanceBn > 0n || isResolved) {
-      const remainingCost =
-        !isResolved && disposalRows.length > 0 ? costPool : totalUserCollateral;
-      synthesized.push({
-        id: String(r.id),
-        chainId: r.chainId,
-        tokenAddress: r.tokenAddress,
-        pickConfigId: r.pickConfigId,
-        isPredictorToken: r.isPredictorToken,
-        holder: r.holder,
-        balance: r.balance,
-        userCollateral: remainingCost > 0n ? remainingCost.toString() : null,
-        totalPayout: totalPayoutStr,
-        realizedPnL: null,
-        createdAt: r.createdAt,
-        updatedAt: r.updatedAt,
-        pickConfig: mappedPickConfig,
-      });
-    }
+    const synthesized = synthesizePositionRow(r, tradesByPos.get(k) ?? []);
+    positionSynthesisCache.set(positionSynthesisCacheKey(r), synthesized);
+    out.push(...synthesized);
   }
-
-  // Re-sort by the requested field. Synthetic sell rows carry the trade's
-  // executedAt as their updatedAt, so without this they'd appear grouped
-  // under their parent Position rather than interleaved by recency.
-  const sortKey: keyof Pick<PositionShape, 'createdAt' | 'updatedAt'> =
-    posOrderField === 'createdAt' ? 'createdAt' : 'updatedAt';
-  synthesized.sort((a, b) => {
-    const diff = b[sortKey].getTime() - a[sortKey].getTime();
-    return posOrderDirection === 'asc' ? -diff : diff;
-  });
-  return { items: synthesized, hasMore };
+  return out;
 };
 
-export const positions: NonNullable<QueryResolvers['positions']> = async (
-  _parent,
-  args,
-  ctx
-) => {
-  const { items } = await runPositions(args, ctx);
-  return items;
+/**
+ * Re-sort by the requested field. Synthetic sell rows carry the trade's
+ * executedAt as their updatedAt, so without this they'd appear grouped
+ * under their parent Position rather than interleaved by recency.
+ */
+const sortSynthesizedRows = (
+  rows: PositionShape[],
+  field: 'createdAt' | 'updatedAt',
+  direction: 'asc' | 'desc'
+): PositionShape[] => {
+  const out = [...rows];
+  out.sort((a, b) => {
+    const diff = b[field].getTime() - a[field].getTime();
+    return direction === 'asc' ? -diff : diff;
+  });
+  return out;
+};
+
+const EMPTY_POSITIONS_PAGE: PositionsPageEnvelope = {
+  items: [],
+  hasMore: false,
+  totalCount: 0,
+};
+
+export const runPositions = async (
+  args: QueryPositionsArgs,
+  ctx: ApolloContext | undefined
+): Promise<PositionsPageEnvelope> => {
+  const norm = normalizePositionsArgs(args);
+
+  let conditionPickConfigIds: string[] | null = null;
+  if (norm.conditionId) {
+    conditionPickConfigIds = await resolveConditionPickConfigIds(
+      norm.conditionId
+    );
+    if (conditionPickConfigIds === null) return EMPTY_POSITIONS_PAGE;
+  }
+
+  let where = buildPositionsWhere(norm, conditionPickConfigIds);
+  if (where === null) return EMPTY_POSITIONS_PAGE;
+
+  if (norm.holderLower && (norm.collateralMin || norm.collateralMax)) {
+    const next = await applyCollateralRangeFilter(
+      where,
+      norm.holderLower,
+      norm.collateralMin,
+      norm.collateralMax
+    );
+    if (next === null) return EMPTY_POSITIONS_PAGE;
+    where = next;
+  }
+
+  // The PickConfiguration → Prediction relation is many-to-many in spirit:
+  // any user who has predicted on this market shows up here. We only need
+  // the rows where the holder is a counterparty to compute their cost
+  // basis, so push the filter into the include and avoid pulling every
+  // other user's prediction back over the wire. When `holder` isn't
+  // pinned (conditionId / pickConfigId path), keep the full set.
+  const predictionsInclude: Prisma.Picks$predictionsArgs | true =
+    norm.holderLower
+      ? {
+          where: {
+            OR: [
+              { predictor: norm.holderLower },
+              { counterparty: norm.holderLower },
+            ],
+          },
+        }
+      : true;
+
+  // Fetch take+1 to detect a `hasMore`-style next page without a count
+  // query. Synthesized event-stream rows from raw positions can be
+  // empty (zero-balance unresolved with no sells), so client-side
+  // `lastPage.length === 0` is unreliable as a stop signal — we need
+  // server-truth pagination.
+  //
+  // `totalCount` is left null here; the PositionsPage.totalCount field
+  // resolver lazily issues `prisma.position.count({ where })` only when
+  // the client actually selects the field. The deprecated `positions`
+  // wrapper discards totalCount entirely, so it now skips the count
+  // query for free.
+  const rawRows = await prisma.position.findMany({
+    where,
+    orderBy: { [norm.orderField]: norm.orderDirection },
+    take: norm.cappedTake + 1,
+    skip: norm.skipVal,
+    include: {
+      pickConfiguration: {
+        include: { picks: true, predictions: predictionsInclude },
+      },
+    },
+  });
+  const hasMore = rawRows.length > norm.cappedTake;
+  const rows = rawRows.slice(0, norm.cappedTake);
+
+  // Warm the per-request condition cache so PickConfig.picks[].condition
+  // field resolutions don't fan out into N+1 queries below. The
+  // synthesis cache only memoizes the trade/WAC computation; condition
+  // metadata is still resolved per-request via this preloader.
+  await preloadPickConditions(
+    ctx,
+    rows.map((r) => r.pickConfiguration)
+  );
+
+  const synthesized = await synthesizePositionsPage(rows);
+  const sorted = sortSynthesizedRows(
+    synthesized,
+    norm.orderField,
+    norm.orderDirection
+  );
+  return { items: sorted, hasMore, totalCount: null, _countWhere: where };
 };
 
 export const positionsPage: NonNullable<

--- a/packages/api/src/graphql/sdl/resolvers/queries/pagination.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/pagination.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared pagination clamps for `*Page` resolvers.
+ *
+ * `MAX_SKIP` exists to bound offset-style pagination: a `skip` of e.g.
+ * 50_000 forces Postgres to scan and discard every preceding row, even
+ * with the right index. 1_000 covers every realistic infinite-scroll
+ * use case (max take is 100, so 11 pages deep) while making accidental
+ * deep-skip queries fail-fast rather than silently expensive.
+ *
+ * Hot paths that need to read further than this should adopt cursor /
+ * keyset pagination (`after: String` on `(createdAt, id)`) — the row
+ * count returned via `totalCount` is already enough for "X items
+ * total" UI badges without paying the offset cost.
+ */
+export const MAX_SKIP = 1000;
+
+export const clampSkip = (
+  skip: number | null | undefined,
+  { maxSkip }: { maxSkip?: number } = {}
+): number => {
+  const value = skip ?? 0;
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  return Math.min(Math.floor(value), maxSkip ?? MAX_SKIP);
+};
+
+export const clampTake = (
+  take: number | null | undefined,
+  { defaultTake, maxTake }: { defaultTake: number; maxTake: number }
+): number => {
+  const value = take ?? defaultTake;
+  if (!Number.isFinite(value) || value <= 0)
+    return Math.min(defaultTake, maxTake);
+  return Math.max(1, Math.min(Math.floor(value), maxTake));
+};

--- a/packages/api/src/graphql/sdl/schema/schema.graphql
+++ b/packages/api/src/graphql/sdl/schema/schema.graphql
@@ -874,7 +874,7 @@ type LegacyPosition {
   id: Int!
   marketAddress: String!
   mintedAt: Int!
-  predictions(cursor: LegacyPredictionWhereUniqueInput, distinct: [LegacyPredictionScalarFieldEnum!], orderBy: [LegacyPredictionOrderByWithRelationInput!], skip: Int, take: Int, where: LegacyPredictionWhereInput): [LegacyPrediction!]!
+  predictions(cursor: LegacyPredictionWhereUniqueInput, distinct: [LegacyPredictionScalarFieldEnum!], orderBy: [LegacyPredictionOrderByWithRelationInput!], skip: Int, take: Int, where: LegacyPredictionWhereInput): [LegacyPrediction!]! @deprecated(reason: "LegacyPosition is the V1 (NFT-based) holdings model and is being phased out. Use `positionsPage` instead.")
   predictor: String!
   predictorCollateral: String
   predictorNftTokenId: String!
@@ -955,10 +955,10 @@ type LegacyPrediction {
   conditionId: String!
   createdAt: DateTimeISO!
   id: Int!
-  limitOrder(where: LimitOrderWhereInput): LimitOrder
+  limitOrder(where: LimitOrderWhereInput): LimitOrder @deprecated(reason: "LimitOrder is deprecated and being phased out.")
   limitOrderId: Int
   outcomeYes: Boolean!
-  position(where: LegacyPositionWhereInput): LegacyPosition
+  position(where: LegacyPositionWhereInput): LegacyPosition @deprecated(reason: "LegacyPosition is the V1 (NFT-based) holdings model and is being phased out. Use `positionsPage` instead.")
   positionId: Int
 }
 
@@ -1054,7 +1054,7 @@ type LimitOrder {
   orderId: String!
   placedAt: Int!
   placedTxHash: String!
-  predictions(cursor: LegacyPredictionWhereUniqueInput, distinct: [LegacyPredictionScalarFieldEnum!], orderBy: [LegacyPredictionOrderByWithRelationInput!], skip: Int, take: Int, where: LegacyPredictionWhereInput): [LegacyPrediction!]!
+  predictions(cursor: LegacyPredictionWhereUniqueInput, distinct: [LegacyPredictionScalarFieldEnum!], orderBy: [LegacyPredictionOrderByWithRelationInput!], skip: Int, take: Int, where: LegacyPredictionWhereInput): [LegacyPrediction!]! @deprecated(reason: "LimitOrder is deprecated and being phased out.")
   predictor: String!
   predictorCollateral: String!
   refCode: String
@@ -1314,10 +1314,38 @@ type PnlDataPoint {
   timestamp: Int!
 }
 
-"""Paginated wrapper around Position rows with a server-truth hasMore flag"""
-type PositionsPage {
+"""
+Common shape implemented by every `*Page` type. `items` is intentionally
+not declared on the interface because each page exposes a different
+concrete row type; clients can fragment on the interface to read
+`hasMore` / `totalCount` generically and on the concrete type to read
+the typed `items` list.
+"""
+interface Page {
+  """Server-truth signal that another page exists after this one."""
+  hasMore: Boolean!
+  """
+  Total rows matching the filters. May be null when the count is not
+  computed for this resolver (e.g. complex unioned feeds).
+  """
+  totalCount: Int
+}
+
+"""
+Paginated wrapper around Position rows with a server-truth hasMore flag.
+`totalCount` is the count of underlying Position rows that match the filters
+(not the count of rendered event-stream rows, which can be larger due to
+per-sell synthetic expansion).
+"""
+type PositionsPage implements Page {
   items: [Position!]!
   hasMore: Boolean!
+  """
+  Total Position rows matching the filters. Computed lazily — the count
+  query only fires when this field is selected in the operation, so
+  pagination requests that don't need a total don't pay for one.
+  """
+  totalCount: Int
 }
 
 """ERC-20 token balance representing a side of a prediction position"""
@@ -1561,12 +1589,12 @@ type Query {
   popularTags: [String!]!
 
   """Count of token positions for a given holder"""
-  positionCount(chainId: Int, holder: String!, settled: Boolean): Int!
+  positionCount(chainId: Int, holder: String!, settled: Boolean): Int! @deprecated(reason: "Use `positionsPage(...).totalCount` — same number, available alongside the page payload, no extra query needed.")
 
   """
   Paginated list of token position balances, filterable by holder, condition, chain, pick config, settlement, date range, collateral range, and won/lost status
   """
-  positions(chainId: Int, collateralMax: String, collateralMin: String, conditionId: String, endsAtMax: Int, endsAtMin: Int, holder: String, holderWon: Boolean, orderBy: PositionSortField, orderDirection: SortOrder, pickConfigId: String, result: SettlementResult, settled: Boolean, skip: Int! = 0, take: Int! = 50): [Position!]!
+  positions(chainId: Int, collateralMax: String, collateralMin: String, conditionId: String, endsAtMax: Int, endsAtMin: Int, holder: String, holderWon: Boolean, orderBy: PositionSortField, orderDirection: SortOrder, pickConfigId: String, result: SettlementResult, settled: Boolean, skip: Int! = 0, take: Int! = 50): [Position!]! @deprecated(reason: "Use `positionsPage` — same data with a server-truth `hasMore` stop signal. The bare-array form can return empty pages mid-stream (synthesized sell rows for zero-balance unresolved positions), so `length === 0` is not a reliable end-of-pagination check.")
 
   """
   Same as `positions`, but wraps the result in a `PositionsPage` with a server-truth `hasMore` flag. Use this for infinite scroll: synthesized rows can be empty for some raw pages (zero-balance unresolved positions with no sells), so client-side `lastPage.length === 0` is not a reliable stop signal.

--- a/packages/app/src/components/profile/ProfileQuickMetrics.tsx
+++ b/packages/app/src/components/profile/ProfileQuickMetrics.tsx
@@ -3,12 +3,12 @@
 import * as React from 'react';
 import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
 
-import type { LegacyPosition as Position } from '@sapience/sdk/queries';
+import { COLLATERAL_SYMBOLS } from '@sapience/sdk/constants';
 import NumberDisplay from '~/components/shared/NumberDisplay';
 import { useUserProfitRank } from '~/hooks/graphql/useUserProfitRank';
 import { useForecasterRank } from '~/hooks/graphql/useForecasterRank';
 import { useCollateralBalance } from '~/hooks/blockchain/useCollateralBalance';
-import { COLLATERAL_SYMBOLS } from '@sapience/sdk/constants';
+import { useProfileVolume } from '~/hooks/useProfileVolume';
 
 function useProfileBalance(
   address?: string,
@@ -40,71 +40,21 @@ function useProfileBalance(
   return memo;
 }
 
-import { useProfileVolume } from '~/hooks/useProfileVolume';
-
-function useFirstActivity(positions: Position[] | undefined) {
-  return React.useMemo(() => {
-    let earliest: Date | undefined;
-    try {
-      for (const position of positions || []) {
-        const sec = Number(position.mintedAt);
-        if (!Number.isFinite(sec)) continue;
-        const d = new Date(sec * 1000);
-        if (!earliest || d < earliest) earliest = d;
-      }
-    } catch {
-      // ignore
-    }
-
-    if (!earliest)
-      return {
-        date: undefined,
-        display: 'Never',
-        tooltip: undefined,
-        isNever: true,
-      };
-
-    const monthYear = new Intl.DateTimeFormat(undefined, {
-      year: 'numeric',
-      month: 'short',
-    }).format(earliest);
-    const full = new Intl.DateTimeFormat(undefined, {
-      year: 'numeric',
-      month: 'long',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-      timeZoneName: 'short',
-    }).format(earliest);
-    return {
-      date: earliest,
-      display: monthYear,
-      tooltip: full,
-      isNever: false,
-    };
-  }, [positions]);
-}
-
 type ProfileQuickMetricsProps = {
   address: string;
   forecastsCount: number;
-  positions: Position[];
   className?: string;
 };
 
 export default function ProfileQuickMetrics({
   address,
   forecastsCount,
-  positions,
   className,
 }: ProfileQuickMetricsProps) {
   const chainId = DEFAULT_CHAIN_ID;
   const collateralSymbol = COLLATERAL_SYMBOLS[chainId] || 'testUSDe';
   const balance = useProfileBalance(address, chainId, collateralSymbol);
   const volume = useProfileVolume(address);
-  const first = useFirstActivity(positions);
-  // Fetch profit and accuracy data
   const { data: profit, isLoading: profitLoading } = useUserProfitRank(address);
   const { data: accuracy, isLoading: accuracyLoading } =
     useForecasterRank(address);
@@ -175,12 +125,6 @@ export default function ProfileQuickMetrics({
       sublabel: collateralSymbol,
     },
   ];
-  if (!first.isNever) {
-    balanceMetrics.push({
-      label: 'Started',
-      value: first.display,
-    });
-  }
 
   const boxes = [volumeMetrics, forecastMetrics, balanceMetrics].filter(
     (b) => b.length > 0

--- a/packages/app/src/components/profile/pages/ProfilePageContent.tsx
+++ b/packages/app/src/components/profile/pages/ProfilePageContent.tsx
@@ -126,7 +126,6 @@ const ProfilePageContent = ({
           <ProfileQuickMetrics
             address={address}
             forecastsCount={attestations?.length ?? 0}
-            positions={[]}
           />
         ) : null}
       </div>

--- a/packages/sdk/queries/positions.ts
+++ b/packages/sdk/queries/positions.ts
@@ -1,37 +1,8 @@
-type PredictedOutcome = {
-  conditionId: string;
-  outcomeYes: boolean;
-  condition?: {
-    id: string;
-    question?: string | null;
-    shortName?: string | null;
-    endTime?: number | null;
-    description?: string | null;
-    settled?: boolean;
-    resolvedToYes?: boolean;
-    resolver?: string | null;
-    category?: {
-      slug: string;
-    } | null;
-  } | null;
-};
-
-export type LegacyPosition = {
-  id: number;
-  chainId: number;
-  marketAddress: string;
-  predictor: string;
-  counterparty: string;
-  predictorNftTokenId: string;
-  counterpartyNftTokenId: string;
-  totalCollateral: string;
-  predictorCollateral?: string | null;
-  counterpartyCollateral?: string | null;
-  refCode?: string | null;
-  status: 'active' | 'settled' | 'consolidated';
-  predictorWon?: boolean | null;
-  mintedAt: number;
-  settledAt?: number | null;
-  endsAt?: number | null;
-  predictions: PredictedOutcome[];
-};
+// Intentionally empty.
+//
+// The hand-written `LegacyPosition` type that previously lived here was
+// only consumed by ProfileQuickMetrics — and that consumer always
+// received an empty array, so the dependency was effectively dead.
+// Both have been removed alongside the V1 (NFT-based) holdings
+// deprecation. Use `positionsPage` for V2 holdings.
+export {};

--- a/packages/sdk/types/graphql.ts
+++ b/packages/sdk/types/graphql.ts
@@ -984,6 +984,7 @@ export type LegacyPosition = {
   id: Scalars['Int']['output'];
   marketAddress: Scalars['String']['output'];
   mintedAt: Scalars['Int']['output'];
+  /** @deprecated LegacyPosition is the V1 (NFT-based) holdings model and is being phased out. Use `positionsPage` instead. */
   predictions: Array<LegacyPrediction>;
   predictor: Scalars['String']['output'];
   predictorCollateral?: Maybe<Scalars['String']['output']>;
@@ -1079,9 +1080,11 @@ export type LegacyPrediction = {
   conditionId: Scalars['String']['output'];
   createdAt: Scalars['DateTimeISO']['output'];
   id: Scalars['Int']['output'];
+  /** @deprecated LimitOrder is deprecated and being phased out. */
   limitOrder?: Maybe<LimitOrder>;
   limitOrderId?: Maybe<Scalars['Int']['output']>;
   outcomeYes: Scalars['Boolean']['output'];
+  /** @deprecated LegacyPosition is the V1 (NFT-based) holdings model and is being phased out. Use `positionsPage` instead. */
   position?: Maybe<LegacyPosition>;
   positionId?: Maybe<Scalars['Int']['output']>;
 };
@@ -1188,6 +1191,7 @@ export type LimitOrder = {
   orderId: Scalars['String']['output'];
   placedAt: Scalars['Int']['output'];
   placedTxHash: Scalars['String']['output'];
+  /** @deprecated LimitOrder is deprecated and being phased out. */
   predictions: Array<LegacyPrediction>;
   predictor: Scalars['String']['output'];
   predictorCollateral: Scalars['String']['output'];
@@ -1417,6 +1421,23 @@ export type NullsOrder =
   | 'first'
   | 'last';
 
+/**
+ * Common shape implemented by every `*Page` type. `items` is intentionally
+ * not declared on the interface because each page exposes a different
+ * concrete row type; clients can fragment on the interface to read
+ * `hasMore` / `totalCount` generically and on the concrete type to read
+ * the typed `items` list.
+ */
+export type Page = {
+  /** Server-truth signal that another page exists after this one. */
+  hasMore: Scalars['Boolean']['output'];
+  /**
+   * Total rows matching the filters. May be null when the count is not
+   * computed for this resolver (e.g. complex unioned feeds).
+   */
+  totalCount?: Maybe<Scalars['Int']['output']>;
+};
+
 /** Individual outcome pick within a pick configuration */
 export type Pick = {
   __typename?: 'Pick';
@@ -1484,11 +1505,22 @@ export type PositionSortField =
   | 'CREATED_AT'
   | 'UPDATED_AT';
 
-/** Paginated wrapper around Position rows with a server-truth hasMore flag */
-export type PositionsPage = {
+/**
+ * Paginated wrapper around Position rows with a server-truth hasMore flag.
+ * `totalCount` is the count of underlying Position rows that match the filters
+ * (not the count of rendered event-stream rows, which can be larger due to
+ * per-sell synthetic expansion).
+ */
+export type PositionsPage = Page & {
   __typename?: 'PositionsPage';
   hasMore: Scalars['Boolean']['output'];
   items: Array<Position>;
+  /**
+   * Total Position rows matching the filters. Computed lazily — the count
+   * query only fires when this field is selected in the operation, so
+   * pagination requests that don't need a total don't pay for one.
+   */
+  totalCount?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Escrow-based prediction record between a predictor and counterparty, with collateral and settlement tracking */
@@ -1655,9 +1687,15 @@ export type Query = {
   pickConfigurations: Array<PickConfiguration>;
   /** Top 20 most-used tags across public conditions */
   popularTags: Array<Scalars['String']['output']>;
-  /** Count of token positions for a given holder */
+  /**
+   * Count of token positions for a given holder
+   * @deprecated Use `positionsPage(...).totalCount` — same number, available alongside the page payload, no extra query needed.
+   */
   positionCount: Scalars['Int']['output'];
-  /** Paginated list of token position balances, filterable by holder, condition, chain, pick config, settlement, date range, collateral range, and won/lost status */
+  /**
+   * Paginated list of token position balances, filterable by holder, condition, chain, pick config, settlement, date range, collateral range, and won/lost status
+   * @deprecated Use `positionsPage` — same data with a server-truth `hasMore` stop signal. The bare-array form can return empty pages mid-stream (synthesized sell rows for zero-balance unresolved positions), so `length === 0` is not a reliable end-of-pagination check.
+   */
   positions: Array<Position>;
   /** Same as `positions`, but wraps the result in a `PositionsPage` with a server-truth `hasMore` flag. Use this for infinite scroll: synthesized rows can be empty for some raw pages (zero-balance unresolved positions with no sells), so client-side `lastPage.length === 0` is not a reliable stop signal. */
   positionsPage: PositionsPage;


### PR DESCRIPTION
## Summary

Slice of the positions-resolver changes from #1696, sized to land
incrementally rather than as one 166-file refactor. Everything is
additive at the API surface — bare `positions` / `positionCount` / V1
`LegacyPosition.*` still work and continue to return identical data;
they're just `@deprecated` now.

### Resolver

- Decompose `runPositions` into focused helpers (`normalizePositionsArgs`,
  `buildPositionsWhere`, `applyCollateralRangeFilter`, `synthesizePositionsPage`,
  `sortSynthesizedRows`) so each step is inspectable in isolation.
- Add a module-scoped `TtlCache` for synthesized event-stream rows
  (30 s TTL, 10k entries, keyed by `Position.updatedAt`). Repeat page
  requests amortize the trade fetch + WAC walk.
- Lazy `PositionsPage.totalCount`: `runPositions` returns `_countWhere`
  and the field resolver only fires `prisma.position.count(...)` when
  the client selects the field. Pages that don't ask pay nothing.
- Move the bare-array `positions` wrapper into `queries/deprecated/` so
  the eventual rm is a one-directory delete.
- Cap `positionsPage(skip:)` at 10_000 (was unbounded). The shared
  `MAX_SKIP=1000` default in `pagination.ts` is reserved for the broader
  `*Page` refactor; positions gets a less aggressive ceiling for now to
  stay close to the previous open-ended behavior while still bounding
  worst-case Postgres offset scans.

### Schema

- New `Page` interface (`hasMore`, optional `totalCount`).
- `PositionsPage implements Page` with the lazy `totalCount: Int`.
- `@deprecated` markers on bare `positions`, `positionCount`,
  `LegacyPosition.predictions`, `LegacyPrediction.position`,
  `LegacyPrediction.limitOrder`, `LimitOrder.predictions`.

### Consumers

- Delete the SDK `LegacyPosition` type (was already dead — its only
  consumer, `ProfileQuickMetrics.useFirstActivity`, always received
  an empty array).

### Bundled migration

`20260511000000_add_questions_sort_indexes` was already applied to
prod out-of-band. Landing the file here syncs Prisma's
`_prisma_migrations` table on the next deploy. `CREATE INDEX IF NOT
EXISTS` makes re-application a no-op. The indexes serve `questionsPage`,
**not** positions — they're bundled here purely for prod/repo sync.

### Downstream guide

Added `packages/api/MIGRATION.md` with before/after snippets for
external API consumers (and their LLM agents) covering all six
deprecations, the new `totalCount` shape, the `skip` cap, and the
30 s staleness window for cost-basis fields.

## Test plan

- [x] `pnpm --filter @sapience/sdk run build:lib`
- [x] `pnpm --filter @sapience/api run generate-types` (regenerated schema diff matches expected scope)
- [x] `pnpm --filter @sapience/api exec vitest run` — 462/462 pass
- [x] `pnpm --filter @sapience/sdk run test` — 658/658 pass
- [x] `pnpm --filter @sapience/app run test` — 623/623 pass
- [x] `pnpm --filter @sapience/api exec tsc --noEmit` clean
- [x] `pnpm --filter @sapience/app run type-check` clean
- [x] lint clean on all files touched (pre-existing `no-console` errors in untracked `stress.test.ts` from another branch are not in this diff)
- [ ] manual: `positionsPage(holder: "0x...", take: 5) { items { id } hasMore totalCount }` returns `totalCount` populated when selected, no count query when omitted
- [ ] manual: deprecated `positions(holder: "0x...", take: 5) { id }` still works and emits a deprecation notice in introspection
- [ ] verify `prisma migrate status` against a fresh local DB after merge

## Notes for reviewers

~93% of the diff is one file: `packages/api/src/graphql/sdl/resolvers/queries/escrow.ts`.
Within it, the meaningful changes are (a) the helper decomposition,
which is a pure refactor (no behavior change), (b) the `TtlCache` for
synthesis memoization, and (c) the `_countWhere` envelope field for
lazy `totalCount`. Everything else is glue or schema bookkeeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)