### PR TITLE
fix(market-keeper): use END_TIME enum value in settle scripts

### DIFF
--- a/packages/market-keeper/scripts/settle-manual.ts
+++ b/packages/market-keeper/scripts/settle-manual.ts
@@ -244,7 +244,7 @@ query UnresolvedConditions($take: Int!, $skip: Int!, $resolver: String!) {
       visibility: ALL
       engagement: ANY
     }
-    orderBy: endTime
+    orderBy: END_TIME
     orderDirection: asc
     take: $take
     skip: $skip

--- a/packages/market-keeper/scripts/settle-polymarket.ts
+++ b/packages/market-keeper/scripts/settle-polymarket.ts
@@ -225,7 +225,7 @@ query UnresolvedConditions($take: Int!, $skip: Int!, $resolver: String!) {
       visibility: ALL
       engagement: ANY
     }
-    orderBy: endTime
+    orderBy: END_TIME
     orderDirection: asc
     take: $take
     skip: $skip

--- a/packages/market-keeper/scripts/settle-pyth.ts
+++ b/packages/market-keeper/scripts/settle-pyth.ts
@@ -243,7 +243,7 @@ const CONDITIONS_QUERY = /* GraphQL */ `
   ) {
     conditionsPage(
       filters: $filters
-      orderBy: endTime
+      orderBy: END_TIME
       orderDirection: asc
       take: $take
       skip: $skip


### PR DESCRIPTION
## Summary
- Fixes a staging GraphQL validation error: \`Value "endTime" does not exist in "ConditionSortField" enum. Did you mean "END_TIME"?\`
- Three settle scripts (\`settle-polymarket.ts\`, \`settle-manual.ts\`, \`settle-pyth.ts\`) hand-roll \`conditionsPage\` queries that still pass the old lowercase Prisma field name as the \`orderBy\` value
- Swap each one to the typed enum value \`END_TIME\`

## Why
\`conditionsPage\` (introduced in #1716) replaced the deprecated \`conditions\` query and takes a typed \`ConditionSortField\` enum (\`CREATED_AT | END_TIME | OPEN_INTEREST | PREDICTION_COUNT\`) instead of free-form Prisma field names. \`cleanup/api.ts\` and the other consumers already pass enum values; these three scripts were missed during the migration because each builds its own query string instead of going through a shared fetcher.

The three scripts are part of the keeper's settlement crons. None of them runs end-to-end against staging today — each fails at the GraphQL request before doing any on-chain work.

## Test plan
- [x] \`grep "orderBy: " packages/market-keeper\` — all 7 call sites now pass uppercase enum values (\`CREATED_AT\` × 4, \`END_TIME\` × 4)
- [x] \`pnpm --filter @sapience/market-keeper run test\` — same baseline as before the change (5 pre-existing failures in \`refresh-metadata.test.ts\` / \`endtime.test.ts\`, none related to these files)
- [ ] End-to-end against staging once merged: \`SAPIENCE_API_URL=https://api.staging.sapience.xyz pnpm --filter @sapience/market-keeper run settle-polymarket:dry-run\` should reach the on-chain phase instead of failing on the GraphQL response

🤖 Generated with [Claude Code](https://claude.com/claude-code)