### PR TITLE
refactor(api,sdk): GraphQL Section B polish — sort args, filter gaps, totalCount factory, doc conventions

### DIFF
--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -1523,6 +1523,33 @@ enum ConditionSortField {
   PREDICTION_COUNT
 }
 
+"""Sort fields for the `conditionGroupsPage` query."""
+enum ConditionGroupSortField {
+  CREATED_AT
+  MAX_END_TIME
+  TOTAL_OPEN_INTEREST
+  TOTAL_PREDICTION_COUNT
+}
+
+"""Sort fields for the `tradesPage` query."""
+enum TradeSortField {
+  EXECUTED_AT
+  BLOCK_NUMBER
+}
+
+"""Sort fields for the `pickConfigurationsPage` query."""
+enum PickConfigurationSortField {
+  CREATED_AT
+  ENDS_AT
+  RESOLVED_AT
+}
+
+"""Sort fields for the `collateralTransfersPage` query."""
+enum CollateralTransferSortField {
+  BLOCK_NUMBER
+  TIMESTAMP
+}
+
 """Visibility filter for the `conditionsPage` query"""
 enum ConditionVisibility {
   PUBLIC
@@ -1663,20 +1690,63 @@ input ConditionGroupFilters {
   includeEmpty: Boolean
 }
 
-"""ERC-20 token balance representing a side of a prediction position"""
+"""
+ERC-20 token balance representing one side of a prediction position. The
+underlying Position row may surface as multiple `*Page` items: one
+"open" row carrying remaining cost basis, plus one synthesized "sell"
+row per secondary-market disposal (so PnL realizes incrementally).
+"""
 type Position {
+  """
+  Number of position tokens still held (decimal string, 18 decimals on
+  Sapience). Synthesized sell rows carry `"0"` here — the realized PnL
+  delta from that sell lives on `realizedPnL`.
+  """
   balance: String!
   chainId: Int!
   createdAt: DateTimeISO!
+
+  """Holder wallet address (lowercase 0x-hex)."""
   holder: String!
+
+  """
+  Synthetic row id. Open rows use the underlying Position row id
+  serialized as a string; synthesized sell rows append `"-sell-<tradeHash>"`.
+  """
   id: String!
+
+  """True if this is the predictor token side; false for counterparty."""
   isPredictorToken: Boolean!
   pickConfig: PickConfiguration
   pickConfigId: String!
+
+  """
+  Realized PnL delta for a synthesized sell row (wei, 18 decimals;
+  signed — negative when sold below cost basis). Null on open rows;
+  use `cumulativePnL` on the bucketed `accountStats` series for the
+  holder-wide aggregate.
+  """
   realizedPnL: String
+
+  """ERC-20 position token address (lowercase 0x-hex)."""
   tokenAddress: String!
+
+  """
+  Cumulative payout the contract would owe this position if every
+  matched prediction resolved in the holder's favour (wei, 18 dec).
+  Equal to the total collateral pool across the holder's matched
+  predictions, NOT the net profit. Null when the holder has no matched
+  predictions on this pickConfig.
+  """
   totalPayout: String
   updatedAt: DateTimeISO!
+
+  """
+  Cost basis remaining on the holder's open balance (wei, 18 dec). For
+  synthesized sell rows this is the basis allocated to the shares
+  disposed of, computed via running WAC. Null when there is no basis to
+  surface (zero-balance settled position, etc.).
+  """
   userCollateral: String
 }
 
@@ -2013,6 +2083,15 @@ input PredictionFilters {
 
   """Restrict to settled (true) or unsettled (false) predictions."""
   settled: Boolean
+
+  """Restrict to predictions whose pickConfig settled with this result."""
+  result: SettlementResult
+
+  """Restrict to predictions whose pickConfig `endsAt >= this`."""
+  endsAtMin: UnixSeconds
+
+  """Restrict to predictions whose pickConfig `endsAt <= this`."""
+  endsAtMax: UnixSeconds
 }
 
 """
@@ -2037,6 +2116,16 @@ input TradeFilters {
 
   """Restrict to a single chain."""
   chainId: Int
+
+  """
+  Restrict to trades with `executedAt >= this` (epoch seconds, inclusive).
+  """
+  executedAtMin: UnixSeconds
+
+  """
+  Restrict to trades with `executedAt <= this` (epoch seconds, inclusive).
+  """
+  executedAtMax: UnixSeconds
 }
 
 """
@@ -2259,13 +2348,36 @@ type Query {
   """
   closes(address: String, chainId: Int, pickConfigId: String, skip: Int! = 0, take: Int! = 50): [Close!]! @deprecated(reason: "Unused; will be removed. No live consumers — close records are reachable as a side-effect of position settlement.")
   collateralBalance(address: String!, atBlock: Int, chainId: Int!): CollateralBalance!
-  collateralBalanceHistory(address: String!, chainId: Int!, count: Int! = 12, intervalHours: Int! = 168): [CollateralBalanceSnapshot!]!
+
+  """
+  Cumulative wUSDe collateral balance for an address at `count + 1`
+  evenly-spaced snapshot boundaries going back from now. The snapshot
+  cadence is `intervalSeconds` (preferred); the legacy `intervalHours`
+  arg is retained as a deprecated alias — when both are supplied,
+  `intervalSeconds` wins.
+  """
+  collateralBalanceHistory(
+    address: String!
+    chainId: Int!
+    count: Int! = 12
+
+    """
+    Snapshot cadence in seconds. Replaces the deprecated `intervalHours`
+    arg; when omitted (and `intervalHours` is also omitted) defaults to
+    168 hours (7 days), matching the previous default.
+    """
+    intervalSeconds: Int
+    intervalHours: Int! = 168 @deprecated(reason: "Use `intervalSeconds:` — drops the unit-suffix to match the unit-on-scalar convention used elsewhere. When both are supplied, `intervalSeconds` wins.")
+  ): [CollateralBalanceSnapshot!]!
   collateralTransfers(address: String!, chainId: Int!, excludeProtocol: Boolean = false, limit: Int! = 100, offset: Int! = 0): [CollateralTransfer!]! @deprecated(reason: "Use `collateralTransfersPage` — same data with standard `take` / `skip` args (replaces `limit` / `offset`) and a server-truth `hasMore` stop signal.")
 
   """
   Same as `collateralTransfers`, but wraps the result in a `CollateralTransfersPage` with a server-truth `hasMore` flag and standard `take`/`skip` args.
+  
+  Sorting via `orderBy: CollateralTransferSortField` + `orderDirection: SortOrder`.
+  Defaults to `BLOCK_NUMBER` / `desc` when omitted.
   """
-  collateralTransfersPage(address: String!, chainId: Int!, excludeProtocol: Boolean = false, take: Int! = 100, skip: Int! = 0): CollateralTransfersPage!
+  collateralTransfersPage(address: String!, chainId: Int!, excludeProtocol: Boolean = false, orderBy: CollateralTransferSortField, orderDirection: SortOrder, take: Int! = 100, skip: Int! = 0): CollateralTransfersPage!
 
   """
   Look up a single account by canonical wallet address. Replacement for
@@ -2279,8 +2391,11 @@ type Query {
 
   """
   Same as `conditionGroups`, but wraps the result in a `ConditionGroupsPage` with a server-truth `hasMore` flag.
+  
+  Sorting via `orderBy: ConditionGroupSortField` + `orderDirection: SortOrder`.
+  Defaults to `CREATED_AT` / `desc` when omitted.
   """
-  conditionGroupsPage(filters: ConditionGroupFilters, take: Int! = 50, skip: Int! = 0): ConditionGroupsPage!
+  conditionGroupsPage(filters: ConditionGroupFilters, orderBy: ConditionGroupSortField, orderDirection: SortOrder, take: Int! = 50, skip: Int! = 0): ConditionGroupsPage!
   conditions(cursor: ConditionWhereUniqueInput, distinct: [ConditionScalarFieldEnum!], orderBy: [ConditionOrderByWithRelationInput!], skip: Int, take: Int, where: ConditionWhereInput): [Condition!]! @deprecated(reason: "Use `conditionsPage` — purpose-built filters via `ConditionFilters`, paginated with a server-truth `hasMore` stop signal.")
 
   """
@@ -2303,8 +2418,11 @@ type Query {
   filters (`chainId`, `resolved`, `result`, `tokens`) are retained for
   one release with `@deprecated` so existing callers can migrate without
   breaking; new callers should use `filters:`.
+  
+  Sorting via `orderBy: PickConfigurationSortField` + `orderDirection: SortOrder`.
+  Defaults to `CREATED_AT` / `desc` when omitted.
   """
-  pickConfigurationsPage(filters: PickConfigurationFilters, take: Int! = 50, skip: Int! = 0, chainId: Int @deprecated(reason: "Use `filters: { chainId: ... }` on `PickConfigurationFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), resolved: Boolean @deprecated(reason: "Use `filters: { resolved: ... }` on `PickConfigurationFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), result: SettlementResult @deprecated(reason: "Use `filters: { result: ... }` on `PickConfigurationFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), tokens: [String!] @deprecated(reason: "Use `filters: { tokens: ... }` on `PickConfigurationFilters` — the flat-arg shape is being unified across all `*Page` resolvers.")): PickConfigurationsPage!
+  pickConfigurationsPage(filters: PickConfigurationFilters, orderBy: PickConfigurationSortField, orderDirection: SortOrder, take: Int! = 50, skip: Int! = 0, chainId: Int @deprecated(reason: "Use `filters: { chainId: ... }` on `PickConfigurationFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), resolved: Boolean @deprecated(reason: "Use `filters: { resolved: ... }` on `PickConfigurationFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), result: SettlementResult @deprecated(reason: "Use `filters: { result: ... }` on `PickConfigurationFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), tokens: [String!] @deprecated(reason: "Use `filters: { tokens: ... }` on `PickConfigurationFilters` — the flat-arg shape is being unified across all `*Page` resolvers.")): PickConfigurationsPage!
 
   """Top 20 most-used tags across public conditions"""
   popularTags: [String!]!
@@ -2434,8 +2552,11 @@ type Query {
   (`address`, `seller`, `buyer`, `token`, `chainId`) are retained for one
   release with `@deprecated` so existing callers can migrate without
   breaking; new callers should use `filters:`.
+  
+  Sorting via `orderBy: TradeSortField` + `orderDirection: SortOrder`.
+  Defaults to `EXECUTED_AT` / `desc` when omitted.
   """
-  tradesPage(filters: TradeFilters, take: Int! = 50, skip: Int! = 0, address: String @deprecated(reason: "Use `filters: { address: ... }` on `TradeFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), buyer: String @deprecated(reason: "Use `filters: { buyer: ... }` on `TradeFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), chainId: Int @deprecated(reason: "Use `filters: { chainId: ... }` on `TradeFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), seller: String @deprecated(reason: "Use `filters: { seller: ... }` on `TradeFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), token: String @deprecated(reason: "Use `filters: { token: ... }` on `TradeFilters` — the flat-arg shape is being unified across all `*Page` resolvers.")): TradesPage!
+  tradesPage(filters: TradeFilters, orderBy: TradeSortField, orderDirection: SortOrder, take: Int! = 50, skip: Int! = 0, address: String @deprecated(reason: "Use `filters: { address: ... }` on `TradeFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), buyer: String @deprecated(reason: "Use `filters: { buyer: ... }` on `TradeFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), chainId: Int @deprecated(reason: "Use `filters: { chainId: ... }` on `TradeFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), seller: String @deprecated(reason: "Use `filters: { seller: ... }` on `TradeFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), token: String @deprecated(reason: "Use `filters: { token: ... }` on `TradeFilters` — the flat-arg shape is being unified across all `*Page` resolvers.")): TradesPage!
   user(where: UserWhereUniqueInput!): User @deprecated(reason: "Use `account(address:)` — flat address arg, returns the same address-keyed referral data via the new public-API-shaped `Account` type. The Prisma-leaked `User` type will be removed once telemetry on this path drains.")
   users(cursor: UserWhereUniqueInput, distinct: [UserScalarFieldEnum!], orderBy: [UserOrderByWithRelationInput!], skip: Int, take: Int, where: UserWhereInput): [User!]! @deprecated(reason: "Unused; will be removed. No live consumers — account lookups go through `account(address:)` or `referralCodesPage`.")
 
@@ -2780,20 +2901,38 @@ input StringNullableListFilter {
 }
 
 """
-Secondary market trade record where position tokens are exchanged between users
+Secondary market trade record where position tokens are exchanged
+between users. The on-chain reference is `tradeHash`; `id` is an
+internal row id (see schema-preamble conventions).
 """
 type Trade {
   blockNumber: Int!
+
+  """Buyer wallet address (lowercase 0x-hex)."""
   buyer: String!
   chainId: Int!
+
+  """Collateral asset address paid in this trade (lowercase 0x-hex)."""
   collateral: String!
   executedAt: UnixSeconds!
   id: Int!
+
+  """
+  Total collateral paid by buyer (wei, 18 dec). `price / tokenAmount` is the per-share price.
+  """
   price: String!
   refCode: String
+
+  """Seller wallet address (lowercase 0x-hex)."""
   seller: String!
+
+  """Position token address being exchanged (lowercase 0x-hex)."""
   token: String!
+
+  """Quantity of position tokens transferred (wei, 18 dec on Sapience)."""
   tokenAmount: String!
+
+  """Canonical trade hash — the on-chain identifier (0x-prefixed)."""
   tradeHash: String!
   txHash: String!
 }

--- a/packages/api/src/graphql/sdl/resolvers/AttestationsPage.ts
+++ b/packages/api/src/graphql/sdl/resolvers/AttestationsPage.ts
@@ -1,22 +1,12 @@
 /**
- * AttestationsPage field resolvers — lazy `totalCount`.
+ * AttestationsPage field resolvers. `totalCount` is lazy — see
+ * `lazyTotalCount` for the shared `_countWhere` contract.
  */
 
 import type { AttestationsPageResolvers } from '../__generated__/resolvers';
 import prisma from '../../../core/db';
-
-type AttestationsPageParent = {
-  totalCount?: number | null;
-  _countWhere?: NonNullable<
-    Parameters<typeof prisma.attestation.count>[0]
-  >['where'];
-};
+import { lazyTotalCount } from './pageTotalCount';
 
 export const AttestationsPage: AttestationsPageResolvers = {
-  totalCount: async (parent: unknown) => {
-    const p = parent as AttestationsPageParent;
-    if (typeof p.totalCount === 'number') return p.totalCount;
-    if (!p._countWhere) return null;
-    return prisma.attestation.count({ where: p._countWhere });
-  },
+  totalCount: lazyTotalCount(prisma.attestation),
 };

--- a/packages/api/src/graphql/sdl/resolvers/CollateralTransfersPage.ts
+++ b/packages/api/src/graphql/sdl/resolvers/CollateralTransfersPage.ts
@@ -1,22 +1,12 @@
 /**
- * CollateralTransfersPage field resolvers — lazy `totalCount`.
+ * CollateralTransfersPage field resolvers. `totalCount` is lazy — see
+ * `lazyTotalCount` for the shared `_countWhere` contract.
  */
 
 import type { CollateralTransfersPageResolvers } from '../__generated__/resolvers';
 import prisma from '../../../core/db';
-
-type CollateralTransfersPageParent = {
-  totalCount?: number | null;
-  _countWhere?: NonNullable<
-    Parameters<typeof prisma.collateralTransfer.count>[0]
-  >['where'];
-};
+import { lazyTotalCount } from './pageTotalCount';
 
 export const CollateralTransfersPage: CollateralTransfersPageResolvers = {
-  totalCount: async (parent: unknown) => {
-    const p = parent as CollateralTransfersPageParent;
-    if (typeof p.totalCount === 'number') return p.totalCount;
-    if (!p._countWhere) return null;
-    return prisma.collateralTransfer.count({ where: p._countWhere });
-  },
+  totalCount: lazyTotalCount(prisma.collateralTransfer),
 };

--- a/packages/api/src/graphql/sdl/resolvers/ConditionGroupsPage.ts
+++ b/packages/api/src/graphql/sdl/resolvers/ConditionGroupsPage.ts
@@ -1,22 +1,12 @@
 /**
- * ConditionGroupsPage field resolvers — lazy `totalCount`.
+ * ConditionGroupsPage field resolvers. `totalCount` is lazy — see
+ * `lazyTotalCount` for the shared `_countWhere` contract.
  */
 
 import type { ConditionGroupsPageResolvers } from '../__generated__/resolvers';
 import prisma from '../../../core/db';
-
-type ConditionGroupsPageParent = {
-  totalCount?: number | null;
-  _countWhere?: NonNullable<
-    Parameters<typeof prisma.conditionGroup.count>[0]
-  >['where'];
-};
+import { lazyTotalCount } from './pageTotalCount';
 
 export const ConditionGroupsPage: ConditionGroupsPageResolvers = {
-  totalCount: async (parent: unknown) => {
-    const p = parent as ConditionGroupsPageParent;
-    if (typeof p.totalCount === 'number') return p.totalCount;
-    if (!p._countWhere) return null;
-    return prisma.conditionGroup.count({ where: p._countWhere });
-  },
+  totalCount: lazyTotalCount(prisma.conditionGroup),
 };

--- a/packages/api/src/graphql/sdl/resolvers/ConditionsPage.ts
+++ b/packages/api/src/graphql/sdl/resolvers/ConditionsPage.ts
@@ -1,23 +1,12 @@
 /**
- * ConditionsPage field resolvers — lazy `totalCount` follows the
- * PredictionsPage / PositionsPage pattern.
+ * ConditionsPage field resolvers. `totalCount` is lazy — see
+ * `lazyTotalCount` for the shared `_countWhere` contract.
  */
 
 import type { ConditionsPageResolvers } from '../__generated__/resolvers';
 import prisma from '../../../core/db';
-
-type ConditionsPageParent = {
-  totalCount?: number | null;
-  _countWhere?: NonNullable<
-    Parameters<typeof prisma.condition.count>[0]
-  >['where'];
-};
+import { lazyTotalCount } from './pageTotalCount';
 
 export const ConditionsPage: ConditionsPageResolvers = {
-  totalCount: async (parent: unknown) => {
-    const p = parent as ConditionsPageParent;
-    if (typeof p.totalCount === 'number') return p.totalCount;
-    if (!p._countWhere) return null;
-    return prisma.condition.count({ where: p._countWhere });
-  },
+  totalCount: lazyTotalCount(prisma.condition),
 };

--- a/packages/api/src/graphql/sdl/resolvers/PickConfigurationsPage.ts
+++ b/packages/api/src/graphql/sdl/resolvers/PickConfigurationsPage.ts
@@ -1,25 +1,12 @@
 /**
- * PickConfigurationsPage field resolvers.
- *
- * `totalCount` is lazy: `runPickConfigurations` returns the matching
- * where clause as `_countWhere` rather than running an eager count, so
- * the `prisma.picks.count(...)` query only fires when the client
- * actually selects `totalCount`. Mirrors PredictionsPage / PositionsPage.
+ * PickConfigurationsPage field resolvers. `totalCount` is lazy — see
+ * `lazyTotalCount` for the shared `_countWhere` contract.
  */
 
 import type { PickConfigurationsPageResolvers } from '../__generated__/resolvers';
 import prisma from '../../../core/db';
-
-type PickConfigurationsPageParent = {
-  totalCount?: number | null;
-  _countWhere?: NonNullable<Parameters<typeof prisma.picks.count>[0]>['where'];
-};
+import { lazyTotalCount } from './pageTotalCount';
 
 export const PickConfigurationsPage: PickConfigurationsPageResolvers = {
-  totalCount: async (parent: unknown) => {
-    const p = parent as PickConfigurationsPageParent;
-    if (typeof p.totalCount === 'number') return p.totalCount;
-    if (!p._countWhere) return null;
-    return prisma.picks.count({ where: p._countWhere });
-  },
+  totalCount: lazyTotalCount(prisma.picks),
 };

--- a/packages/api/src/graphql/sdl/resolvers/PositionsPage.ts
+++ b/packages/api/src/graphql/sdl/resolvers/PositionsPage.ts
@@ -1,33 +1,17 @@
 /**
  * PositionsPage field resolvers.
  *
- * `totalCount` is lazy: `runPositions` returns the matching where
- * clause as `_countWhere` rather than running an eager count, so the
- * `prisma.position.count(...)` query only fires when the client
- * actually selects `totalCount`. The deprecated bare-array `positions`
- * wrapper discards the envelope's totalCount and never reaches this
- * resolver, so it gets the count-skip for free.
- *
- * The count is the number of underlying Position rows matching the
- * filters (not the count of rendered event-stream rows, which can be
- * larger after per-sell synthetic expansion).
+ * `totalCount` is lazy via `lazyTotalCount` — `runPositions` populates
+ * `_countWhere` so the COUNT(*) only fires when the client selects the
+ * field. The count is the number of underlying Position rows matching
+ * the filters (not the count of rendered event-stream rows, which can
+ * be larger due to per-sell synthetic expansion).
  */
 
 import type { PositionsPageResolvers } from '../__generated__/resolvers';
 import prisma from '../../../core/db';
-
-type PositionsPageParent = {
-  totalCount?: number | null;
-  _countWhere?: NonNullable<
-    Parameters<typeof prisma.position.count>[0]
-  >['where'];
-};
+import { lazyTotalCount } from './pageTotalCount';
 
 export const PositionsPage: PositionsPageResolvers = {
-  totalCount: async (parent: unknown) => {
-    const p = parent as PositionsPageParent;
-    if (typeof p.totalCount === 'number') return p.totalCount;
-    if (!p._countWhere) return null;
-    return prisma.position.count({ where: p._countWhere });
-  },
+  totalCount: lazyTotalCount(prisma.position),
 };

--- a/packages/api/src/graphql/sdl/resolvers/PredictionsPage.ts
+++ b/packages/api/src/graphql/sdl/resolvers/PredictionsPage.ts
@@ -1,29 +1,12 @@
 /**
- * PredictionsPage field resolvers.
- *
- * `totalCount` is lazy: `runPredictions` returns the matching where
- * clause as `_countWhere` rather than running an eager count, so the
- * `prisma.prediction.count(...)` query only fires when the client
- * actually selects `totalCount`. The deprecated bare-array
- * `predictions` wrapper discards the envelope's totalCount and never
- * reaches this resolver, so it gets the count-skip for free.
+ * PredictionsPage field resolvers. `totalCount` is lazy — see
+ * `lazyTotalCount` for the shared `_countWhere` contract.
  */
 
 import type { PredictionsPageResolvers } from '../__generated__/resolvers';
 import prisma from '../../../core/db';
-
-type PredictionsPageParent = {
-  totalCount?: number | null;
-  _countWhere?: NonNullable<
-    Parameters<typeof prisma.prediction.count>[0]
-  >['where'];
-};
+import { lazyTotalCount } from './pageTotalCount';
 
 export const PredictionsPage: PredictionsPageResolvers = {
-  totalCount: async (parent: unknown) => {
-    const p = parent as PredictionsPageParent;
-    if (typeof p.totalCount === 'number') return p.totalCount;
-    if (!p._countWhere) return null;
-    return prisma.prediction.count({ where: p._countWhere });
-  },
+  totalCount: lazyTotalCount(prisma.prediction),
 };

--- a/packages/api/src/graphql/sdl/resolvers/ReferralCodesPage.ts
+++ b/packages/api/src/graphql/sdl/resolvers/ReferralCodesPage.ts
@@ -1,26 +1,15 @@
 /**
- * ReferralCodesPage field resolvers — lazy `totalCount` follows the
- * PredictionsPage / PositionsPage pattern. There are no filter args on
- * `referralCodesPage`, so the count is always over the full
- * ReferralCode table; the `_countWhere` envelope is kept as a hook for
- * future filter args.
+ * ReferralCodesPage field resolvers. `totalCount` is lazy — see
+ * `lazyTotalCount` for the shared `_countWhere` contract. There are no
+ * filter args on `referralCodesPage` today, so the count is always over
+ * the full ReferralCode table; the `_countWhere` envelope is kept as a
+ * hook for future filters.
  */
 
 import type { ReferralCodesPageResolvers } from '../__generated__/resolvers';
 import prisma from '../../../core/db';
-
-type ReferralCodesPageParent = {
-  totalCount?: number | null;
-  _countWhere?: NonNullable<
-    Parameters<typeof prisma.referralCode.count>[0]
-  >['where'];
-};
+import { lazyTotalCount } from './pageTotalCount';
 
 export const ReferralCodesPage: ReferralCodesPageResolvers = {
-  totalCount: async (parent: unknown) => {
-    const p = parent as ReferralCodesPageParent;
-    if (typeof p.totalCount === 'number') return p.totalCount;
-    if (!p._countWhere) return null;
-    return prisma.referralCode.count({ where: p._countWhere });
-  },
+  totalCount: lazyTotalCount(prisma.referralCode),
 };

--- a/packages/api/src/graphql/sdl/resolvers/TradesPage.ts
+++ b/packages/api/src/graphql/sdl/resolvers/TradesPage.ts
@@ -1,23 +1,12 @@
 /**
- * TradesPage field resolvers — lazy `totalCount` follows the
- * PredictionsPage / PositionsPage pattern.
+ * TradesPage field resolvers. `totalCount` is lazy — see
+ * `lazyTotalCount` for the shared `_countWhere` contract.
  */
 
 import type { TradesPageResolvers } from '../__generated__/resolvers';
 import prisma from '../../../core/db';
-
-type TradesPageParent = {
-  totalCount?: number | null;
-  _countWhere?: NonNullable<
-    Parameters<typeof prisma.secondaryTrade.count>[0]
-  >['where'];
-};
+import { lazyTotalCount } from './pageTotalCount';
 
 export const TradesPage: TradesPageResolvers = {
-  totalCount: async (parent: unknown) => {
-    const p = parent as TradesPageParent;
-    if (typeof p.totalCount === 'number') return p.totalCount;
-    if (!p._countWhere) return null;
-    return prisma.secondaryTrade.count({ where: p._countWhere });
-  },
+  totalCount: lazyTotalCount(prisma.secondaryTrade),
 };

--- a/packages/api/src/graphql/sdl/resolvers/pageTotalCount.ts
+++ b/packages/api/src/graphql/sdl/resolvers/pageTotalCount.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared lazy-`totalCount` factory for `*Page` field resolvers.
+ *
+ * Every `*Page` envelope returned by a paginated `runX` runner carries:
+ *   - `totalCount?: number | null` — pre-populated when the runner already
+ *     knew the count (cheap in-memory derivation, or zero on an
+ *     early-return path).
+ *   - `_countWhere?: <ModelWhereInput>` — the same Prisma where the
+ *     runner used for `items`, kept so the COUNT(*) only fires when the
+ *     client selects the field.
+ *
+ * The deprecated bare-array wrappers (`positions`, `predictions`, …)
+ * discard the envelope entirely, so they get the count-skip for free.
+ *
+ * Pages whose runner can't cheaply produce a `_countWhere` (the union
+ * feed on `questionsPage`, the merged predictions/trades feed on
+ * `activityPage`) keep their own dedicated resolver and stay `null`
+ * even when selected.
+ */
+
+interface CountableModel<W> {
+  count(args?: { where?: W }): Promise<number>;
+}
+
+type LazyTotalCountParent<W> = {
+  totalCount?: number | null;
+  _countWhere?: W;
+};
+
+/**
+ * Returns a `totalCount` field resolver bound to a Prisma model. The
+ * concrete `*Page` resolver then becomes a single line:
+ *
+ *     export const PositionsPage = { totalCount: lazyTotalCount(prisma.position) };
+ */
+export const lazyTotalCount =
+  <W, M extends CountableModel<W>>(model: M) =>
+  async (parent: unknown): Promise<number | null> => {
+    const p = parent as LazyTotalCountParent<W>;
+    if (typeof p.totalCount === 'number') return p.totalCount;
+    if (!p._countWhere) return null;
+    return model.count({ where: p._countWhere });
+  };

--- a/packages/api/src/graphql/sdl/resolvers/queries/collateralBalance.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/collateralBalance.ts
@@ -45,10 +45,21 @@ export const collateralBalance: NonNullable<
 
 export const collateralBalanceHistory: NonNullable<
   QueryResolvers['collateralBalanceHistory']
-> = async (_parent, { address, intervalHours, count, chainId }) => {
+> = async (
+  _parent,
+  {
+    address,
+    intervalSeconds: intervalSecondsArg,
+    intervalHours,
+    count,
+    chainId,
+  }
+) => {
   const addr = address.toLowerCase();
   const cappedCount = Math.min(count, 365);
-  const intervalSeconds = intervalHours * 3600;
+  // `intervalSeconds` wins when both are passed (matches the SDL doc-string).
+  // Falls back to `intervalHours * 3600` so existing callers keep working.
+  const intervalSeconds = intervalSecondsArg ?? intervalHours * 3600;
   const rows = await prisma.$queryRaw<
     { index: number; boundary: Date; balance: string }[]
   >`
@@ -132,6 +143,8 @@ export const runCollateralTransfers = async ({
   address,
   chainId,
   excludeProtocol,
+  orderBy,
+  orderDirection,
   take,
   skip,
 }: QueryCollateralTransfersPageArgs): Promise<CollateralTransfersPageEnvelope> => {
@@ -147,9 +160,16 @@ export const runCollateralTransfers = async ({
     chainId,
     excludeProtocol
   );
+
+  const direction = orderDirection === 'asc' ? 'asc' : 'desc';
+  const orderByClause: Prisma.CollateralTransferOrderByWithRelationInput =
+    orderBy === 'TIMESTAMP'
+      ? { timestamp: direction }
+      : { blockNumber: direction };
+
   const rawRows = await prisma.collateralTransfer.findMany({
     where,
-    orderBy: { blockNumber: 'desc' },
+    orderBy: orderByClause,
     take: cappedTake + 1,
     skip: skipVal,
   });

--- a/packages/api/src/graphql/sdl/resolvers/queries/conditionGroups.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/conditionGroups.ts
@@ -28,9 +28,18 @@ import type {
   QueryResolvers,
   QueryConditionGroupsPageArgs,
   ConditionGroupFilters,
+  ConditionGroupSortField,
 } from '../../__generated__/resolvers';
 import prisma from '../../../../core/db';
 import { clampSkip, clampTake } from './pagination';
+
+const CONDITION_GROUP_ORDER_FIELD_MAP: Record<ConditionGroupSortField, string> =
+  {
+    CREATED_AT: 'createdAt',
+    MAX_END_TIME: 'maxEndTime',
+    TOTAL_OPEN_INTEREST: 'totalOpenInterest',
+    TOTAL_PREDICTION_COUNT: 'totalPredictionCount',
+  };
 
 type Where = Prisma.ConditionGroupWhereInput;
 
@@ -81,14 +90,24 @@ export const conditionGroup: NonNullable<
 
 export const conditionGroupsPage: NonNullable<
   QueryResolvers['conditionGroupsPage']
-> = async (_parent, { filters, take, skip }: QueryConditionGroupsPageArgs) => {
+> = async (
+  _parent,
+  { filters, orderBy, orderDirection, take, skip }: QueryConditionGroupsPageArgs
+) => {
   const cappedTake = clampTake(take, { defaultTake: 50, maxTake: 100 });
   const skipVal = clampSkip(skip);
   const where = buildConditionGroupsWhereFromFilters(filters);
 
+  const direction: 'asc' | 'desc' = orderDirection === 'asc' ? 'asc' : 'desc';
+  const orderField =
+    (orderBy && CONDITION_GROUP_ORDER_FIELD_MAP[orderBy]) ?? 'createdAt';
+  const orderByClause = {
+    [orderField]: direction,
+  } as Prisma.ConditionGroupOrderByWithRelationInput;
+
   const rawRows = await prisma.conditionGroup.findMany({
     where,
-    orderBy: { createdAt: 'desc' },
+    orderBy: orderByClause,
     take: cappedTake + 1,
     skip: skipVal,
   });

--- a/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
@@ -41,6 +41,7 @@ import type {
   QueryPredictionsPageArgs,
   Prediction,
   ResolversParentTypes,
+  SettlementResult,
 } from '../../__generated__/resolvers';
 import { Prisma } from '../../../../../generated/prisma';
 import prisma from '../../../../core/db';
@@ -100,6 +101,17 @@ export type PredictionsPageEnvelope = {
   _countWhere?: Prisma.PredictionWhereInput;
 };
 
+/**
+ * Extended args for `runPredictions` — superset of the deprecated bare
+ * `predictions(...)` args. The richer filter fields (`result`,
+ * `endsAtMin`/`Max`) live only on `predictionsPage` / `PredictionFilters`.
+ */
+export type RunPredictionsArgs = QueryPredictionsArgs & {
+  result?: SettlementResult | null;
+  endsAtMin?: number | null;
+  endsAtMax?: number | null;
+};
+
 export const runPredictions = async ({
   take,
   skip,
@@ -108,9 +120,12 @@ export const runPredictions = async ({
   chainId,
   settled,
   isLegacy,
+  result,
+  endsAtMin,
+  endsAtMax,
   orderBy,
   orderDirection,
-}: QueryPredictionsArgs): Promise<PredictionsPageEnvelope> => {
+}: RunPredictionsArgs): Promise<PredictionsPageEnvelope> => {
   const cappedTake = clampTake(take, { defaultTake: 50, maxTake: 100 });
   const skipVal = clampSkip(skip);
   const addr = address?.toLowerCase();
@@ -134,6 +149,20 @@ export const runPredictions = async ({
   if (chainId !== undefined && chainId !== null) filters.push({ chainId });
   if (settled !== undefined && settled !== null) filters.push({ settled });
   if (isLegacy !== undefined && isLegacy !== null) filters.push({ isLegacy });
+  // result / endsAt range filters live on the pickConfig join.
+  if (result) {
+    filters.push({
+      pickConfiguration: {
+        result: result as unknown as Prisma.EnumSettlementResultFilter,
+      },
+    });
+  }
+  if (endsAtMin != null || endsAtMax != null) {
+    const range: Prisma.IntFilter = {};
+    if (endsAtMin != null) range.gte = endsAtMin;
+    if (endsAtMax != null) range.lte = endsAtMax;
+    filters.push({ pickConfiguration: { endsAt: range } });
+  }
   if (filters.length > 0) where.AND = filters;
 
   const direction = orderDirection === 'asc' ? 'asc' : 'desc';
@@ -166,11 +195,12 @@ export const runPredictions = async ({
 /**
  * Merge `filters: PredictionFilters` (preferred) with the deprecated flat
  * arg shape, so `runPredictions` sees a single canonical set of fields.
- * When a field appears in both, `filters` wins.
+ * When a field appears in both, `filters` wins. The richer filters
+ * (`result`, `endsAtMin`/`Max`) live only on `PredictionFilters`.
  */
 const mergePredictionFilters = (
   args: QueryPredictionsPageArgs
-): QueryPredictionsArgs => {
+): RunPredictionsArgs => {
   const f = args.filters ?? null;
   return {
     take: args.take,
@@ -182,6 +212,9 @@ const mergePredictionFilters = (
     conditionId: f?.conditionId ?? args.conditionId ?? null,
     isLegacy: f?.isLegacy ?? args.isLegacy ?? null,
     settled: f?.settled ?? args.settled ?? null,
+    result: f?.result ?? null,
+    endsAtMin: f?.endsAtMin ?? null,
+    endsAtMax: f?.endsAtMax ?? null,
   };
 };
 
@@ -206,6 +239,11 @@ export const prediction: NonNullable<QueryResolvers['prediction']> = async (
   return r ? mapPrediction(r) : null;
 };
 
+export type RunPickConfigurationsArgs = QueryPickConfigurationsArgs & {
+  orderBy?: 'CREATED_AT' | 'ENDS_AT' | 'RESOLVED_AT' | null;
+  orderDirection?: 'asc' | 'desc' | null;
+};
+
 export const runPickConfigurations = async ({
   take,
   skip,
@@ -213,7 +251,9 @@ export const runPickConfigurations = async ({
   resolved,
   result,
   tokens,
-}: QueryPickConfigurationsArgs): Promise<{
+  orderBy,
+  orderDirection,
+}: RunPickConfigurationsArgs): Promise<{
   items: ReturnType<typeof mapPickConfig>[];
   hasMore: boolean;
   totalCount: number | null;
@@ -237,9 +277,16 @@ export const runPickConfigurations = async ({
       { counterpartyToken: { in: lowered } },
     ];
   }
+  const direction = orderDirection === 'asc' ? 'asc' : 'desc';
+  const orderByClause: Prisma.PicksOrderByWithRelationInput =
+    orderBy === 'ENDS_AT'
+      ? { endsAt: direction }
+      : orderBy === 'RESOLVED_AT'
+        ? { resolvedAt: direction }
+        : { createdAt: direction };
   const rawRows = await prisma.picks.findMany({
     where,
-    orderBy: { createdAt: 'desc' },
+    orderBy: orderByClause,
     take: cappedTake + 1,
     skip: skipVal,
     include: { picks: true },
@@ -260,7 +307,7 @@ export const runPickConfigurations = async ({
  */
 const mergePickConfigurationFilters = (
   args: QueryPickConfigurationsPageArgs
-): QueryPickConfigurationsArgs => {
+): RunPickConfigurationsArgs => {
   const f = args.filters ?? null;
   return {
     take: args.take,
@@ -269,6 +316,8 @@ const mergePickConfigurationFilters = (
     resolved: f?.resolved ?? args.resolved ?? null,
     result: f?.result ?? args.result ?? null,
     tokens: f?.tokens ?? args.tokens ?? null,
+    orderBy: args.orderBy ?? null,
+    orderDirection: args.orderDirection ?? null,
   };
 };
 

--- a/packages/api/src/graphql/sdl/resolvers/queries/trade.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/trade.ts
@@ -45,6 +45,20 @@ export type TradesPageEnvelope = {
   _countWhere?: Prisma.SecondaryTradeWhereInput;
 };
 
+/**
+ * Extended args accepted by `runTrades` — superset of the deprecated bare
+ * `trades(...)` args. The new filter fields (`executedAtMin`/`Max`) and
+ * sort args (`orderBy`/`orderDirection`) live only on `tradesPage` /
+ * `TradeFilters`; passing them through here keeps a single canonical
+ * pipeline for both surfaces.
+ */
+export type RunTradesArgs = QueryTradesArgs & {
+  executedAtMin?: number | null;
+  executedAtMax?: number | null;
+  orderBy?: 'EXECUTED_AT' | 'BLOCK_NUMBER' | null;
+  orderDirection?: 'asc' | 'desc' | null;
+};
+
 export const runTrades = async ({
   take,
   skip,
@@ -53,7 +67,11 @@ export const runTrades = async ({
   buyer,
   token,
   chainId,
-}: QueryTradesArgs): Promise<TradesPageEnvelope> => {
+  executedAtMin,
+  executedAtMax,
+  orderBy,
+  orderDirection,
+}: RunTradesArgs): Promise<TradesPageEnvelope> => {
   const cappedTake = clampTake(take, { defaultTake: 50, maxTake: 100 });
   const skipVal = clampSkip(skip);
   const where: Prisma.SecondaryTradeWhereInput = {};
@@ -71,9 +89,22 @@ export const runTrades = async ({
   }
   if (token) where.token = token.toLowerCase();
   if (chainId !== undefined && chainId !== null) where.chainId = chainId;
+  if (executedAtMin != null || executedAtMax != null) {
+    const range: Prisma.IntFilter = {};
+    if (executedAtMin != null) range.gte = executedAtMin;
+    if (executedAtMax != null) range.lte = executedAtMax;
+    where.executedAt = range;
+  }
+
+  const direction = orderDirection === 'asc' ? 'asc' : 'desc';
+  const orderByClause: Prisma.SecondaryTradeOrderByWithRelationInput =
+    orderBy === 'BLOCK_NUMBER'
+      ? { blockNumber: direction }
+      : { executedAt: direction };
+
   const rawRows = await prisma.secondaryTrade.findMany({
     where,
-    orderBy: { executedAt: 'desc' },
+    orderBy: orderByClause,
     take: cappedTake + 1,
     skip: skipVal,
   });
@@ -85,9 +116,10 @@ export const runTrades = async ({
 /**
  * Merge `filters: TradeFilters` with the deprecated flat arg shape.
  * `filters` wins on conflicts. The `address` vs `seller`/`buyer`
- * mutual-exclusion check happens downstream in `runTrades`.
+ * mutual-exclusion check happens downstream in `runTrades`. New
+ * filter fields (`executedAtMin`/`Max`) live only on `TradeFilters`.
  */
-const mergeTradeFilters = (args: QueryTradesPageArgs): QueryTradesArgs => {
+const mergeTradeFilters = (args: QueryTradesPageArgs): RunTradesArgs => {
   const f = args.filters ?? null;
   return {
     take: args.take,
@@ -97,6 +129,10 @@ const mergeTradeFilters = (args: QueryTradesPageArgs): QueryTradesArgs => {
     buyer: f?.buyer ?? args.buyer ?? null,
     token: f?.token ?? args.token ?? null,
     chainId: f?.chainId ?? args.chainId ?? null,
+    executedAtMin: f?.executedAtMin ?? null,
+    executedAtMax: f?.executedAtMax ?? null,
+    orderBy: args.orderBy ?? null,
+    orderDirection: args.orderDirection ?? null,
   };
 };
 

--- a/packages/api/src/graphql/sdl/schema/schema.graphql
+++ b/packages/api/src/graphql/sdl/schema/schema.graphql
@@ -4,6 +4,37 @@
 # header is preserved for historical context, but this file IS edited
 # directly. The generated counterpart is `packages/api/schema.graphql`
 # at the package root, emitted by `buildApiSchema` for client codegen.
+#
+# -----------------------------------------------
+# Wire-format conventions (apply across every type in this file)
+# -----------------------------------------------
+#
+#   Amounts (collateral, balances, payouts, PnL, volume):
+#     `String` carrying a base-10 integer in wei. Sapience's collateral
+#     token is wUSDe, 18 decimals — divide by 1e18 to render. Negative
+#     amounts are allowed where it makes sense (`losses`, `cumulativePnL`).
+#
+#   Addresses:
+#     `String` carrying a 0x-prefixed lowercase 20-byte hex address. The
+#     indexer normalizes everything to lowercase; filter args accept
+#     mixed-case and lowercase them server-side.
+#
+#   Hashes / token ids:
+#     `String` carrying a 0x-prefixed lowercase 32-byte hex value.
+#
+#   Timestamps:
+#     - `UnixSeconds` — integer epoch seconds. Used for on-chain
+#       timestamps (event times, deadlines, attestation times).
+#     - `DateTimeISO` — ISO 8601 string. Used for Postgres-managed
+#       timestamps (`createdAt`, `updatedAt`, snapshot row boundaries).
+#
+#   IDs:
+#     - `Int!` ids (`id` fields on Prisma-backed types) are internal row
+#       ids — stable per row, not stable across deployments / re-indexes.
+#       Use type-specific public identifiers when persisting client
+#       state: `predictionId` (on-chain), `tradeHash` (on-chain),
+#       `pickConfigId` (deterministic 0x-hash), condition `id` (chain
+#       :: market :: question hash).
 # -----------------------------------------------
 
 """
@@ -1591,6 +1622,33 @@ enum ConditionSortField {
   PREDICTION_COUNT
 }
 
+"""Sort fields for the `conditionGroupsPage` query."""
+enum ConditionGroupSortField {
+  CREATED_AT
+  MAX_END_TIME
+  TOTAL_OPEN_INTEREST
+  TOTAL_PREDICTION_COUNT
+}
+
+"""Sort fields for the `tradesPage` query."""
+enum TradeSortField {
+  EXECUTED_AT
+  BLOCK_NUMBER
+}
+
+"""Sort fields for the `pickConfigurationsPage` query."""
+enum PickConfigurationSortField {
+  CREATED_AT
+  ENDS_AT
+  RESOLVED_AT
+}
+
+"""Sort fields for the `collateralTransfersPage` query."""
+enum CollateralTransferSortField {
+  BLOCK_NUMBER
+  TIMESTAMP
+}
+
 """Visibility filter for the `conditionsPage` query"""
 enum ConditionVisibility {
   PUBLIC
@@ -1709,21 +1767,55 @@ input ConditionGroupFilters {
 }
 
 """
-ERC-20 token balance representing a side of a prediction position
+ERC-20 token balance representing one side of a prediction position. The
+underlying Position row may surface as multiple `*Page` items: one
+"open" row carrying remaining cost basis, plus one synthesized "sell"
+row per secondary-market disposal (so PnL realizes incrementally).
 """
 type Position {
+  """
+  Number of position tokens still held (decimal string, 18 decimals on
+  Sapience). Synthesized sell rows carry `"0"` here — the realized PnL
+  delta from that sell lives on `realizedPnL`.
+  """
   balance: String!
   chainId: Int!
   createdAt: DateTimeISO!
+  """Holder wallet address (lowercase 0x-hex)."""
   holder: String!
+  """
+  Synthetic row id. Open rows use the underlying Position row id
+  serialized as a string; synthesized sell rows append `"-sell-<tradeHash>"`.
+  """
   id: String!
+  """True if this is the predictor token side; false for counterparty."""
   isPredictorToken: Boolean!
   pickConfig: PickConfiguration
   pickConfigId: String!
+  """
+  Realized PnL delta for a synthesized sell row (wei, 18 decimals;
+  signed — negative when sold below cost basis). Null on open rows;
+  use `cumulativePnL` on the bucketed `accountStats` series for the
+  holder-wide aggregate.
+  """
   realizedPnL: String
+  """ERC-20 position token address (lowercase 0x-hex)."""
   tokenAddress: String!
+  """
+  Cumulative payout the contract would owe this position if every
+  matched prediction resolved in the holder's favour (wei, 18 dec).
+  Equal to the total collateral pool across the holder's matched
+  predictions, NOT the net profit. Null when the holder has no matched
+  predictions on this pickConfig.
+  """
   totalPayout: String
   updatedAt: DateTimeISO!
+  """
+  Cost basis remaining on the holder's open balance (wei, 18 dec). For
+  synthesized sell rows this is the basis allocated to the shares
+  disposed of, computed via running WAC. Null when there is no basis to
+  surface (zero-balance settled position, etc.).
+  """
   userCollateral: String
 }
 
@@ -2093,6 +2185,12 @@ input PredictionFilters {
   isLegacy: Boolean
   """Restrict to settled (true) or unsettled (false) predictions."""
   settled: Boolean
+  """Restrict to predictions whose pickConfig settled with this result."""
+  result: SettlementResult
+  """Restrict to predictions whose pickConfig `endsAt >= this`."""
+  endsAtMin: UnixSeconds
+  """Restrict to predictions whose pickConfig `endsAt <= this`."""
+  endsAtMax: UnixSeconds
 }
 
 """
@@ -2111,6 +2209,10 @@ input TradeFilters {
   token: String
   """Restrict to a single chain."""
   chainId: Int
+  """Restrict to trades with `executedAt >= this` (epoch seconds, inclusive)."""
+  executedAtMin: UnixSeconds
+  """Restrict to trades with `executedAt <= this` (epoch seconds, inclusive)."""
+  executedAtMax: UnixSeconds
 }
 
 """
@@ -2499,11 +2601,27 @@ type Query {
     atBlock: Int
     chainId: Int!
   ): CollateralBalance!
+  """
+  Cumulative wUSDe collateral balance for an address at `count + 1`
+  evenly-spaced snapshot boundaries going back from now. The snapshot
+  cadence is `intervalSeconds` (preferred); the legacy `intervalHours`
+  arg is retained as a deprecated alias — when both are supplied,
+  `intervalSeconds` wins.
+  """
   collateralBalanceHistory(
     address: String!
     chainId: Int!
     count: Int! = 12
+    """
+    Snapshot cadence in seconds. Replaces the deprecated `intervalHours`
+    arg; when omitted (and `intervalHours` is also omitted) defaults to
+    168 hours (7 days), matching the previous default.
+    """
+    intervalSeconds: Int
     intervalHours: Int! = 168
+      @deprecated(
+        reason: "Use `intervalSeconds:` — drops the unit-suffix to match the unit-on-scalar convention used elsewhere. When both are supplied, `intervalSeconds` wins."
+      )
   ): [CollateralBalanceSnapshot!]!
   collateralTransfers(
     address: String!
@@ -2518,11 +2636,16 @@ type Query {
 
   """
   Same as `collateralTransfers`, but wraps the result in a `CollateralTransfersPage` with a server-truth `hasMore` flag and standard `take`/`skip` args.
+
+  Sorting via `orderBy: CollateralTransferSortField` + `orderDirection: SortOrder`.
+  Defaults to `BLOCK_NUMBER` / `desc` when omitted.
   """
   collateralTransfersPage(
     address: String!
     chainId: Int!
     excludeProtocol: Boolean = false
+    orderBy: CollateralTransferSortField
+    orderDirection: SortOrder
     take: Int! = 100
     skip: Int! = 0
   ): CollateralTransfersPage!
@@ -2553,9 +2676,14 @@ type Query {
     )
   """
   Same as `conditionGroups`, but wraps the result in a `ConditionGroupsPage` with a server-truth `hasMore` flag.
+
+  Sorting via `orderBy: ConditionGroupSortField` + `orderDirection: SortOrder`.
+  Defaults to `CREATED_AT` / `desc` when omitted.
   """
   conditionGroupsPage(
     filters: ConditionGroupFilters
+    orderBy: ConditionGroupSortField
+    orderDirection: SortOrder
     take: Int! = 50
     skip: Int! = 0
   ): ConditionGroupsPage!
@@ -2611,9 +2739,14 @@ type Query {
   filters (`chainId`, `resolved`, `result`, `tokens`) are retained for
   one release with `@deprecated` so existing callers can migrate without
   breaking; new callers should use `filters:`.
+
+  Sorting via `orderBy: PickConfigurationSortField` + `orderDirection: SortOrder`.
+  Defaults to `CREATED_AT` / `desc` when omitted.
   """
   pickConfigurationsPage(
     filters: PickConfigurationFilters
+    orderBy: PickConfigurationSortField
+    orderDirection: SortOrder
     take: Int! = 50
     skip: Int! = 0
     chainId: Int
@@ -2968,9 +3101,14 @@ type Query {
   (`address`, `seller`, `buyer`, `token`, `chainId`) are retained for one
   release with `@deprecated` so existing callers can migrate without
   breaking; new callers should use `filters:`.
+
+  Sorting via `orderBy: TradeSortField` + `orderDirection: SortOrder`.
+  Defaults to `EXECUTED_AT` / `desc` when omitted.
   """
   tradesPage(
     filters: TradeFilters
+    orderBy: TradeSortField
+    orderDirection: SortOrder
     take: Int! = 50
     skip: Int! = 0
     address: String
@@ -3398,20 +3536,29 @@ input StringNullableListFilter {
 }
 
 """
-Secondary market trade record where position tokens are exchanged between users
+Secondary market trade record where position tokens are exchanged
+between users. The on-chain reference is `tradeHash`; `id` is an
+internal row id (see schema-preamble conventions).
 """
 type Trade {
   blockNumber: Int!
+  """Buyer wallet address (lowercase 0x-hex)."""
   buyer: String!
   chainId: Int!
+  """Collateral asset address paid in this trade (lowercase 0x-hex)."""
   collateral: String!
   executedAt: UnixSeconds!
   id: Int!
+  """Total collateral paid by buyer (wei, 18 dec). `price / tokenAmount` is the per-share price."""
   price: String!
   refCode: String
+  """Seller wallet address (lowercase 0x-hex)."""
   seller: String!
+  """Position token address being exchanged (lowercase 0x-hex)."""
   token: String!
+  """Quantity of position tokens transferred (wei, 18 dec on Sapience)."""
   tokenAmount: String!
+  """Canonical trade hash — the on-chain identifier (0x-prefixed)."""
   tradeHash: String!
   txHash: String!
 }

--- a/packages/api/test/contract/__snapshots__/introspection.json
+++ b/packages/api/test/contract/__snapshots__/introspection.json
@@ -5143,6 +5143,29 @@
         "possibleTypes": null
       },
       {
+        "kind": "ENUM",
+        "name": "CollateralTransferSortField",
+        "description": "Sort fields for the `collateralTransfersPage` query.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "BLOCK_NUMBER",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "TIMESTAMP",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "CollateralTransfersPage",
         "description": "Paginated wrapper around CollateralTransfer rows with a server-truth hasMore flag",
@@ -7075,6 +7098,41 @@
           },
           {
             "name": "totalSimilarMarketVolumeFiltered24h",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ConditionGroupSortField",
+        "description": "Sort fields for the `conditionGroupsPage` query.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "CREATED_AT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MAX_END_TIME",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "TOTAL_OPEN_INTEREST",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "TOTAL_PREDICTION_COUNT",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -15021,6 +15079,35 @@
         "possibleTypes": null
       },
       {
+        "kind": "ENUM",
+        "name": "PickConfigurationSortField",
+        "description": "Sort fields for the `pickConfigurationsPage` query.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "CREATED_AT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ENDS_AT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "RESOLVED_AT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "PickConfigurationsPage",
         "description": "Paginated wrapper around PickConfiguration rows with a server-truth hasMore flag",
@@ -15151,11 +15238,11 @@
       {
         "kind": "OBJECT",
         "name": "Position",
-        "description": "ERC-20 token balance representing a side of a prediction position",
+        "description": "ERC-20 token balance representing one side of a prediction position. The\nunderlying Position row may surface as multiple `*Page` items: one\n\"open\" row carrying remaining cost basis, plus one synthesized \"sell\"\nrow per secondary-market disposal (so PnL realizes incrementally).",
         "fields": [
           {
             "name": "balance",
-            "description": null,
+            "description": "Number of position tokens still held (decimal string, 18 decimals on\nSapience). Synthesized sell rows carry `\"0\"` here — the realized PnL\ndelta from that sell lives on `realizedPnL`.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -15203,7 +15290,7 @@
           },
           {
             "name": "holder",
-            "description": null,
+            "description": "Holder wallet address (lowercase 0x-hex).",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -15219,7 +15306,7 @@
           },
           {
             "name": "id",
-            "description": null,
+            "description": "Synthetic row id. Open rows use the underlying Position row id\nserialized as a string; synthesized sell rows append `\"-sell-<tradeHash>\"`.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -15235,7 +15322,7 @@
           },
           {
             "name": "isPredictorToken",
-            "description": null,
+            "description": "True if this is the predictor token side; false for counterparty.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -15279,7 +15366,7 @@
           },
           {
             "name": "realizedPnL",
-            "description": null,
+            "description": "Realized PnL delta for a synthesized sell row (wei, 18 decimals;\nsigned — negative when sold below cost basis). Null on open rows;\nuse `cumulativePnL` on the bucketed `accountStats` series for the\nholder-wide aggregate.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -15291,7 +15378,7 @@
           },
           {
             "name": "tokenAddress",
-            "description": null,
+            "description": "ERC-20 position token address (lowercase 0x-hex).",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -15307,7 +15394,7 @@
           },
           {
             "name": "totalPayout",
-            "description": null,
+            "description": "Cumulative payout the contract would owe this position if every\nmatched prediction resolved in the holder's favour (wei, 18 dec).\nEqual to the total collateral pool across the holder's matched\npredictions, NOT the net profit. Null when the holder has no matched\npredictions on this pickConfig.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -15335,7 +15422,7 @@
           },
           {
             "name": "userCollateral",
-            "description": null,
+            "description": "Cost basis remaining on the holder's open balance (wei, 18 dec). For\nsynthesized sell rows this is the basis allocated to the shares\ndisposed of, computed via running WAC. Null when there is no basis to\nsurface (zero-balance settled position, etc.).",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -16070,6 +16157,36 @@
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "result",
+            "description": "Restrict to predictions whose pickConfig settled with this result.",
+            "type": {
+              "kind": "ENUM",
+              "name": "SettlementResult",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "endsAtMin",
+            "description": "Restrict to predictions whose pickConfig `endsAt >= this`.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "UnixSeconds",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "endsAtMax",
+            "description": "Restrict to predictions whose pickConfig `endsAt <= this`.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "UnixSeconds",
               "ofType": null
             },
             "defaultValue": null
@@ -17760,7 +17877,7 @@
           },
           {
             "name": "collateralBalanceHistory",
-            "description": null,
+            "description": "Cumulative wUSDe collateral balance for an address at `count + 1`\nevenly-spaced snapshot boundaries going back from now. The snapshot\ncadence is `intervalSeconds` (preferred); the legacy `intervalHours`\narg is retained as a deprecated alias — when both are supplied,\n`intervalSeconds` wins.",
             "args": [
               {
                 "name": "address",
@@ -17805,18 +17922,14 @@
                 "defaultValue": "12"
               },
               {
-                "name": "intervalHours",
-                "description": null,
+                "name": "intervalSeconds",
+                "description": "Snapshot cadence in seconds. Replaces the deprecated `intervalHours`\narg; when omitted (and `intervalHours` is also omitted) defaults to\n168 hours (7 days), matching the previous default.",
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
                 },
-                "defaultValue": "168"
+                "defaultValue": null
               }
             ],
             "type": {
@@ -17932,7 +18045,7 @@
           },
           {
             "name": "collateralTransfersPage",
-            "description": "Same as `collateralTransfers`, but wraps the result in a `CollateralTransfersPage` with a server-truth `hasMore` flag and standard `take`/`skip` args.",
+            "description": "Same as `collateralTransfers`, but wraps the result in a `CollateralTransfersPage` with a server-truth `hasMore` flag and standard `take`/`skip` args.\n\nSorting via `orderBy: CollateralTransferSortField` + `orderDirection: SortOrder`.\nDefaults to `BLOCK_NUMBER` / `desc` when omitted.",
             "args": [
               {
                 "name": "address",
@@ -17971,6 +18084,26 @@
                   "ofType": null
                 },
                 "defaultValue": "false"
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "CollateralTransferSortField",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "orderDirection",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "SortOrder",
+                  "ofType": null
+                },
+                "defaultValue": null
               },
               {
                 "name": "take",
@@ -18197,7 +18330,7 @@
           },
           {
             "name": "conditionGroupsPage",
-            "description": "Same as `conditionGroups`, but wraps the result in a `ConditionGroupsPage` with a server-truth `hasMore` flag.",
+            "description": "Same as `conditionGroups`, but wraps the result in a `ConditionGroupsPage` with a server-truth `hasMore` flag.\n\nSorting via `orderBy: ConditionGroupSortField` + `orderDirection: SortOrder`.\nDefaults to `CREATED_AT` / `desc` when omitted.",
             "args": [
               {
                 "name": "filters",
@@ -18205,6 +18338,26 @@
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "ConditionGroupFilters",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "ConditionGroupSortField",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "orderDirection",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "SortOrder",
                   "ofType": null
                 },
                 "defaultValue": null
@@ -18556,7 +18709,7 @@
           },
           {
             "name": "pickConfigurationsPage",
-            "description": "Same as `pickConfigurations`, but wraps the result in a `PickConfigurationsPage` with a server-truth `hasMore` flag for paginated infinite scroll.\n\nFiltering is via `filters: PickConfigurationFilters`. The flat-arg\nfilters (`chainId`, `resolved`, `result`, `tokens`) are retained for\none release with `@deprecated` so existing callers can migrate without\nbreaking; new callers should use `filters:`.",
+            "description": "Same as `pickConfigurations`, but wraps the result in a `PickConfigurationsPage` with a server-truth `hasMore` flag for paginated infinite scroll.\n\nFiltering is via `filters: PickConfigurationFilters`. The flat-arg\nfilters (`chainId`, `resolved`, `result`, `tokens`) are retained for\none release with `@deprecated` so existing callers can migrate without\nbreaking; new callers should use `filters:`.\n\nSorting via `orderBy: PickConfigurationSortField` + `orderDirection: SortOrder`.\nDefaults to `CREATED_AT` / `desc` when omitted.",
             "args": [
               {
                 "name": "filters",
@@ -18564,6 +18717,26 @@
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "PickConfigurationFilters",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "PickConfigurationSortField",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "orderDirection",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "SortOrder",
                   "ofType": null
                 },
                 "defaultValue": null
@@ -19866,7 +20039,7 @@
           },
           {
             "name": "tradesPage",
-            "description": "Same as `trades`, but wraps the result in a `TradesPage` with a server-truth `hasMore` flag.\n\nFiltering is via `filters: TradeFilters`. The flat-arg filters\n(`address`, `seller`, `buyer`, `token`, `chainId`) are retained for one\nrelease with `@deprecated` so existing callers can migrate without\nbreaking; new callers should use `filters:`.",
+            "description": "Same as `trades`, but wraps the result in a `TradesPage` with a server-truth `hasMore` flag.\n\nFiltering is via `filters: TradeFilters`. The flat-arg filters\n(`address`, `seller`, `buyer`, `token`, `chainId`) are retained for one\nrelease with `@deprecated` so existing callers can migrate without\nbreaking; new callers should use `filters:`.\n\nSorting via `orderBy: TradeSortField` + `orderDirection: SortOrder`.\nDefaults to `EXECUTED_AT` / `desc` when omitted.",
             "args": [
               {
                 "name": "filters",
@@ -19874,6 +20047,26 @@
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "TradeFilters",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "TradeSortField",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "orderDirection",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "SortOrder",
                   "ofType": null
                 },
                 "defaultValue": null
@@ -21848,7 +22041,7 @@
       {
         "kind": "OBJECT",
         "name": "Trade",
-        "description": "Secondary market trade record where position tokens are exchanged between users",
+        "description": "Secondary market trade record where position tokens are exchanged\nbetween users. The on-chain reference is `tradeHash`; `id` is an\ninternal row id (see schema-preamble conventions).",
         "fields": [
           {
             "name": "blockNumber",
@@ -21868,7 +22061,7 @@
           },
           {
             "name": "buyer",
-            "description": null,
+            "description": "Buyer wallet address (lowercase 0x-hex).",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -21900,7 +22093,7 @@
           },
           {
             "name": "collateral",
-            "description": null,
+            "description": "Collateral asset address paid in this trade (lowercase 0x-hex).",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -21948,7 +22141,7 @@
           },
           {
             "name": "price",
-            "description": null,
+            "description": "Total collateral paid by buyer (wei, 18 dec). `price / tokenAmount` is the per-share price.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -21976,7 +22169,7 @@
           },
           {
             "name": "seller",
-            "description": null,
+            "description": "Seller wallet address (lowercase 0x-hex).",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -21992,7 +22185,7 @@
           },
           {
             "name": "token",
-            "description": null,
+            "description": "Position token address being exchanged (lowercase 0x-hex).",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22008,7 +22201,7 @@
           },
           {
             "name": "tokenAmount",
-            "description": null,
+            "description": "Quantity of position tokens transferred (wei, 18 dec on Sapience).",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22024,7 +22217,7 @@
           },
           {
             "name": "tradeHash",
-            "description": null,
+            "description": "Canonical trade hash — the on-chain identifier (0x-prefixed).",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22115,10 +22308,53 @@
               "ofType": null
             },
             "defaultValue": null
+          },
+          {
+            "name": "executedAtMin",
+            "description": "Restrict to trades with `executedAt >= this` (epoch seconds, inclusive).",
+            "type": {
+              "kind": "SCALAR",
+              "name": "UnixSeconds",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "executedAtMax",
+            "description": "Restrict to trades with `executedAt <= this` (epoch seconds, inclusive).",
+            "type": {
+              "kind": "SCALAR",
+              "name": "UnixSeconds",
+              "ofType": null
+            },
+            "defaultValue": null
           }
         ],
         "interfaces": null,
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "TradeSortField",
+        "description": "Sort fields for the `tradesPage` query.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "EXECUTED_AT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "BLOCK_NUMBER",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {

--- a/packages/api/test/contract/__snapshots__/schema.sdl.graphql
+++ b/packages/api/test/contract/__snapshots__/schema.sdl.graphql
@@ -1523,6 +1523,33 @@ enum ConditionSortField {
   PREDICTION_COUNT
 }
 
+"""Sort fields for the `conditionGroupsPage` query."""
+enum ConditionGroupSortField {
+  CREATED_AT
+  MAX_END_TIME
+  TOTAL_OPEN_INTEREST
+  TOTAL_PREDICTION_COUNT
+}
+
+"""Sort fields for the `tradesPage` query."""
+enum TradeSortField {
+  EXECUTED_AT
+  BLOCK_NUMBER
+}
+
+"""Sort fields for the `pickConfigurationsPage` query."""
+enum PickConfigurationSortField {
+  CREATED_AT
+  ENDS_AT
+  RESOLVED_AT
+}
+
+"""Sort fields for the `collateralTransfersPage` query."""
+enum CollateralTransferSortField {
+  BLOCK_NUMBER
+  TIMESTAMP
+}
+
 """Visibility filter for the `conditionsPage` query"""
 enum ConditionVisibility {
   PUBLIC
@@ -1663,20 +1690,63 @@ input ConditionGroupFilters {
   includeEmpty: Boolean
 }
 
-"""ERC-20 token balance representing a side of a prediction position"""
+"""
+ERC-20 token balance representing one side of a prediction position. The
+underlying Position row may surface as multiple `*Page` items: one
+"open" row carrying remaining cost basis, plus one synthesized "sell"
+row per secondary-market disposal (so PnL realizes incrementally).
+"""
 type Position {
+  """
+  Number of position tokens still held (decimal string, 18 decimals on
+  Sapience). Synthesized sell rows carry `"0"` here — the realized PnL
+  delta from that sell lives on `realizedPnL`.
+  """
   balance: String!
   chainId: Int!
   createdAt: DateTimeISO!
+
+  """Holder wallet address (lowercase 0x-hex)."""
   holder: String!
+
+  """
+  Synthetic row id. Open rows use the underlying Position row id
+  serialized as a string; synthesized sell rows append `"-sell-<tradeHash>"`.
+  """
   id: String!
+
+  """True if this is the predictor token side; false for counterparty."""
   isPredictorToken: Boolean!
   pickConfig: PickConfiguration
   pickConfigId: String!
+
+  """
+  Realized PnL delta for a synthesized sell row (wei, 18 decimals;
+  signed — negative when sold below cost basis). Null on open rows;
+  use `cumulativePnL` on the bucketed `accountStats` series for the
+  holder-wide aggregate.
+  """
   realizedPnL: String
+
+  """ERC-20 position token address (lowercase 0x-hex)."""
   tokenAddress: String!
+
+  """
+  Cumulative payout the contract would owe this position if every
+  matched prediction resolved in the holder's favour (wei, 18 dec).
+  Equal to the total collateral pool across the holder's matched
+  predictions, NOT the net profit. Null when the holder has no matched
+  predictions on this pickConfig.
+  """
   totalPayout: String
   updatedAt: DateTimeISO!
+
+  """
+  Cost basis remaining on the holder's open balance (wei, 18 dec). For
+  synthesized sell rows this is the basis allocated to the shares
+  disposed of, computed via running WAC. Null when there is no basis to
+  surface (zero-balance settled position, etc.).
+  """
   userCollateral: String
 }
 
@@ -2013,6 +2083,15 @@ input PredictionFilters {
 
   """Restrict to settled (true) or unsettled (false) predictions."""
   settled: Boolean
+
+  """Restrict to predictions whose pickConfig settled with this result."""
+  result: SettlementResult
+
+  """Restrict to predictions whose pickConfig `endsAt >= this`."""
+  endsAtMin: UnixSeconds
+
+  """Restrict to predictions whose pickConfig `endsAt <= this`."""
+  endsAtMax: UnixSeconds
 }
 
 """
@@ -2037,6 +2116,16 @@ input TradeFilters {
 
   """Restrict to a single chain."""
   chainId: Int
+
+  """
+  Restrict to trades with `executedAt >= this` (epoch seconds, inclusive).
+  """
+  executedAtMin: UnixSeconds
+
+  """
+  Restrict to trades with `executedAt <= this` (epoch seconds, inclusive).
+  """
+  executedAtMax: UnixSeconds
 }
 
 """
@@ -2259,13 +2348,36 @@ type Query {
   """
   closes(address: String, chainId: Int, pickConfigId: String, skip: Int! = 0, take: Int! = 50): [Close!]! @deprecated(reason: "Unused; will be removed. No live consumers — close records are reachable as a side-effect of position settlement.")
   collateralBalance(address: String!, atBlock: Int, chainId: Int!): CollateralBalance!
-  collateralBalanceHistory(address: String!, chainId: Int!, count: Int! = 12, intervalHours: Int! = 168): [CollateralBalanceSnapshot!]!
+
+  """
+  Cumulative wUSDe collateral balance for an address at `count + 1`
+  evenly-spaced snapshot boundaries going back from now. The snapshot
+  cadence is `intervalSeconds` (preferred); the legacy `intervalHours`
+  arg is retained as a deprecated alias — when both are supplied,
+  `intervalSeconds` wins.
+  """
+  collateralBalanceHistory(
+    address: String!
+    chainId: Int!
+    count: Int! = 12
+
+    """
+    Snapshot cadence in seconds. Replaces the deprecated `intervalHours`
+    arg; when omitted (and `intervalHours` is also omitted) defaults to
+    168 hours (7 days), matching the previous default.
+    """
+    intervalSeconds: Int
+    intervalHours: Int! = 168 @deprecated(reason: "Use `intervalSeconds:` — drops the unit-suffix to match the unit-on-scalar convention used elsewhere. When both are supplied, `intervalSeconds` wins.")
+  ): [CollateralBalanceSnapshot!]!
   collateralTransfers(address: String!, chainId: Int!, excludeProtocol: Boolean = false, limit: Int! = 100, offset: Int! = 0): [CollateralTransfer!]! @deprecated(reason: "Use `collateralTransfersPage` — same data with standard `take` / `skip` args (replaces `limit` / `offset`) and a server-truth `hasMore` stop signal.")
 
   """
   Same as `collateralTransfers`, but wraps the result in a `CollateralTransfersPage` with a server-truth `hasMore` flag and standard `take`/`skip` args.
+  
+  Sorting via `orderBy: CollateralTransferSortField` + `orderDirection: SortOrder`.
+  Defaults to `BLOCK_NUMBER` / `desc` when omitted.
   """
-  collateralTransfersPage(address: String!, chainId: Int!, excludeProtocol: Boolean = false, take: Int! = 100, skip: Int! = 0): CollateralTransfersPage!
+  collateralTransfersPage(address: String!, chainId: Int!, excludeProtocol: Boolean = false, orderBy: CollateralTransferSortField, orderDirection: SortOrder, take: Int! = 100, skip: Int! = 0): CollateralTransfersPage!
 
   """
   Look up a single account by canonical wallet address. Replacement for
@@ -2279,8 +2391,11 @@ type Query {
 
   """
   Same as `conditionGroups`, but wraps the result in a `ConditionGroupsPage` with a server-truth `hasMore` flag.
+  
+  Sorting via `orderBy: ConditionGroupSortField` + `orderDirection: SortOrder`.
+  Defaults to `CREATED_AT` / `desc` when omitted.
   """
-  conditionGroupsPage(filters: ConditionGroupFilters, take: Int! = 50, skip: Int! = 0): ConditionGroupsPage!
+  conditionGroupsPage(filters: ConditionGroupFilters, orderBy: ConditionGroupSortField, orderDirection: SortOrder, take: Int! = 50, skip: Int! = 0): ConditionGroupsPage!
   conditions(cursor: ConditionWhereUniqueInput, distinct: [ConditionScalarFieldEnum!], orderBy: [ConditionOrderByWithRelationInput!], skip: Int, take: Int, where: ConditionWhereInput): [Condition!]! @deprecated(reason: "Use `conditionsPage` — purpose-built filters via `ConditionFilters`, paginated with a server-truth `hasMore` stop signal.")
 
   """
@@ -2303,8 +2418,11 @@ type Query {
   filters (`chainId`, `resolved`, `result`, `tokens`) are retained for
   one release with `@deprecated` so existing callers can migrate without
   breaking; new callers should use `filters:`.
+  
+  Sorting via `orderBy: PickConfigurationSortField` + `orderDirection: SortOrder`.
+  Defaults to `CREATED_AT` / `desc` when omitted.
   """
-  pickConfigurationsPage(filters: PickConfigurationFilters, take: Int! = 50, skip: Int! = 0, chainId: Int @deprecated(reason: "Use `filters: { chainId: ... }` on `PickConfigurationFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), resolved: Boolean @deprecated(reason: "Use `filters: { resolved: ... }` on `PickConfigurationFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), result: SettlementResult @deprecated(reason: "Use `filters: { result: ... }` on `PickConfigurationFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), tokens: [String!] @deprecated(reason: "Use `filters: { tokens: ... }` on `PickConfigurationFilters` — the flat-arg shape is being unified across all `*Page` resolvers.")): PickConfigurationsPage!
+  pickConfigurationsPage(filters: PickConfigurationFilters, orderBy: PickConfigurationSortField, orderDirection: SortOrder, take: Int! = 50, skip: Int! = 0, chainId: Int @deprecated(reason: "Use `filters: { chainId: ... }` on `PickConfigurationFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), resolved: Boolean @deprecated(reason: "Use `filters: { resolved: ... }` on `PickConfigurationFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), result: SettlementResult @deprecated(reason: "Use `filters: { result: ... }` on `PickConfigurationFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), tokens: [String!] @deprecated(reason: "Use `filters: { tokens: ... }` on `PickConfigurationFilters` — the flat-arg shape is being unified across all `*Page` resolvers.")): PickConfigurationsPage!
 
   """Top 20 most-used tags across public conditions"""
   popularTags: [String!]!
@@ -2434,8 +2552,11 @@ type Query {
   (`address`, `seller`, `buyer`, `token`, `chainId`) are retained for one
   release with `@deprecated` so existing callers can migrate without
   breaking; new callers should use `filters:`.
+  
+  Sorting via `orderBy: TradeSortField` + `orderDirection: SortOrder`.
+  Defaults to `EXECUTED_AT` / `desc` when omitted.
   """
-  tradesPage(filters: TradeFilters, take: Int! = 50, skip: Int! = 0, address: String @deprecated(reason: "Use `filters: { address: ... }` on `TradeFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), buyer: String @deprecated(reason: "Use `filters: { buyer: ... }` on `TradeFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), chainId: Int @deprecated(reason: "Use `filters: { chainId: ... }` on `TradeFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), seller: String @deprecated(reason: "Use `filters: { seller: ... }` on `TradeFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), token: String @deprecated(reason: "Use `filters: { token: ... }` on `TradeFilters` — the flat-arg shape is being unified across all `*Page` resolvers.")): TradesPage!
+  tradesPage(filters: TradeFilters, orderBy: TradeSortField, orderDirection: SortOrder, take: Int! = 50, skip: Int! = 0, address: String @deprecated(reason: "Use `filters: { address: ... }` on `TradeFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), buyer: String @deprecated(reason: "Use `filters: { buyer: ... }` on `TradeFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), chainId: Int @deprecated(reason: "Use `filters: { chainId: ... }` on `TradeFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), seller: String @deprecated(reason: "Use `filters: { seller: ... }` on `TradeFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), token: String @deprecated(reason: "Use `filters: { token: ... }` on `TradeFilters` — the flat-arg shape is being unified across all `*Page` resolvers.")): TradesPage!
   user(where: UserWhereUniqueInput!): User @deprecated(reason: "Use `account(address:)` — flat address arg, returns the same address-keyed referral data via the new public-API-shaped `Account` type. The Prisma-leaked `User` type will be removed once telemetry on this path drains.")
   users(cursor: UserWhereUniqueInput, distinct: [UserScalarFieldEnum!], orderBy: [UserOrderByWithRelationInput!], skip: Int, take: Int, where: UserWhereInput): [User!]! @deprecated(reason: "Unused; will be removed. No live consumers — account lookups go through `account(address:)` or `referralCodesPage`.")
 
@@ -2780,20 +2901,38 @@ input StringNullableListFilter {
 }
 
 """
-Secondary market trade record where position tokens are exchanged between users
+Secondary market trade record where position tokens are exchanged
+between users. The on-chain reference is `tradeHash`; `id` is an
+internal row id (see schema-preamble conventions).
 """
 type Trade {
   blockNumber: Int!
+
+  """Buyer wallet address (lowercase 0x-hex)."""
   buyer: String!
   chainId: Int!
+
+  """Collateral asset address paid in this trade (lowercase 0x-hex)."""
   collateral: String!
   executedAt: UnixSeconds!
   id: Int!
+
+  """
+  Total collateral paid by buyer (wei, 18 dec). `price / tokenAmount` is the per-share price.
+  """
   price: String!
   refCode: String
+
+  """Seller wallet address (lowercase 0x-hex)."""
   seller: String!
+
+  """Position token address being exchanged (lowercase 0x-hex)."""
   token: String!
+
+  """Quantity of position tokens transferred (wei, 18 dec on Sapience)."""
   tokenAmount: String!
+
+  """Canonical trade hash — the on-chain identifier (0x-prefixed)."""
   tradeHash: String!
   txHash: String!
 }

--- a/packages/sdk/types/graphql.ts
+++ b/packages/sdk/types/graphql.ts
@@ -704,6 +704,11 @@ export type CollateralTransfer = {
   value: Scalars['String']['output'];
 };
 
+/** Sort fields for the `collateralTransfersPage` query. */
+export type CollateralTransferSortField =
+  | 'BLOCK_NUMBER'
+  | 'TIMESTAMP';
+
 /** Paginated wrapper around CollateralTransfer rows with a server-truth hasMore flag */
 export type CollateralTransfersPage = Page & {
   __typename?: 'CollateralTransfersPage';
@@ -1001,6 +1006,13 @@ export type ConditionGroupScalarFieldEnum =
   | 'totalSimilarMarketVolumeFiltered4h'
   | 'totalSimilarMarketVolumeFiltered7d'
   | 'totalSimilarMarketVolumeFiltered24h';
+
+/** Sort fields for the `conditionGroupsPage` query. */
+export type ConditionGroupSortField =
+  | 'CREATED_AT'
+  | 'MAX_END_TIME'
+  | 'TOTAL_OPEN_INTEREST'
+  | 'TOTAL_PREDICTION_COUNT';
 
 export type ConditionGroupWhereInput = {
   AND?: InputMaybe<Array<ConditionGroupWhereInput>>;
@@ -1898,6 +1910,12 @@ export type PickConfigurationFilters = {
   tokens?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
+/** Sort fields for the `pickConfigurationsPage` query. */
+export type PickConfigurationSortField =
+  | 'CREATED_AT'
+  | 'ENDS_AT'
+  | 'RESOLVED_AT';
+
 /** Paginated wrapper around PickConfiguration rows with a server-truth hasMore flag */
 export type PickConfigurationsPage = Page & {
   __typename?: 'PickConfigurationsPage';
@@ -1917,21 +1935,57 @@ export type PnlDataPoint = {
   timestamp: Scalars['Int']['output'];
 };
 
-/** ERC-20 token balance representing a side of a prediction position */
+/**
+ * ERC-20 token balance representing one side of a prediction position. The
+ * underlying Position row may surface as multiple `*Page` items: one
+ * "open" row carrying remaining cost basis, plus one synthesized "sell"
+ * row per secondary-market disposal (so PnL realizes incrementally).
+ */
 export type Position = {
   __typename?: 'Position';
+  /**
+   * Number of position tokens still held (decimal string, 18 decimals on
+   * Sapience). Synthesized sell rows carry `"0"` here — the realized PnL
+   * delta from that sell lives on `realizedPnL`.
+   */
   balance: Scalars['String']['output'];
   chainId: Scalars['Int']['output'];
   createdAt: Scalars['DateTimeISO']['output'];
+  /** Holder wallet address (lowercase 0x-hex). */
   holder: Scalars['String']['output'];
+  /**
+   * Synthetic row id. Open rows use the underlying Position row id
+   * serialized as a string; synthesized sell rows append `"-sell-<tradeHash>"`.
+   */
   id: Scalars['String']['output'];
+  /** True if this is the predictor token side; false for counterparty. */
   isPredictorToken: Scalars['Boolean']['output'];
   pickConfig?: Maybe<PickConfiguration>;
   pickConfigId: Scalars['String']['output'];
+  /**
+   * Realized PnL delta for a synthesized sell row (wei, 18 decimals;
+   * signed — negative when sold below cost basis). Null on open rows;
+   * use `cumulativePnL` on the bucketed `accountStats` series for the
+   * holder-wide aggregate.
+   */
   realizedPnL?: Maybe<Scalars['String']['output']>;
+  /** ERC-20 position token address (lowercase 0x-hex). */
   tokenAddress: Scalars['String']['output'];
+  /**
+   * Cumulative payout the contract would owe this position if every
+   * matched prediction resolved in the holder's favour (wei, 18 dec).
+   * Equal to the total collateral pool across the holder's matched
+   * predictions, NOT the net profit. Null when the holder has no matched
+   * predictions on this pickConfig.
+   */
   totalPayout?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTimeISO']['output'];
+  /**
+   * Cost basis remaining on the holder's open balance (wei, 18 dec). For
+   * synthesized sell rows this is the basis allocated to the shares
+   * disposed of, computed via running WAC. Null when there is no basis to
+   * surface (zero-balance settled position, etc.).
+   */
   userCollateral?: Maybe<Scalars['String']['output']>;
 };
 
@@ -2040,8 +2094,14 @@ export type PredictionFilters = {
   chainId?: InputMaybe<Scalars['Int']['input']>;
   /** Restrict to predictions on a single condition (via the pickConfig join). */
   conditionId?: InputMaybe<Scalars['String']['input']>;
+  /** Restrict to predictions whose pickConfig `endsAt <= this`. */
+  endsAtMax?: InputMaybe<Scalars['UnixSeconds']['input']>;
+  /** Restrict to predictions whose pickConfig `endsAt >= this`. */
+  endsAtMin?: InputMaybe<Scalars['UnixSeconds']['input']>;
   /** Restrict to legacy (true) or non-legacy (false) predictions. */
   isLegacy?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Restrict to predictions whose pickConfig settled with this result. */
+  result?: InputMaybe<SettlementResult>;
   /** Restrict to settled (true) or unsettled (false) predictions. */
   settled?: InputMaybe<Scalars['Boolean']['input']>;
 };
@@ -2243,10 +2303,22 @@ export type Query = {
    */
   closes: Array<Close>;
   collateralBalance: CollateralBalance;
+  /**
+   * Cumulative wUSDe collateral balance for an address at `count + 1`
+   * evenly-spaced snapshot boundaries going back from now. The snapshot
+   * cadence is `intervalSeconds` (preferred); the legacy `intervalHours`
+   * arg is retained as a deprecated alias — when both are supplied,
+   * `intervalSeconds` wins.
+   */
   collateralBalanceHistory: Array<CollateralBalanceSnapshot>;
   /** @deprecated Use `collateralTransfersPage` — same data with standard `take` / `skip` args (replaces `limit` / `offset`) and a server-truth `hasMore` stop signal. */
   collateralTransfers: Array<CollateralTransfer>;
-  /** Same as `collateralTransfers`, but wraps the result in a `CollateralTransfersPage` with a server-truth `hasMore` flag and standard `take`/`skip` args. */
+  /**
+   * Same as `collateralTransfers`, but wraps the result in a `CollateralTransfersPage` with a server-truth `hasMore` flag and standard `take`/`skip` args.
+   *
+   * Sorting via `orderBy: CollateralTransferSortField` + `orderDirection: SortOrder`.
+   * Defaults to `BLOCK_NUMBER` / `desc` when omitted.
+   */
   collateralTransfersPage: CollateralTransfersPage;
   /** @deprecated Pending flat-id arg flip in the final cleanup PR — single-record `condition(id:)` will replace the Prisma `where:` shape. */
   condition?: Maybe<Condition>;
@@ -2254,7 +2326,12 @@ export type Query = {
   conditionGroup?: Maybe<ConditionGroup>;
   /** @deprecated Use `conditionGroupsPage` — purpose-built filters via `ConditionGroupFilters`, paginated with a server-truth `hasMore` stop signal. */
   conditionGroups: Array<ConditionGroup>;
-  /** Same as `conditionGroups`, but wraps the result in a `ConditionGroupsPage` with a server-truth `hasMore` flag. */
+  /**
+   * Same as `conditionGroups`, but wraps the result in a `ConditionGroupsPage` with a server-truth `hasMore` flag.
+   *
+   * Sorting via `orderBy: ConditionGroupSortField` + `orderDirection: SortOrder`.
+   * Defaults to `CREATED_AT` / `desc` when omitted.
+   */
   conditionGroupsPage: ConditionGroupsPage;
   /** @deprecated Use `conditionsPage` — purpose-built filters via `ConditionFilters`, paginated with a server-truth `hasMore` stop signal. */
   conditions: Array<Condition>;
@@ -2281,6 +2358,9 @@ export type Query = {
    * filters (`chainId`, `resolved`, `result`, `tokens`) are retained for
    * one release with `@deprecated` so existing callers can migrate without
    * breaking; new callers should use `filters:`.
+   *
+   * Sorting via `orderBy: PickConfigurationSortField` + `orderDirection: SortOrder`.
+   * Defaults to `CREATED_AT` / `desc` when omitted.
    */
   pickConfigurationsPage: PickConfigurationsPage;
   /** Top 20 most-used tags across public conditions */
@@ -2399,6 +2479,9 @@ export type Query = {
    * (`address`, `seller`, `buyer`, `token`, `chainId`) are retained for one
    * release with `@deprecated` so existing callers can migrate without
    * breaking; new callers should use `filters:`.
+   *
+   * Sorting via `orderBy: TradeSortField` + `orderDirection: SortOrder`.
+   * Defaults to `EXECUTED_AT` / `desc` when omitted.
    */
   tradesPage: TradesPage;
   /** @deprecated Use `account(address:)` — flat address arg, returns the same address-keyed referral data via the new public-API-shaped `Account` type. The Prisma-leaked `User` type will be removed once telemetry on this path drains. */
@@ -2609,6 +2692,7 @@ export type QueryCollateralBalanceHistoryArgs = {
   chainId: Scalars['Int']['input'];
   count?: Scalars['Int']['input'];
   intervalHours?: Scalars['Int']['input'];
+  intervalSeconds?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -2625,6 +2709,8 @@ export type QueryCollateralTransfersPageArgs = {
   address: Scalars['String']['input'];
   chainId: Scalars['Int']['input'];
   excludeProtocol?: InputMaybe<Scalars['Boolean']['input']>;
+  orderBy?: InputMaybe<CollateralTransferSortField>;
+  orderDirection?: InputMaybe<SortOrder>;
   skip?: Scalars['Int']['input'];
   take?: Scalars['Int']['input'];
 };
@@ -2652,6 +2738,8 @@ export type QueryConditionGroupsArgs = {
 
 export type QueryConditionGroupsPageArgs = {
   filters?: InputMaybe<ConditionGroupFilters>;
+  orderBy?: InputMaybe<ConditionGroupSortField>;
+  orderDirection?: InputMaybe<SortOrder>;
   skip?: Scalars['Int']['input'];
   take?: Scalars['Int']['input'];
 };
@@ -2694,6 +2782,8 @@ export type QueryPickConfigurationsArgs = {
 export type QueryPickConfigurationsPageArgs = {
   chainId?: InputMaybe<Scalars['Int']['input']>;
   filters?: InputMaybe<PickConfigurationFilters>;
+  orderBy?: InputMaybe<PickConfigurationSortField>;
+  orderDirection?: InputMaybe<SortOrder>;
   resolved?: InputMaybe<Scalars['Boolean']['input']>;
   result?: InputMaybe<SettlementResult>;
   skip?: Scalars['Int']['input'];
@@ -2869,6 +2959,8 @@ export type QueryTradesPageArgs = {
   buyer?: InputMaybe<Scalars['String']['input']>;
   chainId?: InputMaybe<Scalars['Int']['input']>;
   filters?: InputMaybe<TradeFilters>;
+  orderBy?: InputMaybe<TradeSortField>;
+  orderDirection?: InputMaybe<SortOrder>;
   seller?: InputMaybe<Scalars['String']['input']>;
   skip?: Scalars['Int']['input'];
   take?: Scalars['Int']['input'];
@@ -3181,20 +3273,31 @@ export type TimeToResolutionBucket = {
   predictionCount: Scalars['Int']['output'];
 };
 
-/** Secondary market trade record where position tokens are exchanged between users */
+/**
+ * Secondary market trade record where position tokens are exchanged
+ * between users. The on-chain reference is `tradeHash`; `id` is an
+ * internal row id (see schema-preamble conventions).
+ */
 export type Trade = {
   __typename?: 'Trade';
   blockNumber: Scalars['Int']['output'];
+  /** Buyer wallet address (lowercase 0x-hex). */
   buyer: Scalars['String']['output'];
   chainId: Scalars['Int']['output'];
+  /** Collateral asset address paid in this trade (lowercase 0x-hex). */
   collateral: Scalars['String']['output'];
   executedAt: Scalars['UnixSeconds']['output'];
   id: Scalars['Int']['output'];
+  /** Total collateral paid by buyer (wei, 18 dec). `price / tokenAmount` is the per-share price. */
   price: Scalars['String']['output'];
   refCode?: Maybe<Scalars['String']['output']>;
+  /** Seller wallet address (lowercase 0x-hex). */
   seller: Scalars['String']['output'];
+  /** Position token address being exchanged (lowercase 0x-hex). */
   token: Scalars['String']['output'];
+  /** Quantity of position tokens transferred (wei, 18 dec on Sapience). */
   tokenAmount: Scalars['String']['output'];
+  /** Canonical trade hash — the on-chain identifier (0x-prefixed). */
   tradeHash: Scalars['String']['output'];
   txHash: Scalars['String']['output'];
 };
@@ -3211,11 +3314,20 @@ export type TradeFilters = {
   buyer?: InputMaybe<Scalars['String']['input']>;
   /** Restrict to a single chain. */
   chainId?: InputMaybe<Scalars['Int']['input']>;
+  /** Restrict to trades with `executedAt <= this` (epoch seconds, inclusive). */
+  executedAtMax?: InputMaybe<Scalars['UnixSeconds']['input']>;
+  /** Restrict to trades with `executedAt >= this` (epoch seconds, inclusive). */
+  executedAtMin?: InputMaybe<Scalars['UnixSeconds']['input']>;
   /** Restrict to a single seller address (case-insensitive). */
   seller?: InputMaybe<Scalars['String']['input']>;
   /** Restrict to a single position token address (case-insensitive). */
   token?: InputMaybe<Scalars['String']['input']>;
 };
+
+/** Sort fields for the `tradesPage` query. */
+export type TradeSortField =
+  | 'BLOCK_NUMBER'
+  | 'EXECUTED_AT';
 
 /** Paginated wrapper around Trade rows with a server-truth hasMore flag */
 export type TradesPage = Page & {


### PR DESCRIPTION
## Summary

Follow-up to Section A renames. Additive polish to the non-deprecated GraphQL surface — no breaking changes, no existing live/deprecated field modified in place.

### D1 — DRY `*Page.totalCount` resolvers
Nine `*Page.ts` resolver files were identical 6-line copies of the lazy-`totalCount` pattern, parameterised only by the Prisma model. Collapsed into one `lazyTotalCount(model)` factory in `pageTotalCount.ts`; each concrete file is now a one-liner. Same `_countWhere` contract; no wire/behaviour change.

### S2 — `orderBy` / `orderDirection` args on four page resolvers
The four `*Page` resolvers that previously had a hardcoded sort order now expose purpose-built sort enums + standard `orderBy` / `orderDirection` args, matching the convention used on the others. Defaults preserve the prior fixed order so existing callers see no change.

| Resolver | New enum | Members |
|---|---|---|
| `tradesPage` | `TradeSortField` | `EXECUTED_AT`, `BLOCK_NUMBER` |
| `conditionGroupsPage` | `ConditionGroupSortField` | `CREATED_AT`, `MAX_END_TIME`, `TOTAL_OPEN_INTEREST`, `TOTAL_PREDICTION_COUNT` |
| `pickConfigurationsPage` | `PickConfigurationSortField` | `CREATED_AT`, `ENDS_AT`, `RESOLVED_AT` |
| `collateralTransfersPage` | `CollateralTransferSortField` | `BLOCK_NUMBER`, `TIMESTAMP` |

### S10 — filter input gaps
- `TradeFilters` gains `executedAtMin` / `executedAtMax: UnixSeconds`
- `PredictionFilters` gains `result: SettlementResult`, `endsAtMin` / `endsAtMax: UnixSeconds`

### S6 — `collateralBalanceHistory.intervalSeconds`
Adds `intervalSeconds: Int` (preferred); newly `@deprecated` `intervalHours`. When both are passed, `intervalSeconds` wins; when only `intervalHours` is passed (the Exchange UI's current callsite), behaviour is identical.

### S14 — schema doc conventions
- Wire-format preamble at the top of the SDL: wei amounts (18 dec wUSDe), lowercase 0x-hex addresses, `UnixSeconds` vs `DateTimeISO`, internal `Int!` row ids.
- Tightened field docstrings on `Position` and `Trade` where the wire shape was previously unexplained (e.g. synthesized sell rows, `price` semantics, `totalPayout` vs net profit).

### Skipped from the original review
- `Condition.resolver` rename — kept as-is (resolver address ≠ contract address; renaming would confuse the protocol-jargon distinction).
- `Pick.conditionResolver` rename — kept (Pick is part of the escrow contract; "conditionResolver" specifically refers to the resolver address).
- `condition(id:)` / `conditionGroup(id:)` flat-id additions — deferred to the final cleanup PR.
- `VolumeWindow` enum split + `enum`-casing normalization — held until consumer migration plan lands.

## What's NOT being changed
Verified diff-wise that no `@deprecated` field/type/resolver is modified in place. The deprecated bare `trades(...)`, `predictions(...)`, `pickConfigurations(...)` resolvers still call the same `runX` runners; new optional fields default to "no filter, no sort change" when the deprecated callers omit them.

## Test plan

- [x] `pnpm --filter @sapience/api run lint` ✅
- [x] `tsc --noEmit` — only the 3 pre-existing `ctx.loaders is possibly undefined` errors from staging (no new errors)
- [x] `pnpm --filter @sapience/api run test` — 765/765 passing
- [x] `pnpm --filter @sapience/api run test:contract` — 19/20 passing; the 1 failure (`conditionsByIds.test.ts` + `attestations.test.ts` paginated case) is **pre-existing on staging** from the Section A SDK query updates not being propagated to the contract tests. Confirmed via `git stash` repro.
- [x] Snapshots updated for the additive schema changes (`introspection.json`, `schema.sdl.graphql`); pre-existing stale snapshot at `findAttestationsPaginated.json` left untouched.
- [ ] Manual smoke: sort args on `tradesPage`, `conditionGroupsPage` from the GraphiQL/Apollo sandbox once deployed to staging
- [ ] Verify Exchange UI's pinned queries still work unchanged against the new schema (additive only — they should)