### PR TITLE
docs: redesign — position filter supersedes #1722/#1730 + connection envelope complexity note

### DIFF
--- a/docs/sapience-graphql-api-redesign.md
+++ b/docs/sapience-graphql-api-redesign.md
@@ -53,14 +53,7 @@ condition(id: ID!)
 conditionGroup(id: ID!)
 ```
 
-A `Question` may still expose a synthetic `id` for UI rendering, caching, and list keys, but that ID should be treated as a view ID rather than a canonical graph entity ID.
-
-Example synthetic IDs:
-
-```text
-question:condition:123
-question:group:456
-```
+A synthetic `Question.id` is deferred (see D1). Clients that need a stable list key today should use the underlying `Condition` / `ConditionGroup` Node ID reachable through `Question.source`. If a future UI need forces a synthetic ID, the format is unfixed — committing to a wire shape prematurely locks it forever.
 
 ### Activity model
 
@@ -329,131 +322,33 @@ Rules:
 
 ## Target Query Surface
 
-```graphql
-type Query {
-  node(id: ID!): Node
-  nodes(ids: [ID!]!): [Node]!
+Prose orientation to the top-level `Query` shape. The full SDL below is the canonical source — argument lists, filters, and order inputs live there.
 
-  account(address: Address!): Account
-  accounts(
-    first: Int
-    after: String
-    filter: AccountFilter
-    orderBy: AccountOrder
-  ): AccountConnection!
+**Polymorphic Relay refetch.** `node(id:)` and `nodes(ids:)` return any durable entity by opaque global ID.
 
-  condition(id: ID!): Condition
-  conditionGroup(id: ID!): ConditionGroup
+**Direct lookup by Node ID** for every durable type: `condition`, `conditionGroup`, `prediction`, `trade`, `forecast`, `position`, `pickConfiguration`, `vault`, `account`.
 
-  questions(
-    first: Int
-    after: String
-    filter: QuestionFilter
-    orderBy: QuestionOrder
-  ): QuestionConnection!
+**Domain-identifier lookup** where the public identifier is the on-chain or external anchor:
 
-  conditions(
-    first: Int
-    after: String
-    filter: ConditionFilter
-    orderBy: ConditionOrder
-  ): ConditionConnection!
+- `predictionByOnchainId(predictionId: BigInt!)`
+- `tradeByHash(hash: Bytes32!)`
+- `forecastByUid(uid: Bytes32!)`
+- `vaultByAddress(address: Address!)`
+- `account(address: Address!)` — Account's domain identifier _is_ its address, so there's no separate `accountByAddress`.
 
-  conditionGroups(
-    first: Int
-    after: String
-    filter: ConditionGroupFilter
-    orderBy: ConditionGroupOrder
-  ): ConditionGroupConnection!
+**Relay-shaped connections** for each durable entity: `accounts`, `conditions`, `conditionGroups`, `predictions`, `trades`, `forecasts`, `positions`, `pickConfigurations`, `vaults`. Each takes `first` / `after` / `filter: <Entity>Filter` / `orderBy: <Entity>Order`.
 
-  prediction(id: ID!): Prediction
-  predictionByOnchainId(predictionId: BigInt!): Prediction
-  predictions(
-    first: Int
-    after: String
-    filter: PredictionFilter
-    orderBy: PredictionOrder
-  ): PredictionConnection!
+**Derived-view feeds** — list access only, no canonical `(id:)` lookup (see "Derived aggregate views"):
 
-  trade(id: ID!): Trade
-  tradeByHash(hash: Bytes32!): Trade
-  trades(
-    first: Int
-    after: String
-    filter: TradeFilter
-    orderBy: TradeOrder
-  ): TradeConnection!
+- `questions` — interleaved `Condition` / `ConditionGroup` feed.
+- `activity` — interleaved `Prediction` / `Trade` / `Forecast` feed.
 
-  forecast(id: ID!): Forecast
-  forecastByUid(uid: Bytes32!): Forecast
-  forecasts(
-    first: Int
-    after: String
-    filter: ForecastFilter
-    orderBy: ForecastOrder
-  ): ForecastConnection!
+**Cross-cutting and namespace fields:**
 
-  activity(
-    first: Int
-    after: String
-    filter: ActivityFilter
-    orderBy: ActivityOrder
-  ): ActivityConnection!
-
-  position(id: ID!): Position
-  positions(
-    first: Int
-    after: String
-    filter: PositionFilter
-    orderBy: PositionOrder
-  ): PositionConnection!
-
-  pickConfiguration(id: ID!): PickConfiguration
-  pickConfigurations(
-    first: Int
-    after: String
-    filter: PickConfigurationFilter
-    orderBy: PickConfigurationOrder
-  ): PickConfigurationConnection!
-
-  vault(id: ID!): Vault
-  vaultByAddress(address: Address!): Vault
-  vaults(first: Int, after: String, filter: VaultFilter): VaultConnection!
-
-  leaderboard(
-    metric: LeaderboardMetric!
-    first: Int
-    after: String
-    filter: LeaderboardFilter
-  ): AccountLeaderboardConnection!
-
-  collateralBalance(
-    account: Address!
-    chainId: Int!
-    atBlock: BigInt
-  ): CollateralBalance!
-
-  collateralBalanceHistory(
-    account: Address!
-    chainId: Int!
-    first: Int
-    after: String
-    intervalSeconds: Int!
-  ): CollateralBalanceSnapshotConnection!
-
-  collateralTransfers(
-    first: Int
-    after: String
-    filter: CollateralTransferFilter
-    orderBy: CollateralTransferOrder
-  ): CollateralTransferConnection!
-
-  protocol: Protocol!
-
-  categories(first: Int, after: String): CategoryConnection!
-  popularTags(first: Int = 50): [String!]!
-}
-```
+- `leaderboard(metric: LeaderboardMetric!, filter:)` — ranked `Account` feed.
+- `collateralBalance` / `collateralBalanceHistory` / `collateralTransfers`.
+- `protocol` — namespace for protocol-wide stats and aggregates.
+- `categories` / `popularTags` — taxonomy.
 
 ---
 
@@ -587,6 +482,12 @@ input PredictionResultFilter {
   isNull: Boolean
 }
 
+# Relay-spec `PageInfo`. `hasPreviousPage` is mandatory to keep the
+# type spec-compatible, but reverse pagination via `last` / `before`
+# is deferred (see D4) — under forward-only pagination
+# (`first` / `after`), `hasPreviousPage` is always `false`. The field
+# becomes meaningful once `last` / `before` ships; until then clients
+# should not infer reverse-traversal capability from its presence.
 type PageInfo {
   hasNextPage: Boolean!
   hasPreviousPage: Boolean!
@@ -990,6 +891,16 @@ type Prediction implements Node {
   settledAt: UnixSeconds
 }
 
+# Result is binary at the payout layer — every settled prediction
+# resolves to one of these two values. Non-decisive `Condition`
+# outcomes (`Condition.outcome = NON_DECISIVE`) resolve their owning
+# predictions to `COUNTERPARTY_WINS` per protocol rules; to distinguish
+# "counterparty won decisively" from "counterparty won because the
+# condition voided," inspect `prediction.conditions[].outcome` directly.
+# Server-side rollups like `AccountStat.predictionsNonDecisive` already
+# do this join. There is intentionally no `NON_DECISIVE` value here —
+# adding one would imply a third payout path that the protocol doesn't
+# implement.
 enum PredictionResult {
   PREDICTOR_WINS
   COUNTERPARTY_WINS
@@ -1196,7 +1107,6 @@ type AccountConnection {
   edges: [AccountEdge!]!
   nodes: [Account!]!
   pageInfo: PageInfo!
-  totalCount: Int
 }
 
 type AccountEdge {
@@ -1208,7 +1118,6 @@ type QuestionConnection {
   edges: [QuestionEdge!]!
   nodes: [Question!]!
   pageInfo: PageInfo!
-  totalCount: Int
 }
 
 type QuestionEdge {
@@ -1220,7 +1129,6 @@ type ConditionConnection {
   edges: [ConditionEdge!]!
   nodes: [Condition!]!
   pageInfo: PageInfo!
-  totalCount: Int
 }
 
 type ConditionEdge {
@@ -1232,7 +1140,6 @@ type ConditionGroupConnection {
   edges: [ConditionGroupEdge!]!
   nodes: [ConditionGroup!]!
   pageInfo: PageInfo!
-  totalCount: Int
 }
 
 type ConditionGroupEdge {
@@ -1244,7 +1151,6 @@ type PredictionConnection {
   edges: [PredictionEdge!]!
   nodes: [Prediction!]!
   pageInfo: PageInfo!
-  totalCount: Int
 }
 
 type PredictionEdge {
@@ -1256,7 +1162,6 @@ type ForecastConnection {
   edges: [ForecastEdge!]!
   nodes: [Forecast!]!
   pageInfo: PageInfo!
-  totalCount: Int
 }
 
 type ForecastEdge {
@@ -1268,7 +1173,6 @@ type TradeConnection {
   edges: [TradeEdge!]!
   nodes: [Trade!]!
   pageInfo: PageInfo!
-  totalCount: Int
 }
 
 type TradeEdge {
@@ -1280,7 +1184,6 @@ type ActivityConnection {
   edges: [ActivityEdge!]!
   nodes: [Activity!]!
   pageInfo: PageInfo!
-  totalCount: Int
 }
 
 type ActivityEdge {
@@ -1292,7 +1195,6 @@ type PositionConnection {
   edges: [PositionEdge!]!
   nodes: [Position!]!
   pageInfo: PageInfo!
-  totalCount: Int
 }
 
 type PositionEdge {
@@ -1304,7 +1206,6 @@ type PickConfigurationConnection {
   edges: [PickConfigurationEdge!]!
   nodes: [PickConfiguration!]!
   pageInfo: PageInfo!
-  totalCount: Int
 }
 
 type PickConfigurationEdge {
@@ -1316,7 +1217,6 @@ type CollateralBalanceSnapshotConnection {
   edges: [CollateralBalanceSnapshotEdge!]!
   nodes: [CollateralBalanceSnapshot!]!
   pageInfo: PageInfo!
-  totalCount: Int
 }
 
 type CollateralBalanceSnapshotEdge {
@@ -1328,7 +1228,6 @@ type CollateralTransferConnection {
   edges: [CollateralTransferEdge!]!
   nodes: [CollateralTransfer!]!
   pageInfo: PageInfo!
-  totalCount: Int
 }
 
 type CollateralTransferEdge {
@@ -1340,7 +1239,6 @@ type ProtocolStatsConnection {
   edges: [ProtocolStatsEdge!]!
   nodes: [ProtocolStat!]!
   pageInfo: PageInfo!
-  totalCount: Int
 }
 
 type ProtocolStatsEdge {
@@ -1352,7 +1250,6 @@ type VaultStatsConnection {
   edges: [VaultStatsEdge!]!
   nodes: [VaultStat!]!
   pageInfo: PageInfo!
-  totalCount: Int
 }
 
 type VaultStatsEdge {
@@ -1364,7 +1261,6 @@ type VaultConnection {
   edges: [VaultEdge!]!
   nodes: [Vault!]!
   pageInfo: PageInfo!
-  totalCount: Int
 }
 
 type VaultEdge {
@@ -1376,7 +1272,6 @@ type AccountStatsConnection {
   edges: [AccountStatsEdge!]!
   nodes: [AccountStat!]!
   pageInfo: PageInfo!
-  totalCount: Int
 }
 
 type AccountStatsEdge {
@@ -1388,7 +1283,6 @@ type AccountLeaderboardConnection {
   edges: [AccountLeaderboardEdge!]!
   nodes: [AccountLeaderboardEntry!]!
   pageInfo: PageInfo!
-  totalCount: Int
 }
 
 type AccountLeaderboardEdge {
@@ -1400,7 +1294,6 @@ type CategoryConnection {
   edges: [CategoryEdge!]!
   nodes: [Category!]!
   pageInfo: PageInfo!
-  totalCount: Int
 }
 
 type CategoryEdge {
@@ -1840,7 +1733,7 @@ Numbering is section-prefixed: **D**eferred (`D#`), **P**er-entity (`P#`). Stabl
 
 - **D1. `Question.id` synthetic ID** — Underlying `Condition` / `ConditionGroup` already carry Node IDs; clients can key on those. Add a synthetic `Question.id` later if a concrete UI need surfaces. Adding a field is non-breaking; committing to a format prematurely locks it forever.
 - **D2. `Activity.id` synthetic ID** — Same logic. Each `Activity` row embeds a Prediction / Trade / Forecast that already has a Node ID; cursor handles in-page identity. Skip until a use case appears.
-- **D3. `totalCount` per-connection** — Per-connection call. Add where the count is cheap (covered index, materialized aggregate); omit where it's a table scan. Adding later is non-breaking.
+- **D3. `totalCount` per-connection** — Default is **omit** — the SDL connection types ship without `totalCount` and per-entity PRs add it on a case-by-case basis where the count is cheap (covered index, materialized aggregate). A `totalCount: Int!` field on a row-scanning query is a footgun; addition is non-breaking, so default-off is safer than default-on.
 - **D4. `last` / `before` reverse pagination** — Forward is a strict subset; reverse is purely additive. Ship forward-only; revisit if clients need reverse traversal.
 
 ### Per-entity — resolve at each PR

--- a/docs/sapience-graphql-api-redesign.md
+++ b/docs/sapience-graphql-api-redesign.md
@@ -1795,6 +1795,21 @@ Be cautious with fields that are derived, cross-chain, asynchronously indexed, o
 
 Derived convenience fields (e.g. `Trade.conditions`, `Position.conditions`) must be costed equivalently to their underlying chain in the complexity estimator. A naive field-count cost lets clients smuggle expensive joins through the shortcut path. If a derived field traverses an unbounded list, do not expose it — keep clients on the explicit chain so the estimator sees the work.
 
+### Connection envelope complexity
+
+The `listMultiplierEstimator` already multiplies `childComplexity` by the list-size arg (`take` / `first`) on the envelope field and _also_ multiplies the inner list field (`items` on `*Page`, `nodes` / `edges` on `*Connection`) by `defaultListSize`. The result is a 10x over-count on every envelope query — a `*Page(take: 15) { items { ... } }` selection scores `1 + (1 + leaf * defaultListSize) * 15` instead of `1 + leaf * 15`, large enough to push reasonable FE queries past the default 15k budget.
+
+#1722 carried a fix for the `*Page` case (detect envelope by name suffix, pass child through unmultiplied for the inner `items` field). That PR was closed alongside #1730 because the flat `balanceMin` filter it introduced is forbidden under the operator-pattern convention, but the estimator fix needs to be re-applied for `*Connection` envelopes when they land in the per-entity migration — same mechanism, different name suffix, plus the dual `nodes` / `edges` shape (both inner list fields, both need the pass-through).
+
+### Position filter — operator pattern supersedes #1722 / #1730
+
+Two in-flight PRs targeting the legacy `positionsPage` filter shape were closed in favor of the operator-pattern surface on `PositionFilter` above:
+
+- **#1722** added `balanceMin: String` (flat `<field>Min` arg) with a permissive `OR pickConfig.resolved = true` keepalive.
+- **#1730** redesigned #1722's surface into operator-pattern `balance: BigIntFilter` and `collateral: BigIntFilter` on the legacy field names, deprecating the flat `collateralMin` / `collateralMax` args.
+
+`PositionFilter.size: DecimalFilter` and `PositionFilter.collateralAmount: DecimalFilter` cover the same query needs under the redesign's naming and convention: strict semantics, no implicit OR (the keepalive from #1722 doesn't carry forward), and renamed to match `size` / `collateralAmount` rather than `balance` / `collateral` to avoid two FE migrations in quick succession (`balance` → operator filter now, then `balance` → `size` later). Lands as part of the per-entity Position migration; until then, FE that needs balance filtering composes on the existing `*Page` surface or accepts the complexity budget hit.
+
 ### Versioning
 
 Recommended migration path:


### PR DESCRIPTION
## Summary

Two in-flight PRs against the legacy `positionsPage` filter shape were just closed:

- **#1722** added `balanceMin: String` (flat `<field>Min` arg with permissive `OR pickConfig.resolved = true` keepalive). Conflicts with redesign principle #6 (\"Forbid flat `<field>Min` / `<field>Max` on new types\") and \"strict semantics, no implicit OR.\"
- **#1730** redesigned #1722's surface into operator-pattern `balance: BigIntFilter` and `collateral: BigIntFilter` on the legacy field names. Right pattern, wrong names — landing it before the per-entity rename creates two FE migrations in quick succession.

Both query needs are already captured by `PositionFilter.size: DecimalFilter` and `PositionFilter.collateralAmount: DecimalFilter` in the SDL draft. This PR adds a subsection to Implementation Notes documenting that so future readers don't re-litigate.

Also adds a sibling subsection flagging that the `*Page` complexity estimator bug #1722 fixed (`listMultiplierEstimator` double-counts inner list fields against the envelope's own list-size arg, 10x over-count) will recur on `*Connection` envelopes — `nodes` and `edges` have the same shape, and the fix needs to be re-applied when connections land.

## Test plan

- [x] Doc-only change; no schema or resolver edits.
- [x] PRs #1722 and #1730 closed with comments pointing to this doc + each other.