### PR TITLE
fix(api): allow staging LAN dev CORS origins

### DIFF
--- a/packages/api/src/runtime/middleware.test.ts
+++ b/packages/api/src/runtime/middleware.test.ts
@@ -6,6 +6,86 @@ beforeEach(() => {
   vi.resetModules();
 });
 
+// ─── CORS ────────────────────────────────────────────────────────────────────
+
+describe('CORS origin allowlist', () => {
+  it('allows local LAN Vite dev origins only when explicitly enabled', async () => {
+    const { isAllowedCorsOrigin } = await import('./middleware');
+
+    expect(
+      isAllowedCorsOrigin('https://192.168.1.42:5173', {
+        allowPrivateLanDevOrigins: true,
+      })
+    ).toBe(true);
+    expect(
+      isAllowedCorsOrigin('http://10.0.0.8:5173', {
+        allowPrivateLanDevOrigins: true,
+      })
+    ).toBe(true);
+    expect(
+      isAllowedCorsOrigin('https://172.16.0.12:5173', {
+        allowPrivateLanDevOrigins: true,
+      })
+    ).toBe(true);
+    expect(isAllowedCorsOrigin('https://127.0.0.1:5173')).toBe(true);
+  });
+
+  it('rejects non-private hosts and non-dev ports', async () => {
+    const { isAllowedCorsOrigin } = await import('./middleware');
+
+    expect(isAllowedCorsOrigin('https://192.168.1.42:5173')).toBe(false);
+    expect(isAllowedCorsOrigin('https://192.168.1.42:3000')).toBe(false);
+    expect(
+      isAllowedCorsOrigin('https://192.168.1.42:3000', {
+        allowPrivateLanDevOrigins: true,
+      })
+    ).toBe(false);
+    expect(
+      isAllowedCorsOrigin('https://172.32.0.12:5173', {
+        allowPrivateLanDevOrigins: true,
+      })
+    ).toBe(false);
+    expect(
+      isAllowedCorsOrigin('https://8.8.8.8:5173', {
+        allowPrivateLanDevOrigins: true,
+      })
+    ).toBe(false);
+    expect(isAllowedCorsOrigin('https://evil.example:5173')).toBe(false);
+  });
+
+  it('allows LAN dev preflight on staging API host only', async () => {
+    vi.doMock('../core/config', () => ({
+      config: {
+        isProd: true,
+        NODE_ENV: 'production',
+        RATE_LIMIT_WINDOW_MS: 60000,
+        RATE_LIMIT_MAX_REQUESTS: 100,
+      },
+    }));
+
+    const { createApp } = await import('../core/app');
+    const app = createApp();
+    const origin = 'https://192.168.1.42:5173';
+
+    const stagingRes = await request(app)
+      .options('/graphql')
+      .set('Host', 'api.staging.sapience.xyz')
+      .set('Origin', origin)
+      .set('Access-Control-Request-Method', 'POST');
+
+    expect(stagingRes.status).toBe(200);
+    expect(stagingRes.headers['access-control-allow-origin']).toBe(origin);
+
+    const prodRes = await request(app)
+      .options('/graphql')
+      .set('Host', 'api.sapience.xyz')
+      .set('Origin', origin)
+      .set('Access-Control-Request-Method', 'POST');
+
+    expect(prodRes.headers['access-control-allow-origin']).toBeUndefined();
+  });
+});
+
 // ─── Rate limiting ──────────────────────────────────────────────────────────
 
 describe('rate limiting with trust proxy', () => {

--- a/packages/api/src/runtime/middleware.ts
+++ b/packages/api/src/runtime/middleware.ts
@@ -95,62 +95,119 @@ export async function adminAuth(
 
 // ─── CORS ────────────────────────────────────────────────────────────────────
 
-const corsOptions: cors.CorsOptions = {
-  origin: (
-    origin: string | undefined,
-    callback: (error: Error | null, allow?: boolean) => void,
-    request?: Request
-  ) => {
-    // Allow all requests unless in production
-    if (!config.isProd) {
-      callback(null, true);
-      return;
-    }
+const PRIVATE_LAN_DEV_PORTS = new Set(['5173']);
 
-    // Check for API token in production
-    const authHeader = request?.headers?.authorization;
-    const apiToken = process.env.API_ACCESS_TOKEN;
-
-    // If API token is provided and matches, allow the request regardless of origin
-    if (
-      apiToken &&
-      authHeader?.startsWith('Bearer ') &&
-      authHeader.slice(7) === apiToken
-    ) {
-      callback(null, true);
-      return;
-    }
-
-    // Otherwise, only allow specific domains
-    if (
-      !origin || // Allow same-origin requests
-      /^https?:\/\/([a-zA-Z0-9-]+\.)*sapience\.xyz$/.test(origin) ||
-      /^https?:\/\/([a-zA-Z0-9-]+\.)*ethereal\.trade$/.test(origin) ||
-      /^https?:\/\/([a-zA-Z0-9-]+\.)*etherealtest\.net$/.test(origin) ||
-      /^https?:\/\/([a-zA-Z0-9-]+\.)*etherealdev\.net$/.test(origin) ||
-      /^https?:\/\/(app|docs)\.vercel\.app$/.test(origin) || // production Vercel
-      /^https?:\/\/(app|docs)-[a-z0-9-]+-sapiencexyz\.vercel\.app$/.test(
-        origin
-      ) || // preview deploys (git branches and hash-based)
-      /^https?:\/\/([a-zA-Z0-9-]+-)?meridianxyz\.vercel\.app$/.test(origin) || // Meridian Vercel deploys
-      /^https?:\/\/localhost(:\d+)?$/.test(origin) // Allow localhost with optional port
-    ) {
-      callback(null, true);
-    } else {
-      // Reject without throwing — omits CORS headers so browsers still block,
-      // but avoids Sentry noise from originless requests (bots/crawlers/SSR).
-      callback(null, false);
-    }
-  },
-  optionsSuccessStatus: 200,
-  allowedHeaders: [
-    'Authorization',
-    'Content-Type',
-    'x-admin-signature',
-    'x-admin-signature-timestamp',
-    'X-Request-ID',
-  ],
+type CorsOriginOptions = {
+  allowPrivateLanDevOrigins?: boolean;
 };
+
+function isPrivateIpv4(hostname: string): boolean {
+  const octets = hostname.split('.').map((part) => Number(part));
+  if (
+    octets.length !== 4 ||
+    octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)
+  ) {
+    return false;
+  }
+
+  const [first, second] = octets;
+  return (
+    first === 10 ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168)
+  );
+}
+
+export function isAllowedCorsOrigin(
+  origin: string | undefined,
+  options: CorsOriginOptions = {}
+): boolean {
+  if (!origin) {
+    return true;
+  }
+
+  if (
+    /^https?:\/\/([a-zA-Z0-9-]+\.)*sapience\.xyz$/.test(origin) ||
+    /^https?:\/\/([a-zA-Z0-9-]+\.)*ethereal\.trade$/.test(origin) ||
+    /^https?:\/\/([a-zA-Z0-9-]+\.)*etherealtest\.net$/.test(origin) ||
+    /^https?:\/\/([a-zA-Z0-9-]+\.)*etherealdev\.net$/.test(origin) ||
+    /^https?:\/\/(app|docs)\.vercel\.app$/.test(origin) ||
+    /^https?:\/\/(app|docs)-[a-z0-9-]+-sapiencexyz\.vercel\.app$/.test(
+      origin
+    ) ||
+    /^https?:\/\/([a-zA-Z0-9-]+-)?meridianxyz\.vercel\.app$/.test(origin) ||
+    /^https?:\/\/localhost(:\d+)?$/.test(origin) ||
+    /^https?:\/\/127\.0\.0\.1(:\d+)?$/.test(origin)
+  ) {
+    return true;
+  }
+
+  try {
+    const url = new URL(origin);
+    return (
+      options.allowPrivateLanDevOrigins === true &&
+      (url.protocol === 'http:' || url.protocol === 'https:') &&
+      PRIVATE_LAN_DEV_PORTS.has(url.port) &&
+      isPrivateIpv4(url.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isStagingRequest(request: Request): boolean {
+  const host = request.hostname.toLowerCase();
+  return config.NODE_ENV === 'staging' || host === 'api.staging.sapience.xyz';
+}
+
+function createCorsOptions(request: Request): cors.CorsOptions {
+  return {
+    origin: (
+      origin: string | undefined,
+      callback: (error: Error | null, allow?: boolean) => void
+    ) => {
+      // Allow all requests unless in production
+      if (!config.isProd) {
+        callback(null, true);
+        return;
+      }
+
+      // Check for API token in production
+      const authHeader = request.headers.authorization;
+      const apiToken = process.env.API_ACCESS_TOKEN;
+
+      // If API token is provided and matches, allow the request regardless of origin
+      if (
+        apiToken &&
+        authHeader?.startsWith('Bearer ') &&
+        authHeader.slice(7) === apiToken
+      ) {
+        callback(null, true);
+        return;
+      }
+
+      if (
+        isAllowedCorsOrigin(origin, {
+          allowPrivateLanDevOrigins: isStagingRequest(request),
+        })
+      ) {
+        callback(null, true);
+      } else {
+        // Reject without throwing — omits CORS headers so browsers still block,
+        // but avoids Sentry noise from originless requests (bots/crawlers/SSR).
+        callback(null, false);
+      }
+    },
+    optionsSuccessStatus: 200,
+    allowedHeaders: [
+      'Authorization',
+      'Content-Type',
+      'x-admin-signature',
+      'x-admin-signature-timestamp',
+      'X-Request-ID',
+    ],
+  };
+}
 
 // ─── Middleware setup ────────────────────────────────────────────────────────
 
@@ -213,7 +270,7 @@ export function setupMiddleware(app: Express) {
       crossOriginEmbedderPolicy: false,
     })
   );
-  app.use(cors(corsOptions));
+  app.use((req, res, next) => cors(createCorsOptions(req))(req, res, next));
 
   // Rate limiting runs before body parsing so rejected requests are cheap.
   // Custom handler emits a structured `gql_shed` log line and returns a


### PR DESCRIPTION
## Summary
- allow RFC1918 LAN Vite dev origins (`10.*`, `172.16-31.*`, `192.168.*` on port `5173`) for the staging API host
- keep production API CORS strict by only enabling LAN origins when the request host is `api.staging.sapience.xyz` or `NODE_ENV=staging`
- route CORS options through the request so the existing bearer-token bypass can actually inspect request headers
- add tests for allowed private LAN origins, rejected public/non-dev origins, and staging-only preflight behavior

## Security notes
- this does **not** add a wildcard origin
- this does **not** allow arbitrary ports
- production `api.sapience.xyz` does not allow LAN origins in the regression test
- admin actions remain protected by signature headers; CORS is treated as browser boundary, not auth

## Test plan
- `pnpm --filter @sapience/api exec vitest run src/runtime/middleware.test.ts`
- `pnpm --filter @sapience/api run lint`
- `pnpm exec prettier --check packages/api/src/runtime/middleware.ts packages/api/src/runtime/middleware.test.ts`
- `pnpm --filter @sapience/api run type-check` *(fails on existing generated resolver strictness: `ctx.loaders` possibly undefined in `Account.ts` and `queries/crud.ts`)*
