### PR TITLE
Alert secondary trade executions in Discord

### DIFF
--- a/packages/api/src/services/discordAlert.test.ts
+++ b/packages/api/src/services/discordAlert.test.ts
@@ -4,9 +4,11 @@ import {
   formatCollateral,
   getChainName,
   buildPositionEmbed,
+  buildSecondaryTradeEmbed,
   sendPositionAlert,
   STALE_BLOCK_THRESHOLD_S,
   type PositionAlertData,
+  type SecondaryTradeAlertData,
 } from './discordAlert';
 
 // --- Helpers ---
@@ -34,6 +36,26 @@ function makeAlertData(
     chainId: 42161,
     predictionId:
       '0xdeadbeef1234567890abcdef1234567890abcdef1234567890abcdef12345678',
+    ...overrides,
+  };
+}
+
+function makeSecondaryTradeAlertData(
+  overrides: Partial<SecondaryTradeAlertData> = {}
+): SecondaryTradeAlertData {
+  const nowSec = Math.floor(Date.now() / 1000);
+  return {
+    seller: '0xaabbccddee1122334455aabbccddee1122334455',
+    buyer: '0x1234567890abcdef1234567890abcdef12345678',
+    token: '0x3333333333333333333333333333333333333333',
+    tokenAmount: '100000000000000000000',
+    price: '47302695983166986167',
+    blockTimestamp: nowSec - 10,
+    transactionHash:
+      '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+    chainId: 5064014,
+    tradeHash:
+      '0xbeefbeef1234567890abcdef1234567890abcdef1234567890abcdef12345678',
     ...overrides,
   };
 }
@@ -222,6 +244,46 @@ describe('buildPositionEmbed', () => {
     expect(fields).toHaveLength(5);
     expect(fields[4].name).toBe('📄 Position');
     // No transaction field present
+    expect(fields.find((f) => f.name === '🔗 Transaction')).toBeUndefined();
+  });
+});
+
+describe('buildSecondaryTradeEmbed', () => {
+  it('builds a valid Discord embed object for secondary sales', () => {
+    const embed = buildSecondaryTradeEmbed(
+      makeSecondaryTradeAlertData()
+    ) as Record<string, unknown>;
+
+    expect(embed.title).toBe('🤝 Secondary Sale');
+    expect(embed.color).toBe(0x2563eb);
+    expect(embed.timestamp).toBeDefined();
+
+    const fields = embed.fields as Array<{
+      name: string;
+      value: string;
+      inline: boolean;
+    }>;
+
+    expect(fields).toHaveLength(5);
+    expect(fields[0].name).toBe('👤 Seller');
+    expect(fields[0].value).toContain('0xaabb…4455');
+    expect(fields[1].name).toBe('🤝 Buyer');
+    expect(fields[1].value).toContain('0x1234…5678');
+    expect(fields[2].name).toBe('🎟️ Position Tokens');
+    expect(fields[2].value).toContain('100');
+    expect(fields[3].name).toBe('💰 Sale Price');
+    expect(fields[3].value).toContain('47.3 USDe');
+    expect(fields[4].name).toBe('🔗 Transaction');
+    expect(fields[4].value).toContain('explorer.ethereal.trade');
+  });
+
+  it('handles missing transaction hash gracefully', () => {
+    const embed = buildSecondaryTradeEmbed(
+      makeSecondaryTradeAlertData({ transactionHash: '' })
+    ) as Record<string, unknown>;
+    const fields = embed.fields as Array<{ name: string }>;
+
+    expect(fields).toHaveLength(4);
     expect(fields.find((f) => f.name === '🔗 Transaction')).toBeUndefined();
   });
 });

--- a/packages/api/src/services/discordAlert.ts
+++ b/packages/api/src/services/discordAlert.ts
@@ -58,6 +58,21 @@ export interface PositionAlertData {
   predictionId?: string;
 }
 
+export interface SecondaryTradeAlertData {
+  seller: string;
+  buyer: string;
+  token: string;
+  tokenAmount: string;
+  price: string;
+  /** Token decimals for collateral/token formatting (default 18) */
+  collateralDecimals?: number;
+  tokenDecimals?: number;
+  blockTimestamp: number;
+  transactionHash: string;
+  chainId: number;
+  tradeHash?: string;
+}
+
 export function truncateAddress(addr: string): string {
   if (addr.length <= 10) return addr;
   return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
@@ -97,6 +112,32 @@ export function getChainName(chainId: number): string {
   }
 }
 
+function getExplorerBaseUrl(chainId: number): string {
+  return chainId === CHAIN_ID_ETHEREAL
+    ? 'https://explorer.ethereal.trade'
+    : chainId === CHAIN_ID_ETHEREAL_TESTNET
+      ? 'https://explorer.etherealtest.net'
+      : chainId === 42161
+        ? 'https://arbiscan.io'
+        : chainId === 8453
+          ? 'https://basescan.org'
+          : chainId === 11155111
+            ? 'https://sepolia.etherscan.io'
+            : 'https://etherscan.io';
+}
+
+function buildTransactionField(chainId: number, transactionHash: string) {
+  if (!transactionHash) return [];
+
+  return [
+    {
+      name: '🔗 Transaction',
+      value: `[View tx](${getExplorerBaseUrl(chainId)}/tx/${transactionHash})`,
+      inline: true,
+    },
+  ];
+}
+
 /**
  * Build the Discord embed payload for a position alert.
  * Exported for testing — sendPositionAlert calls this internally.
@@ -109,21 +150,8 @@ export function buildPositionEmbed(data: PositionAlertData): object {
     .map((p) => `• ${p.question} → **${p.outcomeYes ? 'YES' : 'NO'}**`)
     .join('\n');
 
-  const explorerBaseUrl =
-    data.chainId === CHAIN_ID_ETHEREAL
-      ? 'https://explorer.ethereal.trade'
-      : data.chainId === CHAIN_ID_ETHEREAL_TESTNET
-        ? 'https://explorer.etherealtest.net'
-        : data.chainId === 42161
-          ? 'https://arbiscan.io'
-          : data.chainId === 8453
-            ? 'https://basescan.org'
-            : data.chainId === 11155111
-              ? 'https://sepolia.etherscan.io'
-              : 'https://etherscan.io';
-
   const txLink = data.transactionHash
-    ? `[View tx](${explorerBaseUrl}/tx/${data.transactionHash})`
+    ? `[View tx](${getExplorerBaseUrl(data.chainId)}/tx/${data.transactionHash})`
     : '';
 
   return {
@@ -173,7 +201,47 @@ export function buildPositionEmbed(data: PositionAlertData): object {
   };
 }
 
-export function sendPositionAlert(data: PositionAlertData): void {
+export function buildSecondaryTradeEmbed(
+  data: SecondaryTradeAlertData
+): object {
+  const collateralDecimals = data.collateralDecimals ?? 18;
+  const tokenDecimals = data.tokenDecimals ?? 18;
+  const symbol = COLLATERAL_SYMBOLS[data.chainId] ?? 'N/A';
+
+  return {
+    title: '🤝 Secondary Sale',
+    color: 0x2563eb,
+    fields: [
+      {
+        name: '👤 Seller',
+        value: `\`${truncateAddress(data.seller)}\``,
+        inline: true,
+      },
+      {
+        name: '🤝 Buyer',
+        value: `\`${truncateAddress(data.buyer)}\``,
+        inline: true,
+      },
+      {
+        name: '🎟️ Position Tokens',
+        value: `${formatCollateral(data.tokenAmount, tokenDecimals)} tokens`,
+        inline: true,
+      },
+      {
+        name: '💰 Sale Price',
+        value: `${formatCollateral(data.price, collateralDecimals)} ${symbol}`,
+        inline: true,
+      },
+      ...buildTransactionField(data.chainId, data.transactionHash),
+    ],
+    timestamp: new Date(data.blockTimestamp * 1000).toISOString(),
+  };
+}
+
+function sendDiscordAlert(
+  data: { blockTimestamp: number },
+  buildEmbed: () => object
+): void {
   // Skip stale blocks (reindex safety)
   const nowSec = Math.floor(Date.now() / 1000);
   if (nowSec - data.blockTimestamp > STALE_BLOCK_THRESHOLD_S) {
@@ -186,7 +254,7 @@ export function sendPositionAlert(data: PositionAlertData): void {
   // Skip if no webhooks configured
   if (DISCORD_WEBHOOK_URLS.length === 0) return;
 
-  const embed = buildPositionEmbed(data);
+  const embed = buildEmbed();
   const payload = JSON.stringify({ embeds: [embed] });
 
   // Fire-and-forget: send to all webhook URLs
@@ -216,4 +284,12 @@ export function sendPositionAlert(data: PositionAlertData): void {
         );
       });
   }
+}
+
+export function sendPositionAlert(data: PositionAlertData): void {
+  sendDiscordAlert(data, () => buildPositionEmbed(data));
+}
+
+export function sendSecondaryTradeAlert(data: SecondaryTradeAlertData): void {
+  sendDiscordAlert(data, () => buildSecondaryTradeEmbed(data));
 }

--- a/packages/api/src/workers/indexers/secondaryMarketIndexer.test.ts
+++ b/packages/api/src/workers/indexers/secondaryMarketIndexer.test.ts
@@ -6,6 +6,7 @@ import {
   toHex,
   type Block,
 } from 'viem';
+import { sendSecondaryTradeAlert } from '../../services/discordAlert';
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
@@ -43,6 +44,9 @@ vi.mock('@sapience/sdk/contracts', () => ({
       legacy: [],
     },
   },
+}));
+vi.mock('../../services/discordAlert', () => ({
+  sendSecondaryTradeAlert: vi.fn(),
 }));
 vi.mock('@sapience/sdk/abis', () => {
   const abi = [
@@ -180,6 +184,17 @@ describe('SecondaryMarketIndexer', () => {
     expect(call.create.refCode).toBeNull();
     expect(call.create.executedAt).toBe(1700000000);
     expect(call.create.blockNumber).toBe(50);
+    expect(sendSecondaryTradeAlert).toHaveBeenCalledWith({
+      seller: SELLER,
+      buyer: BUYER,
+      token: TOKEN,
+      tokenAmount: '1000000000000000000',
+      price: '500000000000000000',
+      blockTimestamp: 1700000000,
+      transactionHash: log.transactionHash,
+      chainId: 13374202,
+      tradeHash: TRADE_HASH.toLowerCase(),
+    });
   });
 
   it('should be idempotent — same tradeHash upserted twice without error', async () => {

--- a/packages/api/src/workers/indexers/secondaryMarketIndexer.ts
+++ b/packages/api/src/workers/indexers/secondaryMarketIndexer.ts
@@ -5,6 +5,7 @@ import { IIndexer } from '../../interfaces';
 import { secondaryMarketEscrow } from '@sapience/sdk/contracts';
 import { secondaryMarketEscrowAbi } from '@sapience/sdk/abis';
 import { createLogger } from '../../core/logger';
+import { sendSecondaryTradeAlert } from '../../services/discordAlert';
 
 const logger = createLogger('secondaryMarketIndexer');
 
@@ -366,6 +367,18 @@ class SecondaryMarketIndexer implements IIndexer {
         blockNumber: Number(log.blockNumber),
       },
       update: {},
+    });
+
+    sendSecondaryTradeAlert({
+      seller: event.seller,
+      buyer: event.buyer,
+      token: event.token,
+      tokenAmount: event.tokenAmount.toString(),
+      price: event.price.toString(),
+      blockTimestamp: timestamp,
+      transactionHash: log.transactionHash || '',
+      chainId: this.chainId,
+      tradeHash: tradeHashLower,
     });
 
     logger.info(


### PR DESCRIPTION
## Summary
- Add a secondary-sale Discord embed builder and sender using the existing webhook/staleness/rate-limit plumbing
- Emit secondary-sale alerts from the secondary market indexer after TradeExecuted events are indexed
- Cover the new embed and indexer alert call with API tests

## Testing
- `pnpm --filter @sapience/api exec vitest run src/services/discordAlert.test.ts src/workers/indexers/secondaryMarketIndexer.test.ts --pool=threads --poolOptions.threads.singleThread=true`
- `pnpm --filter @sapience/api run lint`
- `pnpm --filter @sapience/api run type-check`
