### PR TITLE
fix(api): opt conditionsPage out of MAX_SKIP=1000 cap

### DIFF
--- a/packages/api/src/graphql/sdl/resolvers/queries/conditions.test.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/conditions.test.ts
@@ -68,6 +68,22 @@ describe('conditionsPage — pagination envelope', () => {
     expect(result.hasMore).toBe(false);
     expect(result.items).toHaveLength(1);
   });
+
+  it('passes skip through unclamped past the global MAX_SKIP', async () => {
+    // conditionsPage opts out of the MAX_SKIP=1000 default so the keeper's
+    // bulk refresh-metadata loop can read past row 1000 with offset
+    // pagination. Cursor pagination is the longer-term answer; until then
+    // this resolver must not silently re-window high skip values.
+    await callPage({ skip: 5000 });
+    const args = mockPrisma.condition.findMany.mock.calls[0][0];
+    expect(args.skip).toBe(5000);
+  });
+
+  it('still floors negative skip to 0', async () => {
+    await callPage({ skip: -50 });
+    const args = mockPrisma.condition.findMany.mock.calls[0][0];
+    expect(args.skip).toBe(0);
+  });
 });
 
 describe('conditionsPage — orderBy mapping', () => {

--- a/packages/api/src/graphql/sdl/resolvers/queries/conditions.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/conditions.ts
@@ -147,7 +147,9 @@ export const conditionsPage: NonNullable<
   { filters, orderBy, orderDirection, take, skip }: QueryConditionsPageArgs
 ) => {
   const cappedTake = clampTake(take, { defaultTake: 50, maxTake: 100 });
-  const skipVal = clampSkip(skip);
+  // Opts out of MAX_SKIP=1000 so the keeper's bulk refresh-metadata loop
+  // can read past row 1000. Switch to cursor pagination to remove this.
+  const skipVal = clampSkip(skip, { maxSkip: Number.POSITIVE_INFINITY });
   const where = buildConditionsWhereFromFilters(filters);
   const direction = orderDirection === 'asc' ? 'asc' : 'desc';
   const orderField = ORDER_FIELD_MAP[orderBy ?? 'CREATED_AT'] ?? 'createdAt';

--- a/packages/api/src/graphql/sdl/resolvers/queries/pagination.test.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/pagination.test.ts
@@ -81,6 +81,14 @@ describe('clampSkip', () => {
     expect(clampSkip(9_999_999, { maxSkip: 10_000 })).toBe(10_000);
   });
 
+  it('removes the ceiling when maxSkip is Infinity (conditionsPage opt-out)', () => {
+    // conditionsPage passes maxSkip: Infinity so the keeper's bulk
+    // refresh-metadata loop can read past the default MAX_SKIP=1000.
+    expect(clampSkip(9_999_999, { maxSkip: Number.POSITIVE_INFINITY })).toBe(
+      9_999_999
+    );
+  });
+
   it('floors fractional input', () => {
     expect(clampSkip(50.9)).toBe(50);
   });


### PR DESCRIPTION
## Summary
- Stops the keeper's `refresh-metadata` bulk loop from hanging on staging
- `conditionsPage` resolver now passes `maxSkip: Number.POSITIVE_INFINITY` to `clampSkip`, opting this single resolver out of the global `MAX_SKIP=1000` cap from #1716
- Other `*Page` resolvers (positions, predictions, questions, activity, …) keep the cap

## Why

The keeper's `refresh-metadata` script paginates `conditionsPage` with `skip += 100`. Once `skip > 1000` the resolver's `clampSkip` silently caps `skip` back to 1000 and re-returns the same window. The keeper's `Map<id, ExistingCondition>` dedupes by id, so cumulative plateaus at 11 × 100 = **1100** while `hasMore` stays `true` — the `while(true)` loop never exits. Logs from staging show >24k requests served with cumulative stuck at 1100:

```
[RefreshMetadata]   GraphQL page 24576: fetched 100 (cumulative 1100, 24ms)
[RefreshMetadata]   GraphQL page 24559: fetched 100 (cumulative 1100, 35ms)
…
```

The `MAX_SKIP` cap (commit `03b87866f`) was a deliberate guardrail against silently-expensive deep-offset reads, and its own commit message recommends cursor (keyset) pagination on `(createdAt, id)` for hot paths that need to read past it. That's the proper fix; this PR is the minimal stopgap to unstick the keeper while cursor pagination is built.

## What's deferred (not in this PR)

- **Cursor pagination on `conditionsPage`** (`after: String` + `endCursor`, keyset on `(createdAt, id)`, composite Prisma index). When that lands, this opt-out should be removed.
- **Deterministic ordering tiebreaker.** `conditionsPage` orders by a single field (`createdAt`) with no `id` secondary sort — rows sharing a timestamp can shuffle across pages. The keeper's Map dedupes the duplicates silently so refresh-metadata won't loop, but reported counts may be slightly off vs. true DB count. Resolved by the cursor migration above.

## Test plan
- [x] New unit test: `conditionsPage` with `skip = 5000` calls Prisma with `skip: 5000` (not clamped). Verified failing before fix, passing after.
- [x] New unit test: `conditionsPage` with `skip = -50` still floors to 0.
- [x] New helper test: `clampSkip(v, { maxSkip: Infinity })` returns `v` unchanged.
- [x] Full API suite green: `pnpm --filter @sapience/api run test` — 814 / 814 pass.
- [ ] End-to-end smoke: run keeper refresh-metadata against staging and confirm cumulative grows past 1100 and loop terminates with `hasMore=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)