### PR TITLE
fix(market-keeper): align settlement filters with condition connection

### DIFF
--- a/packages/app/src/app/og/question/route.tsx
+++ b/packages/app/src/app/og/question/route.tsx
@@ -184,7 +184,7 @@ async function fetchConditionData(
 
     const filters: Record<string, unknown> = { ids: [conditionId] };
     if (resolver) {
-      filters.resolver = resolver;
+      filters.contractAddress = resolver;
     }
 
     const response = await fetch(getGraphQLEndpoint(), {

--- a/packages/app/src/app/questions/[...parts]/page.tsx
+++ b/packages/app/src/app/questions/[...parts]/page.tsx
@@ -41,7 +41,7 @@ async function fetchQuestionTitle(
 
     const filters: Record<string, unknown> = { ids: [conditionId] };
     if (resolverAddress) {
-      filters.resolver = resolverAddress;
+      filters.contractAddress = resolverAddress;
     }
 
     const response = await fetch(getGraphQLEndpoint(), {

--- a/packages/app/src/components/markets/pages/QuestionPageContent.tsx
+++ b/packages/app/src/components/markets/pages/QuestionPageContent.tsx
@@ -122,7 +122,7 @@ export default function QuestionPageContent({
       `;
       const filters: Record<string, unknown> = { ids: [conditionId] };
       if (resolverAddressFromUrl) {
-        filters.resolver = resolverAddressFromUrl;
+        filters.contractAddress = resolverAddressFromUrl;
       }
       const resp = await graphqlRequest<{
         conditionsConnection: {

--- a/packages/market-keeper/scripts/settle-manual.ts
+++ b/packages/market-keeper/scripts/settle-manual.ts
@@ -237,7 +237,7 @@ query UnresolvedConditions($take: Int!, $skip: Int!, $resolver: String!) {
   conditionsConnection(
     filter: {
       settled: false
-      resolver: $resolver
+      contractAddress: $resolver
       # Pick up both public and private — the deprecated resolver's
       # implicit public=true filter would silently exclude privated
       # conditions that still have engagement to settle.

--- a/packages/market-keeper/scripts/settle-polymarket.ts
+++ b/packages/market-keeper/scripts/settle-polymarket.ts
@@ -218,7 +218,7 @@ query UnresolvedConditions($take: Int!, $skip: Int!, $resolver: String!) {
   conditionsConnection(
     filter: {
       settled: false
-      resolver: $resolver
+      contractAddress: $resolver
       # Pick up both public and private — the deprecated resolver's
       # implicit public=true filter would silently exclude privated
       # conditions that still have engagement to settle.

--- a/packages/market-keeper/scripts/settle-pyth.ts
+++ b/packages/market-keeper/scripts/settle-pyth.ts
@@ -559,9 +559,9 @@ async function main() {
     }>(sapienceApiUrl, CONDITIONS_QUERY, {
       filters: {
         chainId: CHAIN_ID,
-        maxEndTime: nowSec,
+        resolvesAt: { lte: nowSec },
         settled: false,
-        resolver: PYTH_RESOLVER_ADDRESS,
+        contractAddress: PYTH_RESOLVER_ADDRESS,
       },
       take,
       skip,


### PR DESCRIPTION
## Summary
- use `contractAddress` on `conditionsConnection.filter` instead of the removed `resolver` alias
- use `resolvesAt: { lte }` for Pyth settlement discovery instead of the removed `maxEndTime` filter
- update app question/OG condition lookups that include resolver-from-URL to use `contractAddress`

## Verification
- Live staging GraphQL validation for manual/polymarket settlement query shape: 200 OK
- Live staging GraphQL validation for Pyth settlement query shape: 200 OK
- Live staging GraphQL validation for app condition lookup shape with `ids + contractAddress`: 200 OK
- `pnpm --filter @sapience/market-keeper run type-check`
- `pnpm exec prettier --check packages/market-keeper/scripts/settle-manual.ts packages/market-keeper/scripts/settle-polymarket.ts packages/market-keeper/scripts/settle-pyth.ts`
- `pnpm --filter @sapience/market-keeper exec vitest run src/__tests__/resolver.test.ts --pool forks --maxWorkers=1 --minWorkers=1`
- `pnpm exec prettier --check packages/app/src/app/og/question/route.tsx 'packages/app/src/app/questions/[...parts]/page.tsx' packages/app/src/components/markets/pages/QuestionPageContent.tsx`
- `pnpm --filter @sapience/app exec eslint src/app/og/question/route.tsx 'src/app/questions/[...parts]/page.tsx' src/components/markets/pages/QuestionPageContent.tsx --quiet`

## Notes
- Full app type-check currently hits pre-existing unrelated Zod resolver type errors in `ConditionForecastForm.tsx` and `CreatePositionForm/index.tsx`.
- Full market-keeper lint/format checks currently hit pre-existing unrelated issues in `src/resolver.ts` and several already-unformatted files.
