### PR TITLE
fix(app): use staging-compatible pick config query

### DIFF
--- a/packages/app/src/hooks/graphql/usePickConfigsByTokens.ts
+++ b/packages/app/src/hooks/graphql/usePickConfigsByTokens.ts
@@ -7,46 +7,45 @@ import type { PickConfigData, PickData } from '~/hooks/graphql/usePositions';
 
 // tokens arg on pickConfigurations added in PR #1440. `picks.condition`
 // is fetched inline so callers can build their conditionsMap from a
-// single round trip — see Pick resolver + pickConfigurationsConnection resolver.
+// single round trip. Use the deprecated bare-list field here for staging
+// compatibility while API/app deploys can be briefly out of sync.
 const PICK_CONFIGS_BY_TOKENS_QUERY = /* GraphQL */ `
-  query PickConfigsByTokens($filter: PickConfigurationFilter) {
-    pickConfigurationsConnection(filter: $filter, first: 100) {
-      nodes {
+  query PickConfigsByTokens($tokens: [String!]) {
+    pickConfigurations(tokens: $tokens, take: 100) {
+      id
+      chainId
+      marketAddress
+      totalPredictorCollateral
+      totalCounterpartyCollateral
+      claimedPredictorCollateral
+      claimedCounterpartyCollateral
+      resolved
+      result
+      resolvedAt
+      predictorToken
+      counterpartyToken
+      endsAt
+      isLegacy
+      picks {
         id
-        chainId
-        marketAddress
-        totalPredictorCollateral
-        totalCounterpartyCollateral
-        claimedPredictorCollateral
-        claimedCounterpartyCollateral
-        resolved
-        result
-        resolvedAt
-        predictorToken
-        counterpartyToken
-        endsAt
-        isLegacy
-        picks {
+        pickConfigId
+        conditionResolver
+        conditionId
+        predictedOutcome
+        condition {
           id
-          pickConfigId
-          conditionResolver
-          conditionId
-          predictedOutcome
-          condition {
-            id
-            shortName
-            optionName
-            question
-            description
-            endTime
-            resolver
-            settled
-            resolvedToYes
-            nonDecisive
-            estimatedPrice
-            category {
-              slug
-            }
+          shortName
+          optionName
+          question
+          description
+          endTime
+          resolver
+          settled
+          resolvedToYes
+          nonDecisive
+          estimatedPrice
+          category {
+            slug
           }
         }
       }
@@ -75,9 +74,9 @@ export function usePickConfigsByTokens(tokens: string[]) {
     refetchOnWindowFocus: false,
     queryFn: async () => {
       const resp = await graphqlRequest<{
-        pickConfigurationsConnection: { nodes: PickConfigData[] };
-      }>(PICK_CONFIGS_BY_TOKENS_QUERY, { filter: { tokens: sorted } });
-      return resp?.pickConfigurationsConnection?.nodes ?? [];
+        pickConfigurations: PickConfigData[];
+      }>(PICK_CONFIGS_BY_TOKENS_QUERY, { tokens: sorted });
+      return resp?.pickConfigurations ?? [];
     },
   });
 

--- a/packages/sdk/queries/__tests__/pickConfigurations.test.ts
+++ b/packages/sdk/queries/__tests__/pickConfigurations.test.ts
@@ -16,50 +16,50 @@ beforeEach(() => {
 describe('fetchPickConfigurations', () => {
   test('uses default take=10 and skip=0 when no opts provided', async () => {
     mockGraphqlRequest.mockResolvedValue({
-      pickConfigurationsConnection: { nodes: [] },
+      pickConfigurations: [],
     });
     await fetchPickConfigurations();
     expect(mockGraphqlRequest).toHaveBeenCalledWith(
       GET_PICK_CONFIGURATIONS,
-      expect.objectContaining({ first: 10, after: null })
+      expect.objectContaining({ take: 10, skip: 0 })
     );
   });
 
   test('passes custom take, skip, and chainId', async () => {
     mockGraphqlRequest.mockResolvedValue({
-      pickConfigurationsConnection: { nodes: [] },
+      pickConfigurations: [],
     });
     await fetchPickConfigurations({ take: 50, skip: 5, chainId: 42161 });
     expect(mockGraphqlRequest).toHaveBeenCalledWith(
       GET_PICK_CONFIGURATIONS,
       expect.objectContaining({
-        first: 50,
-        after: expect.any(String),
-        filter: expect.objectContaining({ chainId: 42161 }),
+        take: 50,
+        skip: 5,
+        chainId: 42161,
       })
     );
   });
 
   test('passes resolved param when provided', async () => {
     mockGraphqlRequest.mockResolvedValue({
-      pickConfigurationsConnection: { nodes: [] },
+      pickConfigurations: [],
     });
     await fetchPickConfigurations({ resolved: false });
     expect(mockGraphqlRequest).toHaveBeenCalledWith(
       GET_PICK_CONFIGURATIONS,
       expect.objectContaining({
-        filter: expect.objectContaining({ resolved: false }),
+        resolved: false,
       })
     );
   });
 
-  test('does not send resolved key when not provided', async () => {
+  test('sends null resolved when not provided', async () => {
     mockGraphqlRequest.mockResolvedValue({
-      pickConfigurationsConnection: { nodes: [] },
+      pickConfigurations: [],
     });
     await fetchPickConfigurations({ take: 5 });
     const vars = mockGraphqlRequest.mock.calls[0][1];
-    expect(vars.filter.resolved).toBeNull();
+    expect(vars.resolved).toBeNull();
   });
 
   test('returns pickConfigurations from response', async () => {
@@ -76,14 +76,14 @@ describe('fetchPickConfigurations', () => {
       },
     ];
     mockGraphqlRequest.mockResolvedValue({
-      pickConfigurationsConnection: { nodes: configs },
+      pickConfigurations: configs,
     });
     const result = await fetchPickConfigurations();
     expect(result).toEqual(configs);
   });
 
-  test('returns empty array when response pickConfigurationsConnection.nodes is missing', async () => {
-    mockGraphqlRequest.mockResolvedValue({ pickConfigurationsConnection: {} });
+  test('returns empty array when response pickConfigurations is missing', async () => {
+    mockGraphqlRequest.mockResolvedValue({});
     const result = await fetchPickConfigurations();
     expect(result).toEqual([]);
   });

--- a/packages/sdk/queries/pickConfigurations.ts
+++ b/packages/sdk/queries/pickConfigurations.ts
@@ -2,40 +2,40 @@ import { graphqlRequest } from './client/graphqlClient';
 
 export const GET_PICK_CONFIGURATIONS = /* GraphQL */ `
   query PickConfigurations(
-    $filter: PickConfigurationFilter
-    $first: Int
-    $after: String
+    $chainId: Int
+    $resolved: Boolean
+    $skip: Int!
+    $take: Int!
   ) {
-    pickConfigurationsConnection(
-      filter: $filter
-      first: $first
-      after: $after
+    pickConfigurations(
+      chainId: $chainId
+      resolved: $resolved
+      skip: $skip
+      take: $take
     ) {
-      nodes {
-        id
-        chainId
-        totalPredictorCollateral
-        totalCounterpartyCollateral
-        resolved
-        picks {
-          conditionId
-          conditionResolver
-          predictedOutcome
-          condition {
-            id
-            shortName
-            optionName
-            question
-            description
-            endTime
-            resolver
-            settled
-            resolvedToYes
-            nonDecisive
-            estimatedPrice
-            category {
-              slug
-            }
+      id
+      chainId
+      totalPredictorCollateral
+      totalCounterpartyCollateral
+      resolved
+      picks {
+        conditionId
+        conditionResolver
+        predictedOutcome
+        condition {
+          id
+          shortName
+          optionName
+          question
+          description
+          endTime
+          resolver
+          settled
+          resolvedToYes
+          nonDecisive
+          estimatedPrice
+          category {
+            slug
           }
         }
       }
@@ -79,19 +79,12 @@ export async function fetchPickConfigurations(opts?: {
   resolved?: boolean;
 }): Promise<PickConfigurationResult[]> {
   const data = await graphqlRequest<{
-    pickConfigurationsConnection: { nodes: PickConfigurationResult[] };
+    pickConfigurations: PickConfigurationResult[];
   }>(GET_PICK_CONFIGURATIONS, {
-    first: opts?.take ?? 10,
-    after: cursorFromSkip(opts?.skip ?? 0),
-    filter: {
-      chainId: opts?.chainId ?? null,
-      resolved: opts?.resolved ?? null,
-    },
+    take: opts?.take ?? 10,
+    skip: opts?.skip ?? 0,
+    chainId: opts?.chainId ?? null,
+    resolved: opts?.resolved ?? null,
   });
-  return data.pickConfigurationsConnection?.nodes ?? [];
+  return data.pickConfigurations ?? [];
 }
-
-const cursorFromSkip = (skip: number): string | null => {
-  if (skip <= 0) return null;
-  return btoa(JSON.stringify({ k: String(skip - 1), id: String(skip - 1) }));
-};


### PR DESCRIPTION
## Summary
- switch app token pick-config lookup back to deprecated `pickConfigurations(...)`
- switch SDK pick-configuration helper back to the same bare-list query
- update SDK tests for the legacy-compatible variable/response shape

## Why
Staging Sentry is seeing GraphQL validation failures for `pickConfigurationsConnection` / `PickConfigurationFilter`. The staging branch already has the newer connection schema, but the runtime error shape matches the pre-PR3 API schema, where `pickConfigurations(...)`, `pickConfigurationsPage(...)`, and `PickConfigurationFilters` exist but the singular connection field/type do not. This makes the app/SDK query tolerate API/app deploy skew while the deprecated field remains available on both schemas.

## Verification
- `pnpm --filter @sapience/sdk exec vitest run queries/__tests__/pickConfigurations.test.ts --pool=threads --poolOptions.threads.singleThread`
- `pnpm --filter @sapience/sdk run type-check`
- `pnpm --filter @sapience/app run type-check`
- `pnpm --filter @sapience/sdk run lint`
- `pnpm --filter @sapience/app run lint`
- `git diff --check`
