### PR TITLE
docs: redesign — filter/sort conventions + resolve subject/Question shape

### DIFF
--- a/docs/sapience-graphql-api-redesign.md
+++ b/docs/sapience-graphql-api-redesign.md
@@ -258,8 +258,8 @@ Scalar fields on `<Entity>Filter` use operator-pattern inputs:
 input PositionFilter {
   account: AddressFilter
   conditionId: IDFilter
-  balance: BigIntFilter
-  collateral: BigIntFilter
+  size: DecimalFilter
+  collateralAmount: DecimalFilter
   createdAt: DateTimeFilter
   settled: Boolean
 }
@@ -280,7 +280,7 @@ input BigIntFilter {
 }
 ```
 
-A parallel input exists for each scalar (`IntFilter`, `StringFilter`, `DateTimeFilter`, `BooleanFilter`, `AddressFilter`, plus parameterized `EnumFilter<T>` per enum where filtering is useful).
+A parallel input exists for each filterable scalar (`IntFilter`, `DecimalFilter`, `StringFilter`, `DateTimeFilter`, `AddressFilter`, plus parameterized `EnumFilter<T>` per enum where filtering is useful). There is no `BooleanFilter` — see the next rule.
 
 Rules:
 
@@ -538,6 +538,17 @@ input StringFilter {
   in: [String!]
   notIn: [String!]
   not: String
+}
+
+input DecimalFilter {
+  equals: Decimal
+  gt: Decimal
+  gte: Decimal
+  lt: Decimal
+  lte: Decimal
+  in: [Decimal!]
+  notIn: [Decimal!]
+  not: Decimal
 }
 
 type PageInfo {
@@ -936,9 +947,12 @@ type Forecast implements Node {
   forecaster: Account!
   schemaId: Bytes32!
 
+  # Forecasts attach to a single Condition (the EAS subject). Group /
+  # pickConfiguration membership is reachable via `condition.conditionGroup`
+  # and `condition.pickConfigurations`. Nullable because the Prisma column
+  # is nullable today — schemas that aren't condition-keyed produce
+  # forecasts without a Condition link.
   condition: Condition
-  conditionGroup: ConditionGroup
-  pickConfiguration: PickConfiguration
 
   forecastScore: Decimal
 
@@ -969,8 +983,15 @@ type Position implements Node {
   pickConfiguration: PickConfiguration!
   conditions: [Condition!]!
 
+  # `size` is the raw token balance (renamed from the underlying
+  # `Position.balance` column). `collateral` is the token reference;
+  # `collateralAmount` is the derived collateral amount this position
+  # represents — both are non-null because `balance` is non-null in
+  # the data model.
+  size: Decimal!
   collateral: CollateralToken!
-  size: Decimal
+  collateralAmount: Decimal!
+
   averagePrice: Decimal
   realizedPnl: Decimal
   unrealizedPnl: Decimal
@@ -1454,7 +1475,6 @@ enum PredictionOrderField {
 input ForecastFilter {
   forecaster: AddressFilter
   conditionId: IDFilter
-  pickConfigurationId: IDFilter
   createdAt: DateTimeFilter
 }
 
@@ -1511,8 +1531,8 @@ input PositionFilter {
   conditionId: IDFilter
   conditionGroupId: IDFilter
   pickConfigurationId: IDFilter
-  balance: BigIntFilter
-  collateral: BigIntFilter
+  size: DecimalFilter
+  collateralAmount: DecimalFilter
   settled: Boolean
   createdAt: DateTimeFilter
 }
@@ -1754,7 +1774,7 @@ Numbering is section-prefixed: **D**eferred (`D#`), **P**er-entity (`P#`), **R**
 
 ### Resolved — locked direction, doc updated
 
-- **R1. `Forecast.subject` naming** — The EAS "subject" (recipient) on a forecast attestation is the conditionId it targets; that link is already typed as `condition: Condition` on `Forecast`. The redundant `subject: Address` field is dropped from the SDL. Forecasts target a single `Condition` (not a `ConditionGroup`), so `ForecastFilter.conditionGroupId` is also dropped.
+- **R1. `Forecast` shape — single Condition link only.** The EAS "subject" (recipient) on a forecast attestation is the conditionId it targets; that link is already typed as `condition: Condition` on `Forecast`. The redundant `subject: Address` field is dropped from the SDL. The Prisma `Attestation` model carries exactly one graph link (`conditionId → Condition`); there is no `conditionGroupId` or `pickConfigurationId` column, and the resolver doesn't synthesize them. Accordingly: the aspirational `conditionGroup: ConditionGroup` and `pickConfiguration: PickConfiguration` fields are dropped from `Forecast`, and `ForecastFilter.conditionGroupId` / `pickConfigurationId` are dropped from the filter. Group / pickConfig membership is reachable via `condition.conditionGroup` and `condition.pickConfigurations`. `Forecast.condition` stays nullable because the Prisma column is nullable; tightening to non-null requires a data audit (parallel to R2 for counterparty).
 - **R2. `Prediction.counterparty` nullability** — Ship non-null (`counterparty: Account!`). Prisma schema declares the column non-null (`counterparty String @db.VarChar` in `prisma/schema.prisma`); every indexer write path (`predictionMarketEscrowIndexer.ts:706, 743`) sets it from the on-chain event payload, which is itself a non-null `0x${string}`. No backfill or schema migration needed.
 - **R3. `Question` union vs. nullable pair** — Modeled as `union ConditionOrConditionGroup = Condition | ConditionGroup`, exposed as `Question.source: ConditionOrConditionGroup!`. Schema enforces "exactly one of," eliminating the both-null / both-set bug class. The `questionType: QuestionType` enum is removed — `__typename` on the union member subsumes it. Name follows GitHub's `IssueOrPullRequest` precedent: literal, no abbreviation, no parallel concept ("Market", "Source") introduced.
 - **R4. Collateral field and type naming** — Type is `CollateralToken` (was `CollateralAsset`); field is `collateral: CollateralToken!` on every type that exposes it (`Prediction`, `Position`, `Trade`, `CollateralBalance`, `CollateralBalanceSnapshot`, `CollateralTransfer`). The full `CollateralToken` record carries `{ symbol, address, decimals, chainId }`, so the field name doesn't need to disambiguate between address and ticker — both live inside.
@@ -1769,7 +1789,7 @@ Numbering is section-prefixed: **D**eferred (`D#`), **P**er-entity (`P#`), **R**
   **Follow-up cleanup (separate PR to staging, not this doc PR):** the indexer's `mapSettlementResult` retains a `case 3 → 'NON_DECISIVE'` branch unreachable from current contract behavior; the Prisma `SettlementResult` enum still lists `NON_DECISIVE`. Both are vestigial. Cleanup can either drop them outright (after confirming no live rows carry the value) or leave a tombstone on the Prisma side and remove only the indexer branch.
 
 - **R6. Sort shape (singular vs array)** — Singular `orderBy: <Entity>Order` (matching GitHub's `IssueOrder` precedent), not the array shape originally drafted. Multi-key tiebreakers can be added later non-breakingly via a `then: <Entity>Order` field on the order input if real demand surfaces.
-- **R7. Filter convention** — Operator-pattern (Prisma-style) for single-value scalars (`AddressFilter`, `IDFilter`, `BigIntFilter`, `IntFilter`, `DateTimeFilter`, `StringFilter`). Multi-value membership filters and full-text search stay flat. See principles section for details.
+- **R7. Filter convention** — Operator-pattern (Prisma-style) for single-value scalars (`AddressFilter`, `IDFilter`, `BigIntFilter`, `IntFilter`, `DecimalFilter`, `DateTimeFilter`, `StringFilter`). No `BooleanFilter` — Booleans stay flat per the principles. Multi-value membership filters and full-text search stay flat. See principles section for details. Position-specific corollary: the filter on `Position` uses `size: DecimalFilter` and `collateralAmount: DecimalFilter` to match the type's field names (the PR 1730 column-aligned names `balance` / `collateral` are not used on the wire — `size` is the renamed `balance` column, and `collateral` on the type is the `CollateralToken` reference).
 - **R8. `Vault` root access** — Vault is a Node, so it gets `vault(id:)`, `vaultByAddress(address:)`, and `vaults(...)` root fields — matching the prediction/trade/forecast pattern. The previous nesting under `protocol.vault(address)` is removed; Vault is independent and shouldn't sit behind a Protocol grouping.
 - **R9. Stat-row connections over non-Node types** — `ProtocolStat`, `VaultStat`, `AccountStat`, and `CollateralBalanceSnapshot` stay as Connection members without implementing `Node`. They are time-bucketed values, not addressable entities; refetching a stat row by ID is meaningless because the row is uniquely identified by `(entity, timestamp)` already reachable via the parent + filter. Cursors on these connections encode timestamp position. The type-level descriptions in the SDL document this.
 - **R10. `UnixSeconds` scalar** — Declared explicitly. Used for timestamps that come directly from chain storage (uint256 seconds) where round-tripping to `DateTime` loses precision. Indexed / derived timestamps continue to use `DateTime`.

--- a/docs/sapience-graphql-api-redesign.md
+++ b/docs/sapience-graphql-api-redesign.md
@@ -35,7 +35,7 @@ These are canonical graph entities and should generally implement `Node`:
 These are product views, not canonical database-backed entities:
 
 - `Question`
-- `ActivityItem`
+- `Activity`
 
 ### Question model
 
@@ -64,7 +64,7 @@ question:group:456
 
 ### Activity model
 
-`ActivityItem` is a derived aggregate feed item over:
+`Activity` is a derived aggregate feed item over:
 
 - `Prediction`
 - `Trade`
@@ -186,7 +186,7 @@ No canonical:
 
 ```graphql
 question(id:)
-activityItem(id:)
+activity(id:)
 ```
 
 unless those views become durable records later.
@@ -876,16 +876,22 @@ type Position implements Node {
   updatedAt: DateTime
 }
 
-type ActivityItem {
+type Activity {
   id: ID!
-  activityType: ActivityType!
-  subject: ActivitySubject!
+  # The underlying entity this activity row wraps. Concrete type is
+  # available via `__typename` — no separate `activityType` enum field
+  # because it would duplicate what the union already encodes.
+  source: ActivitySource!
   account: Account
   createdAt: DateTime!
 }
 
-union ActivitySubject = Prediction | Trade | Forecast
+union ActivitySource = Prediction | Trade | Forecast
 
+# Retained for use in ActivityFilter (filtering an interleaved feed by
+# member type is a real use case — clients ask "only my forecasts" or
+# "only trades"). On the wire of an Activity row itself, prefer
+# `__typename` on `source`.
 enum ActivityType {
   PREDICTION
   TRADE
@@ -1073,13 +1079,13 @@ type TradeEdge {
 
 type ActivityConnection {
   edges: [ActivityEdge!]!
-  nodes: [ActivityItem!]!
+  nodes: [Activity!]!
   pageInfo: PageInfo!
   totalCount: Int
 }
 
 type ActivityEdge {
-  node: ActivityItem!
+  node: Activity!
   cursor: String!
 }
 
@@ -1604,7 +1610,7 @@ Questions that lock public wire format must be resolved before the per-entity PR
 ### Deferred — safe to ship later
 
 1. **`Question.id` synthetic ID** — Underlying `Condition` / `ConditionGroup` already carry Node IDs; clients can key on those. Add a synthetic `Question.id` later if a concrete UI need surfaces. Adding a field is non-breaking; committing to a format prematurely locks it forever.
-2. **`ActivityItem.id` synthetic ID** — Same logic. Each `ActivityItem` embeds a Prediction / Trade / Forecast that already has a Node ID; cursor handles in-page identity. Skip until a use case appears.
+2. **`Activity.id` synthetic ID** — Same logic. Each `Activity` row embeds a Prediction / Trade / Forecast that already has a Node ID; cursor handles in-page identity. Skip until a use case appears.
 3. **`totalCount` per-connection** — Per-connection call. Add where the count is cheap (covered index, materialized aggregate); omit where it's a table scan. Adding later is non-breaking.
 4. **`last` / `before` reverse pagination** — Forward is a strict subset; reverse is purely additive. Ship forward-only; revisit if clients need reverse traversal.
 

--- a/docs/sapience-graphql-api-redesign.md
+++ b/docs/sapience-graphql-api-redesign.md
@@ -284,7 +284,7 @@ A parallel input exists for each filterable scalar (`IntFilter`, `DecimalFilter`
 
 Rules:
 
-- **Strict semantics, no implicit OR.** `{ balance: { gte: "1" } }` means `balance >= 1`, full stop. Clients that want richer composition issue separate queries or rely on the server to add an explicit `OR` shape later if real demand surfaces.
+- **Strict semantics, no implicit OR.** `{ size: { gte: "1" } }` means `size >= 1`, full stop. Clients that want richer composition issue separate queries or rely on the server to add an explicit `OR` shape later if real demand surfaces.
 - **Unsupported operators on a specific field reject** with a clear error, not silently no-op. If a field can only be filtered by `equals` (e.g., a hashed identifier), the resolver rejects `gt`/`lt` rather than returning empty or full results.
 - **Forbid flat `<field>Min` / `<field>Max` on new types.** Existing flat args get `@deprecated` with a one-release migration cycle. See PR 1730 (positions `balance` / `collateral`) for the reference migration shape.
 - **Booleans stay flat.** `settled: Boolean` rather than `settled: BooleanFilter` — there is no `gt true` and the operator pattern adds noise without benefit.
@@ -683,6 +683,7 @@ type Query {
 type Account implements Node {
   id: ID!
   address: Address!
+  createdAt: DateTime!
 
   stats(
     first: Int
@@ -692,6 +693,9 @@ type Account implements Node {
   ): AccountStatsConnection!
   rank(metric: LeaderboardMetric!, filter: LeaderboardFilter): AccountRank
 
+  # Predictions where this account is either the predictor OR the
+  # counterparty. The two roles are symmetric; clients that need to
+  # disambiguate read `predictor` / `counterparty` on each row.
   predictions(
     first: Int
     after: String
@@ -929,7 +933,10 @@ type Prediction implements Node {
   payout: Decimal!
 
   createdAt: DateTime!
-  settledAt: DateTime
+  # `UnixSeconds` rather than `DateTime` — this comes from chain
+  # storage (uint256 seconds) like `Condition.settledAt`, not from the
+  # indexer's row-write clock.
+  settledAt: UnixSeconds
 }
 
 enum PredictionResult {
@@ -965,11 +972,14 @@ type Trade implements Node {
   pickConfiguration: PickConfiguration!
   conditions: [Condition!]!
 
+  # All trade economics columns (`collateral`, `tokenAmount`, `price`)
+  # are non-null in the `SecondaryTrade` indexer model — every row
+  # carries them.
   collateral: CollateralToken!
-  collateralAmount: Decimal
+  collateralAmount: Decimal!
 
-  price: Decimal
-  quantity: Decimal
+  price: Decimal!
+  quantity: Decimal!
 
   createdAt: DateTime!
 }
@@ -1008,7 +1018,10 @@ type Activity {
   # available via `__typename` — no separate `activityType` enum field
   # because it would duplicate what the union already encodes.
   source: ActivitySource!
-  account: Account
+  # The actor on the wrapped row: `predictor` for a Prediction,
+  # `account` for a Trade, `forecaster` for a Forecast. Always present
+  # — every union member has a non-null actor account.
+  account: Account!
   createdAt: DateTime!
 }
 
@@ -1039,7 +1052,8 @@ type CollateralBalance {
   atBlock: BigInt
 }
 
-# Not a Node — see R9. Cursors over `collateralBalanceHistory` encode
+# Not a Node — stat rows are time-bucketed values, not addressable
+# entities. Cursors over `collateralBalanceHistory` encode
 # (block, timestamp) position. Unlike other stat types, this one is
 # bucketed at read time via `intervalSeconds:` on the root field — the
 # only exception in the schema; see the field description for why.
@@ -1348,7 +1362,6 @@ type CategoryEdge {
 # do not implement Node and cannot be refetched via `node(id:)`.
 # Connection cursors over these types encode timestamp position;
 # clients re-query with a `timestamp: DateTimeFilter` to traverse.
-# See open question R9.
 
 type ProtocolStat {
   timestamp: DateTime!
@@ -1449,6 +1462,11 @@ enum ConditionGroupOrderField {
   VOLUME
 }
 
+# `account` matches Predictions where the address appears in either
+# role — predictor OR counterparty. The two roles are symmetric:
+# both sides post collateral and both are `Account` values. Clients
+# that need to disambiguate filter on the resolved type's `predictor`
+# / `counterparty` fields client-side.
 input PredictionFilter {
   account: AddressFilter
   conditionId: IDFilter
@@ -1531,7 +1549,6 @@ input PositionFilter {
   pickConfigurationId: IDFilter
   size: DecimalFilter
   collateralAmount: DecimalFilter
-  settled: Boolean
   createdAt: DateTimeFilter
 }
 
@@ -1747,7 +1764,7 @@ type Query {
 
 Questions that lock public wire format must be resolved before the per-entity PR that ships the affected type. Additive-only questions can be deferred — adding a field, query, or arg later is non-breaking; removing or reshaping one is.
 
-Numbering is section-prefixed: **D**eferred (`D#`), **P**er-entity (`P#`), **R**esolved (`R#`). Stable across edits — cross-references in the body of this document use these prefixes.
+Numbering is section-prefixed: **D**eferred (`D#`), **P**er-entity (`P#`). Stable across edits — cross-references in the body of this document use these prefixes. Resolved items have been folded into the SDL and principles above and removed from this list; consult `git log` on this file for prior decisions.
 
 ### Deferred — safe to ship later
 
@@ -1759,25 +1776,3 @@ Numbering is section-prefixed: **D**eferred (`D#`), **P**er-entity (`P#`), **R**
 ### Per-entity — resolve at each PR
 
 - **P1. Sort fields by entity** — Each entity declares its own `<Entity>OrderField` enum listing the fields its indexes support (see "One filter convention, one sort convention" above). Per-entity PRs decide their enum members based on actual index coverage; the SDL enforces the answer.
-
-### Resolved — locked direction, doc updated
-
-- **R1. `Forecast` shape — single Condition link only.** The EAS "subject" (recipient) on a forecast attestation is the conditionId it targets; that link is already typed as `condition: Condition` on `Forecast`. The redundant `subject: Address` field is dropped from the SDL. The Prisma `Attestation` model carries exactly one graph link (`conditionId → Condition`); there is no `conditionGroupId` or `pickConfigurationId` column, and the resolver doesn't synthesize them. Accordingly: the aspirational `conditionGroup: ConditionGroup` and `pickConfiguration: PickConfiguration` fields are dropped from `Forecast`, and `ForecastFilter.conditionGroupId` / `pickConfigurationId` are dropped from the filter. Group / pickConfig membership is reachable via `condition.conditionGroup` and `condition.pickConfigurations`. `Forecast.condition` stays nullable because the Prisma column is nullable; tightening to non-null requires a data audit (parallel to R2 for counterparty).
-- **R2. `Prediction.counterparty` nullability** — Ship non-null (`counterparty: Account!`). Prisma schema declares the column non-null (`counterparty String @db.VarChar` in `prisma/schema.prisma`); every indexer write path (`predictionMarketEscrowIndexer.ts:706, 743`) sets it from the on-chain event payload, which is itself a non-null `0x${string}`. No backfill or schema migration needed.
-- **R3. `Question` union vs. nullable pair** — Modeled as `union ConditionOrConditionGroup = Condition | ConditionGroup`, exposed as `Question.source: ConditionOrConditionGroup!`. Schema enforces "exactly one of," eliminating the both-null / both-set bug class. The `questionType: QuestionType` enum is removed — `__typename` on the union member subsumes it. Name follows GitHub's `IssueOrPullRequest` precedent: literal, no abbreviation, no parallel concept ("Market", "Source") introduced.
-- **R4. Collateral field and type naming** — Type is `CollateralToken` (was `CollateralAsset`); field is `collateral: CollateralToken!` on every type that exposes it (`Prediction`, `Position`, `Trade`, `CollateralBalance`, `CollateralBalanceSnapshot`, `CollateralTransfer`). The full `CollateralToken` record carries `{ symbol, address, decimals, chainId }`, so the field name doesn't need to disambiguate between address and ticker — both live inside.
-- **R5. Status enums** — The audit revealed that the doc's status enums were aspirational, not migrations from existing wire fields. Once we accept that the data model has only the states it has, every proposed `*Status` enum collapses to either a Boolean (which we already have) or a derivation clients can do themselves. So:
-
-  - **`ConditionStatus` enum — dropped.** No synthetic status. `Condition` directly exposes the three Booleans that carry its actual state: `settled: Boolean!`, `resolvedToYes: Boolean!`, `nonDecisive: Boolean!`, plus `settledAt: UnixSeconds`. Clients render `ACTIVE`/`RESOLVED`/`TIE`/etc. however they want from these. `ConditionFilter.status` replaced with flat Boolean filters (`settled`, `resolvedToYes`, `nonDecisive`).
-  - **`ConditionGroupStatus` enum — dropped.** ConditionGroup has no status field today and isn't getting one. If any UI needs a group-level state, it derives from child Conditions.
-  - **`PredictionStatus` enum — dropped.** Was sugar on the existing `settled` Boolean (`OPEN = !settled`, `SETTLED = settled`); no `CANCELLED` state exists in the data model. `Prediction` directly exposes `settled: Boolean!` + `result: PredictionResult!`. `PredictionFilter.status` replaced with `settled: Boolean`.
-  - **`QuestionStatus` enum — dropped.** Question wraps either Condition or ConditionGroup via the `source` union; clients read state through `... on Condition { settled, resolvedToYes, nonDecisive }`. No view-level status field needed.
-  - **`PredictionResult` enum values — finalized as** `{ UNRESOLVED, PREDICTOR_WINS, COUNTERPARTY_WINS }`. Contract collapses non-decisive outcomes to `COUNTERPARTY_WINS` at the resolution layer (`PredictionMarketEscrow.sol:_evaluatePick`, comment at L1262–1267: "SettlementResult has no DRAW variant ... counterparties bear no prediction risk on void/tie outcomes"). Made `Prediction.result` non-null.
-
-  **Follow-up cleanup (separate PR to staging, not this doc PR):** the indexer's `mapSettlementResult` retains a `case 3 → 'NON_DECISIVE'` branch unreachable from current contract behavior; the Prisma `SettlementResult` enum still lists `NON_DECISIVE`. Both are vestigial. Cleanup can either drop them outright (after confirming no live rows carry the value) or leave a tombstone on the Prisma side and remove only the indexer branch.
-
-- **R6. Sort shape (singular vs array)** — Singular `orderBy: <Entity>Order` (matching GitHub's `IssueOrder` precedent), not the array shape originally drafted. Multi-key tiebreakers can be added later non-breakingly via a `then: <Entity>Order` field on the order input if real demand surfaces.
-- **R7. Filter convention** — Operator-pattern (Prisma-style) for single-value scalars (`AddressFilter`, `IDFilter`, `BigIntFilter`, `IntFilter`, `DecimalFilter`, `DateTimeFilter`, `StringFilter`). No `BooleanFilter` — Booleans stay flat per the principles. Multi-value membership filters and full-text search stay flat. See principles section for details. Position-specific corollary: the filter on `Position` uses `size: DecimalFilter` and `collateralAmount: DecimalFilter` to match the type's field names (the PR 1730 column-aligned names `balance` / `collateral` are not used on the wire — `size` is the renamed `balance` column, and `collateral` on the type is the `CollateralToken` reference).
-- **R8. `Vault` root access + no top-level sort** — Vault is a Node, so it gets `vault(id:)`, `vaultByAddress(address:)`, and `vaults(...)` root fields — matching the prediction/trade/forecast pattern. The previous nesting under `protocol.vault(address)` is removed; Vault is independent and shouldn't sit behind a Protocol grouping. Structurally, a Vault is "an address with an attached time series" — parallel to `Account` for stats purposes (`Vault.stats: VaultStatsConnection!` mirrors `Account.stats: AccountStatsConnection!`). There is no `Vault` table in Prisma; vaults come from static config (`getConfiguredVaults(chainId)`). So `vaults(...)` has no `orderBy:` arg and there is no `VaultOrder` / `VaultOrderField` — the entity has no indexed column to sort on. The field description should document that rows return in registration order. This is the one Connection in the schema without an `orderBy:` arg; that's a deliberate consequence of P1 ("the order-field enum lists fields the entity's indexes actually support"), not an oversight.
-- **R9. Stat-row connections over non-Node types** — `ProtocolStat`, `VaultStat`, `AccountStat`, and `CollateralBalanceSnapshot` stay as Connection members without implementing `Node`. They are time-bucketed values, not addressable entities; refetching a stat row by ID is meaningless because the row is uniquely identified by `(entity, timestamp)` already reachable via the parent + filter. Cursors on these connections encode timestamp position. The type-level descriptions in the SDL document this.
-- **R10. `UnixSeconds` scalar** — Declared explicitly. Used for timestamps that come directly from chain storage (uint256 seconds) where round-tripping to `DateTime` loses precision. Indexed / derived timestamps continue to use `DateTime`.

--- a/docs/sapience-graphql-api-redesign.md
+++ b/docs/sapience-graphql-api-redesign.md
@@ -289,18 +289,18 @@ Rules:
 - **Forbid flat `<field>Min` / `<field>Max` on new types.** Existing flat args get `@deprecated` with a one-release migration cycle. See PR 1730 (positions `balance` / `collateral`) for the reference migration shape.
 - **Booleans stay flat.** `settled: Boolean` rather than `settled: BooleanFilter` — there is no `gt true` and the operator pattern adds noise without benefit.
 
-The SDL draft elsewhere in this document predates the operator-pattern convention and still shows flat fields like `conditionId: ID` and `createdAfter: DateTime`. Those examples will be normalized to operator-pattern as per-entity PRs land — the draft is illustrative of shape, not the final filter input definitions.
+The SDL draft below has been normalized to operator-pattern. Multi-value membership filters (`categoryIds: [ID!]`, `tags: [String!]`, `activityTypes: [ActivityType!]`) intentionally stay flat — the operator pattern is for single-value scalar comparisons; "is any of" is a different beast. Full-text `search: String` also stays flat — it isn't a field filter.
 
 #### Sort
 
-Replace the today-pattern of `orderBy: <FieldEnum>, orderDirection: ASC|DESC` with a single multi-key argument:
+Replace the today-pattern of `orderBy: <FieldEnum>, orderDirection: ASC|DESC` with a single `orderBy: <Entity>Order` input bundling both:
 
 ```graphql
 predictions(
   first: Int
   after: String
   filter: PredictionFilter
-  orderBy: [PredictionOrder!]
+  orderBy: PredictionOrder
 ): PredictionConnection!
 
 input PredictionOrder {
@@ -311,17 +311,19 @@ input PredictionOrder {
 enum PredictionOrderField {
   CREATED_AT
   SETTLED_AT
-  COLLATERAL
+  COLLATERAL_AMOUNT
   PAYOUT
 }
 ```
 
+This matches GitHub's `IssueOrder` / `RepositoryOrder` precedent — the same precedent we followed on `ConditionOrConditionGroup`. Singular orderBy is the dominant convention for hand-designed public GraphQL APIs (GitHub, Linear, Shopify); the array shape is mostly an ORM-generation artifact (Hasura, Prisma).
+
 Rules:
 
-- **Array shape unlocks multi-key sort.** `[{field: ENDS_AT, direction: ASC}, {field: VOLUME, direction: DESC}]` is a single sort key with a tie-breaker.
-- **Each entity declares its own `<Entity>OrderField` enum** listing the fields the entity's indexes actually support. This answers open question #6 (which sort fields are supported) at the SDL level: if a field isn't in the enum, you can't sort by it.
+- **Each entity declares its own `<Entity>OrderField` enum** listing the fields the entity's indexes actually support. This answers open question P1 (which sort fields are supported per entity) structurally — if a field isn't in the enum, you can't sort by it.
 - **Adding a sort field is non-breaking; removing one is.** Treat the order-field enum like every other public enum — addition-only after first ship.
 - **Default order belongs in the resolver, not the schema.** Document the default in the field description ("orders by `CREATED_AT DESC` when `orderBy` is omitted") rather than encoding it as a default argument that drifts.
+- **Multi-key sort path is open.** If real demand surfaces, add a `then: <Entity>Order` field to the order input for tie-breakers — purely additive, non-breaking. Until then, the single-key shape is simpler for clients and resolvers alike.
 
 ---
 
@@ -414,6 +416,22 @@ type Query {
     orderBy: PickConfigurationOrder
   ): PickConfigurationConnection!
 
+  vault(id: ID!): Vault
+  vaultByAddress(address: Address!): Vault
+  vaults(
+    first: Int
+    after: String
+    filter: VaultFilter
+    orderBy: VaultOrder
+  ): VaultConnection!
+
+  leaderboard(
+    metric: LeaderboardMetric!
+    first: Int
+    after: String
+    filter: LeaderboardFilter
+  ): AccountLeaderboardConnection!
+
   collateralBalance(
     account: Address!
     chainId: Int!
@@ -453,8 +471,73 @@ scalar Bytes32
 scalar DateTime
 scalar Decimal
 
+# Unix seconds (uint256 in contract storage). Used for timestamps that
+# come directly from chain state, where round-tripping to DateTime would
+# require server-side conversion and lose precision. Indexed / derived
+# timestamps use `DateTime`.
+scalar UnixSeconds
+
 interface Node {
   id: ID!
+}
+
+# Operator-pattern filter inputs. Used on per-field filter members in
+# `<Entity>Filter` types. Operators an entity doesn't support reject
+# at the resolver with a clear error rather than silently no-op. See
+# "One filter convention, one sort convention" in the principles.
+
+input AddressFilter {
+  equals: Address
+  in: [Address!]
+  notIn: [Address!]
+  not: Address
+}
+
+input IDFilter {
+  equals: ID
+  in: [ID!]
+  notIn: [ID!]
+  not: ID
+}
+
+input BigIntFilter {
+  equals: BigInt
+  gt: BigInt
+  gte: BigInt
+  lt: BigInt
+  lte: BigInt
+  in: [BigInt!]
+  notIn: [BigInt!]
+  not: BigInt
+}
+
+input IntFilter {
+  equals: Int
+  gt: Int
+  gte: Int
+  lt: Int
+  lte: Int
+  in: [Int!]
+  notIn: [Int!]
+  not: Int
+}
+
+input DateTimeFilter {
+  equals: DateTime
+  gt: DateTime
+  gte: DateTime
+  lt: DateTime
+  lte: DateTime
+}
+
+input StringFilter {
+  equals: String
+  contains: String
+  startsWith: String
+  endsWith: String
+  in: [String!]
+  notIn: [String!]
+  not: String
 }
 
 type PageInfo {
@@ -553,6 +636,22 @@ type Query {
     orderBy: PickConfigurationOrder
   ): PickConfigurationConnection!
 
+  vault(id: ID!): Vault
+  vaultByAddress(address: Address!): Vault
+  vaults(
+    first: Int
+    after: String
+    filter: VaultFilter
+    orderBy: VaultOrder
+  ): VaultConnection!
+
+  leaderboard(
+    metric: LeaderboardMetric!
+    first: Int
+    after: String
+    filter: LeaderboardFilter
+  ): AccountLeaderboardConnection!
+
   collateralBalance(
     account: Address!
     chainId: Int!
@@ -619,7 +718,10 @@ type Account implements Node {
 }
 
 type Question {
-  id: ID!
+  # No synthetic `id` field yet — Question is a derived view, not a
+  # durable entity. Clients key on the underlying `Condition` /
+  # `ConditionGroup` Node IDs reachable through `source`. See
+  # open question D1.
 
   # Exactly one of Condition | ConditionGroup. Modeled as a union so
   # the schema enforces mutual exclusion and clients can't silently
@@ -731,6 +833,7 @@ type Condition implements Node {
     first: Int
     after: String
     filter: PickConfigurationFilter
+    orderBy: PickConfigurationOrder
   ): PickConfigurationConnection!
 
   predictions(
@@ -877,7 +980,11 @@ type Position implements Node {
 }
 
 type Activity {
-  id: ID!
+  # No synthetic `id` field yet — Activity is a derived feed row, not a
+  # durable entity. The wrapped `source` already carries a Node ID;
+  # in-page identity is handled by the connection cursor. See open
+  # question D2.
+
   # The underlying entity this activity row wraps. Concrete type is
   # available via `__typename` — no separate `activityType` enum field
   # because it would duplicate what the union already encodes.
@@ -913,6 +1020,10 @@ type CollateralBalance {
   atBlock: BigInt
 }
 
+# Not a Node — see R9. Cursors over `collateralBalanceHistory` encode
+# (block, timestamp) position. Unlike other stat types, this one is
+# bucketed at read time via `intervalSeconds:` on the root field — the
+# only exception in the schema; see the field description for why.
 type CollateralBalanceSnapshot {
   account: Account!
   chainId: Int!
@@ -941,12 +1052,15 @@ type Protocol {
   ): ProtocolStatsConnection!
   openInterestByCategory: [CategoryOpenInterest!]!
   openInterestByTimeToResolution: [TimeToResolutionBucket!]!
-  vault(address: Address!): Vault
+
+  # Vault is a top-level Node; access via root `vault(id:)`,
+  # `vaultByAddress(address:)`, or `vaults(...)`.
 }
 
 type Vault implements Node {
   id: ID!
   address: Address!
+  collateral: CollateralToken!
   stats(
     first: Int
     after: String
@@ -1161,6 +1275,18 @@ type VaultStatsEdge {
   cursor: String!
 }
 
+type VaultConnection {
+  edges: [VaultEdge!]!
+  nodes: [Vault!]!
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+type VaultEdge {
+  node: Vault!
+  cursor: String!
+}
+
 type AccountStatsConnection {
   edges: [AccountStatsEdge!]!
   nodes: [AccountStat!]!
@@ -1198,6 +1324,12 @@ type CategoryEdge {
 }
 
 # Stats Types
+#
+# Stat rows are time-bucketed values, not addressable entities — they
+# do not implement Node and cannot be refetched via `node(id:)`.
+# Connection cursors over these types encode timestamp position;
+# clients re-query with a `timestamp: DateTimeFilter` to traverse.
+# See open question R9.
 
 type ProtocolStat {
   timestamp: DateTime!
@@ -1259,7 +1391,7 @@ enum QuestionOrderField {
 
 input ConditionFilter {
   search: String
-  conditionGroupId: ID
+  conditionGroupId: IDFilter
   categoryIds: [ID!]
   tags: [String!]
   settled: Boolean
@@ -1299,13 +1431,12 @@ enum ConditionGroupOrderField {
 }
 
 input PredictionFilter {
-  account: Address
-  conditionId: ID
-  conditionGroupId: ID
-  pickConfigurationId: ID
+  account: AddressFilter
+  conditionId: IDFilter
+  conditionGroupId: IDFilter
+  pickConfigurationId: IDFilter
   settled: Boolean
-  createdAfter: DateTime
-  createdBefore: DateTime
+  createdAt: DateTimeFilter
 }
 
 input PredictionOrder {
@@ -1338,12 +1469,11 @@ enum ForecastOrderField {
 }
 
 input TradeFilter {
-  account: Address
-  conditionId: ID
-  conditionGroupId: ID
-  pickConfigurationId: ID
-  createdAfter: DateTime
-  createdBefore: DateTime
+  account: AddressFilter
+  conditionId: IDFilter
+  conditionGroupId: IDFilter
+  pickConfigurationId: IDFilter
+  createdAt: DateTimeFilter
 }
 
 input TradeOrder {
@@ -1359,13 +1489,12 @@ enum TradeOrderField {
 }
 
 input ActivityFilter {
-  account: Address
+  account: AddressFilter
   activityTypes: [ActivityType!]
-  conditionId: ID
-  conditionGroupId: ID
-  pickConfigurationId: ID
-  createdAfter: DateTime
-  createdBefore: DateTime
+  conditionId: IDFilter
+  conditionGroupId: IDFilter
+  pickConfigurationId: IDFilter
+  createdAt: DateTimeFilter
 }
 
 input ActivityOrder {
@@ -1378,10 +1507,14 @@ enum ActivityOrderField {
 }
 
 input PositionFilter {
-  account: Address
-  conditionId: ID
-  conditionGroupId: ID
-  pickConfigurationId: ID
+  account: AddressFilter
+  conditionId: IDFilter
+  conditionGroupId: IDFilter
+  pickConfigurationId: IDFilter
+  balance: BigIntFilter
+  collateral: BigIntFilter
+  settled: Boolean
+  createdAt: DateTimeFilter
 }
 
 input PositionOrder {
@@ -1398,8 +1531,8 @@ enum PositionOrderField {
 }
 
 input PickConfigurationFilter {
-  conditionId: ID
-  conditionGroupId: ID
+  conditionId: IDFilter
+  conditionGroupId: IDFilter
 }
 
 input PickConfigurationOrder {
@@ -1412,11 +1545,10 @@ enum PickConfigurationOrderField {
 }
 
 input CollateralTransferFilter {
-  account: Address
-  chainId: Int
+  account: AddressFilter
+  chainId: IntFilter
   excludeProtocol: Boolean
-  createdAfter: DateTime
-  createdBefore: DateTime
+  createdAt: DateTimeFilter
 }
 
 input CollateralTransferOrder {
@@ -1430,8 +1562,7 @@ enum CollateralTransferOrderField {
 }
 
 input ProtocolStatsFilter {
-  from: DateTime
-  to: DateTime
+  timestamp: DateTimeFilter
 }
 
 input ProtocolStatsOrder {
@@ -1444,8 +1575,7 @@ enum ProtocolStatsOrderField {
 }
 
 input VaultStatsFilter {
-  from: DateTime
-  to: DateTime
+  timestamp: DateTimeFilter
 }
 
 input VaultStatsOrder {
@@ -1457,9 +1587,22 @@ enum VaultStatsOrderField {
   TIMESTAMP
 }
 
+input VaultFilter {
+  address: AddressFilter
+}
+
+input VaultOrder {
+  field: VaultOrderField!
+  direction: OrderDirection! = DESC
+}
+
+enum VaultOrderField {
+  CREATED_AT
+  TOTAL_ASSETS
+}
+
 input AccountStatsFilter {
-  from: DateTime
-  to: DateTime
+  timestamp: DateTimeFilter
 }
 
 input AccountStatsOrder {
@@ -1472,8 +1615,7 @@ enum AccountStatsOrderField {
 }
 
 input LeaderboardFilter {
-  from: DateTime
-  to: DateTime
+  timestamp: DateTimeFilter
 }
 ```
 
@@ -1506,7 +1648,7 @@ input LeaderboardFilter {
 | `protocolStats(from, to)`                                                                         | `protocol.stats(filter: { from, to })`                                                      |
 | `openInterestByCategory`                                                                          | `protocol.openInterestByCategory`                                                           |
 | `openInterestByTimeToResolution`                                                                  | `protocol.openInterestByTimeToResolution`                                                   |
-| `vaultStats(vaultAddress, from, to)`                                                              | `protocol.vault(address).stats(filter: { from, to })`                                       |
+| `vaultStats(vaultAddress, from, to)`                                                              | `vaultByAddress(address).stats(filter: { timestamp: { gte, lte } })`                        |
 | `categoriesPage(take, skip)`                                                                      | `categories(...)`                                                                           |
 | `popularTags`                                                                                     | `popularTags(...)`                                                                          |
 
@@ -1597,30 +1739,37 @@ type Query {
 
 Questions that lock public wire format must be resolved before the per-entity PR that ships the affected type. Additive-only questions can be deferred — adding a field, query, or arg later is non-breaking; removing or reshaping one is.
 
+Numbering is section-prefixed: **D**eferred (`D#`), **P**er-entity (`P#`), **R**esolved (`R#`). Stable across edits — cross-references in the body of this document use these prefixes.
+
 ### Deferred — safe to ship later
 
-1. **`Question.id` synthetic ID** — Underlying `Condition` / `ConditionGroup` already carry Node IDs; clients can key on those. Add a synthetic `Question.id` later if a concrete UI need surfaces. Adding a field is non-breaking; committing to a format prematurely locks it forever.
-2. **`Activity.id` synthetic ID** — Same logic. Each `Activity` row embeds a Prediction / Trade / Forecast that already has a Node ID; cursor handles in-page identity. Skip until a use case appears.
-3. **`totalCount` per-connection** — Per-connection call. Add where the count is cheap (covered index, materialized aggregate); omit where it's a table scan. Adding later is non-breaking.
-4. **`last` / `before` reverse pagination** — Forward is a strict subset; reverse is purely additive. Ship forward-only; revisit if clients need reverse traversal.
+- **D1. `Question.id` synthetic ID** — Underlying `Condition` / `ConditionGroup` already carry Node IDs; clients can key on those. Add a synthetic `Question.id` later if a concrete UI need surfaces. Adding a field is non-breaking; committing to a format prematurely locks it forever.
+- **D2. `Activity.id` synthetic ID** — Same logic. Each `Activity` row embeds a Prediction / Trade / Forecast that already has a Node ID; cursor handles in-page identity. Skip until a use case appears.
+- **D3. `totalCount` per-connection** — Per-connection call. Add where the count is cheap (covered index, materialized aggregate); omit where it's a table scan. Adding later is non-breaking.
+- **D4. `last` / `before` reverse pagination** — Forward is a strict subset; reverse is purely additive. Ship forward-only; revisit if clients need reverse traversal.
 
 ### Per-entity — resolve at each PR
 
-6. **Sort fields by entity** — Now answered structurally: each entity declares its own `<Entity>OrderField` enum listing the fields its indexes support (see "One filter convention, one sort convention" above). Per-entity PRs decide their enum members based on actual index coverage; the SDL enforces the answer.
+- **P1. Sort fields by entity** — Each entity declares its own `<Entity>OrderField` enum listing the fields its indexes support (see "One filter convention, one sort convention" above). Per-entity PRs decide their enum members based on actual index coverage; the SDL enforces the answer.
 
 ### Resolved — locked direction, doc updated
 
-3. **`Forecast.subject` naming** — RESOLVED. The EAS "subject" (recipient) on a forecast attestation is the conditionId it targets; that link is already typed as `condition: Condition` on `Forecast`. The redundant `subject: Address` field is dropped from the SDL. Forecasts target a single `Condition` (not a `ConditionGroup`), so `ForecastFilter.conditionGroupId` is also dropped.
-4. **`Prediction.counterparty` nullability** — RESOLVED. Ship non-null (`counterparty: Account!`). Prisma schema declares the column non-null (`counterparty String @db.VarChar` in `prisma/schema.prisma`); every indexer write path (`predictionMarketEscrowIndexer.ts:706, 743`) sets it from the on-chain event payload, which is itself a non-null `0x${string}`. No backfill or schema migration needed.
-5. **`Question` union vs. nullable pair** — RESOLVED. Modeled as `union ConditionOrConditionGroup = Condition | ConditionGroup`, exposed as `Question.source: ConditionOrConditionGroup!`. Schema enforces "exactly one of," eliminating the both-null / both-set bug class. The `questionType: QuestionType` enum is removed — `__typename` on the union member subsumes it. Name follows GitHub's `IssueOrPullRequest` precedent: literal, no abbreviation, no parallel concept ("Market", "Source") introduced.
-6. **Collateral field and type naming** — RESOLVED. Type is `CollateralToken` (was `CollateralAsset`); field is `collateral: CollateralToken!` on every type that exposes it (`Prediction`, `Position`, `Trade`, `CollateralBalance`, `CollateralBalanceSnapshot`, `CollateralTransfer`). The full `CollateralToken` record carries `{ symbol, address, decimals, chainId }`, so the field name doesn't need to disambiguate between address and ticker — both live inside.
+- **R1. `Forecast.subject` naming** — The EAS "subject" (recipient) on a forecast attestation is the conditionId it targets; that link is already typed as `condition: Condition` on `Forecast`. The redundant `subject: Address` field is dropped from the SDL. Forecasts target a single `Condition` (not a `ConditionGroup`), so `ForecastFilter.conditionGroupId` is also dropped.
+- **R2. `Prediction.counterparty` nullability** — Ship non-null (`counterparty: Account!`). Prisma schema declares the column non-null (`counterparty String @db.VarChar` in `prisma/schema.prisma`); every indexer write path (`predictionMarketEscrowIndexer.ts:706, 743`) sets it from the on-chain event payload, which is itself a non-null `0x${string}`. No backfill or schema migration needed.
+- **R3. `Question` union vs. nullable pair** — Modeled as `union ConditionOrConditionGroup = Condition | ConditionGroup`, exposed as `Question.source: ConditionOrConditionGroup!`. Schema enforces "exactly one of," eliminating the both-null / both-set bug class. The `questionType: QuestionType` enum is removed — `__typename` on the union member subsumes it. Name follows GitHub's `IssueOrPullRequest` precedent: literal, no abbreviation, no parallel concept ("Market", "Source") introduced.
+- **R4. Collateral field and type naming** — Type is `CollateralToken` (was `CollateralAsset`); field is `collateral: CollateralToken!` on every type that exposes it (`Prediction`, `Position`, `Trade`, `CollateralBalance`, `CollateralBalanceSnapshot`, `CollateralTransfer`). The full `CollateralToken` record carries `{ symbol, address, decimals, chainId }`, so the field name doesn't need to disambiguate between address and ticker — both live inside.
+- **R5. Status enums** — The audit revealed that the doc's status enums were aspirational, not migrations from existing wire fields. Once we accept that the data model has only the states it has, every proposed `*Status` enum collapses to either a Boolean (which we already have) or a derivation clients can do themselves. So:
 
-7. **Status enums — RESOLVED.** The audit revealed that the doc's status enums were aspirational, not migrations from existing wire fields. Once we accept that the data model has only the states it has, every proposed `*Status` enum collapses to either a Boolean (which we already have) or a derivation clients can do themselves. So:
+  - **`ConditionStatus` enum — dropped.** No synthetic status. `Condition` directly exposes the three Booleans that carry its actual state: `settled: Boolean!`, `resolvedToYes: Boolean!`, `nonDecisive: Boolean!`, plus `settledAt: UnixSeconds`. Clients render `ACTIVE`/`RESOLVED`/`TIE`/etc. however they want from these. `ConditionFilter.status` replaced with flat Boolean filters (`settled`, `resolvedToYes`, `nonDecisive`).
+  - **`ConditionGroupStatus` enum — dropped.** ConditionGroup has no status field today and isn't getting one. If any UI needs a group-level state, it derives from child Conditions.
+  - **`PredictionStatus` enum — dropped.** Was sugar on the existing `settled` Boolean (`OPEN = !settled`, `SETTLED = settled`); no `CANCELLED` state exists in the data model. `Prediction` directly exposes `settled: Boolean!` + `result: PredictionResult!`. `PredictionFilter.status` replaced with `settled: Boolean`.
+  - **`QuestionStatus` enum — dropped.** Question wraps either Condition or ConditionGroup via the `source` union; clients read state through `... on Condition { settled, resolvedToYes, nonDecisive }`. No view-level status field needed.
+  - **`PredictionResult` enum values — finalized as** `{ UNRESOLVED, PREDICTOR_WINS, COUNTERPARTY_WINS }`. Contract collapses non-decisive outcomes to `COUNTERPARTY_WINS` at the resolution layer (`PredictionMarketEscrow.sol:_evaluatePick`, comment at L1262–1267: "SettlementResult has no DRAW variant ... counterparties bear no prediction risk on void/tie outcomes"). Made `Prediction.result` non-null.
 
-   - **`ConditionStatus` enum — dropped.** No synthetic status. `Condition` directly exposes the three Booleans that carry its actual state: `settled: Boolean!`, `resolvedToYes: Boolean!`, `nonDecisive: Boolean!`, plus `settledAt: UnixSeconds`. Clients render `ACTIVE`/`RESOLVED`/`TIE`/etc. however they want from these. `ConditionFilter.status` replaced with flat Boolean filters (`settled`, `resolvedToYes`, `nonDecisive`).
-   - **`ConditionGroupStatus` enum — dropped.** ConditionGroup has no status field today and isn't getting one. If any UI needs a group-level state, it derives from child Conditions.
-   - **`PredictionStatus` enum — dropped.** Was sugar on the existing `settled` Boolean (`OPEN = !settled`, `SETTLED = settled`); no `CANCELLED` state exists in the data model. `Prediction` directly exposes `settled: Boolean!` + `result: PredictionResult!`. `PredictionFilter.status` replaced with `settled: Boolean`.
-   - **`QuestionStatus` enum — dropped.** Question wraps either Condition or ConditionGroup via the `source` union; clients read state through `... on Condition { settled, resolvedToYes, nonDecisive }`. No view-level status field needed.
-   - **`PredictionResult` enum values — finalized as** `{ UNRESOLVED, PREDICTOR_WINS, COUNTERPARTY_WINS }`. Contract collapses non-decisive outcomes to `COUNTERPARTY_WINS` at the resolution layer (`PredictionMarketEscrow.sol:_evaluatePick`, comment at L1262–1267: "SettlementResult has no DRAW variant ... counterparties bear no prediction risk on void/tie outcomes"). Made `Prediction.result` non-null.
+  **Follow-up cleanup (separate PR to staging, not this doc PR):** the indexer's `mapSettlementResult` retains a `case 3 → 'NON_DECISIVE'` branch unreachable from current contract behavior; the Prisma `SettlementResult` enum still lists `NON_DECISIVE`. Both are vestigial. Cleanup can either drop them outright (after confirming no live rows carry the value) or leave a tombstone on the Prisma side and remove only the indexer branch.
 
-   **Follow-up cleanup (separate PR to staging, not this doc PR):** the indexer's `mapSettlementResult` retains a `case 3 → 'NON_DECISIVE'` branch unreachable from current contract behavior; the Prisma `SettlementResult` enum still lists `NON_DECISIVE`. Both are vestigial. Cleanup can either drop them outright (after confirming no live rows carry the value) or leave a tombstone on the Prisma side and remove only the indexer branch.
+- **R6. Sort shape (singular vs array)** — Singular `orderBy: <Entity>Order` (matching GitHub's `IssueOrder` precedent), not the array shape originally drafted. Multi-key tiebreakers can be added later non-breakingly via a `then: <Entity>Order` field on the order input if real demand surfaces.
+- **R7. Filter convention** — Operator-pattern (Prisma-style) for single-value scalars (`AddressFilter`, `IDFilter`, `BigIntFilter`, `IntFilter`, `DateTimeFilter`, `StringFilter`). Multi-value membership filters and full-text search stay flat. See principles section for details.
+- **R8. `Vault` root access** — Vault is a Node, so it gets `vault(id:)`, `vaultByAddress(address:)`, and `vaults(...)` root fields — matching the prediction/trade/forecast pattern. The previous nesting under `protocol.vault(address)` is removed; Vault is independent and shouldn't sit behind a Protocol grouping.
+- **R9. Stat-row connections over non-Node types** — `ProtocolStat`, `VaultStat`, `AccountStat`, and `CollateralBalanceSnapshot` stay as Connection members without implementing `Node`. They are time-bucketed values, not addressable entities; refetching a stat row by ID is meaningless because the row is uniquely identified by `(entity, timestamp)` already reachable via the parent + filter. Cursors on these connections encode timestamp position. The type-level descriptions in the SDL document this.
+- **R10. `UnixSeconds` scalar** — Declared explicitly. Used for timestamps that come directly from chain storage (uint256 seconds) where round-tripping to `DateTime` loses precision. Indexed / derived timestamps continue to use `DateTime`.

--- a/docs/sapience-graphql-api-redesign.md
+++ b/docs/sapience-graphql-api-redesign.md
@@ -629,7 +629,6 @@ type Question {
 
   title: String!
   description: String
-  status: QuestionStatus!
   category: Category
   tags: [String!]!
 
@@ -665,13 +664,6 @@ type Question {
   createdAt: DateTime!
   updatedAt: DateTime
   resolvesAt: DateTime
-}
-
-enum QuestionStatus {
-  ACTIVE
-  RESOLVED
-  CANCELLED
-  ARCHIVED
 }
 
 union ConditionOrConditionGroup = Condition | ConditionGroup
@@ -718,7 +710,19 @@ type Condition implements Node {
   databaseId: Int!
   title: String!
   description: String
-  status: ConditionStatus!
+
+  # Resolution state. Three Booleans match the underlying on-chain
+  # state machine: `settled` flips true when the resolver returns,
+  # `resolvedToYes` is only meaningful when `settled` is true, and
+  # `nonDecisive` marks tie/void outcomes (which the protocol collapses
+  # to COUNTERPARTY_WINS at the Prediction layer). Question-level views
+  # derive their state from these Booleans on the underlying Condition;
+  # there's no separate `ConditionStatus` enum because today's data
+  # model has no other states (no `CANCELLED`, no `ARCHIVED`).
+  settled: Boolean!
+  resolvedToYes: Boolean!
+  nonDecisive: Boolean!
+  settledAt: UnixSeconds
 
   conditionGroup: ConditionGroup
   question: Question!
@@ -751,13 +755,6 @@ type Condition implements Node {
   createdAt: DateTime!
   updatedAt: DateTime
   resolvesAt: DateTime
-}
-
-enum ConditionStatus {
-  ACTIVE
-  RESOLVED
-  CANCELLED
-  ARCHIVED
 }
 
 type PickConfiguration implements Node {
@@ -804,25 +801,23 @@ type Prediction implements Node {
   predictionId: BigInt!
 
   predictor: Account!
-  counterparty: Account
+  counterparty: Account!
   pickConfiguration: PickConfiguration!
   conditions: [Condition!]!
 
   collateral: CollateralToken!
   collateralAmount: Decimal!
 
-  status: PredictionStatus!
+  # Settlement state. `settled` flips true when the on-chain prediction
+  # is resolved; `result` carries the outcome. No separate
+  # `PredictionStatus` enum — today's data model has no `CANCELLED`
+  # state, so a derived status enum would just be sugar on the Boolean.
+  settled: Boolean!
   result: PredictionResult!
   payout: Decimal
 
   createdAt: DateTime!
   settledAt: DateTime
-}
-
-enum PredictionStatus {
-  OPEN
-  SETTLED
-  CANCELLED
 }
 
 enum PredictionResult {
@@ -1241,7 +1236,6 @@ input QuestionFilter {
   search: String
   categoryIds: [ID!]
   tags: [String!]
-  status: [QuestionStatus!]
 }
 
 input QuestionOrder {
@@ -1262,7 +1256,9 @@ input ConditionFilter {
   conditionGroupId: ID
   categoryIds: [ID!]
   tags: [String!]
-  status: [ConditionStatus!]
+  settled: Boolean
+  resolvedToYes: Boolean
+  nonDecisive: Boolean
 }
 
 input ConditionOrder {
@@ -1301,7 +1297,7 @@ input PredictionFilter {
   conditionId: ID
   conditionGroupId: ID
   pickConfigurationId: ID
-  status: [PredictionStatus!]
+  settled: Boolean
   createdAfter: DateTime
   createdBefore: DateTime
 }
@@ -1623,16 +1619,12 @@ Questions that lock public wire format must be resolved before the per-entity PR
 5. **`Question` union vs. nullable pair** — RESOLVED. Modeled as `union ConditionOrConditionGroup = Condition | ConditionGroup`, exposed as `Question.source: ConditionOrConditionGroup!`. Schema enforces "exactly one of," eliminating the both-null / both-set bug class. The `questionType: QuestionType` enum is removed — `__typename` on the union member subsumes it. Name follows GitHub's `IssueOrPullRequest` precedent: literal, no abbreviation, no parallel concept ("Market", "Source") introduced.
 6. **Collateral field and type naming** — RESOLVED. Type is `CollateralToken` (was `CollateralAsset`); field is `collateral: CollateralToken!` on every type that exposes it (`Prediction`, `Position`, `Trade`, `CollateralBalance`, `CollateralBalanceSnapshot`, `CollateralTransfer`). The full `CollateralToken` record carries `{ symbol, address, decimals, chainId }`, so the field name doesn't need to disambiguate between address and ticker — both live inside.
 
-### Still open
+7. **Status enums — RESOLVED.** The audit revealed that the doc's status enums were aspirational, not migrations from existing wire fields. Once we accept that the data model has only the states it has, every proposed `*Status` enum collapses to either a Boolean (which we already have) or a derivation clients can do themselves. So:
 
-7. **Status enums — audit done, design call needed.** The audit revealed that the doc's status enums were aspirational, not migrations from existing String fields. Findings + remaining design questions:
+   - **`ConditionStatus` enum — dropped.** No synthetic status. `Condition` directly exposes the three Booleans that carry its actual state: `settled: Boolean!`, `resolvedToYes: Boolean!`, `nonDecisive: Boolean!`, plus `settledAt: UnixSeconds`. Clients render `ACTIVE`/`RESOLVED`/`TIE`/etc. however they want from these. `ConditionFilter.status` replaced with flat Boolean filters (`settled`, `resolvedToYes`, `nonDecisive`).
+   - **`ConditionGroupStatus` enum — dropped.** ConditionGroup has no status field today and isn't getting one. If any UI needs a group-level state, it derives from child Conditions.
+   - **`PredictionStatus` enum — dropped.** Was sugar on the existing `settled` Boolean (`OPEN = !settled`, `SETTLED = settled`); no `CANCELLED` state exists in the data model. `Prediction` directly exposes `settled: Boolean!` + `result: PredictionResult!`. `PredictionFilter.status` replaced with `settled: Boolean`.
+   - **`QuestionStatus` enum — dropped.** Question wraps either Condition or ConditionGroup via the `source` union; clients read state through `... on Condition { settled, resolvedToYes, nonDecisive }`. No view-level status field needed.
+   - **`PredictionResult` enum values — finalized as** `{ UNRESOLVED, PREDICTOR_WINS, COUNTERPARTY_WINS }`. Contract collapses non-decisive outcomes to `COUNTERPARTY_WINS` at the resolution layer (`PredictionMarketEscrow.sol:_evaluatePick`, comment at L1262–1267: "SettlementResult has no DRAW variant ... counterparties bear no prediction risk on void/tie outcomes"). Made `Prediction.result` non-null.
 
-   **ConditionGroup — RESOLVED inside this open question.** No `status` field today, no `status` field going forward. `ConditionGroupStatus` enum dropped; `ConditionGroup.status` field dropped; `ConditionGroupFilter.status` dropped. Group-level state is derivable client-side from child Condition state if any UI needs it.
-
-   **Prediction `result` — RESOLVED inside this open question.** Public enum is `enum PredictionResult { UNRESOLVED, PREDICTOR_WINS, COUNTERPARTY_WINS }`. The Prisma `SettlementResult` enum has a fourth value `NON_DECISIVE`, but the contract collapses non-decisive outcomes to `COUNTERPARTY_WINS` at the resolution layer (`PredictionMarketEscrow.sol:_evaluatePick` and the rationale comment at L1262–1267: "non-decisive outcomes are treated as counterparty wins ... SettlementResult has no DRAW variant"). The indexer's `mapSettlementResult` retains a `case 3 → 'NON_DECISIVE'` branch that is unreachable from current contract behavior — vestigial code, future cleanup. Any historical rows carrying `NON_DECISIVE` from an earlier protocol version can be folded to `COUNTERPARTY_WINS` on the fly in the resolver; no backfill required.
-
-   **Condition `status` — still open.** No `status` field today; state is three Booleans (`settled`, `resolvedToYes`, `nonDecisive`). The proposed `enum ConditionStatus { ACTIVE, RESOLVED, CANCELLED, ARCHIVED }` contains values (`CANCELLED`, `ARCHIVED`) that nothing in the data model produces. Open: drop those values and derive `status` from the Booleans (`ACTIVE`/`RESOLVED`, with `nonDecisive` either folded into `RESOLVED` or surfaced as a distinct state), or add columns to support `CANCELLED` / `ARCHIVED` if there's a real product need?
-
-   **Prediction `status` vs. `settled` — still open.** Proposed `enum PredictionStatus { OPEN, SETTLED, CANCELLED }` is mostly sugar on the existing `settled` Boolean (`OPEN = !settled`, `SETTLED = settled`). `CANCELLED` has no source in the data model today. Open: drop `CANCELLED` and let `status` be a derived two-state enum, or define what produces a cancelled prediction (admin override? on-chain unwind path?) and add the column.
-
-   **`Question.status` derivation — still open.** Since `Question` wraps either a `Condition` or a `ConditionGroup`, and `ConditionGroup` has no status, the `Question.status` field needs an explicit derivation rule. Plausible: when source is a Condition, mirror its status; when source is a ConditionGroup, compute from children (all child Conditions resolved → `RESOLVED`, any unresolved → `ACTIVE`, etc.). Open: define the rule formally, or drop `Question.status` and let clients derive whatever view-state they need themselves.
+   **Follow-up cleanup (separate PR to staging, not this doc PR):** the indexer's `mapSettlementResult` retains a `case 3 → 'NON_DECISIVE'` branch unreachable from current contract behavior; the Prisma `SettlementResult` enum still lists `NON_DECISIVE`. Both are vestigial. Cleanup can either drop them outright (after confirming no live rows carry the value) or leave a tombstone on the Prisma side and remove only the indexer branch.

--- a/docs/sapience-graphql-api-redesign.md
+++ b/docs/sapience-graphql-api-redesign.md
@@ -681,7 +681,6 @@ type ConditionGroup implements Node {
   databaseId: Int!
   title: String!
   description: String
-  status: ConditionGroupStatus!
 
   question: Question!
   conditions(
@@ -712,13 +711,6 @@ type ConditionGroup implements Node {
 
   createdAt: DateTime!
   updatedAt: DateTime
-}
-
-enum ConditionGroupStatus {
-  ACTIVE
-  RESOLVED
-  CANCELLED
-  ARCHIVED
 }
 
 type Condition implements Node {
@@ -820,7 +812,7 @@ type Prediction implements Node {
   collateralAmount: Decimal!
 
   status: PredictionStatus!
-  result: PredictionResult
+  result: PredictionResult!
   payout: Decimal
 
   createdAt: DateTime!
@@ -834,9 +826,9 @@ enum PredictionStatus {
 }
 
 enum PredictionResult {
-  WON
-  LOST
-  PUSH
+  UNRESOLVED
+  PREDICTOR_WINS
+  COUNTERPARTY_WINS
 }
 
 type Forecast implements Node {
@@ -1290,7 +1282,6 @@ input ConditionGroupFilter {
   search: String
   categoryIds: [ID!]
   tags: [String!]
-  status: [ConditionGroupStatus!]
 }
 
 input ConditionGroupOrder {
@@ -1628,10 +1619,20 @@ Questions that lock public wire format must be resolved before the per-entity PR
 ### Resolved — locked direction, doc updated
 
 3. **`Forecast.subject` naming** — RESOLVED. The EAS "subject" (recipient) on a forecast attestation is the conditionId it targets; that link is already typed as `condition: Condition` on `Forecast`. The redundant `subject: Address` field is dropped from the SDL. Forecasts target a single `Condition` (not a `ConditionGroup`), so `ForecastFilter.conditionGroupId` is also dropped.
-4. **`Prediction.counterparty` nullability** — DECISION: ship non-null (`counterparty: Account!`). Prerequisite: data audit confirming no rows in production have a null counterparty (orphaned indexer rows, mid-settlement intermediate states). If any null rows exist, either backfill or fix the indexer before flipping the field to non-null — GraphQL surfaces a null on a non-null field as a query-level error, which would break list queries silently for affected accounts.
+4. **`Prediction.counterparty` nullability** — RESOLVED. Ship non-null (`counterparty: Account!`). Prisma schema declares the column non-null (`counterparty String @db.VarChar` in `prisma/schema.prisma`); every indexer write path (`predictionMarketEscrowIndexer.ts:706, 743`) sets it from the on-chain event payload, which is itself a non-null `0x${string}`. No backfill or schema migration needed.
 5. **`Question` union vs. nullable pair** — RESOLVED. Modeled as `union ConditionOrConditionGroup = Condition | ConditionGroup`, exposed as `Question.source: ConditionOrConditionGroup!`. Schema enforces "exactly one of," eliminating the both-null / both-set bug class. The `questionType: QuestionType` enum is removed — `__typename` on the union member subsumes it. Name follows GitHub's `IssueOrPullRequest` precedent: literal, no abbreviation, no parallel concept ("Market", "Source") introduced.
 6. **Collateral field and type naming** — RESOLVED. Type is `CollateralToken` (was `CollateralAsset`); field is `collateral: CollateralToken!` on every type that exposes it (`Prediction`, `Position`, `Trade`, `CollateralBalance`, `CollateralBalanceSnapshot`, `CollateralTransfer`). The full `CollateralToken` record carries `{ symbol, address, decimals, chainId }`, so the field name doesn't need to disambiguate between address and ticker — both live inside.
 
 ### Still open
 
-7. **Status enum audit** — Need an audit of what status values exist today on `Condition`, `ConditionGroup`, and `Prediction` across the Prisma schema, resolvers, and any String-typed status fields currently on the wire. Output: a canonical `<Entity>Status` enum per entity, with a deprecation plan for any existing String fields. Blocks the first per-entity PR for any of those three types. Investigation pending.
+7. **Status enums — audit done, design call needed.** The audit revealed that the doc's status enums were aspirational, not migrations from existing String fields. Findings + remaining design questions:
+
+   **ConditionGroup — RESOLVED inside this open question.** No `status` field today, no `status` field going forward. `ConditionGroupStatus` enum dropped; `ConditionGroup.status` field dropped; `ConditionGroupFilter.status` dropped. Group-level state is derivable client-side from child Condition state if any UI needs it.
+
+   **Prediction `result` — RESOLVED inside this open question.** Public enum is `enum PredictionResult { UNRESOLVED, PREDICTOR_WINS, COUNTERPARTY_WINS }`. The Prisma `SettlementResult` enum has a fourth value `NON_DECISIVE`, but the contract collapses non-decisive outcomes to `COUNTERPARTY_WINS` at the resolution layer (`PredictionMarketEscrow.sol:_evaluatePick` and the rationale comment at L1262–1267: "non-decisive outcomes are treated as counterparty wins ... SettlementResult has no DRAW variant"). The indexer's `mapSettlementResult` retains a `case 3 → 'NON_DECISIVE'` branch that is unreachable from current contract behavior — vestigial code, future cleanup. Any historical rows carrying `NON_DECISIVE` from an earlier protocol version can be folded to `COUNTERPARTY_WINS` on the fly in the resolver; no backfill required.
+
+   **Condition `status` — still open.** No `status` field today; state is three Booleans (`settled`, `resolvedToYes`, `nonDecisive`). The proposed `enum ConditionStatus { ACTIVE, RESOLVED, CANCELLED, ARCHIVED }` contains values (`CANCELLED`, `ARCHIVED`) that nothing in the data model produces. Open: drop those values and derive `status` from the Booleans (`ACTIVE`/`RESOLVED`, with `nonDecisive` either folded into `RESOLVED` or surfaced as a distinct state), or add columns to support `CANCELLED` / `ARCHIVED` if there's a real product need?
+
+   **Prediction `status` vs. `settled` — still open.** Proposed `enum PredictionStatus { OPEN, SETTLED, CANCELLED }` is mostly sugar on the existing `settled` Boolean (`OPEN = !settled`, `SETTLED = settled`). `CANCELLED` has no source in the data model today. Open: drop `CANCELLED` and let `status` be a derived two-state enum, or define what produces a cancelled prediction (admin override? on-chain unwind path?) and add the column.
+
+   **`Question.status` derivation — still open.** Since `Question` wraps either a `Condition` or a `ConditionGroup`, and `ConditionGroup` has no status, the `Question.status` field needs an explicit derivation rule. Plausible: when source is a Condition, mirror its status; when source is a ConditionGroup, compute from children (all child Conditions resolved → `RESOLVED`, any unresolved → `ACTIVE`, etc.). Open: define the rule formally, or drop `Question.status` and let clients derive whatever view-state they need themselves.

--- a/docs/sapience-graphql-api-redesign.md
+++ b/docs/sapience-graphql-api-redesign.md
@@ -1626,7 +1626,7 @@ input LeaderboardFilter {
 | Current Resolver                                                                                  | Target API                                                                                  |
 | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | `account(address)`                                                                                | `account(address)`                                                                          |
-| `accountStats(address, from, to)`                                                                 | `account(address).stats(filter: { from, to })`                                              |
+| `accountStats(address, from, to)`                                                                 | `account(address).stats(filter: { timestamp: { gte, lte } })`                               |
 | `accountStatsRank(address, filters)`                                                              | `account(address).rank(metric: ..., filter: ...)`                                           |
 | `accountStatsLeaderboardPage(filters, take, skip)`                                                | `leaderboard(metric: ..., ...)`                                                             |
 | `accountAccuracyRank(address)`                                                                    | `account(address).rank(metric: ACCURACY)`                                                   |
@@ -1645,7 +1645,7 @@ input LeaderboardFilter {
 | `collateralBalance(address, chainId, atBlock)`                                                    | `collateralBalance(account, chainId, atBlock)` or `account(address).collateralBalance(...)` |
 | `collateralBalanceHistory(address, chainId, count, intervalSeconds)`                              | `collateralBalanceHistory(account, chainId, first, after, intervalSeconds)`                 |
 | `collateralTransfersPage(address, chainId, excludeProtocol, orderBy, orderDirection, take, skip)` | `collateralTransfers(...)`                                                                  |
-| `protocolStats(from, to)`                                                                         | `protocol.stats(filter: { from, to })`                                                      |
+| `protocolStats(from, to)`                                                                         | `protocol.stats(filter: { timestamp: { gte, lte } })`                                       |
 | `openInterestByCategory`                                                                          | `protocol.openInterestByCategory`                                                           |
 | `openInterestByTimeToResolution`                                                                  | `protocol.openInterestByTimeToResolution`                                                   |
 | `vaultStats(vaultAddress, from, to)`                                                              | `vaultByAddress(address).stats(filter: { timestamp: { gte, lte } })`                        |

--- a/docs/sapience-graphql-api-redesign.md
+++ b/docs/sapience-graphql-api-redesign.md
@@ -1432,7 +1432,6 @@ enum CollateralTransferOrderField {
 input ProtocolStatsFilter {
   from: DateTime
   to: DateTime
-  interval: StatsInterval
 }
 
 input ProtocolStatsOrder {
@@ -1447,7 +1446,6 @@ enum ProtocolStatsOrderField {
 input VaultStatsFilter {
   from: DateTime
   to: DateTime
-  interval: StatsInterval
 }
 
 input VaultStatsOrder {
@@ -1462,7 +1460,6 @@ enum VaultStatsOrderField {
 input AccountStatsFilter {
   from: DateTime
   to: DateTime
-  interval: StatsInterval
 }
 
 input AccountStatsOrder {
@@ -1472,13 +1469,6 @@ input AccountStatsOrder {
 
 enum AccountStatsOrderField {
   TIMESTAMP
-}
-
-enum StatsInterval {
-  HOUR
-  DAY
-  WEEK
-  MONTH
 }
 
 input LeaderboardFilter {

--- a/docs/sapience-graphql-api-redesign.md
+++ b/docs/sapience-graphql-api-redesign.md
@@ -129,7 +129,7 @@ where `conditions` is a derived convenience field.
 
 Collateral is currently always wUSDe.
 
-However, because the model is technically multi-collateral aware, public types should expose a `collateralAsset` field for forward compatibility.
+However, because the model is technically multi-collateral aware, public types should expose a `collateral: CollateralToken!` field for forward compatibility.
 
 Recommended documentation language:
 
@@ -621,11 +621,11 @@ type Account implements Node {
 type Question {
   id: ID!
 
-  # Exactly one of Condition | ConditionGroup. Resolved as a union
-  # (open question #9) so the schema enforces mutual exclusion and
-  # clients can't silently observe a both-null or both-set state.
-  # Union name is TBD — see open question #9 for the options.
-  source: QuestionSourceTBD!
+  # Exactly one of Condition | ConditionGroup. Modeled as a union so
+  # the schema enforces mutual exclusion and clients can't silently
+  # observe a both-null or both-set state. `__typename` on the union
+  # member subsumes the old `questionType` enum.
+  source: ConditionOrConditionGroup!
 
   title: String!
   description: String
@@ -673,6 +673,8 @@ enum QuestionStatus {
   CANCELLED
   ARCHIVED
 }
+
+union ConditionOrConditionGroup = Condition | ConditionGroup
 
 type ConditionGroup implements Node {
   id: ID!
@@ -814,7 +816,7 @@ type Prediction implements Node {
   pickConfiguration: PickConfiguration!
   conditions: [Condition!]!
 
-  collateralAsset: CollateralAsset!
+  collateral: CollateralToken!
   collateralAmount: Decimal!
 
   status: PredictionStatus!
@@ -861,7 +863,7 @@ type Trade implements Node {
   pickConfiguration: PickConfiguration!
   conditions: [Condition!]!
 
-  collateralAsset: CollateralAsset!
+  collateral: CollateralToken!
   collateralAmount: Decimal
 
   price: Decimal
@@ -877,7 +879,7 @@ type Position implements Node {
   pickConfiguration: PickConfiguration!
   conditions: [Condition!]!
 
-  collateralAsset: CollateralAsset!
+  collateral: CollateralToken!
   size: Decimal
   averagePrice: Decimal
   realizedPnl: Decimal
@@ -903,7 +905,7 @@ enum ActivityType {
   FORECAST
 }
 
-type CollateralAsset {
+type CollateralToken {
   symbol: String!
   address: Address!
   decimals: Int!
@@ -913,7 +915,7 @@ type CollateralAsset {
 type CollateralBalance {
   account: Account!
   chainId: Int!
-  asset: CollateralAsset!
+  collateral: CollateralToken!
   amount: Decimal!
   atBlock: BigInt
 }
@@ -921,7 +923,7 @@ type CollateralBalance {
 type CollateralBalanceSnapshot {
   account: Account!
   chainId: Int!
-  asset: CollateralAsset!
+  collateral: CollateralToken!
   amount: Decimal!
   blockNumber: BigInt!
   timestamp: DateTime!
@@ -931,7 +933,7 @@ type CollateralTransfer implements Node {
   id: ID!
   account: Account!
   chainId: Int!
-  asset: CollateralAsset!
+  collateral: CollateralToken!
   amount: Decimal!
   transactionHash: Bytes32!
   createdAt: DateTime!
@@ -1627,18 +1629,9 @@ Questions that lock public wire format must be resolved before the per-entity PR
 
 3. **`Forecast.subject` naming** — RESOLVED. The EAS "subject" (recipient) on a forecast attestation is the conditionId it targets; that link is already typed as `condition: Condition` on `Forecast`. The redundant `subject: Address` field is dropped from the SDL. Forecasts target a single `Condition` (not a `ConditionGroup`), so `ForecastFilter.conditionGroupId` is also dropped.
 4. **`Prediction.counterparty` nullability** — DECISION: ship non-null (`counterparty: Account!`). Prerequisite: data audit confirming no rows in production have a null counterparty (orphaned indexer rows, mid-settlement intermediate states). If any null rows exist, either backfill or fix the indexer before flipping the field to non-null — GraphQL surfaces a null on a non-null field as a query-level error, which would break list queries silently for affected accounts.
-5. **`Question` union vs. nullable pair** — RESOLVED on the shape: union. Schema enforces "exactly one of `Condition` | `ConditionGroup`," eliminating the both-null / both-set bug class. The `questionType: QuestionType` enum is removed (`__typename` on the union member subsumes it). Union name is still open — see "Still open" below.
+5. **`Question` union vs. nullable pair** — RESOLVED. Modeled as `union ConditionOrConditionGroup = Condition | ConditionGroup`, exposed as `Question.source: ConditionOrConditionGroup!`. Schema enforces "exactly one of," eliminating the both-null / both-set bug class. The `questionType: QuestionType` enum is removed — `__typename` on the union member subsumes it. Name follows GitHub's `IssueOrPullRequest` precedent: literal, no abbreviation, no parallel concept ("Market", "Source") introduced.
+6. **Collateral field and type naming** — RESOLVED. Type is `CollateralToken` (was `CollateralAsset`); field is `collateral: CollateralToken!` on every type that exposes it (`Prediction`, `Position`, `Trade`, `CollateralBalance`, `CollateralBalanceSnapshot`, `CollateralTransfer`). The full `CollateralToken` record carries `{ symbol, address, decimals, chainId }`, so the field name doesn't need to disambiguate between address and ticker — both live inside.
 
 ### Still open
 
-5. **Status enum audit** — Need an audit of what status values exist today on `Condition`, `ConditionGroup`, and `Prediction` across the Prisma schema, resolvers, and any String-typed status fields currently on the wire. Output: a canonical `<Entity>Status` enum per entity, with a deprecation plan for any existing String fields. Blocks the first per-entity PR for any of those three types. Investigation pending.
-   9b. **`Question` union name** — Candidates under consideration:
-   - `Market` — cleanest, but introduces a domain term not yet used elsewhere in the schema; risk of collision if "market" later means something narrower (orderbook-backed market, secondary market, etc.).
-   - `QuestionMarket` — explicit prefix, no collision risk, slight redundancy.
-   - `QuestionSource` — emphasizes "the underlying data source for this Question view"; reads well, no domain-term capture.
-   - `QuestionSubject` — mirrors the existing `ActivitySubject` union pattern; potential confusion since we just dropped "subject" as EAS jargon from `Forecast`.
-6. **`collateralAsset` field naming** — The type shape is settled (`type CollateralAsset { symbol, address, decimals, chainId }` — a full asset record, not a scalar). What's open is whether the field `Prediction.collateralAsset: CollateralAsset!` is the clearest name, or whether one of these reads better:
-   - `collateral: CollateralAsset!` — shortest; field name is the role, type is the shape.
-   - `collateralToken: CollateralAsset!` — explicit that it's an ERC-20 token, not a generic asset class.
-   - Rename type to `CollateralToken` and field to `collateral: CollateralToken!` — same idea, expressed through the type name instead of the field name.
-     Note: this is field-naming polish, not a wire-shape question — once chosen, every type that exposes collateral (`Prediction`, `Position`, `Trade`, `CollateralBalance`, `CollateralTransfer`) uses the same convention.
+7. **Status enum audit** — Need an audit of what status values exist today on `Condition`, `ConditionGroup`, and `Prediction` across the Prisma schema, resolvers, and any String-typed status fields currently on the wire. Output: a canonical `<Entity>Status` enum per entity, with a deprecation plan for any existing String fields. Blocks the first per-entity PR for any of those three types. Investigation pending.

--- a/docs/sapience-graphql-api-redesign.md
+++ b/docs/sapience-graphql-api-redesign.md
@@ -523,6 +523,8 @@ input DateTimeFilter {
   gte: DateTime
   lt: DateTime
   lte: DateTime
+  in: [DateTime!]
+  notIn: [DateTime!]
 }
 
 input StringFilter {
@@ -858,6 +860,9 @@ type Condition implements Node {
 
   createdAt: DateTime!
   updatedAt: DateTime
+  # Off-chain metadata sourced from Polymarket's market API (not chain
+  # storage), so `DateTime` rather than `UnixSeconds` is the right
+  # scalar here.
   resolvesAt: DateTime
 }
 
@@ -916,9 +921,12 @@ type Prediction implements Node {
   # is resolved; `result` carries the outcome. No separate
   # `PredictionStatus` enum — today's data model has no `CANCELLED`
   # state, so a derived status enum would just be sugar on the Boolean.
+  # `payout` is non-null: it's derived from the prize pool
+  # (`predictorCollateral + counterpartyCollateral`) and the `result`,
+  # both of which are non-null on every Prediction row.
   settled: Boolean!
   result: PredictionResult!
-  payout: Decimal
+  payout: Decimal!
 
   createdAt: DateTime!
   settledAt: DateTime

--- a/docs/sapience-graphql-api-redesign.md
+++ b/docs/sapience-graphql-api-redesign.md
@@ -418,12 +418,7 @@ type Query {
 
   vault(id: ID!): Vault
   vaultByAddress(address: Address!): Vault
-  vaults(
-    first: Int
-    after: String
-    filter: VaultFilter
-    orderBy: VaultOrder
-  ): VaultConnection!
+  vaults(first: Int, after: String, filter: VaultFilter): VaultConnection!
 
   leaderboard(
     metric: LeaderboardMetric!
@@ -649,12 +644,7 @@ type Query {
 
   vault(id: ID!): Vault
   vaultByAddress(address: Address!): Vault
-  vaults(
-    first: Int
-    after: String
-    filter: VaultFilter
-    orderBy: VaultOrder
-  ): VaultConnection!
+  vaults(first: Int, after: String, filter: VaultFilter): VaultConnection!
 
   leaderboard(
     metric: LeaderboardMetric!
@@ -1611,16 +1601,6 @@ input VaultFilter {
   address: AddressFilter
 }
 
-input VaultOrder {
-  field: VaultOrderField!
-  direction: OrderDirection! = DESC
-}
-
-enum VaultOrderField {
-  CREATED_AT
-  TOTAL_ASSETS
-}
-
 input AccountStatsFilter {
   timestamp: DateTimeFilter
 }
@@ -1790,6 +1770,6 @@ Numbering is section-prefixed: **D**eferred (`D#`), **P**er-entity (`P#`), **R**
 
 - **R6. Sort shape (singular vs array)** — Singular `orderBy: <Entity>Order` (matching GitHub's `IssueOrder` precedent), not the array shape originally drafted. Multi-key tiebreakers can be added later non-breakingly via a `then: <Entity>Order` field on the order input if real demand surfaces.
 - **R7. Filter convention** — Operator-pattern (Prisma-style) for single-value scalars (`AddressFilter`, `IDFilter`, `BigIntFilter`, `IntFilter`, `DecimalFilter`, `DateTimeFilter`, `StringFilter`). No `BooleanFilter` — Booleans stay flat per the principles. Multi-value membership filters and full-text search stay flat. See principles section for details. Position-specific corollary: the filter on `Position` uses `size: DecimalFilter` and `collateralAmount: DecimalFilter` to match the type's field names (the PR 1730 column-aligned names `balance` / `collateral` are not used on the wire — `size` is the renamed `balance` column, and `collateral` on the type is the `CollateralToken` reference).
-- **R8. `Vault` root access** — Vault is a Node, so it gets `vault(id:)`, `vaultByAddress(address:)`, and `vaults(...)` root fields — matching the prediction/trade/forecast pattern. The previous nesting under `protocol.vault(address)` is removed; Vault is independent and shouldn't sit behind a Protocol grouping.
+- **R8. `Vault` root access + no top-level sort** — Vault is a Node, so it gets `vault(id:)`, `vaultByAddress(address:)`, and `vaults(...)` root fields — matching the prediction/trade/forecast pattern. The previous nesting under `protocol.vault(address)` is removed; Vault is independent and shouldn't sit behind a Protocol grouping. Structurally, a Vault is "an address with an attached time series" — parallel to `Account` for stats purposes (`Vault.stats: VaultStatsConnection!` mirrors `Account.stats: AccountStatsConnection!`). There is no `Vault` table in Prisma; vaults come from static config (`getConfiguredVaults(chainId)`). So `vaults(...)` has no `orderBy:` arg and there is no `VaultOrder` / `VaultOrderField` — the entity has no indexed column to sort on. The field description should document that rows return in registration order. This is the one Connection in the schema without an `orderBy:` arg; that's a deliberate consequence of P1 ("the order-field enum lists fields the entity's indexes actually support"), not an oversight.
 - **R9. Stat-row connections over non-Node types** — `ProtocolStat`, `VaultStat`, `AccountStat`, and `CollateralBalanceSnapshot` stay as Connection members without implementing `Node`. They are time-bucketed values, not addressable entities; refetching a stat row by ID is meaningless because the row is uniquely identified by `(entity, timestamp)` already reachable via the parent + filter. Cursors on these connections encode timestamp position. The type-level descriptions in the SDL document this.
 - **R10. `UnixSeconds` scalar** — Declared explicitly. Used for timestamps that come directly from chain storage (uint256 seconds) where round-tripping to `DateTime` loses precision. Indexed / derived timestamps continue to use `DateTime`.

--- a/docs/sapience-graphql-api-redesign.md
+++ b/docs/sapience-graphql-api-redesign.md
@@ -244,6 +244,85 @@ attestationScore
 
 except in internal code or low-level docs explaining the EAS backing model.
 
+### 6. One filter convention, one sort convention
+
+The current schema mixes flat `<field>Min` / `<field>Max` args, operator-pattern `<field>Filter` input objects, top-level filter args on the root field (`positionsPage(address, owner, settled, ...)`), and consolidated `filters:` input objects. New types should pick one convention and hold it.
+
+#### Filters
+
+Every list / connection field accepts a single `filter: <Entity>Filter` input.
+
+Scalar fields on `<Entity>Filter` use operator-pattern inputs:
+
+```graphql
+input PositionFilter {
+  account: AddressFilter
+  conditionId: IDFilter
+  balance: BigIntFilter
+  collateral: BigIntFilter
+  createdAt: DateTimeFilter
+  settled: Boolean
+}
+```
+
+The operator inputs themselves are the Prisma-style set:
+
+```graphql
+input BigIntFilter {
+  equals: BigInt
+  gt: BigInt
+  gte: BigInt
+  lt: BigInt
+  lte: BigInt
+  in: [BigInt!]
+  notIn: [BigInt!]
+  not: BigInt
+}
+```
+
+A parallel input exists for each scalar (`IntFilter`, `StringFilter`, `DateTimeFilter`, `BooleanFilter`, `AddressFilter`, plus parameterized `EnumFilter<T>` per enum where filtering is useful).
+
+Rules:
+
+- **Strict semantics, no implicit OR.** `{ balance: { gte: "1" } }` means `balance >= 1`, full stop. Clients that want richer composition issue separate queries or rely on the server to add an explicit `OR` shape later if real demand surfaces.
+- **Unsupported operators on a specific field reject** with a clear error, not silently no-op. If a field can only be filtered by `equals` (e.g., a hashed identifier), the resolver rejects `gt`/`lt` rather than returning empty or full results.
+- **Forbid flat `<field>Min` / `<field>Max` on new types.** Existing flat args get `@deprecated` with a one-release migration cycle. See PR 1730 (positions `balance` / `collateral`) for the reference migration shape.
+- **Booleans stay flat.** `settled: Boolean` rather than `settled: BooleanFilter` — there is no `gt true` and the operator pattern adds noise without benefit.
+
+The SDL draft elsewhere in this document predates the operator-pattern convention and still shows flat fields like `conditionId: ID` and `createdAfter: DateTime`. Those examples will be normalized to operator-pattern as per-entity PRs land — the draft is illustrative of shape, not the final filter input definitions.
+
+#### Sort
+
+Replace the today-pattern of `orderBy: <FieldEnum>, orderDirection: ASC|DESC` with a single multi-key argument:
+
+```graphql
+predictions(
+  first: Int
+  after: String
+  filter: PredictionFilter
+  orderBy: [PredictionOrder!]
+): PredictionConnection!
+
+input PredictionOrder {
+  field: PredictionOrderField!
+  direction: OrderDirection!
+}
+
+enum PredictionOrderField {
+  CREATED_AT
+  SETTLED_AT
+  COLLATERAL
+  PAYOUT
+}
+```
+
+Rules:
+
+- **Array shape unlocks multi-key sort.** `[{field: ENDS_AT, direction: ASC}, {field: VOLUME, direction: DESC}]` is a single sort key with a tie-breaker.
+- **Each entity declares its own `<Entity>OrderField` enum** listing the fields the entity's indexes actually support. This answers open question #6 (which sort fields are supported) at the SDL level: if a field isn't in the enum, you can't sort by it.
+- **Adding a sort field is non-breaking; removing one is.** Treat the order-field enum like every other public enum — addition-only after first ship.
+- **Default order belongs in the resolver, not the schema.** Document the default in the field description ("orders by `CREATED_AT DESC` when `orderBy` is omitted") rather than encoding it as a default argument that drifts.
+
 ---
 
 ## Target Query Surface
@@ -541,10 +620,12 @@ type Account implements Node {
 
 type Question {
   id: ID!
-  questionType: QuestionType!
 
-  condition: Condition
-  conditionGroup: ConditionGroup
+  # Exactly one of Condition | ConditionGroup. Resolved as a union
+  # (open question #9) so the schema enforces mutual exclusion and
+  # clients can't silently observe a both-null or both-set state.
+  # Union name is TBD — see open question #9 for the options.
+  source: QuestionSourceTBD!
 
   title: String!
   description: String
@@ -584,11 +665,6 @@ type Question {
   createdAt: DateTime!
   updatedAt: DateTime
   resolvesAt: DateTime
-}
-
-enum QuestionType {
-  CONDITION
-  GROUP
 }
 
 enum QuestionStatus {
@@ -766,7 +842,6 @@ type Forecast implements Node {
   uid: Bytes32!
 
   forecaster: Account!
-  subject: Address
   schemaId: Bytes32!
 
   condition: Condition
@@ -1251,12 +1326,10 @@ enum PredictionOrderField {
 }
 
 input ForecastFilter {
-  account: Address
-  conditionId: ID
-  conditionGroupId: ID
-  pickConfigurationId: ID
-  createdAfter: DateTime
-  createdBefore: DateTime
+  forecaster: AddressFilter
+  conditionId: IDFilter
+  pickConfigurationId: IDFilter
+  createdAt: DateTimeFilter
 }
 
 input ForecastOrder {
@@ -1537,15 +1610,35 @@ type Query {
 
 ## Open Questions
 
-These should be resolved before implementation:
+Questions that lock public wire format must be resolved before the per-entity PR that ships the affected type. Additive-only questions can be deferred — adding a field, query, or arg later is non-breaking; removing or reshaping one is.
 
-1. Should `Question.id` be exposed publicly as a synthetic stable view ID, or should it be omitted to avoid implying canonical identity?
-2. Should `ActivityItem.id` be exposed as a synthetic ID, or should activity feed items rely only on cursor identity?
-3. Should `Forecast.subject` use EAS language, or should it be named more product-semantically?
-4. Should `Prediction.counterparty` be nullable in all cases?
-5. Which exact statuses exist today for `Condition`, `ConditionGroup`, and `Prediction`?
-6. Which sort fields are actually supported efficiently by indexes today?
-7. Should `totalCount` be available on all connections, or only where it is cheap?
-8. Do public clients need `last` / `before`, or is forward pagination enough?
-9. Should `Question` expose `condition` and `conditionGroup` as nullable fields, or should it be modeled as a union?
-10. Should `collateralAsset` be a scalar enum-like object for wUSDe today, or fully backed by an asset table/type?
+### Deferred — safe to ship later
+
+1. **`Question.id` synthetic ID** — Underlying `Condition` / `ConditionGroup` already carry Node IDs; clients can key on those. Add a synthetic `Question.id` later if a concrete UI need surfaces. Adding a field is non-breaking; committing to a format prematurely locks it forever.
+2. **`ActivityItem.id` synthetic ID** — Same logic. Each `ActivityItem` embeds a Prediction / Trade / Forecast that already has a Node ID; cursor handles in-page identity. Skip until a use case appears.
+3. **`totalCount` per-connection** — Per-connection call. Add where the count is cheap (covered index, materialized aggregate); omit where it's a table scan. Adding later is non-breaking.
+4. **`last` / `before` reverse pagination** — Forward is a strict subset; reverse is purely additive. Ship forward-only; revisit if clients need reverse traversal.
+
+### Per-entity — resolve at each PR
+
+6. **Sort fields by entity** — Now answered structurally: each entity declares its own `<Entity>OrderField` enum listing the fields its indexes support (see "One filter convention, one sort convention" above). Per-entity PRs decide their enum members based on actual index coverage; the SDL enforces the answer.
+
+### Resolved — locked direction, doc updated
+
+3. **`Forecast.subject` naming** — RESOLVED. The EAS "subject" (recipient) on a forecast attestation is the conditionId it targets; that link is already typed as `condition: Condition` on `Forecast`. The redundant `subject: Address` field is dropped from the SDL. Forecasts target a single `Condition` (not a `ConditionGroup`), so `ForecastFilter.conditionGroupId` is also dropped.
+4. **`Prediction.counterparty` nullability** — DECISION: ship non-null (`counterparty: Account!`). Prerequisite: data audit confirming no rows in production have a null counterparty (orphaned indexer rows, mid-settlement intermediate states). If any null rows exist, either backfill or fix the indexer before flipping the field to non-null — GraphQL surfaces a null on a non-null field as a query-level error, which would break list queries silently for affected accounts.
+5. **`Question` union vs. nullable pair** — RESOLVED on the shape: union. Schema enforces "exactly one of `Condition` | `ConditionGroup`," eliminating the both-null / both-set bug class. The `questionType: QuestionType` enum is removed (`__typename` on the union member subsumes it). Union name is still open — see "Still open" below.
+
+### Still open
+
+5. **Status enum audit** — Need an audit of what status values exist today on `Condition`, `ConditionGroup`, and `Prediction` across the Prisma schema, resolvers, and any String-typed status fields currently on the wire. Output: a canonical `<Entity>Status` enum per entity, with a deprecation plan for any existing String fields. Blocks the first per-entity PR for any of those three types. Investigation pending.
+   9b. **`Question` union name** — Candidates under consideration:
+   - `Market` — cleanest, but introduces a domain term not yet used elsewhere in the schema; risk of collision if "market" later means something narrower (orderbook-backed market, secondary market, etc.).
+   - `QuestionMarket` — explicit prefix, no collision risk, slight redundancy.
+   - `QuestionSource` — emphasizes "the underlying data source for this Question view"; reads well, no domain-term capture.
+   - `QuestionSubject` — mirrors the existing `ActivitySubject` union pattern; potential confusion since we just dropped "subject" as EAS jargon from `Forecast`.
+6. **`collateralAsset` field naming** — The type shape is settled (`type CollateralAsset { symbol, address, decimals, chainId }` — a full asset record, not a scalar). What's open is whether the field `Prediction.collateralAsset: CollateralAsset!` is the clearest name, or whether one of these reads better:
+   - `collateral: CollateralAsset!` — shortest; field name is the role, type is the shape.
+   - `collateralToken: CollateralAsset!` — explicit that it's an ERC-20 token, not a generic asset class.
+   - Rename type to `CollateralToken` and field to `collateral: CollateralToken!` — same idea, expressed through the type name instead of the field name.
+     Note: this is field-naming polish, not a wire-shape question — once chosen, every type that exposes collateral (`Prediction`, `Position`, `Trade`, `CollateralBalance`, `CollateralTransfer`) uses the same convention.

--- a/docs/sapience-graphql-api-redesign.md
+++ b/docs/sapience-graphql-api-redesign.md
@@ -322,7 +322,7 @@ Rules:
 
 - **Each entity declares its own `<Entity>OrderField` enum** listing the fields the entity's indexes actually support. This answers open question P1 (which sort fields are supported per entity) structurally — if a field isn't in the enum, you can't sort by it.
 - **Adding a sort field is non-breaking; removing one is.** Treat the order-field enum like every other public enum — addition-only after first ship.
-- **Default order belongs in the resolver, not the schema.** Document the default in the field description ("orders by `CREATED_AT DESC` when `orderBy` is omitted") rather than encoding it as a default argument that drifts.
+- **Default order belongs in the resolver, not the schema.** Both `field` and `direction` on `<Entity>Order` are non-null with no schema-level defaults — clients either supply both or omit `orderBy` entirely. When omitted, the resolver picks; the field description documents the choice ("orders by `CREATED_AT DESC` when `orderBy` is omitted"). Matches GitHub / Shopify / Linear convention.
 - **Multi-key sort path is open.** If real demand surfaces, add a `then: <Entity>Order` field to the order input for tie-breakers — purely additive, non-breaking. Until then, the single-key shape is simpler for clients and resolvers alike.
 
 ---
@@ -1374,7 +1374,7 @@ input AccountFilter {
 
 input AccountOrder {
   field: AccountOrderField!
-  direction: OrderDirection! = DESC
+  direction: OrderDirection!
 }
 
 enum AccountOrderField {
@@ -1389,7 +1389,7 @@ input QuestionFilter {
 
 input QuestionOrder {
   field: QuestionOrderField!
-  direction: OrderDirection! = DESC
+  direction: OrderDirection!
 }
 
 enum QuestionOrderField {
@@ -1412,7 +1412,7 @@ input ConditionFilter {
 
 input ConditionOrder {
   field: ConditionOrderField!
-  direction: OrderDirection! = DESC
+  direction: OrderDirection!
 }
 
 enum ConditionOrderField {
@@ -1431,7 +1431,7 @@ input ConditionGroupFilter {
 
 input ConditionGroupOrder {
   field: ConditionGroupOrderField!
-  direction: OrderDirection! = DESC
+  direction: OrderDirection!
 }
 
 enum ConditionGroupOrderField {
@@ -1452,7 +1452,7 @@ input PredictionFilter {
 
 input PredictionOrder {
   field: PredictionOrderField!
-  direction: OrderDirection! = DESC
+  direction: OrderDirection!
 }
 
 enum PredictionOrderField {
@@ -1470,7 +1470,7 @@ input ForecastFilter {
 
 input ForecastOrder {
   field: ForecastOrderField!
-  direction: OrderDirection! = DESC
+  direction: OrderDirection!
 }
 
 enum ForecastOrderField {
@@ -1488,7 +1488,7 @@ input TradeFilter {
 
 input TradeOrder {
   field: TradeOrderField!
-  direction: OrderDirection! = DESC
+  direction: OrderDirection!
 }
 
 enum TradeOrderField {
@@ -1509,7 +1509,7 @@ input ActivityFilter {
 
 input ActivityOrder {
   field: ActivityOrderField!
-  direction: OrderDirection! = DESC
+  direction: OrderDirection!
 }
 
 enum ActivityOrderField {
@@ -1529,7 +1529,7 @@ input PositionFilter {
 
 input PositionOrder {
   field: PositionOrderField!
-  direction: OrderDirection! = DESC
+  direction: OrderDirection!
 }
 
 enum PositionOrderField {
@@ -1547,7 +1547,7 @@ input PickConfigurationFilter {
 
 input PickConfigurationOrder {
   field: PickConfigurationOrderField!
-  direction: OrderDirection! = DESC
+  direction: OrderDirection!
 }
 
 enum PickConfigurationOrderField {
@@ -1563,7 +1563,7 @@ input CollateralTransferFilter {
 
 input CollateralTransferOrder {
   field: CollateralTransferOrderField!
-  direction: OrderDirection! = DESC
+  direction: OrderDirection!
 }
 
 enum CollateralTransferOrderField {
@@ -1577,7 +1577,7 @@ input ProtocolStatsFilter {
 
 input ProtocolStatsOrder {
   field: ProtocolStatsOrderField!
-  direction: OrderDirection! = ASC
+  direction: OrderDirection!
 }
 
 enum ProtocolStatsOrderField {
@@ -1590,7 +1590,7 @@ input VaultStatsFilter {
 
 input VaultStatsOrder {
   field: VaultStatsOrderField!
-  direction: OrderDirection! = ASC
+  direction: OrderDirection!
 }
 
 enum VaultStatsOrderField {
@@ -1607,7 +1607,7 @@ input AccountStatsFilter {
 
 input AccountStatsOrder {
   field: AccountStatsOrderField!
-  direction: OrderDirection! = ASC
+  direction: OrderDirection!
 }
 
 enum AccountStatsOrderField {


### PR DESCRIPTION
## Summary

Doc-only update to `docs/sapience-graphql-api-redesign.md`. Targets `feat/graphql-redesign-foundation` (this PR sits on top of PR 1 of the redesign).

- **New design principle: one filter convention, one sort convention.** Codifies the operator-pattern filter shape from #1730 (`balance: BigIntFilter` style) as the standard for every list / connection field. Adds a parallel sort convention: `orderBy: [<Entity>Order!]` with per-entity `<Entity>OrderField` enums (multi-key sort; the enum declares which fields the entity's indexes actually support, answering open question #6 structurally).
- **Open questions list, restructured.** Splits into Deferred (additive-only, safe to ship later), Per-entity (answered at each PR), Resolved (locked + doc updated), and Still open (need investigation/discussion).
- **#3 Forecast.subject — resolved.** The EAS subject is the conditionId, already typed as `condition: Condition` on `Forecast`. Dropped `subject: Address` from the SDL draft. Forecasts target a single Condition, so `ForecastFilter.conditionGroupId` is also dropped.
- **#4 Counterparty — direction locked.** Ship non-null, pending a data audit confirming no null counterparty rows exist in production.
- **#9 Question shape — resolved.** Union, not nullable pair. Schema now enforces "exactly one of `Condition` | `ConditionGroup`." The `questionType: QuestionType` enum is removed (`__typename` on the union member subsumes it). Union name itself is still open — see #9b in the doc.
- **#10 collateralAsset — type shape resolved.** Full `CollateralAsset` record (symbol/address/decimals/chainId). Field naming is still open — see #10 in the doc.

## Still open after this PR

- #5 — status enum audit (Condition / ConditionGroup / Prediction)
- #9b — union name (`Market` / `QuestionMarket` / `QuestionSource` / `QuestionSubject`)
- #10 — field naming (`collateralAsset` vs. `collateral` vs. rename type to `CollateralToken`)

## Test plan

- [x] Doc-only diff; no code, schema, or test changes
- [x] Prettier-clean (lintstaged ran on commit)