### PR TITLE
indexer: drop vestigial NON_DECISIVE branch from settlement result mapper

### DIFF
--- a/packages/api/src/workers/indexers/__tests__/predictionMarketEscrowIndexer.test.ts
+++ b/packages/api/src/workers/indexers/__tests__/predictionMarketEscrowIndexer.test.ts
@@ -507,12 +507,12 @@ describe('PredictionMarketEscrowIndexer', () => {
       expect(update.data.result).toBe('COUNTERPARTY_WINS');
     });
 
-    it('should settle with NON_DECISIVE for result=3', async () => {
+    it('should settle with UNRESOLVED for result=3 (no longer emitted; contract collapses non-decisive to COUNTERPARTY_WINS)', async () => {
       const indexer = setupSettledTest(3);
       await indexer.indexBlocks('test', [50]);
 
       const update = mockPrisma.prediction.updateMany.mock.calls[0][0];
-      expect(update.data.result).toBe('NON_DECISIVE');
+      expect(update.data.result).toBe('UNRESOLVED');
     });
 
     it('should settle with UNRESOLVED for unknown result values', async () => {

--- a/packages/api/src/workers/indexers/predictionMarketEscrowIndexer.ts
+++ b/packages/api/src/workers/indexers/predictionMarketEscrowIndexer.ts
@@ -135,10 +135,24 @@ interface PositionsBurnedEvent {
   refCode: `0x${string}`;
 }
 
-// Map settlement result number to enum value
+/**
+ * Map the on-chain `SettlementResult` uint8 to the Prisma enum.
+ *
+ * Current protocol contracts emit only three values for predictions:
+ * 0 = UNRESOLVED, 1 = PREDICTOR_WINS, 2 = COUNTERPARTY_WINS. Non-decisive
+ * outcomes (ties, voids) are collapsed to COUNTERPARTY_WINS at the
+ * resolution layer — see `PredictionMarketEscrow._evaluatePick` and the
+ * rationale comment at PredictionMarketEscrow.sol:L1262-L1267
+ * ("SettlementResult has no DRAW variant ... counterparties bear no
+ * prediction risk on void/tie outcomes").
+ *
+ * The Prisma `SettlementResult` enum still lists `NON_DECISIVE` for
+ * historical rows written by an earlier protocol version; the schema-
+ * level removal is out of scope here (needs a backfill migration).
+ */
 function mapSettlementResult(
   result: number
-): 'UNRESOLVED' | 'PREDICTOR_WINS' | 'COUNTERPARTY_WINS' | 'NON_DECISIVE' {
+): 'UNRESOLVED' | 'PREDICTOR_WINS' | 'COUNTERPARTY_WINS' {
   switch (result) {
     case 0:
       return 'UNRESOLVED';
@@ -146,9 +160,11 @@ function mapSettlementResult(
       return 'PREDICTOR_WINS';
     case 2:
       return 'COUNTERPARTY_WINS';
-    case 3:
-      return 'NON_DECISIVE';
     default:
+      logger.warn(
+        { settlementResult: result },
+        'Unexpected settlement result value. Current contracts emit only 0/1/2 for predictions (non-decisive collapses to COUNTERPARTY_WINS at the resolution layer). Recording as UNRESOLVED.'
+      );
       return 'UNRESOLVED';
   }
 }


### PR DESCRIPTION
## Summary

Drops dead code from the prediction settlement indexer. Current protocol contracts collapse non-decisive outcomes (ties, voids) to \`COUNTERPARTY_WINS\` at the resolution layer (\`PredictionMarketEscrow._evaluatePick\`, rationale comment at L1262-L1267: *\"SettlementResult has no DRAW variant ... counterparties bear no prediction risk on void/tie outcomes\"*). The contract emits only three values for predictions: \`0=UNRESOLVED\`, \`1=PREDICTOR_WINS\`, \`2=COUNTERPARTY_WINS\`.

The indexer's \`mapSettlementResult\` retained a \`case 3 → 'NON_DECISIVE'\` branch left over from an earlier protocol version — unreachable from current contract behavior. The silent default branch also returned \`UNRESOLVED\` for any unexpected value, so the indexer would silently record the wrong state if a future event ever did emit an unexpected uint8.

## Changes

- Drop the \`case 3\` branch; narrow the return type to the three values the contract actually emits.
- Add \`logger.warn\` in the default branch so any future unexpected value surfaces instead of silently mapping to \`UNRESOLVED\`.
- Add a JSDoc block citing the contract's resolution-layer policy and the rationale for keeping the Prisma enum value intact.
- Flip the indexer test from *\"settles NON_DECISIVE for result=3\"* to *\"settles UNRESOLVED for result=3 (no longer emitted by the contract)\"*.

## Out of scope (separate follow-ups)

- Prisma \`SettlementResult\` enum still lists \`NON_DECISIVE\` for historical rows. Removing it would need a backfill migration to fold those rows to \`COUNTERPARTY_WINS\`.
- Public GraphQL SDL still exposes \`NON_DECISIVE\` as a valid wire enum value. Removing it is a client-breaking change.
- \`timeSeriesQueries.ts\` still has \`WHERE result = 'NON_DECISIVE'\` counting historical non-decisive rows for account stats.

The vestigial enum value is preserved at the data + wire layer precisely so historical rows remain readable. This PR just removes the dead write path.

## Test plan

- [x] Full API suite (759 tests) green
- [x] Indexer test \`should settle with UNRESOLVED for result=3 (no longer emitted...)\` passes
- [x] Lint-staged (eslint + prettier) clean