### PR TITLE
fix(api): stop double-counting *Page items in query complexity

### DIFF
--- a/packages/api/src/graphql/estimators/listMultiplierEstimator.ts
+++ b/packages/api/src/graphql/estimators/listMultiplierEstimator.ts
@@ -5,7 +5,7 @@
  * `first` / `limit`) so cost analysis reflects "how many rows the
  * resolver will materialize", not just the depth of the selection set.
  *
- * Two cases are recognized:
+ * Three cases are recognized:
  *
  * 1. Direct list fields — `predictions: [Prediction!]!`. The deprecated
  *    bare-array shape. Take comes from the field's own args.
@@ -19,12 +19,22 @@
  *    named return type ends in `Page` (and exposes an `items: [X!]!`
  *    field, matching the SDL contract test) as a list of `take` rows
  *    so the two shapes price equivalently.
+ *
+ * 3. The `items` field *inside* a `*Page` envelope — passthrough. The
+ *    envelope above already applied the `take` multiplier, so treating
+ *    `items` as a normal list would double-count: `take * defaultListSize`
+ *    rows instead of `take`. A paginated query with a fat selection set
+ *    would price 10× higher than the equivalent deprecated bare-array
+ *    (see PR — `questionsPage(take: 20)` was hitting ~83k, well past
+ *    the 15k cap). Returning `childComplexity` here lets the envelope's
+ *    multiplier stand alone.
  */
 import {
   isListType,
   getNullableType,
   getNamedType,
   GraphQLObjectType,
+  GraphQLCompositeType,
 } from 'graphql';
 import type { ComplexityEstimator } from '../queryComplexity.js';
 
@@ -47,6 +57,22 @@ const fieldReturnsPageEnvelope = (field: {
   return isListType(getNullableType(items.type));
 };
 
+const isItemsFieldOfPageEnvelope = (
+  fieldName: string,
+  parentType: GraphQLCompositeType
+): boolean => {
+  if (fieldName !== 'items') return false;
+  if (!(parentType instanceof GraphQLObjectType)) return false;
+  // The `Page` interface itself has `items: [Node!]!` but is never the
+  // concrete return type of a query field — only concrete `*Page`
+  // objects implement it. Excluding the interface name keeps us aligned
+  // with `fieldReturnsPageEnvelope` above.
+  if (parentType.name === 'Page' || !parentType.name.endsWith('Page')) {
+    return false;
+  }
+  return true;
+};
+
 export function listMultiplierEstimator(
   options?: ListMultiplierEstimatorOptions
 ): ComplexityEstimator {
@@ -54,7 +80,7 @@ export function listMultiplierEstimator(
   const maxListSize = options?.maxListSize ?? 1000;
 
   return (args) => {
-    const { field, args: fieldArgs, childComplexity } = args;
+    const { field, args: fieldArgs, childComplexity, type, node } = args;
 
     const isListField = isListType(getNullableType(field.type));
     const isPageEnvelope = !isListField && fieldReturnsPageEnvelope(field);
@@ -62,6 +88,12 @@ export function listMultiplierEstimator(
     if (!isListField && !isPageEnvelope) {
       // Not a list or *Page envelope, let other estimators handle.
       return undefined;
+    }
+
+    // The `items` field inside a *Page envelope is a passthrough —
+    // multiplying here on top of the envelope's `take` would double-count.
+    if (isListField && isItemsFieldOfPageEnvelope(node.name.value, type)) {
+      return 1 + childComplexity;
     }
 
     // Read the list size from the field's own args. *Page fields keep

--- a/packages/api/src/graphql/queryComplexity.test.ts
+++ b/packages/api/src/graphql/queryComplexity.test.ts
@@ -285,11 +285,9 @@ describe('queryComplexity', () => {
             simpleEstimator({ defaultComplexity: 1 }),
           ],
         });
-        // itemsPage selection set: items (which itself is a list of
-        // ItemType, default 10) → 1 + 1*10 = 11. hasMore/totalCount
-        // would be smaller. Selection set picks max = 11.
-        // itemsPage applies the envelope multiplier: 1 + 11 * 50 = 551.
-        expect(complexity).toBe(551);
+        // items is the *Page passthrough: 1 + 1 = 2.
+        // itemsPage applies the envelope multiplier: 1 + 2 * 50 = 101.
+        expect(complexity).toBe(101);
       });
 
       it('uses default listSize when *Page take arg is missing', () => {
@@ -302,10 +300,10 @@ describe('queryComplexity', () => {
             simpleEstimator({ defaultComplexity: 1 }),
           ],
         });
-        // Both the inner items list and the outer envelope fall back
-        // to the default listSize of 10.
-        // items: 1 + 1*10 = 11. itemsPage: 1 + 11*10 = 111.
-        expect(complexity).toBe(111);
+        // items passthrough: 1 + 1 = 2.
+        // itemsPage envelope falls back to default listSize of 10:
+        // 1 + 2 * 10 = 21.
+        expect(complexity).toBe(21);
       });
 
       it('caps *Page envelope at maxListSize', () => {
@@ -318,14 +316,15 @@ describe('queryComplexity', () => {
             simpleEstimator({ defaultComplexity: 1 }),
           ],
         });
-        // take=5000 caps at 100. items default 10 (already <= maxListSize).
-        // items: 1 + 1*10 = 11. itemsPage: 1 + 11*100 = 1101.
-        expect(complexity).toBe(1101);
+        // take=5000 caps at 100. items passthrough: 1 + 1 = 2.
+        // itemsPage: 1 + 2 * 100 = 201.
+        expect(complexity).toBe(201);
       });
 
       it('paginated `*Page` and bare-array list with the same take price equivalently', () => {
         // Same selection set, same take — switching to the *Page
-        // wrapper should not change the cost order of magnitude.
+        // wrapper should price identically (modulo the envelope's
+        // own field-cost contribution).
         const bareQuery = parse(`{ items(take: 50) { id name } }`);
         const pageQuery = parse(
           `{ itemsPage(take: 50) { items { id name } } }`
@@ -344,12 +343,47 @@ describe('queryComplexity', () => {
           query: pageQuery,
           estimators: ests,
         });
-        // Both are in the same order of magnitude. *Page is somewhat
-        // higher because the inner `items` list also applies the
-        // default-10 multiplier; that's the safe bias direction
-        // (over-price the envelope, not under-price it).
+        // bare: 1 + 2 * 50 = 101.
+        // page: items passthrough = 1 + 2 = 3. envelope = 1 + 3 * 50 = 151.
+        // The +50 difference is the envelope's per-row "1" contribution
+        // (items still pays a base cost of 1) — same order of magnitude.
         expect(pageCost).toBeGreaterThanOrEqual(bareCost);
-        expect(pageCost).toBeLessThan(bareCost * 20);
+        expect(pageCost - bareCost).toBeLessThanOrEqual(100);
+      });
+
+      it('regression: `questionsPage` fat selection stays under the 15k cap', () => {
+        // The frontend's GET_QUESTIONS query hit 82,762 before the
+        // double-count fix. Reconstruct a comparable fat selection on
+        // the simplified test schema and verify the new pricing is
+        // bounded by `take` rather than `take * defaultListSize`.
+        const query = parse(`{
+          itemsPage(take: 50) {
+            items {
+              id
+              name
+              value
+              children {
+                id
+                name
+                value
+              }
+            }
+          }
+        }`);
+        const complexity = getComplexity({
+          schema: testSchema,
+          query,
+          estimators: [
+            listMultiplierEstimator({ defaultListSize: 10, maxListSize: 100 }),
+            simpleEstimator({ defaultComplexity: 1 }),
+          ],
+        });
+        // children (real list, default 10): 1 + 3*10 = 31.
+        // items passthrough: 1 + (1 + 1 + 1 + 31) = 35.
+        // itemsPage: 1 + 35 * 50 = 1751.
+        // Pre-fix this same shape would be 1 + (1 + (3 + 31)*10) * 50 = 17051.
+        expect(complexity).toBe(1751);
+        expect(complexity).toBeLessThan(15000);
       });
     });
   });


### PR DESCRIPTION
## Summary

- `listMultiplierEstimator` was multiplying the `*Page` envelope by `take` **and** the inner `items` list by `defaultListSize` (10), so paginated queries with a fat selection set priced ~10× higher than the equivalent deprecated bare-array.
- `questionsPage(take: 20)` on the frontend's `GET_QUESTIONS` shape hit ~83k complexity, blocking the request at the 15k cap — the markets page wouldn't load.
- Fix: treat the `items` field of a `*Page` parent as a passthrough so the envelope's `take` multiplier stands alone.

## Math (questionsPage, take ≈ 20)

Before: `items` list applied 1 + 395×10 = 3,951; envelope applied 1 + 3,951×20 ≈ **79k**.
After: `items` passthrough = 1 + 395 = 396; envelope = 1 + 396×20 ≈ **7.9k** — well under the 15k cap.

## Test plan

- [x] `vitest run src/graphql/queryComplexity.test.ts` — 31/31 pass
- [x] `vitest run src/graphql` — 446/446 pass
- [x] Updated `*Page envelope recognition` assertions to reflect single multiplication (no double-count)
- [x] Added a regression test pegging the questionsPage-style fat selection at <15k
- [ ] Deploy to staging and confirm `questionsPage(take: 50)` from the markets page loads