### PR TITLE
Operator-pattern balance/collateral filter (redesign of #1722's balanceMin)

### DIFF
--- a/packages/api/MIGRATION.md
+++ b/packages/api/MIGRATION.md
@@ -4,39 +4,49 @@ A running log of API changes that downstream services should adopt. Entries are 
 
 ---
 
-## `balanceMin` — server-side balance filter on positions queries
+## `PositionFilters.balance` / `PositionFilters.collateral` — operator-pattern numeric filters on positions queries
 
 ### TL;DR
 
-New optional `balanceMin: String` arg on `positionsPage`, `positionCount`, and the deprecated `positions` query — also a field on `PositionFilters` (the preferred path post-#1719). Decimal-string wei value (e.g. `"1"`, `"1000000000000000000"` for 1 ETH). Defaults to omitted; existing callers are unaffected.
+Two new optional fields on `PositionFilters`:
 
-When set to a positive value, the resolver:
+- **`balance: BigIntFilter`** — strict numeric filter on `Position.balance` (wei). Supported operators: `equals`, `gt`, `gte`, `lt`, `lte`. New.
+- **`collateral: BigIntFilter`** — same shape, on the holder's collateral on the pickConfig. Replaces the flat `collateralMin: String` / `collateralMax: String` pair.
 
-1. Pre-queries matching `Position` IDs via raw SQL with `(CAST(balance AS DECIMAL) >= <minVal>) OR pickConfig.resolved = true` (Prisma's native `gte` would lex-compare the VarChar column — `"10" < "9"` — so the cast is required; the OR-`resolved` branch is the permissive keepalive, see below).
-2. Constrains the main `findMany` via `id IN (…)`.
-3. Skips emission of synthesized per-sell **CLOSED** rows in the synthesis layer — those carry `balance: "0"` so any positive lower bound would exclude them, and they're only emitted from unresolved positions in the first place.
+The flat `collateralMin` / `collateralMax` args are now `@deprecated`. They keep working for one release; migrate at your convenience.
 
-### Semantics — permissive
+`BigIntFilter` is the existing Prisma-style filter input (`{ equals, gt, gte, lt, lte, in, notIn, not }`); we wire up the common comparators and reject `in` / `notIn` / `not` at the resolver with a clear error message. They are accepted by the input type only because the surface is shared with Prisma CRUD inputs; treat them as "not yet supported" until a use case lands.
 
-`balance >= min` **OR** `pickConfig.resolved = true`. Resolved zero-balance rows (claimed winners whose payout has been redeemed) stay visible regardless of the bound. They carry meaningful settlement PnL (cost basis, payout, final outcome) that the FE typically wants on a position-list view; silently dropping them under a numeric filter would surprise callers. Matches the existing `positionCount` baseline visibility rule (`NOT (balance='0' AND resolved=false)`) so count and list semantics agree.
+### Why the operator pattern, not flat `<field>Min` / `<field>Max`
 
-To scope to **open positions only** (exclude both zero-balance unresolved AND all resolved rows), combine `balanceMin: "1"` with `settled: false` — `settled` narrows both branches of the OR, so the resolved-keepalive branch is implicitly disabled.
+- Composable. `{ balance: { gte: "1", lte: "1000000000000000000" } }` is one filter object; the flat form would need `balanceMin: "1", balanceMax: "1000…"` plus per-operator naming bikeshed.
+- Extensible. Adding `gt` / `lt` / `equals` doesn't grow the arg surface combinatorially.
+- Matches the Prisma / Hasura / Linear convention. Most modern GraphQL APIs surface comparator-style filter inputs this way.
 
-`PositionsPage.totalCount` reflects the same `id IN (…)` filter via the lazy `_countWhere` plumbing, so pagination stays consistent under the bound.
+`endsAtMin` / `endsAtMax` (on `PredictionFilters`) and other flat `<field>Min/Max` pairs across the schema follow the same migration path in a separate PR.
 
-### Why a `String`, not a `Number`
+### Strict semantics — no implicit OR
 
-`Position.balance` is wei (no decimals on-chain). 1 ETH = `10**18` wei = exceeds JS `Number.MAX_SAFE_INTEGER` (`2**53`) by 5 orders of magnitude. The codebase uses `String` for every wei-scale arg (see `collateralMin`/`collateralMax` on the same `PositionFilters` input); `balanceMin` follows the same convention.
+A row is kept iff its balance satisfies **every** operator on the filter. There is no permissive "OR resolved" magic — `{ balance: { gte: "1" } }` excludes claimed winners (resolved, zero-balance) because their raw balance fails the predicate. This is a deliberate departure from the implicit-OR semantic that the unshipped `balanceMin` arg carried during PR review.
 
-### When to use it
+To get "open positions + recently-claimed winners" in one result set, either:
 
-UI surfaces that show "currently held positions" — anywhere a zero-balance unresolved row would otherwise be filtered client-side. Server-side filtering keeps `skip`/`take` pagination and `totalCount` accurate; client-side filtering after fetch silently breaks both.
+- **Omit the balance filter entirely** and let the FE display the full set, or
+- **Issue two queries** — one with `balance: { gte: "1" }` for open positions, one with `settled: true` for resolved winners — and merge client-side.
 
-### Usage — preferred (`filters:` input)
+Synthesized per-sell CLOSED rows (the `balance: "0"` event rows recording realized PnL from secondary-market sells) follow the same strict rule: they're emitted iff `0` satisfies the filter (so `{ equals: "0" }` keeps them, `{ gte: "1" }` suppresses them).
+
+`PositionsPage.totalCount` honors the same filter via the lazy `_countWhere` plumbing, so pagination stays consistent.
+
+### Why `BigIntFilter` (and not `StringFilter`)
+
+`Position.balance` is wei. 1 ETH = `10**18` wei = exceeds JS `Number.MAX_SAFE_INTEGER` (`2**53`) by 5 orders of magnitude. The `BigInt` scalar (graphql-scalars `BigIntResolver`) accepts string / number / bigint on the wire and parses to a JS `bigint` at the resolver. The values round-trip safely at every layer.
+
+### Usage — preferred
 
 ```graphql
 query OpenPositions($holder: String!) {
-  positionsPage(filters: { holder: $holder, balanceMin: "1" }, take: 50) {
+  positionsPage(filters: { holder: $holder, balance: { gte: "1" } }, take: 50) {
     hasMore
     totalCount
     items {
@@ -50,12 +60,17 @@ query OpenPositions($holder: String!) {
 }
 ```
 
-### Usage — deprecated flat-arg form
+Combine operators on the same filter for a range:
 
 ```graphql
-query OpenPositions($holder: String!) {
-  positionsPage(holder: $holder, balanceMin: "1", take: 50) {
-    hasMore
+query DustyPositions($holder: String!) {
+  positionsPage(
+    filters: {
+      holder: $holder
+      balance: { gte: "1", lte: "1000000000000000000" } # 1 wei to 1 ETH
+    }
+    take: 50
+  ) {
     items {
       id
       balance
@@ -64,9 +79,31 @@ query OpenPositions($holder: String!) {
 }
 ```
 
-### `positionCount` under the bound
+### Migration: `collateralMin` / `collateralMax` → `collateral: { ... }`
 
-`positionCount(holder, balanceMin: "1")` returns the same number as `positionsPage(filters: { holder, balanceMin: "1" }, take: 1).totalCount`. The count goes through a raw SQL path when `balanceMin > 0` (Prisma can't cast the VarChar column), but applies the same predicate as the list query. Prefer the `*Page.totalCount` shape on new callers; `positionCount` remains for one release alongside the flat-arg deprecations.
+**Before** (still works for one release with `@deprecated` notices):
+
+```graphql
+positionsPage(
+  filters: { holder: $holder, collateralMin: "100", collateralMax: "1000" }
+  take: 50
+) { items { id } }
+```
+
+**After**:
+
+```graphql
+positionsPage(
+  filters: { holder: $holder, collateral: { gte: "100", lte: "1000" } }
+  take: 50
+) { items { id } }
+```
+
+When both shapes are set on the same input, the new `collateral` filter wins; the deprecated flat args are ignored.
+
+### `positionCount` — no balance filter
+
+`positionCount` no longer accepts a balance bound. Use `positionsPage(filters: { balance: ... }, take: 1).totalCount` instead — same count, lazy, and consistent with the list query.
 
 ---
 

--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -2044,14 +2044,22 @@ input PositionFilters {
   holderWon: Boolean
 
   """
+  Numeric range filter on the holder's total collateral on the
+  pickConfig (wei). Supported operators: `equals`, `gt`, `gte`, `lt`,
+  `lte`. Multiple operators on the same filter combine with AND.
+  Unsupported operators (`in`, `notIn`, `not`) raise an error.
+  """
+  collateral: BigIntFilter
+
+  """
   Restrict to positions whose holder collateral on the pickConfig is `>= this` (wei).
   """
-  collateralMin: String
+  collateralMin: String @deprecated(reason: "Use `collateral: { gte: ... }` operator filter instead.")
 
   """
   Restrict to positions whose holder collateral on the pickConfig is `<= this` (wei).
   """
-  collateralMax: String
+  collateralMax: String @deprecated(reason: "Use `collateral: { lte: ... }` operator filter instead.")
 
   """Restrict to positions whose pickConfig `endsAt >= this`."""
   endsAtMin: UnixSeconds
@@ -2060,30 +2068,28 @@ input PositionFilters {
   endsAtMax: UnixSeconds
 
   """
-  Lower bound on `Position.balance` (wei, decimal string — values
-  exceed JS Number precision). Compared numerically against the raw
-  `Position.balance` column, which is stored as a VarChar of the wei
-  integer.
+  Numeric range filter on `Position.balance` (wei). Strict semantics:
+  a row is kept iff its raw balance satisfies every operator on this
+  filter. Compared numerically against the VarChar `Position.balance`
+  column via a raw SQL cast (Prisma's native comparisons are
+  lexicographic on VarChar — `'10' < '9'`).
   
-  Permissive semantics: keeps a row when `balance >= balanceMin` **OR**
-  the pickConfig is resolved. Claimed winners (zero-balance, resolved)
-  remain visible regardless of the bound — they carry meaningful
-  settlement PnL and shouldn't be silently dropped by a numeric filter.
-  Matches the existing `positionCount` baseline visibility rule so
-  count and list semantics agree on resolved-row visibility.
+  Supported operators: `equals`, `gt`, `gte`, `lt`, `lte`. Multiple
+  operators combine with AND (e.g. `{ gte: "1", lte: "1000" }` is an
+  inclusive range). Unsupported operators (`in`, `notIn`, `not`) raise
+  an error.
   
-  When `balanceMin > 0`, also suppresses synthesized per-sell CLOSED
-  rows (the `balance: "0"` event rows recording realized PnL from
-  secondary-market sells on unresolved positions) — those carry
-  `balance: "0"` so any positive lower bound excludes them. Pagination
-  and `totalCount` honor the same filter so they stay consistent.
+  Also applies to synthesized per-sell CLOSED rows (the `balance: "0"`
+  event rows recording realized PnL from secondary-market sells) —
+  they're emitted iff `0` satisfies the filter. Pagination and
+  `totalCount` honor the same filter so they stay consistent.
   
-  Practical use: pass `"1"` to exclude raw zero-balance unresolved
-  rows AND the synthetic CLOSED rows; pair with `settled: false` to
-  scope to "open positions only" (suppresses the resolved-keepalive
-  branch of the OR — `settled` narrows both branches).
+  Composition: `{ balance: { gte: "1" } }` returns rows with positive
+  balance only. To include claimed winners (resolved, zero-balance) in
+  the same result set, omit the filter or compose with `settled: true`
+  as a separate query — there is no implicit OR.
   """
-  balanceMin: String
+  balance: BigIntFilter
 }
 
 """
@@ -2454,12 +2460,12 @@ type Query {
   popularTags: [String!]!
 
   """Count of token positions for a given holder"""
-  positionCount(balanceMin: String, chainId: Int, holder: String!, settled: Boolean): Int! @deprecated(reason: "Use `positionsPage(...).totalCount` — same number, available alongside the page payload, no extra query needed.")
+  positionCount(chainId: Int, holder: String!, settled: Boolean): Int! @deprecated(reason: "Use `positionsPage(...).totalCount` — same number, available alongside the page payload, no extra query needed.")
 
   """
   Paginated list of token position balances, filterable by holder, condition, chain, pick config, settlement, date range, collateral range, and won/lost status
   """
-  positions(balanceMin: String, chainId: Int, collateralMax: String, collateralMin: String, conditionId: String, endsAtMax: Int, endsAtMin: Int, holder: String, holderWon: Boolean, orderBy: PositionSortField, orderDirection: SortOrder, pickConfigId: String, result: SettlementResult, settled: Boolean, skip: Int! = 0, take: Int! = 50): [Position!]! @deprecated(reason: "Use `positionsPage` — same data with a server-truth `hasMore` stop signal. The bare-array form can return empty pages mid-stream (synthesized sell rows for zero-balance unresolved positions), so `length === 0` is not a reliable end-of-pagination check.")
+  positions(chainId: Int, collateralMax: String, collateralMin: String, conditionId: String, endsAtMax: Int, endsAtMin: Int, holder: String, holderWon: Boolean, orderBy: PositionSortField, orderDirection: SortOrder, pickConfigId: String, result: SettlementResult, settled: Boolean, skip: Int! = 0, take: Int! = 50): [Position!]! @deprecated(reason: "Use `positionsPage` — same data with a server-truth `hasMore` stop signal. The bare-array form can return empty pages mid-stream (synthesized sell rows for zero-balance unresolved positions), so `length === 0` is not a reliable end-of-pagination check.")
 
   """
   Same as `positions`, but wraps the result in a `PositionsPage` with a server-truth `hasMore` flag. Use this for infinite scroll: synthesized rows can be empty for some raw pages (zero-balance unresolved positions with no sells), so client-side `lastPage.length === 0` is not a reliable stop signal.
@@ -2469,7 +2475,7 @@ type Query {
   with `@deprecated` so existing callers can migrate without breaking;
   new callers should use `filters:`.
   """
-  positionsPage(filters: PositionFilters, orderBy: PositionSortField, orderDirection: SortOrder, take: Int! = 50, skip: Int! = 0, balanceMin: String @deprecated(reason: "Use `filters: { balanceMin: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), chainId: Int @deprecated(reason: "Use `filters: { chainId: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), collateralMax: String @deprecated(reason: "Use `filters: { collateralMax: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), collateralMin: String @deprecated(reason: "Use `filters: { collateralMin: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), conditionId: String @deprecated(reason: "Use `filters: { conditionId: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), endsAtMax: UnixSeconds @deprecated(reason: "Use `filters: { endsAtMax: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), endsAtMin: UnixSeconds @deprecated(reason: "Use `filters: { endsAtMin: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), holder: String @deprecated(reason: "Use `filters: { holder: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), holderWon: Boolean @deprecated(reason: "Use `filters: { holderWon: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), pickConfigId: String @deprecated(reason: "Use `filters: { pickConfigId: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), result: SettlementResult @deprecated(reason: "Use `filters: { result: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), settled: Boolean @deprecated(reason: "Use `filters: { settled: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers.")): PositionsPage!
+  positionsPage(filters: PositionFilters, orderBy: PositionSortField, orderDirection: SortOrder, take: Int! = 50, skip: Int! = 0, chainId: Int @deprecated(reason: "Use `filters: { chainId: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), collateralMax: String @deprecated(reason: "Use `filters: { collateralMax: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), collateralMin: String @deprecated(reason: "Use `filters: { collateralMin: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), conditionId: String @deprecated(reason: "Use `filters: { conditionId: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), endsAtMax: UnixSeconds @deprecated(reason: "Use `filters: { endsAtMax: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), endsAtMin: UnixSeconds @deprecated(reason: "Use `filters: { endsAtMin: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), holder: String @deprecated(reason: "Use `filters: { holder: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), holderWon: Boolean @deprecated(reason: "Use `filters: { holderWon: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), pickConfigId: String @deprecated(reason: "Use `filters: { pickConfigId: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), result: SettlementResult @deprecated(reason: "Use `filters: { result: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), settled: Boolean @deprecated(reason: "Use `filters: { settled: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers.")): PositionsPage!
 
   """
   Look up a single prediction by its on-chain prediction ID. Pass

--- a/packages/api/src/graphql/sdl/resolvers/queries/deprecated/escrow.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/deprecated/escrow.ts
@@ -62,51 +62,9 @@ export const predictionCount: NonNullable<
 
 export const positionCount: NonNullable<
   QueryResolvers['positionCount']
-> = async (_parent, { holder, settled, chainId, balanceMin }) => {
+> = async (_parent, { holder, settled, chainId }) => {
   logDeprecatedHit('positionCount');
   const holderLower = holder.toLowerCase();
-  // `balanceMin` is a decimal-string wei value (can exceed JS Number
-  // precision). Unparseable / non-positive inputs collapse to 0n (no
-  // filter) — lenient treatment matches the resolver.
-  let balanceMinWei = 0n;
-  if (balanceMin) {
-    try {
-      const v = BigInt(balanceMin);
-      if (v > 0n) balanceMinWei = v;
-    } catch {
-      /* noop — treat as 0n */
-    }
-  }
-
-  // `Position.balance` is VarChar; Prisma can't natively cast it to
-  // numeric. When `balanceMin > 0` we count via a raw SQL query that
-  // applies the same filters as the Prisma path, so the deprecated
-  // `positionCount(balanceMin:)` matches `positionsPage(...).totalCount`
-  // exactly. Otherwise fall through to the standard Prisma count with
-  // the baseline visibility rule (drop balance=0 unresolved rows that
-  // the holder has transferred / burned off-platform).
-  if (balanceMinWei > 0n) {
-    // Permissive: `balance >= min OR resolved = true`. Mirrors
-    // `applyBalanceMinFilter` in the list resolver so the count and
-    // the list agree under the same bound. The optional `settled`
-    // filter narrows BOTH branches of the OR — passing `settled:false`
-    // implicitly disables the resolved-keepalive branch, which is the
-    // correct interpretation (caller asked for unsettled only).
-    const rows = await prisma.$queryRaw<{ count: bigint }[]>`
-      SELECT COUNT(*)::bigint AS count
-      FROM "Position" p
-      LEFT JOIN "Picks" pc ON pc.id = p."pickConfigId"
-      WHERE p.holder = ${holderLower}
-        AND (
-          CAST(p.balance AS DECIMAL) >= ${balanceMinWei.toString()}::DECIMAL
-          OR pc.resolved = true
-        )
-        ${chainId !== undefined && chainId !== null ? Prisma.sql`AND p."chainId" = ${chainId}` : Prisma.empty}
-        ${settled !== undefined && settled !== null ? Prisma.sql`AND pc.resolved = ${settled}` : Prisma.empty}
-    `;
-    return Number(rows[0]?.count ?? 0n);
-  }
-
   const where: Prisma.PositionWhereInput = {
     holder: holderLower,
     // Drop zero-balance unresolved rows (off-platform transfers/burns)

--- a/packages/api/src/graphql/sdl/resolvers/queries/escrow.test.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/escrow.test.ts
@@ -12,6 +12,7 @@ vi.mock('../../../../core/db', () => ({ default: mockPrisma }));
 
 import type {
   QueryPositionsArgs,
+  QueryPositionsPageArgs,
   QueryPositionCountArgs,
   QueryPickConfigurationsArgs,
 } from '../../__generated__/resolvers';
@@ -29,7 +30,7 @@ import { positionCount } from './deprecated/escrow';
 // tests.
 type PositionsPageFn = (
   parent: unknown,
-  args: QueryPositionsArgs,
+  args: QueryPositionsPageArgs,
   ctx: unknown,
   info: unknown
 ) => Promise<{
@@ -160,7 +161,7 @@ type PositionRowShape = {
 // array directly) keep working — the synthetic-row + WAC logic is the
 // same regardless of which Page/non-Page entry point is used.
 const callPositions = async (
-  args: Partial<QueryPositionsArgs> = {}
+  args: Partial<QueryPositionsPageArgs> = {}
 ): Promise<PositionRowShape[]> => {
   const result = await positionsPageFn(
     undefined,
@@ -828,50 +829,15 @@ describe('positionCount resolver', () => {
       NOT: { balance: '0', pickConfiguration: { resolved: false } },
     });
   });
-
-  it('balanceMin > 0: counts via raw SQL (Prisma can’t cast VarChar balance numerically)', async () => {
-    mockPrisma.$queryRaw.mockResolvedValue([{ count: 4n }]);
-
-    const result = await positionCountFn(
-      undefined,
-      { holder: ALICE, balanceMin: '1' },
-      undefined,
-      undefined
-    );
-
-    expect(result).toBe(4);
-    // Prisma's `count()` must NOT be used when balanceMin > 0 — the
-    // raw SQL path is the source of truth.
-    expect(mockPrisma.position.count).not.toHaveBeenCalled();
-    expect(mockPrisma.$queryRaw).toHaveBeenCalledTimes(1);
-  });
-
-  it('balanceMin = "0" or unparseable: falls back to the Prisma count path', async () => {
-    mockPrisma.position.count.mockResolvedValue(7);
-
-    const result = await positionCountFn(
-      undefined,
-      { holder: ALICE, balanceMin: '0' },
-      undefined,
-      undefined
-    );
-
-    expect(result).toBe(7);
-    expect(mockPrisma.$queryRaw).not.toHaveBeenCalled();
-    const callArgs = mockPrisma.position.count.mock.calls[0][0];
-    expect(callArgs.where).toMatchObject({
-      holder: ALICE.toLowerCase(),
-      NOT: { balance: '0', pickConfiguration: { resolved: false } },
-    });
-  });
 });
 
-describe('positions resolver — balanceMin filter', () => {
-  it('partial sale: balanceMin = "1" emits OPEN row only, suppresses CLOSED rows', async () => {
-    // Without the filter this fixture emits one CLOSED + one OPEN row
-    // (see "partial secondary sale" test). With balanceMin > 0, the
-    // synthesizer skips CLOSED-row emission because their `balance: "0"`
-    // falls below the bound.
+describe('positions resolver — balance: BigIntFilter (operator-pattern)', () => {
+  it('partial sale: `balance: { gte: "1" }` keeps OPEN row, suppresses synthesized CLOSED rows', async () => {
+    // Without a balance filter this fixture emits one CLOSED + one OPEN
+    // row (see "partial secondary sale" test). With `gte: "1"`, the
+    // synthesizer's CLOSED rows (balance="0") don't satisfy the
+    // operator and are skipped; the OPEN row's balance is 100 and
+    // passes through unchanged.
     mockPrisma.$queryRaw.mockResolvedValue([{ id: 1 }]);
     mockPrisma.position.findMany.mockResolvedValue([
       makePosition({
@@ -892,7 +858,9 @@ describe('positions resolver — balanceMin filter', () => {
       }),
     ]);
 
-    const result = await callPositions({ balanceMin: '1' });
+    const result = await callPositions({
+      filters: { balance: { gte: 1n } },
+    });
 
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
@@ -902,15 +870,17 @@ describe('positions resolver — balanceMin filter', () => {
     });
   });
 
-  it('runPositions: balanceMin > 0 runs a raw-SQL pre-query and constrains findMany via id IN (…)', async () => {
-    // Position.balance is VarChar; Prisma's `gte` is lexicographic and
-    // would mis-order numerically (e.g. "10" < "9"). The resolver pre-
-    // queries matching IDs with CAST(... AS DECIMAL) and then narrows
-    // findMany by `id`.
+  it('runs a raw-SQL pre-query (CAST balance AS DECIMAL) and constrains findMany via id IN (…)', async () => {
+    // Position.balance is VarChar; Prisma's native `gte` is
+    // lexicographic and would mis-order numerically (e.g. "10" < "9").
+    // The resolver pre-queries matching IDs with CAST(... AS DECIMAL)
+    // and then narrows findMany by `id`.
     mockPrisma.$queryRaw.mockResolvedValue([{ id: 11 }, { id: 22 }]);
     mockPrisma.position.findMany.mockResolvedValue([]);
 
-    await callPositions({ balanceMin: '500000000000000000' });
+    await callPositions({
+      filters: { balance: { gte: 500000000000000000n } },
+    });
 
     expect(mockPrisma.$queryRaw).toHaveBeenCalledTimes(1);
     const findManyWhere = mockPrisma.position.findMany.mock.calls[0][0].where;
@@ -921,53 +891,38 @@ describe('positions resolver — balanceMin filter', () => {
   });
 
   it('empty pre-query result → empty page (no findMany or trades fetch)', async () => {
-    // When the pre-query returns no IDs (holder has no positions
-    // matching the bound OR resolved), the resolver short-circuits
-    // to an empty page without paying for findMany / synthesis.
+    // When the pre-query returns no IDs the resolver short-circuits to
+    // an empty page without paying for findMany / synthesis.
     mockPrisma.$queryRaw.mockResolvedValue([]);
 
-    const result = await callPositions({ balanceMin: '1' });
+    const result = await callPositions({
+      filters: { balance: { gte: 1n } },
+    });
 
     expect(result).toHaveLength(0);
     expect(mockPrisma.position.findMany).not.toHaveBeenCalled();
     expect(mockPrisma.secondaryTrade.findMany).not.toHaveBeenCalled();
   });
 
-  it('permissive: claimed winner (resolved, balance=0) stays visible under balanceMin > 0', async () => {
-    // The pre-query SQL is `(balance >= min) OR pc.resolved = true`,
-    // so resolved zero-balance rows pass through. The synthesizer
-    // then emits a single OPEN row for the resolved position
-    // (disposal loop is skipped for resolved positions regardless of
-    // the bound; OPEN row emits because `isResolved` is true).
-    mockPrisma.$queryRaw.mockResolvedValue([{ id: 1 }]);
-    mockPrisma.position.findMany.mockResolvedValue([
-      makePosition({
-        balance: '0',
-        pickConfiguration: makePickConfig({
-          resolved: true,
-          result: 'PREDICTOR_WINS',
-          resolvedAt: TS_SELL,
-          predictions: [makePrediction()],
-        }),
-      }),
-    ]);
+  it('strict: claimed winner (resolved, balance=0) is excluded by `balance: { gte: "1" }`', async () => {
+    // Strict semantics — there is no permissive OR. The raw `0`
+    // balance fails the `gte: "1"` operator, so the pre-query SQL
+    // returns no IDs for this fixture and the page is empty. Callers
+    // who want claimed winners alongside open positions must omit
+    // the balance filter (or query `settled: true` separately).
+    mockPrisma.$queryRaw.mockResolvedValue([]);
 
-    const result = await callPositions({ balanceMin: '1' });
-
-    expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({
-      id: '1',
-      balance: '0',
-      userCollateral: '100',
-      totalPayout: '200',
+    const result = await callPositions({
+      filters: { balance: { gte: 1n } },
     });
+
+    expect(result).toHaveLength(0);
   });
 
-  it('synthesis suppresses CLOSED rows even if findMany returns a zero-balance row', async () => {
-    // Defense-in-depth: the pre-query normally excludes zero-balance
-    // rows, but if a fixture/test forces one through, the synthesis
-    // gate (`balanceMinWei > 0n` skips disposal emission) must still
-    // suppress the CLOSED rows.
+  it('`balance: { equals: "0" }` keeps synthesized CLOSED rows (zero satisfies equals=0)', async () => {
+    // Strict semantics flow into the synthesizer: a CLOSED row carries
+    // balance="0" and is emitted iff `0n` satisfies the filter. `equals: "0"`
+    // does — so CLOSED rows survive — while `gte: "1"` does not.
     mockPrisma.$queryRaw.mockResolvedValue([{ id: 1 }]);
     mockPrisma.position.findMany.mockResolvedValue([
       makePosition({
@@ -988,9 +943,42 @@ describe('positions resolver — balanceMin filter', () => {
       }),
     ]);
 
-    const result = await callPositions({ balanceMin: '1' });
+    const result = await callPositions({
+      filters: { balance: { equals: 0n } },
+    });
 
-    expect(result).toHaveLength(0);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ balance: '0' });
+  });
+
+  it('`balance: { gte: "1", lte: "1000" }` ANDs operators in the same SQL HAVING', async () => {
+    // Multiple operators on the same BigIntFilter combine with AND. The
+    // raw SQL pre-query renders both fragments joined by AND.
+    mockPrisma.$queryRaw.mockResolvedValue([{ id: 7 }]);
+    mockPrisma.position.findMany.mockResolvedValue([]);
+
+    await callPositions({
+      filters: { balance: { gte: 1n, lte: 1000n } },
+    });
+
+    expect(mockPrisma.$queryRaw).toHaveBeenCalledTimes(1);
+    // We don't introspect the SQL string here (Prisma.sql is opaque to
+    // the mock); the round-trip through findMany.id confirms the
+    // pre-query produced the expected narrowing.
+    const findManyWhere = mockPrisma.position.findMany.mock.calls[0][0].where;
+    expect(findManyWhere).toMatchObject({ id: { in: [7] } });
+  });
+
+  it('unsupported operators on `balance` (`in`, `notIn`, `not`) throw with a clear message', async () => {
+    await expect(
+      callPositions({ filters: { balance: { in: [1n] } } })
+    ).rejects.toThrow(/balance:.*in.*not supported/);
+    await expect(
+      callPositions({ filters: { balance: { notIn: [1n] } } })
+    ).rejects.toThrow(/balance:.*notIn.*not supported/);
+    await expect(
+      callPositions({ filters: { balance: { not: { equals: 0n } } } })
+    ).rejects.toThrow(/balance:.*not.*not supported/);
   });
 
   it('positionsPage _countWhere mirrors the findMany where (id IN …) so totalCount stays consistent', async () => {
@@ -999,7 +987,12 @@ describe('positions resolver — balanceMin filter', () => {
 
     const result = await positionsPageFn(
       undefined,
-      { take: 50, skip: 0, holder: ALICE, balanceMin: '1' },
+      {
+        take: 50,
+        skip: 0,
+        holder: ALICE,
+        filters: { balance: { gte: 1n } },
+      },
       undefined,
       undefined
     );
@@ -1010,12 +1003,11 @@ describe('positions resolver — balanceMin filter', () => {
     });
   });
 
-  it('synthesis cache: balanceMin bound is part of the cache key', async () => {
-    // The synthesizer's disposal-emission gate flips on `balanceMinWei
-    // > 0n`, so a cached entry computed without the bound would serve
-    // the wrong row set when the same Position.updatedAt is requested
-    // with the bound on. The cache key includes a `0n` vs `>0n` bucket
-    // — flipping between them must trigger a fresh trades fetch.
+  it('synthesis cache: the parsed balance filter is part of the cache key', async () => {
+    // The synthesizer's disposal-emission gate evaluates the filter
+    // against `0n`, so swapping filters flips the cached row set. The
+    // cache key must encode the filter — otherwise two requests with
+    // different filters on the same Position.updatedAt would collide.
     const positionRow = makePosition({
       balance: '200',
       pickConfiguration: makePickConfig({
@@ -1035,15 +1027,75 @@ describe('positions resolver — balanceMin filter', () => {
       }),
     ]);
 
-    // First call: no balanceMin, full CLOSED + OPEN synthesis cached.
-    const withoutMin = await callPositions({});
+    // First call: no filter — full CLOSED + OPEN synthesis cached.
+    const withoutFilter = await callPositions({});
     expect(mockPrisma.secondaryTrade.findMany).toHaveBeenCalledTimes(1);
 
-    // Second call: balanceMin > 0, different cache bucket → fresh fetch.
-    const withMin = await callPositions({ balanceMin: '1' });
+    // Second call: `gte: "1"` — different cache bucket → fresh fetch.
+    const withFilter = await callPositions({
+      filters: { balance: { gte: 1n } },
+    });
     expect(mockPrisma.secondaryTrade.findMany).toHaveBeenCalledTimes(2);
 
-    expect(withoutMin.length).toBeGreaterThan(withMin.length);
+    expect(withoutFilter.length).toBeGreaterThan(withFilter.length);
+  });
+});
+
+describe('positions resolver — collateral: BigIntFilter (operator-pattern)', () => {
+  it('`collateral: { gte: "X" }` pre-queries pickConfigIds via raw UNION', async () => {
+    // Mirror of the existing collateralMin path but via the operator
+    // surface. The pre-query UNIONs predictor + counterparty branches
+    // and applies the operator(s) in HAVING.
+    mockPrisma.$queryRaw.mockResolvedValueOnce([
+      { pickConfigId: PC_ID, is_predictor: true },
+    ]);
+    mockPrisma.position.findMany.mockResolvedValue([]);
+
+    await callPositions({
+      filters: { collateral: { gte: 50n } },
+    });
+
+    expect(mockPrisma.$queryRaw).toHaveBeenCalledTimes(1);
+    const findManyWhere = mockPrisma.position.findMany.mock.calls[0][0].where;
+    expect(findManyWhere).toMatchObject({
+      holder: ALICE.toLowerCase(),
+      pickConfigId: { in: [PC_ID] },
+    });
+  });
+
+  it('unsupported operators on `collateral` (`in`, `notIn`, `not`) throw with a clear message', async () => {
+    await expect(
+      callPositions({ filters: { collateral: { in: [1n] } } })
+    ).rejects.toThrow(/collateral:.*in.*not supported/);
+  });
+
+  it('deprecated flat `collateralMin`/`Max` still work (legacy path)', async () => {
+    // The deprecated flat args remain functional for one release.
+    // They map to `{ gte, lte }` internally and use the same SQL path.
+    mockPrisma.$queryRaw.mockResolvedValueOnce([
+      { pickConfigId: PC_ID, is_predictor: true },
+    ]);
+    mockPrisma.position.findMany.mockResolvedValue([]);
+
+    await callPositions({ collateralMin: '50', collateralMax: '500' });
+
+    expect(mockPrisma.$queryRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it('operator-pattern `collateral` wins over the deprecated flat args when both are set', async () => {
+    // Mixed input — the new shape takes precedence; flat args ignored.
+    mockPrisma.$queryRaw.mockResolvedValueOnce([
+      { pickConfigId: PC_ID, is_predictor: true },
+    ]);
+    mockPrisma.position.findMany.mockResolvedValue([]);
+
+    await callPositions({
+      filters: { collateral: { gte: 50n } },
+      collateralMin: '999999',
+      collateralMax: '999999',
+    });
+
+    expect(mockPrisma.$queryRaw).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
@@ -39,6 +39,7 @@ import type {
   QueryPositionsPageArgs,
   QueryPredictionsArgs,
   QueryPredictionsPageArgs,
+  BigIntFilter,
   Prediction,
   ResolversParentTypes,
   SettlementResult,
@@ -49,6 +50,160 @@ import { mapPickConfig } from '../pickConfigHelpers';
 import { TtlCache } from '../../../../lib/ttlCache';
 import { logDeprecatedHit } from '../../../../lib/deprecationTelemetry';
 import { clampSkip, clampTake } from './pagination';
+
+/**
+ * Parsed `BigIntFilter` (operator-pattern numeric filter input). All
+ * operators combine with AND. Only the supported subset is represented
+ * here; unsupported operators (`in`, `notIn`, `not`) are rejected at
+ * parse time so they never reach SQL generation.
+ */
+type ParsedBigIntFilter = {
+  equals?: bigint;
+  gt?: bigint;
+  gte?: bigint;
+  lt?: bigint;
+  lte?: bigint;
+};
+
+const BIGINT_FILTER_SUPPORTED_OPS = [
+  'equals',
+  'gt',
+  'gte',
+  'lt',
+  'lte',
+] as const;
+const BIGINT_FILTER_UNSUPPORTED_OPS = ['in', 'notIn', 'not'] as const;
+
+/**
+ * Parse a GraphQL `BigIntFilter` input into a `ParsedBigIntFilter`.
+ * Returns `null` when the filter is unset or has no narrowing operator.
+ * Throws on unsupported operators (`in`/`notIn`/`not`) and on values
+ * that don't coerce to bigint — invalid input is a programming error
+ * and shouldn't silently degrade.
+ *
+ * `fieldName` is interpolated into error messages so the client knows
+ * which input was rejected (e.g. `balance.gte`, `collateral.lte`).
+ */
+const parseBigIntFilter = (
+  raw: BigIntFilter | null | undefined,
+  fieldName: string
+): ParsedBigIntFilter | null => {
+  if (!raw) return null;
+  for (const op of BIGINT_FILTER_UNSUPPORTED_OPS) {
+    if (raw[op] != null) {
+      throw new Error(
+        `${fieldName}: \`${op}\` is not supported. Use \`equals\`, \`gt\`, \`gte\`, \`lt\`, or \`lte\`.`
+      );
+    }
+  }
+  const out: ParsedBigIntFilter = {};
+  for (const op of BIGINT_FILTER_SUPPORTED_OPS) {
+    const v = raw[op];
+    if (v == null) continue;
+    try {
+      out[op] = BigInt(v as string | number | bigint);
+    } catch {
+      throw new Error(
+        `${fieldName}.${op}: expected an integer value; got ${String(v)}`
+      );
+    }
+  }
+  return Object.keys(out).length > 0 ? out : null;
+};
+
+/**
+ * Build a `ParsedBigIntFilter` from the deprecated flat
+ * `<field>Min` / `<field>Max` string args. Returns `null` when both
+ * are empty/null. Malformed strings are silently ignored (lenient
+ * legacy semantics — these args are on their way out).
+ */
+const flatRangeToFilter = (
+  min: string | null | undefined,
+  max: string | null | undefined
+): ParsedBigIntFilter | null => {
+  if (!min && !max) return null;
+  const out: ParsedBigIntFilter = {};
+  if (min) {
+    try {
+      out.gte = BigInt(min);
+    } catch {
+      /* malformed — ignore */
+    }
+  }
+  if (max) {
+    try {
+      out.lte = BigInt(max);
+    } catch {
+      /* malformed — ignore */
+    }
+  }
+  return out.gte !== undefined || out.lte !== undefined ? out : null;
+};
+
+/**
+ * Evaluate a parsed filter against a value in JS. Used for filtering
+ * synthesized rows that don't reach SQL (per-sell CLOSED rows with
+ * `balance: '0'`).
+ */
+const evalBigIntFilter = (
+  filter: ParsedBigIntFilter | null,
+  value: bigint
+): boolean => {
+  if (!filter) return true;
+  if (filter.equals !== undefined && value !== filter.equals) return false;
+  if (filter.gt !== undefined && !(value > filter.gt)) return false;
+  if (filter.gte !== undefined && !(value >= filter.gte)) return false;
+  if (filter.lt !== undefined && !(value < filter.lt)) return false;
+  if (filter.lte !== undefined && !(value <= filter.lte)) return false;
+  return true;
+};
+
+/**
+ * Render a parsed filter to a list of SQL fragments comparing the
+ * given column expression against decimal-cast wei literals. Returns
+ * an empty list when the filter has no narrowing operator. Callers
+ * `AND` the fragments into the surrounding WHERE.
+ */
+const renderBigIntFilterToSql = (
+  filter: ParsedBigIntFilter,
+  columnExpr: Prisma.Sql
+): Prisma.Sql[] => {
+  const parts: Prisma.Sql[] = [];
+  if (filter.equals !== undefined) {
+    parts.push(
+      Prisma.sql`${columnExpr} = ${filter.equals.toString()}::DECIMAL`
+    );
+  }
+  if (filter.gt !== undefined) {
+    parts.push(Prisma.sql`${columnExpr} > ${filter.gt.toString()}::DECIMAL`);
+  }
+  if (filter.gte !== undefined) {
+    parts.push(Prisma.sql`${columnExpr} >= ${filter.gte.toString()}::DECIMAL`);
+  }
+  if (filter.lt !== undefined) {
+    parts.push(Prisma.sql`${columnExpr} < ${filter.lt.toString()}::DECIMAL`);
+  }
+  if (filter.lte !== undefined) {
+    parts.push(Prisma.sql`${columnExpr} <= ${filter.lte.toString()}::DECIMAL`);
+  }
+  return parts;
+};
+
+/**
+ * Stable JSON key for a parsed filter — used in cache keys where the
+ * filter discriminates output (synthesized CLOSED rows depend on
+ * whether `0n` satisfies the filter, and balance filters can also
+ * suppress otherwise-valid synthesized rows).
+ */
+const filterCacheKey = (filter: ParsedBigIntFilter | null): string => {
+  if (!filter) return '-';
+  return BIGINT_FILTER_SUPPORTED_OPS.map((op) => {
+    const v = filter[op];
+    return v === undefined ? '' : `${op}:${v.toString()}`;
+  })
+    .filter(Boolean)
+    .join(',');
+};
 
 type PredictionWithPickConfig = Prisma.PredictionGetPayload<{
   include: { pickConfiguration: { include: { picks: true } } };
@@ -382,18 +537,14 @@ const positionSynthesisCacheKey = (
     holder: string;
     updatedAt: Date;
   },
-  balanceMinWei: bigint
+  balanceFilter: ParsedBigIntFilter | null
 ) =>
-  // `balanceMinWei` changes synthesizer output (suppresses CLOSED rows
-  // whose `balance: "0"` would fall below the bound), so it must be
-  // part of the cache key — otherwise a request with one bound can
-  // serve another's entry under the same updatedAt and return the
-  // wrong row set. Bucketed as `0` vs `>0` since the synthesis
-  // decision is binary (emit or skip CLOSED rows); finer bucketing
-  // isn't needed today.
-  `${r.chainId}:${r.tokenAddress}:${r.holder}:${r.updatedAt.getTime()}:${
-    balanceMinWei > 0n ? 'p' : 'a'
-  }`;
+  // The balance filter changes synthesizer output (CLOSED rows carry
+  // `balance: "0"` and are emitted iff `0n` satisfies the filter), so
+  // it must be part of the cache key — otherwise a request with one
+  // filter can serve another's entry under the same updatedAt and
+  // return the wrong row set.
+  `${r.chainId}:${r.tokenAddress}:${r.holder}:${r.updatedAt.getTime()}:${filterCacheKey(balanceFilter)}`;
 
 /** Test-only: clear synthesis cache between test cases. */
 export const __clearPositionSynthesisCache = () =>
@@ -404,6 +555,19 @@ export type PositionsPageEnvelope = {
   hasMore: boolean;
   totalCount: number | null;
   _countWhere?: Prisma.PositionWhereInput;
+};
+
+/**
+ * Extended args for `runPositions` — superset of the deprecated bare
+ * `positions(...)` args. The operator-pattern filter inputs
+ * (`balance: BigIntFilter`, `collateral: BigIntFilter`) live only on
+ * `positionsPage(filters: PositionFilters)` and aren't exposed on the
+ * deprecated `positions` query; this internal type carries them
+ * through `mergePositionFilters` → `runPositions` → `normalizePositionsArgs`.
+ */
+export type RunPositionsArgs = QueryPositionsArgs & {
+  balance?: BigIntFilter | null;
+  collateral?: BigIntFilter | null;
 };
 
 type NormalizedPositionsArgs = {
@@ -418,38 +582,34 @@ type NormalizedPositionsArgs = {
   endsAtMin: number | null | undefined;
   endsAtMax: number | null | undefined;
   holderWon: boolean | null | undefined;
-  collateralMin: string | null | undefined;
-  collateralMax: string | null | undefined;
+  collateralFilter: ParsedBigIntFilter | null;
   /**
-   * Minimum on-chain token balance the row must carry (wei, bigint).
-   * `0n` means no filter. Synthesized CLOSED rows (whose `balance: "0"`
-   * is below any positive lower bound) are also gated on this — see
-   * `synthesizePositionRow`.
+   * Strict numeric filter on `Position.balance` (wei). `null` means no
+   * filter — every row matches on this axis. Synthesized CLOSED rows
+   * (whose `balance: "0"` event values are constructed in-memory) are
+   * filtered against this in `synthesizePositionRow`.
    */
-  balanceMinWei: bigint;
+  balanceFilter: ParsedBigIntFilter | null;
   orderField: 'createdAt' | 'updatedAt';
   orderDirection: 'asc' | 'desc';
 };
 
 /**
- * Parse the SDL `balanceMin: String` arg into a bigint. Unparseable
- * or negative inputs collapse to `0n` (no filter) — same lenient
- * treatment as the `collateralMin`/`collateralMax` filter args, where
- * a malformed string would otherwise propagate a runtime exception
- * through every resolver invocation on the path.
+ * Resolve the effective collateral filter: prefer the operator-pattern
+ * `collateral: BigIntFilter` when present; fall back to the deprecated
+ * flat `collateralMin`/`collateralMax` strings otherwise. The two
+ * cannot meaningfully be merged — callers should use one or the other.
  */
-const parseBalanceMin = (raw: string | null | undefined): bigint => {
-  if (!raw) return 0n;
-  try {
-    const v = BigInt(raw);
-    return v > 0n ? v : 0n;
-  } catch {
-    return 0n;
-  }
+const resolveCollateralFilter = (
+  args: RunPositionsArgs
+): ParsedBigIntFilter | null => {
+  const parsed = parseBigIntFilter(args.collateral ?? null, 'collateral');
+  if (parsed) return parsed;
+  return flatRangeToFilter(args.collateralMin, args.collateralMax);
 };
 
 const normalizePositionsArgs = (
-  args: QueryPositionsArgs
+  args: RunPositionsArgs
 ): NormalizedPositionsArgs => ({
   cappedTake: clampTake(args.take, { defaultTake: 50, maxTake: 100 }),
   // Positions uses a 10_000 ceiling rather than the shared
@@ -471,13 +631,12 @@ const normalizePositionsArgs = (
   endsAtMin: args.endsAtMin,
   endsAtMax: args.endsAtMax,
   holderWon: args.holderWon,
-  collateralMin: args.collateralMin,
-  collateralMax: args.collateralMax,
-  // `balanceMin` is a decimal-string wei value (can exceed JS Number
-  // precision). Parse here so downstream code works with bigint; an
-  // unparseable input becomes 0n (no filter) rather than throwing —
-  // matches the lenient null/undefined semantics of the other filters.
-  balanceMinWei: parseBalanceMin(args.balanceMin),
+  collateralFilter: resolveCollateralFilter(args),
+  // `balance: BigIntFilter` is the operator-pattern numeric filter.
+  // Strict semantics — see `applyBalanceFilter`. Unsupported operators
+  // throw; supported operators (equals/gt/gte/lt/lte) flow through to
+  // raw SQL with a DECIMAL cast on the VarChar `Position.balance`.
+  balanceFilter: parseBigIntFilter(args.balance ?? null, 'balance'),
   // PositionSortField SDL enum values are CREATED_AT / UPDATED_AT; map
   // to the Prisma column name for orderBy.
   orderField: args.orderBy === 'CREATED_AT' ? 'createdAt' : 'updatedAt',
@@ -538,9 +697,9 @@ const buildPositionsWhere = (
     where.pickConfigId = { in: conditionPickConfigIds };
   if (chainId !== undefined && chainId !== null) where.chainId = chainId;
   if (pickConfigIdLower && !conditionId) where.pickConfigId = pickConfigIdLower;
-  // `balanceMin` isn't applied here — it requires a numeric comparison
+  // `balance` isn't applied here — it requires a numeric comparison
   // against the VarChar `balance` column, which Prisma can't express
-  // (its `gte` is lexicographic). `applyBalanceMinFilter` runs a raw
+  // (its `gte` is lexicographic). `applyBalanceFilter` runs a raw
   // SQL pre-query and constrains the main findMany via `id IN (…)`.
 
   if (settled !== undefined && settled !== null) {
@@ -600,21 +759,33 @@ const buildPositionsWhere = (
 };
 
 /**
- * Pre-query pickConfigIds where the holder's collateral is in
- * [collateralMin, collateralMax] via a raw UNION grouped by side
- * (predictor vs counterparty). Returns the intersected pickConfigId
- * filter to merge into the where, or `null` to signal "no matching
- * configs — return empty page".
+ * Pre-query pickConfigIds where the holder's collateral on the
+ * pickConfig satisfies every operator on the filter. Groups raw
+ * `Prediction` rows by `pickConfigId` and side (predictor vs
+ * counterparty) via a UNION; each branch sums the holder's collateral
+ * on that side and applies the operator(s) in the `HAVING` clause.
+ * Returns the intersected pickConfigId filter to merge into the where,
+ * or `null` to signal "no matching configs — return empty page".
  */
-const applyCollateralRangeFilter = async (
+const applyCollateralFilter = async (
   where: Prisma.PositionWhereInput,
   holderLower: string,
-  collateralMin: string | null | undefined,
-  collateralMax: string | null | undefined
+  filter: ParsedBigIntFilter
 ): Promise<Prisma.PositionWhereInput | null> => {
-  if (!collateralMin && !collateralMax) return where;
-  const minVal = collateralMin ? BigInt(collateralMin) : 0n;
-  const maxVal = collateralMax ? BigInt(collateralMax) : null;
+  const predictorConditions = renderBigIntFilterToSql(
+    filter,
+    Prisma.sql`SUM(CAST("predictorCollateral" AS DECIMAL))`
+  );
+  const counterpartyConditions = renderBigIntFilterToSql(
+    filter,
+    Prisma.sql`SUM(CAST("counterpartyCollateral" AS DECIMAL))`
+  );
+  // `renderBigIntFilterToSql` only returns empty when the parsed filter
+  // has no operators; the caller short-circuits on a null filter, so a
+  // non-null filter here always produces at least one fragment.
+  if (predictorConditions.length === 0) return where;
+  const predictorHaving = Prisma.join(predictorConditions, ' AND ');
+  const counterpartyHaving = Prisma.join(counterpartyConditions, ' AND ');
   interface PickConfigRow {
     pickConfigId: string;
     is_predictor: boolean;
@@ -624,15 +795,13 @@ const applyCollateralRangeFilter = async (
     FROM "Prediction"
     WHERE predictor = ${holderLower} AND "pickConfigId" IS NOT NULL
     GROUP BY "pickConfigId"
-    HAVING SUM(CAST("predictorCollateral" AS DECIMAL)) >= ${minVal.toString()}::DECIMAL
-      ${maxVal !== null ? Prisma.sql`AND SUM(CAST("predictorCollateral" AS DECIMAL)) <= ${maxVal.toString()}::DECIMAL` : Prisma.empty}
+    HAVING ${predictorHaving}
     UNION
     SELECT "pickConfigId", false AS is_predictor
     FROM "Prediction"
     WHERE counterparty = ${holderLower} AND "pickConfigId" IS NOT NULL
     GROUP BY "pickConfigId"
-    HAVING SUM(CAST("counterpartyCollateral" AS DECIMAL)) >= ${minVal.toString()}::DECIMAL
-      ${maxVal !== null ? Prisma.sql`AND SUM(CAST("counterpartyCollateral" AS DECIMAL)) <= ${maxVal.toString()}::DECIMAL` : Prisma.empty}
+    HAVING ${counterpartyHaving}
   `;
   if (matchingConfigs.length === 0) return null;
   const validPickConfigIds = matchingConfigs.map((r) => r.pickConfigId);
@@ -654,30 +823,36 @@ const applyCollateralRangeFilter = async (
 };
 
 /**
- * Numeric lower-bound filter on `Position.balance`. The column is
- * stored as a VarChar of the wei integer (values exceed JS Number
- * precision), so Prisma's native `gte` would lex-compare (`'10' < '9'`).
- * Pre-query matching Position IDs via raw SQL with `CAST(... AS DECIMAL)`,
- * then constrain the main findMany via `id IN (…)`.
+ * Strict operator-pattern numeric filter on `Position.balance`. The
+ * column is stored as a VarChar of the wei integer (values exceed JS
+ * Number precision), so Prisma's native comparators are lexicographic
+ * (`'10' < '9'`). Pre-query matching Position IDs via raw SQL with
+ * `CAST(... AS DECIMAL)`, then constrain the main findMany via
+ * `id IN (…)`.
  *
- * Permissive semantics: `(balance >= min) OR pickConfig.resolved = true`.
- * Resolved positions stay visible regardless of remaining balance —
- * claimed winners (balance=0, resolved=true) carry meaningful
- * settlement PnL and shouldn't be silently dropped by a balance bound.
- * Matches the existing `positionCount` baseline visibility rule
- * (`NOT (balance='0' AND resolved=false)`) so count and list semantics
- * agree on resolved-row visibility.
+ * Strict semantics — the row is kept iff its balance satisfies every
+ * operator. To include claimed winners (resolved, zero-balance) in
+ * the same result set, omit the filter or compose with `settled: true`
+ * as a separate query — there is no implicit OR.
  *
  * Returns `null` to signal "no positions match — short-circuit to an
  * empty page" so callers can avoid the downstream findMany/synthesis
  * work.
  */
-const applyBalanceMinFilter = async (
+const applyBalanceFilter = async (
   where: Prisma.PositionWhereInput,
   holderLower: string | undefined,
-  balanceMinWei: bigint
+  filter: ParsedBigIntFilter
 ): Promise<Prisma.PositionWhereInput | null> => {
-  if (balanceMinWei <= 0n) return where;
+  const conditions = renderBigIntFilterToSql(
+    filter,
+    Prisma.sql`CAST(p.balance AS DECIMAL)`
+  );
+  // No-op filter (parsed but every operator was undefined) — return
+  // the where unchanged. Callers should already have short-circuited
+  // on a null parsed filter; this guard is defense in depth.
+  if (conditions.length === 0) return where;
+  const balanceWhere = Prisma.join(conditions, ' AND ');
   interface IdRow {
     id: number;
   }
@@ -686,27 +861,15 @@ const applyBalanceMinFilter = async (
   // holder, the conditionId / pickConfigId paths already narrow the
   // working set via the main where, so the unscoped variant only
   // runs when the caller has explicitly opened a broader query.
-  //
-  // The LEFT JOIN to `Picks` lets the `pc.resolved = true` branch of
-  // the OR contribute — a Position whose pickConfig is resolved stays
-  // in the result set even if its balance is below the bound.
   const rows = holderLower
     ? await prisma.$queryRaw<IdRow[]>`
         SELECT p.id FROM "Position" p
-        LEFT JOIN "Picks" pc ON pc.id = p."pickConfigId"
         WHERE p.holder = ${holderLower}
-          AND (
-            CAST(p.balance AS DECIMAL) >= ${balanceMinWei.toString()}::DECIMAL
-            OR pc.resolved = true
-          )
+          AND ${balanceWhere}
       `
     : await prisma.$queryRaw<IdRow[]>`
         SELECT p.id FROM "Position" p
-        LEFT JOIN "Picks" pc ON pc.id = p."pickConfigId"
-        WHERE (
-          CAST(p.balance AS DECIMAL) >= ${balanceMinWei.toString()}::DECIMAL
-          OR pc.resolved = true
-        )
+        WHERE ${balanceWhere}
       `;
   if (rows.length === 0) return null;
   const matchingIds = rows.map((r) => r.id);
@@ -760,7 +923,7 @@ const positionKey = (chainId: number, token: string, holder: string) =>
 const synthesizePositionRow = (
   r: PositionRow,
   trades: readonly TradeRow[],
-  balanceMinWei: bigint
+  balanceFilter: ParsedBigIntFilter | null
 ): PositionShape[] => {
   const pc = r.pickConfiguration;
   let totalPayout = 0n;
@@ -857,10 +1020,10 @@ const synthesizePositionRow = (
 
   // Emit one synthetic row per sell (only meaningful for unresolved
   // pickConfigs — once settled, the existing PnL flow takes over).
-  // CLOSED rows carry `balance: '0'`, so any positive `balanceMinWei`
-  // bound would exclude them; gate emission accordingly so the UI can
-  // show only currently-held positions when it asks for it.
-  if (!isResolved && balanceMinWei === 0n) {
+  // CLOSED rows carry `balance: '0'`; emit iff `0n` satisfies the
+  // balance filter (strict semantics — `{ gte: "1" }` suppresses them,
+  // `{ equals: "0" }` or no filter keeps them).
+  if (!isResolved && evalBigIntFilter(balanceFilter, 0n)) {
     for (const d of disposalRows) {
       out.push({
         id: `${r.id}-sell-${d.tradeHash}`,
@@ -914,13 +1077,13 @@ const synthesizePositionRow = (
  */
 const synthesizePositionsPage = async (
   rows: PositionRow[],
-  balanceMinWei: bigint
+  balanceFilter: ParsedBigIntFilter | null
 ): Promise<PositionShape[]> => {
   const cachedByRow = new Map<PositionRow, PositionShape[]>();
   const missedRows: PositionRow[] = [];
   for (const r of rows) {
     const cached = positionSynthesisCache.get(
-      positionSynthesisCacheKey(r, balanceMinWei)
+      positionSynthesisCacheKey(r, balanceFilter)
     );
     if (cached) cachedByRow.set(r, cached);
     else missedRows.push(r);
@@ -974,10 +1137,10 @@ const synthesizePositionsPage = async (
     const synthesized = synthesizePositionRow(
       r,
       tradesByPos.get(k) ?? [],
-      balanceMinWei
+      balanceFilter
     );
     positionSynthesisCache.set(
-      positionSynthesisCacheKey(r, balanceMinWei),
+      positionSynthesisCacheKey(r, balanceFilter),
       synthesized
     );
     out.push(...synthesized);
@@ -1010,7 +1173,7 @@ const EMPTY_POSITIONS_PAGE: PositionsPageEnvelope = {
 };
 
 export const runPositions = async (
-  args: QueryPositionsArgs
+  args: RunPositionsArgs
 ): Promise<PositionsPageEnvelope> => {
   const norm = normalizePositionsArgs(args);
 
@@ -1025,22 +1188,21 @@ export const runPositions = async (
   let where = buildPositionsWhere(norm, conditionPickConfigIds);
   if (where === null) return EMPTY_POSITIONS_PAGE;
 
-  if (norm.holderLower && (norm.collateralMin || norm.collateralMax)) {
-    const next = await applyCollateralRangeFilter(
+  if (norm.holderLower && norm.collateralFilter) {
+    const next = await applyCollateralFilter(
       where,
       norm.holderLower,
-      norm.collateralMin,
-      norm.collateralMax
+      norm.collateralFilter
     );
     if (next === null) return EMPTY_POSITIONS_PAGE;
     where = next;
   }
 
-  if (norm.balanceMinWei > 0n) {
-    const next = await applyBalanceMinFilter(
+  if (norm.balanceFilter) {
+    const next = await applyBalanceFilter(
       where,
       norm.holderLower,
-      norm.balanceMinWei
+      norm.balanceFilter
     );
     if (next === null) return EMPTY_POSITIONS_PAGE;
     where = next;
@@ -1089,7 +1251,7 @@ export const runPositions = async (
   const hasMore = rawRows.length > norm.cappedTake;
   const rows = rawRows.slice(0, norm.cappedTake);
 
-  const synthesized = await synthesizePositionsPage(rows, norm.balanceMinWei);
+  const synthesized = await synthesizePositionsPage(rows, norm.balanceFilter);
   const sorted = sortSynthesizedRows(
     synthesized,
     norm.orderField,
@@ -1104,7 +1266,7 @@ export const runPositions = async (
  */
 const mergePositionFilters = (
   args: QueryPositionsPageArgs
-): QueryPositionsArgs => {
+): RunPositionsArgs => {
   const f = args.filters ?? null;
   return {
     take: args.take,
@@ -1118,11 +1280,12 @@ const mergePositionFilters = (
     result: f?.result ?? args.result ?? null,
     settled: f?.settled ?? args.settled ?? null,
     holderWon: f?.holderWon ?? args.holderWon ?? null,
+    collateral: f?.collateral ?? null,
     collateralMin: f?.collateralMin ?? args.collateralMin ?? null,
     collateralMax: f?.collateralMax ?? args.collateralMax ?? null,
     endsAtMin: f?.endsAtMin ?? args.endsAtMin ?? null,
     endsAtMax: f?.endsAtMax ?? args.endsAtMax ?? null,
-    balanceMin: f?.balanceMin ?? args.balanceMin ?? null,
+    balance: f?.balance ?? null,
   };
 };
 

--- a/packages/api/src/graphql/sdl/schema/schema.graphql
+++ b/packages/api/src/graphql/sdl/schema/schema.graphql
@@ -2160,39 +2160,50 @@ input PositionFilters {
   settled: Boolean
   """Restrict to positions where the holder won (true) or lost (false). Combines side with settlement result."""
   holderWon: Boolean
+  """
+  Numeric range filter on the holder's total collateral on the
+  pickConfig (wei). Supported operators: `equals`, `gt`, `gte`, `lt`,
+  `lte`. Multiple operators on the same filter combine with AND.
+  Unsupported operators (`in`, `notIn`, `not`) raise an error.
+  """
+  collateral: BigIntFilter
   """Restrict to positions whose holder collateral on the pickConfig is `>= this` (wei)."""
   collateralMin: String
+    @deprecated(
+      reason: "Use `collateral: { gte: ... }` operator filter instead."
+    )
   """Restrict to positions whose holder collateral on the pickConfig is `<= this` (wei)."""
   collateralMax: String
+    @deprecated(
+      reason: "Use `collateral: { lte: ... }` operator filter instead."
+    )
   """Restrict to positions whose pickConfig `endsAt >= this`."""
   endsAtMin: UnixSeconds
   """Restrict to positions whose pickConfig `endsAt <= this`."""
   endsAtMax: UnixSeconds
   """
-  Lower bound on `Position.balance` (wei, decimal string — values
-  exceed JS Number precision). Compared numerically against the raw
-  `Position.balance` column, which is stored as a VarChar of the wei
-  integer.
+  Numeric range filter on `Position.balance` (wei). Strict semantics:
+  a row is kept iff its raw balance satisfies every operator on this
+  filter. Compared numerically against the VarChar `Position.balance`
+  column via a raw SQL cast (Prisma's native comparisons are
+  lexicographic on VarChar — `'10' < '9'`).
 
-  Permissive semantics: keeps a row when `balance >= balanceMin` **OR**
-  the pickConfig is resolved. Claimed winners (zero-balance, resolved)
-  remain visible regardless of the bound — they carry meaningful
-  settlement PnL and shouldn't be silently dropped by a numeric filter.
-  Matches the existing `positionCount` baseline visibility rule so
-  count and list semantics agree on resolved-row visibility.
+  Supported operators: `equals`, `gt`, `gte`, `lt`, `lte`. Multiple
+  operators combine with AND (e.g. `{ gte: "1", lte: "1000" }` is an
+  inclusive range). Unsupported operators (`in`, `notIn`, `not`) raise
+  an error.
 
-  When `balanceMin > 0`, also suppresses synthesized per-sell CLOSED
-  rows (the `balance: "0"` event rows recording realized PnL from
-  secondary-market sells on unresolved positions) — those carry
-  `balance: "0"` so any positive lower bound excludes them. Pagination
-  and `totalCount` honor the same filter so they stay consistent.
+  Also applies to synthesized per-sell CLOSED rows (the `balance: "0"`
+  event rows recording realized PnL from secondary-market sells) —
+  they're emitted iff `0` satisfies the filter. Pagination and
+  `totalCount` honor the same filter so they stay consistent.
 
-  Practical use: pass `"1"` to exclude raw zero-balance unresolved
-  rows AND the synthetic CLOSED rows; pair with `settled: false` to
-  scope to "open positions only" (suppresses the resolved-keepalive
-  branch of the OR — `settled` narrows both branches).
+  Composition: `{ balance: { gte: "1" } }` returns rows with positive
+  balance only. To include claimed winners (resolved, zero-balance) in
+  the same result set, omit the filter or compose with `settled: true`
+  as a separate query — there is no implicit OR.
   """
-  balanceMin: String
+  balance: BigIntFilter
 }
 
 """
@@ -2801,7 +2812,6 @@ type Query {
   Count of token positions for a given holder
   """
   positionCount(
-    balanceMin: String
     chainId: Int
     holder: String!
     settled: Boolean
@@ -2814,10 +2824,6 @@ type Query {
   Paginated list of token position balances, filterable by holder, condition, chain, pick config, settlement, date range, collateral range, and won/lost status
   """
   positions(
-    # Decimal-string lower bound on `Position.balance` (wei). Pass `"1"`
-    # to exclude raw zero-balance rows and suppress synthesized per-sell
-    # CLOSED rows. See `positionsPage` for details.
-    balanceMin: String
     chainId: Int
     collateralMax: String
     collateralMin: String
@@ -2855,10 +2861,6 @@ type Query {
     orderDirection: SortOrder
     take: Int! = 50
     skip: Int! = 0
-    balanceMin: String
-      @deprecated(
-        reason: "Use `filters: { balanceMin: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."
-      )
     chainId: Int
       @deprecated(
         reason: "Use `filters: { chainId: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."

--- a/packages/api/test/contract/__snapshots__/introspection.json
+++ b/packages/api/test/contract/__snapshots__/introspection.json
@@ -15515,21 +15515,11 @@
             "defaultValue": null
           },
           {
-            "name": "collateralMin",
-            "description": "Restrict to positions whose holder collateral on the pickConfig is `>= this` (wei).",
+            "name": "collateral",
+            "description": "Numeric range filter on the holder's total collateral on the\npickConfig (wei). Supported operators: `equals`, `gt`, `gte`, `lt`,\n`lte`. Multiple operators on the same filter combine with AND.\nUnsupported operators (`in`, `notIn`, `not`) raise an error.",
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "collateralMax",
-            "description": "Restrict to positions whose holder collateral on the pickConfig is `<= this` (wei).",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
+              "kind": "INPUT_OBJECT",
+              "name": "BigIntFilter",
               "ofType": null
             },
             "defaultValue": null
@@ -15555,11 +15545,11 @@
             "defaultValue": null
           },
           {
-            "name": "balanceMin",
-            "description": "Lower bound on `Position.balance` (wei, decimal string — values\nexceed JS Number precision). Compared numerically against the raw\n`Position.balance` column, which is stored as a VarChar of the wei\ninteger.\n\nPermissive semantics: keeps a row when `balance >= balanceMin` **OR**\nthe pickConfig is resolved. Claimed winners (zero-balance, resolved)\nremain visible regardless of the bound — they carry meaningful\nsettlement PnL and shouldn't be silently dropped by a numeric filter.\nMatches the existing `positionCount` baseline visibility rule so\ncount and list semantics agree on resolved-row visibility.\n\nWhen `balanceMin > 0`, also suppresses synthesized per-sell CLOSED\nrows (the `balance: \"0\"` event rows recording realized PnL from\nsecondary-market sells on unresolved positions) — those carry\n`balance: \"0\"` so any positive lower bound excludes them. Pagination\nand `totalCount` honor the same filter so they stay consistent.\n\nPractical use: pass `\"1\"` to exclude raw zero-balance unresolved\nrows AND the synthetic CLOSED rows; pair with `settled: false` to\nscope to \"open positions only\" (suppresses the resolved-keepalive\nbranch of the OR — `settled` narrows both branches).",
+            "name": "balance",
+            "description": "Numeric range filter on `Position.balance` (wei). Strict semantics:\na row is kept iff its raw balance satisfies every operator on this\nfilter. Compared numerically against the VarChar `Position.balance`\ncolumn via a raw SQL cast (Prisma's native comparisons are\nlexicographic on VarChar — `'10' < '9'`).\n\nSupported operators: `equals`, `gt`, `gte`, `lt`, `lte`. Multiple\noperators combine with AND (e.g. `{ gte: \"1\", lte: \"1000\" }` is an\ninclusive range). Unsupported operators (`in`, `notIn`, `not`) raise\nan error.\n\nAlso applies to synthesized per-sell CLOSED rows (the `balance: \"0\"`\nevent rows recording realized PnL from secondary-market sells) —\nthey're emitted iff `0` satisfies the filter. Pagination and\n`totalCount` honor the same filter so they stay consistent.\n\nComposition: `{ balance: { gte: \"1\" } }` returns rows with positive\nbalance only. To include claimed winners (resolved, zero-balance) in\nthe same result set, omit the filter or compose with `settled: true`\nas a separate query — there is no implicit OR.",
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
+              "kind": "INPUT_OBJECT",
+              "name": "BigIntFilter",
               "ofType": null
             },
             "defaultValue": null
@@ -18821,16 +18811,6 @@
             "description": "Count of token positions for a given holder",
             "args": [
               {
-                "name": "balanceMin",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
                 "name": "chainId",
                 "description": null,
                 "type": {
@@ -18881,16 +18861,6 @@
             "name": "positions",
             "description": "Paginated list of token position balances, filterable by holder, condition, chain, pick config, settlement, date range, collateral range, and won/lost status",
             "args": [
-              {
-                "name": "balanceMin",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
               {
                 "name": "chainId",
                 "description": null,

--- a/packages/api/test/contract/__snapshots__/schema.sdl.graphql
+++ b/packages/api/test/contract/__snapshots__/schema.sdl.graphql
@@ -2044,14 +2044,22 @@ input PositionFilters {
   holderWon: Boolean
 
   """
+  Numeric range filter on the holder's total collateral on the
+  pickConfig (wei). Supported operators: `equals`, `gt`, `gte`, `lt`,
+  `lte`. Multiple operators on the same filter combine with AND.
+  Unsupported operators (`in`, `notIn`, `not`) raise an error.
+  """
+  collateral: BigIntFilter
+
+  """
   Restrict to positions whose holder collateral on the pickConfig is `>= this` (wei).
   """
-  collateralMin: String
+  collateralMin: String @deprecated(reason: "Use `collateral: { gte: ... }` operator filter instead.")
 
   """
   Restrict to positions whose holder collateral on the pickConfig is `<= this` (wei).
   """
-  collateralMax: String
+  collateralMax: String @deprecated(reason: "Use `collateral: { lte: ... }` operator filter instead.")
 
   """Restrict to positions whose pickConfig `endsAt >= this`."""
   endsAtMin: UnixSeconds
@@ -2060,30 +2068,28 @@ input PositionFilters {
   endsAtMax: UnixSeconds
 
   """
-  Lower bound on `Position.balance` (wei, decimal string — values
-  exceed JS Number precision). Compared numerically against the raw
-  `Position.balance` column, which is stored as a VarChar of the wei
-  integer.
+  Numeric range filter on `Position.balance` (wei). Strict semantics:
+  a row is kept iff its raw balance satisfies every operator on this
+  filter. Compared numerically against the VarChar `Position.balance`
+  column via a raw SQL cast (Prisma's native comparisons are
+  lexicographic on VarChar — `'10' < '9'`).
   
-  Permissive semantics: keeps a row when `balance >= balanceMin` **OR**
-  the pickConfig is resolved. Claimed winners (zero-balance, resolved)
-  remain visible regardless of the bound — they carry meaningful
-  settlement PnL and shouldn't be silently dropped by a numeric filter.
-  Matches the existing `positionCount` baseline visibility rule so
-  count and list semantics agree on resolved-row visibility.
+  Supported operators: `equals`, `gt`, `gte`, `lt`, `lte`. Multiple
+  operators combine with AND (e.g. `{ gte: "1", lte: "1000" }` is an
+  inclusive range). Unsupported operators (`in`, `notIn`, `not`) raise
+  an error.
   
-  When `balanceMin > 0`, also suppresses synthesized per-sell CLOSED
-  rows (the `balance: "0"` event rows recording realized PnL from
-  secondary-market sells on unresolved positions) — those carry
-  `balance: "0"` so any positive lower bound excludes them. Pagination
-  and `totalCount` honor the same filter so they stay consistent.
+  Also applies to synthesized per-sell CLOSED rows (the `balance: "0"`
+  event rows recording realized PnL from secondary-market sells) —
+  they're emitted iff `0` satisfies the filter. Pagination and
+  `totalCount` honor the same filter so they stay consistent.
   
-  Practical use: pass `"1"` to exclude raw zero-balance unresolved
-  rows AND the synthetic CLOSED rows; pair with `settled: false` to
-  scope to "open positions only" (suppresses the resolved-keepalive
-  branch of the OR — `settled` narrows both branches).
+  Composition: `{ balance: { gte: "1" } }` returns rows with positive
+  balance only. To include claimed winners (resolved, zero-balance) in
+  the same result set, omit the filter or compose with `settled: true`
+  as a separate query — there is no implicit OR.
   """
-  balanceMin: String
+  balance: BigIntFilter
 }
 
 """
@@ -2454,12 +2460,12 @@ type Query {
   popularTags: [String!]!
 
   """Count of token positions for a given holder"""
-  positionCount(balanceMin: String, chainId: Int, holder: String!, settled: Boolean): Int! @deprecated(reason: "Use `positionsPage(...).totalCount` — same number, available alongside the page payload, no extra query needed.")
+  positionCount(chainId: Int, holder: String!, settled: Boolean): Int! @deprecated(reason: "Use `positionsPage(...).totalCount` — same number, available alongside the page payload, no extra query needed.")
 
   """
   Paginated list of token position balances, filterable by holder, condition, chain, pick config, settlement, date range, collateral range, and won/lost status
   """
-  positions(balanceMin: String, chainId: Int, collateralMax: String, collateralMin: String, conditionId: String, endsAtMax: Int, endsAtMin: Int, holder: String, holderWon: Boolean, orderBy: PositionSortField, orderDirection: SortOrder, pickConfigId: String, result: SettlementResult, settled: Boolean, skip: Int! = 0, take: Int! = 50): [Position!]! @deprecated(reason: "Use `positionsPage` — same data with a server-truth `hasMore` stop signal. The bare-array form can return empty pages mid-stream (synthesized sell rows for zero-balance unresolved positions), so `length === 0` is not a reliable end-of-pagination check.")
+  positions(chainId: Int, collateralMax: String, collateralMin: String, conditionId: String, endsAtMax: Int, endsAtMin: Int, holder: String, holderWon: Boolean, orderBy: PositionSortField, orderDirection: SortOrder, pickConfigId: String, result: SettlementResult, settled: Boolean, skip: Int! = 0, take: Int! = 50): [Position!]! @deprecated(reason: "Use `positionsPage` — same data with a server-truth `hasMore` stop signal. The bare-array form can return empty pages mid-stream (synthesized sell rows for zero-balance unresolved positions), so `length === 0` is not a reliable end-of-pagination check.")
 
   """
   Same as `positions`, but wraps the result in a `PositionsPage` with a server-truth `hasMore` flag. Use this for infinite scroll: synthesized rows can be empty for some raw pages (zero-balance unresolved positions with no sells), so client-side `lastPage.length === 0` is not a reliable stop signal.
@@ -2469,7 +2475,7 @@ type Query {
   with `@deprecated` so existing callers can migrate without breaking;
   new callers should use `filters:`.
   """
-  positionsPage(filters: PositionFilters, orderBy: PositionSortField, orderDirection: SortOrder, take: Int! = 50, skip: Int! = 0, balanceMin: String @deprecated(reason: "Use `filters: { balanceMin: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), chainId: Int @deprecated(reason: "Use `filters: { chainId: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), collateralMax: String @deprecated(reason: "Use `filters: { collateralMax: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), collateralMin: String @deprecated(reason: "Use `filters: { collateralMin: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), conditionId: String @deprecated(reason: "Use `filters: { conditionId: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), endsAtMax: UnixSeconds @deprecated(reason: "Use `filters: { endsAtMax: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), endsAtMin: UnixSeconds @deprecated(reason: "Use `filters: { endsAtMin: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), holder: String @deprecated(reason: "Use `filters: { holder: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), holderWon: Boolean @deprecated(reason: "Use `filters: { holderWon: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), pickConfigId: String @deprecated(reason: "Use `filters: { pickConfigId: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), result: SettlementResult @deprecated(reason: "Use `filters: { result: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), settled: Boolean @deprecated(reason: "Use `filters: { settled: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers.")): PositionsPage!
+  positionsPage(filters: PositionFilters, orderBy: PositionSortField, orderDirection: SortOrder, take: Int! = 50, skip: Int! = 0, chainId: Int @deprecated(reason: "Use `filters: { chainId: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), collateralMax: String @deprecated(reason: "Use `filters: { collateralMax: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), collateralMin: String @deprecated(reason: "Use `filters: { collateralMin: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), conditionId: String @deprecated(reason: "Use `filters: { conditionId: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), endsAtMax: UnixSeconds @deprecated(reason: "Use `filters: { endsAtMax: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), endsAtMin: UnixSeconds @deprecated(reason: "Use `filters: { endsAtMin: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), holder: String @deprecated(reason: "Use `filters: { holder: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), holderWon: Boolean @deprecated(reason: "Use `filters: { holderWon: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), pickConfigId: String @deprecated(reason: "Use `filters: { pickConfigId: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), result: SettlementResult @deprecated(reason: "Use `filters: { result: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers."), settled: Boolean @deprecated(reason: "Use `filters: { settled: ... }` on `PositionFilters` — the flat-arg shape is being unified across all `*Page` resolvers.")): PositionsPage!
 
   """
   Look up a single prediction by its on-chain prediction ID. Pass

--- a/packages/sdk/types/graphql.ts
+++ b/packages/sdk/types/graphql.ts
@@ -1997,35 +1997,46 @@ export type Position = {
  */
 export type PositionFilters = {
   /**
-   * Lower bound on `Position.balance` (wei, decimal string — values
-   * exceed JS Number precision). Compared numerically against the raw
-   * `Position.balance` column, which is stored as a VarChar of the wei
-   * integer.
+   * Numeric range filter on `Position.balance` (wei). Strict semantics:
+   * a row is kept iff its raw balance satisfies every operator on this
+   * filter. Compared numerically against the VarChar `Position.balance`
+   * column via a raw SQL cast (Prisma's native comparisons are
+   * lexicographic on VarChar — `'10' < '9'`).
    *
-   * Permissive semantics: keeps a row when `balance >= balanceMin` **OR**
-   * the pickConfig is resolved. Claimed winners (zero-balance, resolved)
-   * remain visible regardless of the bound — they carry meaningful
-   * settlement PnL and shouldn't be silently dropped by a numeric filter.
-   * Matches the existing `positionCount` baseline visibility rule so
-   * count and list semantics agree on resolved-row visibility.
+   * Supported operators: `equals`, `gt`, `gte`, `lt`, `lte`. Multiple
+   * operators combine with AND (e.g. `{ gte: "1", lte: "1000" }` is an
+   * inclusive range). Unsupported operators (`in`, `notIn`, `not`) raise
+   * an error.
    *
-   * When `balanceMin > 0`, also suppresses synthesized per-sell CLOSED
-   * rows (the `balance: "0"` event rows recording realized PnL from
-   * secondary-market sells on unresolved positions) — those carry
-   * `balance: "0"` so any positive lower bound excludes them. Pagination
-   * and `totalCount` honor the same filter so they stay consistent.
+   * Also applies to synthesized per-sell CLOSED rows (the `balance: "0"`
+   * event rows recording realized PnL from secondary-market sells) —
+   * they're emitted iff `0` satisfies the filter. Pagination and
+   * `totalCount` honor the same filter so they stay consistent.
    *
-   * Practical use: pass `"1"` to exclude raw zero-balance unresolved
-   * rows AND the synthetic CLOSED rows; pair with `settled: false` to
-   * scope to "open positions only" (suppresses the resolved-keepalive
-   * branch of the OR — `settled` narrows both branches).
+   * Composition: `{ balance: { gte: "1" } }` returns rows with positive
+   * balance only. To include claimed winners (resolved, zero-balance) in
+   * the same result set, omit the filter or compose with `settled: true`
+   * as a separate query — there is no implicit OR.
    */
-  balanceMin?: InputMaybe<Scalars['String']['input']>;
+  balance?: InputMaybe<BigIntFilter>;
   /** Restrict to a single chain. */
   chainId?: InputMaybe<Scalars['Int']['input']>;
-  /** Restrict to positions whose holder collateral on the pickConfig is `<= this` (wei). */
+  /**
+   * Numeric range filter on the holder's total collateral on the
+   * pickConfig (wei). Supported operators: `equals`, `gt`, `gte`, `lt`,
+   * `lte`. Multiple operators on the same filter combine with AND.
+   * Unsupported operators (`in`, `notIn`, `not`) raise an error.
+   */
+  collateral?: InputMaybe<BigIntFilter>;
+  /**
+   * Restrict to positions whose holder collateral on the pickConfig is `<= this` (wei).
+   * @deprecated Use `collateral: { lte: ... }` operator filter instead.
+   */
   collateralMax?: InputMaybe<Scalars['String']['input']>;
-  /** Restrict to positions whose holder collateral on the pickConfig is `>= this` (wei). */
+  /**
+   * Restrict to positions whose holder collateral on the pickConfig is `>= this` (wei).
+   * @deprecated Use `collateral: { gte: ... }` operator filter instead.
+   */
   collateralMin?: InputMaybe<Scalars['String']['input']>;
   /** Restrict to positions tied to a single condition (via the pickConfig join). */
   conditionId?: InputMaybe<Scalars['String']['input']>;
@@ -2818,7 +2829,6 @@ export type QueryPickConfigurationsPageArgs = {
 
 
 export type QueryPositionCountArgs = {
-  balanceMin?: InputMaybe<Scalars['String']['input']>;
   chainId?: InputMaybe<Scalars['Int']['input']>;
   holder: Scalars['String']['input'];
   settled?: InputMaybe<Scalars['Boolean']['input']>;
@@ -2826,7 +2836,6 @@ export type QueryPositionCountArgs = {
 
 
 export type QueryPositionsArgs = {
-  balanceMin?: InputMaybe<Scalars['String']['input']>;
   chainId?: InputMaybe<Scalars['Int']['input']>;
   collateralMax?: InputMaybe<Scalars['String']['input']>;
   collateralMin?: InputMaybe<Scalars['String']['input']>;
@@ -2846,7 +2855,6 @@ export type QueryPositionsArgs = {
 
 
 export type QueryPositionsPageArgs = {
-  balanceMin?: InputMaybe<Scalars['String']['input']>;
   chainId?: InputMaybe<Scalars['Int']['input']>;
   collateralMax?: InputMaybe<Scalars['String']['input']>;
   collateralMin?: InputMaybe<Scalars['String']['input']>;


### PR DESCRIPTION
## Summary

Targets **#1722's branch**, not staging. Pivots the unshipped `balanceMin: String` filter to the operator-pattern `balance: BigIntFilter` on `PositionFilters`, and adds matching `collateral: BigIntFilter` while deprecating the flat `collateralMin`/`collateralMax` args.

Strict semantics — no implicit OR. Supports `equals`/`gt`/`gte`/`lt`/`lte`; rejects `in`/`notIn`/`not` with a clear error.

`balanceMin` was unshipped (still in review), so this is a nonbreaking redesign of an unreleased surface. `collateralMin`/`collateralMax` keep working for one release with `@deprecated` notices.

## What changed vs. the current PR 1722 head

- **Surface**: `balanceMin: String` → `balance: BigIntFilter`. Also new `collateral: BigIntFilter`.
- **Semantics**: dropped the permissive `OR pickConfig.resolved = true` keepalive. `{ balance: { gte: "1" } }` strictly means `balance >= 1`. To include claimed winners, omit the balance filter or compose with `settled: true` as a separate query.
- **Deprecation**: flat `collateralMin: String` / `collateralMax: String` on `PositionFilters` now carry `@deprecated(reason: "Use \`collateral: { gte/lte: ... }\` operator filter instead.")`.
- **Top-level args**: dropped the unshipped flat `balanceMin: String` arg from `positionsPage`, `positionCount`, and the deprecated `positions` query.

## Why operator-pattern over `<field>Min`/`<field>Max`

- Composable: `{ balance: { gte: "1", lte: "10**18" } }` is one filter object; the flat form forces per-operator naming bikeshed.
- Extensible: adding `gt`/`lt`/`equals` doesn't combinatorially explode the arg surface.
- Matches the existing `BigIntFilter` input used elsewhere in the schema (typegraphql-prisma generated), and the broader Prisma/Hasura/Linear convention. Sets a single pattern for the upcoming `endsAtMin/Max` sweep on `PredictionFilters`.

## Why strict, no implicit OR

The original `balanceMin: "1"` had an opinionated `OR pickConfig.resolved = true` keepalive so claimed winners stayed visible. Under the operator pattern that's a leaky abstraction — readers expect `gte: "1"` to mean `>= 1`, full stop. The strict path lets the FE compose explicitly (omit the filter, or two queries) and avoids a footgun that surprises typed-client users.

## Test plan

- [x] 779/779 API unit tests pass (incl. 9 new operator-pattern tests in `escrow.test.ts` covering: strict `gte`, raw-SQL pre-query, empty pre-query, strict-excludes-claimed-winner, `equals: 0` keeps CLOSED rows, multi-operator AND, unsupported-operator rejection, `_countWhere` consistency, cache-key discrimination, collateral path).
- [x] Contract snapshots regenerated (`introspection.json`, `schema.sdl.graphql`).
- [x] `tsc --noEmit` clean on api (3 pre-existing `ctx.loaders` errors unrelated).
- [x] `tsc --noEmit` clean on app (FE doesn't consume `balanceMin` yet, no breakage).
- [x] `@sapience/sdk` rebuilds clean against the updated schema.
- [x] Generated `schema.graphql` regenerated; SDL is the source of truth.
- [ ] FE migration is a follow-up PR (FE doesn't reference `balanceMin` today, so nothing to migrate).

## Reference

- MIGRATION.md section rewritten — search `PositionFilters.balance`.
- Resolver: `packages/api/src/graphql/sdl/resolvers/queries/escrow.ts` — new `parseBigIntFilter`, `flatRangeToFilter`, `evalBigIntFilter`, `renderBigIntFilterToSql`, `filterCacheKey` helpers; `applyBalanceMinFilter` → `applyBalanceFilter`; `applyCollateralRangeFilter` → `applyCollateralFilter`.
- SDL: `packages/api/src/graphql/sdl/schema/schema.graphql` — `PositionFilters` updated.