### PR TITLE
refactor(api): replace by-attr resolvers with connection filters

### DIFF
--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -2380,6 +2380,38 @@ type Vault implements Node {
   stats(filter: VaultStatsFilter): VaultStatsConnection!
 }
 
+type VaultConnection {
+  edges: [VaultEdge!]!
+  nodes: [Vault!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type VaultEdge {
+  node: Vault!
+  cursor: String!
+}
+
+"""
+Filter input for `vaultsConnection`. Vaults are a small statically
+configured set, so the filter exists primarily to support
+`vaultsConnection(filter: { address: $a })` as the by-address lookup
+pattern — the connection replaces the dedicated `vaultByAddress` query.
+"""
+input VaultFilter {
+  """
+  Restrict to a single vault address (case-insensitive). Matches both
+  the canonical vault address and any of its configured legacy aliases.
+  """
+  address: Address
+
+  """
+  Restrict to a single chain. Defaults to the SDK's `DEFAULT_CHAIN_ID`
+  when omitted.
+  """
+  chainId: Int
+}
+
 """Protocol-wide stats snapshot — no vault scoping."""
 type ProtocolStat {
   """Snapshot boundary, aligned to the snapshot interval."""
@@ -2526,6 +2558,13 @@ Filter input for the Relay-shaped `tradesConnection` query. Combines with AND.
 """
 input TradeFilter {
   """
+  Restrict to a single trade by execution hash. Supports the
+  by-hash single-record lookup pattern — `tradesConnection(filter: { tradeHash: $h }).nodes[0]`
+  replaces the dedicated `tradeByHash` query.
+  """
+  tradeHash: Bytes32
+
+  """
   Restrict to trades where the address is seller or buyer (case-insensitive). Mutually exclusive with `seller`/`buyer`.
   """
   address: String
@@ -2624,6 +2663,14 @@ Filter input for the `predictionsConnection` query. Each field is optional;
 values combine with AND.
 """
 input PredictionFilter {
+  """
+  Restrict to a single prediction by on-chain id. Supports the
+  by-predictionId single-record lookup pattern —
+  `predictionsConnection(filter: { predictionId: $p }).nodes[0]` replaces
+  the dedicated `predictionByOnchainId` query.
+  """
+  predictionId: String
+
   """
   Restrict to predictions where the address is predictor or counterparty (case-insensitive).
   """
@@ -2741,10 +2788,11 @@ type Query {
   """
   Refetch any `Node`-implementing entity by its opaque global id. Returns
   `null` when the id is malformed, the type is not registered, or the
-  underlying entity has been deleted. Domain-id lookups (e.g.
-  `predictionByOnchainId`, `tradeByHash`) remain the preferred entry point
-  for new traffic; `node(id:)` exists so Relay-style clients can refetch
-  cached entities polymorphically without knowing their concrete type.
+  underlying entity has been deleted. By-attribute lookups go through the
+  matching `*Connection(filter:)` — e.g. `tradesConnection(filter: { tradeHash: $h }).nodes[0]`
+  or `predictionsConnection(filter: { predictionId: $p }).nodes[0]`. `node(id:)`
+  exists so Relay-style clients can refetch cached entities polymorphically
+  without knowing their concrete type.
   """
   node(id: ID!): Node
 
@@ -2853,7 +2901,14 @@ type Query {
   """
   protocol: Protocol!
   vault(id: ID!): Vault
-  vaultByAddress(address: Address!, chainId: Int = 13374202): Vault
+
+  """
+  Paginated vault list, filterable by address / chain. Vaults are a
+  small statically configured set, so this exists mainly as the
+  by-address lookup pattern (`vaultsConnection(filter: { address: $a })`)
+  — replacing the dedicated `vaultByAddress` query.
+  """
+  vaultsConnection(first: Int = 50, after: String, filter: VaultFilter): VaultConnection!
   accountStatsLeaderboardPage(filters: AccountStatsFilters, take: Int! = 25, skip: Int! = 0): AccountStatsLeaderboardPage! @deprecated(reason: "Use `leaderboard(metric: PNL|VOLUME|ROI, first:, after:, filter:)` — Relay-shaped pagination over the same ranked set.")
 
   """
@@ -2890,7 +2945,6 @@ type Query {
   `attestations` sibling above is removed.
   """
   forecastsConnection(first: Int = 50, after: String, filter: ForecastFilter, orderBy: ForecastOrder): ForecastConnection!
-  forecastByUid(uid: String!): Forecast
   categories(cursor: CategoryWhereUniqueInput, distinct: [CategoryScalarFieldEnum!], orderBy: [CategoryOrderByWithRelationInput!], skip: Int, take: Int, where: CategoryWhereInput): [Category!]! @deprecated(reason: "Use `categoriesConnection(first:, after:)` — Relay-shaped cursor pagination over categories.")
 
   """
@@ -3052,7 +3106,6 @@ type Query {
   callers keep working through one release.
   """
   prediction(predictionId: String, id: String @deprecated(reason: "Use `predictionId:` — same value, the new arg name disambiguates it from the `Prediction.id` (Int!) row id surfaced on `predictionsConnection` nodes.")): Prediction
-  predictionByOnchainId(predictionId: String!): Prediction
 
   """Count of escrow predictions involving the given address"""
   predictionCount(address: String!, chainId: Int): Int! @deprecated(reason: "Use `predictionsConnection(...).totalCount` — same number, available alongside the connection payload, no extra query needed.")
@@ -3139,9 +3192,6 @@ type Query {
   """
   trades(address: String, buyer: String, chainId: Int, seller: String, skip: Int! = 0, take: Int! = 50, token: String): [Trade!]! @deprecated(reason: "Use `tradesConnection` — Relay-shaped cursor pagination over the same data.")
 
-  """Look up a single secondary market trade by its trade hash."""
-  tradeByHash(hash: Bytes32!): Trade
-
   """
   Relay-shaped connection over secondary market trades.
   
@@ -3165,7 +3215,7 @@ type Query {
   trailing live candle (anchored to the *current* interval boundary) is
   appended when `toEpoch` covers now.
   """
-  vaultStats(vaultAddress: String!, from: UnixSeconds, to: UnixSeconds, fromEpoch: Int @deprecated(reason: "Use `from: UnixSeconds` — same wire format, drops the unit-suffix."), toEpoch: Int @deprecated(reason: "Use `to: UnixSeconds` — same wire format, drops the unit-suffix.")): [VaultStat!]! @deprecated(reason: "Use `vaultByAddress(address:).stats(filter:)` — per-vault snapshots now live on Vault.")
+  vaultStats(vaultAddress: String!, from: UnixSeconds, to: UnixSeconds, fromEpoch: Int @deprecated(reason: "Use `from: UnixSeconds` — same wire format, drops the unit-suffix."), toEpoch: Int @deprecated(reason: "Use `to: UnixSeconds` — same wire format, drops the unit-suffix.")): [VaultStat!]! @deprecated(reason: "Use `vaultsConnection(filter: { address: $a }).nodes[0].stats(filter:)` — per-vault snapshots live on Vault.")
 }
 
 """

--- a/packages/api/src/graphql/sdl/resolvers/index.ts
+++ b/packages/api/src/graphql/sdl/resolvers/index.ts
@@ -52,7 +52,7 @@ import {
   Protocol,
   vault,
   Vault,
-  vaultByAddress,
+  vaultsConnection,
   vaultStats,
 } from './queries/analytics';
 import {
@@ -76,7 +76,6 @@ import {
   categories,
   categoriesConnection,
   condition,
-  forecastByUid,
   forecastsConnection,
   user,
 } from './queries/crud';
@@ -89,7 +88,6 @@ import {
   positionsConnection,
   positionsPage,
   prediction,
-  predictionByOnchainId,
   predictionsConnection,
 } from './queries/escrow';
 import {
@@ -110,7 +108,7 @@ import {
   protocolVolume,
 } from './queries/timeSeries';
 import { node, nodes } from './queries/node';
-import { trade, tradeByHash, tradesConnection } from './queries/trade';
+import { trade, tradesConnection } from './queries/trade';
 import { trades, tradeCount } from './queries/deprecated/trade';
 import { accountTotalVolume } from './queries/volume';
 
@@ -141,7 +139,7 @@ export const resolvers: Resolvers = {
     protocol,
     protocolStats,
     vault,
-    vaultByAddress,
+    vaultsConnection,
     vaultStats,
     // Legacy per-metric time series (DEPRECATED — superseded by accountStats / accountStatsRank.volume / protocolStats).
     accountBalance,
@@ -171,13 +169,11 @@ export const resolvers: Resolvers = {
     positionsConnection,
     positionsPage,
     prediction,
-    predictionByOnchainId,
     predictionCount,
     predictions,
     predictionsConnection,
     // Secondary market trades
     trade,
-    tradeByHash,
     tradeCount,
     trades,
     tradesConnection,
@@ -187,7 +183,6 @@ export const resolvers: Resolvers = {
     account,
     accountsConnection,
     attestations,
-    forecastByUid,
     forecastsConnection,
     categories,
     categoriesConnection,

--- a/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
@@ -17,7 +17,7 @@ import {
   toGlobalId,
 } from '../../../relay/globalId';
 import { synthesizeAccount } from '../accountSynthesis';
-import { encodeCursor } from '../../../relay/cursor';
+import { decodeCursor, encodeCursor } from '../../../relay/cursor';
 import type {
   QueryResolvers,
   ProtocolStat,
@@ -736,36 +736,70 @@ export const protocol = (async () => ({})) as unknown as NonNullable<
   QueryResolvers['protocol']
 >;
 
-type VaultLookupArgs = {
-  address: string;
-  chainId?: number | null;
-};
-
-const vaultByAddressImpl = async (
-  _parent: unknown,
-  { address, chainId }: VaultLookupArgs
-) => {
-  const resolvedChainId = chainId ?? DEFAULT_CHAIN_ID;
+const findVaultByAddress = (chainId: number, address: string) => {
   const addr = address.toLowerCase();
-  const vault = getConfiguredVaults(resolvedChainId).find(
+  const vault = getConfiguredVaults(chainId).find(
     (v) =>
       v.address === addr ||
       (v.config.legacy ?? []).some(
         (le) => normalizeLegacyEntry(le).address.toLowerCase() === addr
       )
   );
-  return vault ? mapVault({ ...vault, address: addr }, resolvedChainId) : null;
+  return vault ? mapVault({ ...vault, address: addr }, chainId) : null;
 };
-
-export const vaultByAddress = vaultByAddressImpl as unknown as NonNullable<
-  QueryResolvers['vaultByAddress']
->;
 
 export const vault = (async (_parent: unknown, { id }: { id: string }) => {
   const parsed = parseVaultDomainId(fromGlobalId(id).id);
   if (!parsed) return null;
-  return vaultByAddressImpl(null, parsed);
+  return findVaultByAddress(parsed.chainId, parsed.address);
 }) as unknown as NonNullable<QueryResolvers['vault']>;
+
+type VaultsConnectionArgs = {
+  first?: number | null;
+  after?: string | null;
+  filter?: { address?: string | null; chainId?: number | null } | null;
+};
+
+export const vaultsConnection = (async (
+  _parent: unknown,
+  { first, after, filter }: VaultsConnectionArgs
+) => {
+  const cappedFirst = Math.min(Math.max(first ?? 50, 1), 100);
+  const chainId = filter?.chainId ?? DEFAULT_CHAIN_ID;
+
+  // Optimization: when filter.address is set, short-circuit to a direct
+  // lookup — same payload, no list scan.
+  let nodes: ReturnType<typeof mapVault>[];
+  if (filter?.address) {
+    const node = findVaultByAddress(chainId, filter.address);
+    nodes = node ? [node] : [];
+  } else {
+    nodes = getConfiguredVaults(chainId).map((v) => mapVault(v, chainId));
+  }
+
+  const totalCount = nodes.length;
+  const startOffset = (() => {
+    const payload = after ? decodeCursor(after) : null;
+    const offset = payload ? Number(payload.k) : Number.NaN;
+    return Number.isInteger(offset) && offset >= 0 ? offset + 1 : 0;
+  })();
+  const window = nodes.slice(startOffset, startOffset + cappedFirst);
+  const edges = window.map((node, i) => ({
+    node,
+    cursor: encodeCursor({ k: String(startOffset + i), id: node.address }),
+  }));
+  return {
+    edges,
+    nodes: window,
+    totalCount,
+    pageInfo: {
+      hasNextPage: startOffset + window.length < totalCount,
+      hasPreviousPage: startOffset > 0,
+      startCursor: edges[0]?.cursor ?? null,
+      endCursor: edges[edges.length - 1]?.cursor ?? null,
+    },
+  };
+}) as unknown as NonNullable<QueryResolvers['vaultsConnection']>;
 
 export const Protocol = {
   stats: async (

--- a/packages/api/src/graphql/sdl/resolvers/queries/crud.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/crud.ts
@@ -378,13 +378,6 @@ export const forecastsConnection: NonNullable<
   };
 };
 
-export const forecastByUid: NonNullable<
-  QueryResolvers['forecastByUid']
-> = async (_parent, { uid }) => {
-  const row = await prisma.attestation.findUnique({ where: { uid } });
-  return row ? mapForecast(row) : null;
-};
-
 const buildCategoryCursorPredicate = (
   name: string,
   id: string

--- a/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
@@ -122,6 +122,7 @@ export type PredictionsEnvelope = {
  * `predictionsConnection` / `PredictionFilter`.
  */
 export type RunPredictionsArgs = QueryPredictionsArgs & {
+  predictionId?: string | null;
   pickConfigId?: string | null;
   conditionGroupId?: string | number | null;
   conditionIds?: string[] | null;
@@ -132,6 +133,7 @@ export type RunPredictionsArgs = QueryPredictionsArgs & {
 };
 
 const buildPredictionWhere = async ({
+  predictionId,
   address,
   conditionId,
   pickConfigId,
@@ -146,6 +148,7 @@ const buildPredictionWhere = async ({
   endsAtMax,
 }: Pick<
   RunPredictionsArgs,
+  | 'predictionId'
   | 'address'
   | 'conditionId'
   | 'pickConfigId'
@@ -162,6 +165,9 @@ const buildPredictionWhere = async ({
   const addr = address?.toLowerCase();
   const where: Prisma.PredictionWhereInput = {};
   const filters: Prisma.PredictionWhereInput[] = [];
+  if (predictionId) {
+    filters.push({ predictionId: predictionId.toLowerCase() });
+  }
   if (addr) filters.push({ OR: [{ predictor: addr }, { counterparty: addr }] });
   if (pickConfigId) {
     filters.push({ pickConfigId: pickConfigId.toLowerCase() });
@@ -232,6 +238,7 @@ const buildPredictionWhere = async ({
 export const runPredictions = async ({
   take,
   skip,
+  predictionId,
   address,
   conditionId,
   pickConfigId,
@@ -249,6 +256,7 @@ export const runPredictions = async ({
   const cappedTake = clampTake(take, { defaultTake: 50, maxTake: 100 });
   const skipVal = clampSkip(skip);
   const { where, empty } = await buildPredictionWhere({
+    predictionId,
     address,
     conditionId,
     pickConfigId,
@@ -325,6 +333,9 @@ export const predictionsConnection: NonNullable<
   const prismaDir = direction === OrderDirection.Asc ? 'asc' : 'desc';
 
   const { where: filterWhere, empty } = await buildPredictionWhere({
+    predictionId:
+      (filter as { predictionId?: string | null } | null | undefined)
+        ?.predictionId ?? null,
     address: filter?.address ?? null,
     conditionId: filter?.conditionId ?? null,
     pickConfigId:
@@ -406,16 +417,6 @@ export const predictionsConnection: NonNullable<
       endCursor: edges[edges.length - 1]?.cursor ?? null,
     },
   };
-};
-
-export const predictionByOnchainId: NonNullable<
-  QueryResolvers['predictionByOnchainId']
-> = async (_parent, { predictionId }) => {
-  const r = await prisma.prediction.findUnique({
-    where: { predictionId: predictionId.toLowerCase() },
-    include: { pickConfiguration: { include: { picks: true } } },
-  });
-  return r ? mapPrediction(r) : null;
 };
 
 export const prediction: NonNullable<QueryResolvers['prediction']> = async (

--- a/packages/api/src/graphql/sdl/resolvers/queries/trade.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/trade.ts
@@ -55,6 +55,7 @@ export type TradesPageEnvelope = {
  * pipeline for both surfaces.
  */
 export type RunTradesArgs = QueryTradesArgs & {
+  tradeHash?: string | null;
   executedAtMin?: number | null;
   executedAtMax?: number | null;
   orderBy?: 'EXECUTED_AT' | 'BLOCK_NUMBER' | null;
@@ -65,6 +66,7 @@ export type RunTradesArgs = QueryTradesArgs & {
 export const runTrades = async ({
   take,
   skip,
+  tradeHash,
   address,
   seller,
   buyer,
@@ -79,6 +81,7 @@ export const runTrades = async ({
   const cappedTake = clampTake(take, { defaultTake: 50, maxTake: 100 });
   const skipVal = clampSkip(skip);
   const where: Prisma.SecondaryTradeWhereInput = {};
+  if (tradeHash) where.tradeHash = tradeHash.toLowerCase();
   if (address && (seller || buyer)) {
     throw new Error(
       'Cannot combine "address" with "seller" or "buyer" filters'
@@ -168,6 +171,9 @@ const mergeTradeFilters = (args: QueryTradesConnectionArgs): RunTradesArgs => {
   return {
     take: args.first ?? 50,
     skip: offsetFromCursor(args.after),
+    tradeHash:
+      (f as { tradeHash?: string | null } | null | undefined)?.tradeHash ??
+      null,
     address: f?.address ?? null,
     seller: f?.seller ?? null,
     buyer: f?.buyer ?? null,
@@ -227,16 +233,6 @@ export const trade: NonNullable<QueryResolvers['trade']> = async (
   }
   const r = await prisma.secondaryTrade.findUnique({
     where: { tradeHash: key.toLowerCase() },
-  });
-  return r ? mapTrade(r) : null;
-};
-
-export const tradeByHash: NonNullable<QueryResolvers['tradeByHash']> = async (
-  _parent,
-  { hash }
-) => {
-  const r = await prisma.secondaryTrade.findUnique({
-    where: { tradeHash: hash.toLowerCase() },
   });
   return r ? mapTrade(r) : null;
 };

--- a/packages/api/src/graphql/sdl/resolvers/queries/treasury.test.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/treasury.test.ts
@@ -22,7 +22,7 @@ import {
   collateralBalance,
 } from './collateralBalance';
 import { categoriesConnection } from './crud';
-import { protocol, vaultByAddress } from './analytics';
+import { protocol, vaultsConnection } from './analytics';
 
 const TESTNET = 13374202;
 const ACCOUNT = '0x000000000000000000000000000000000000aaaa';
@@ -225,14 +225,23 @@ describe('treasury — protocol/vault/categories surface', () => {
     expect(p).toEqual({});
   });
 
-  it('resolves vaultByAddress with lowercase Vault node id', async () => {
-    const vault = await callResolver(vaultByAddress)(
+  it('vaultsConnection resolves by address with lowercase Vault node id', async () => {
+    const result = await callResolver<{
+      nodes: Array<{
+        id: string;
+        address: string;
+        chainId: number;
+        account: { address: string };
+      }>;
+      totalCount: number;
+    }>(vaultsConnection)(
       null,
-      { address: VAULT.toUpperCase(), chainId: TESTNET },
+      { filter: { address: VAULT.toUpperCase(), chainId: TESTNET } },
       {} as never,
       null as never
     );
-    expect(vault).toMatchObject({
+    expect(result.totalCount).toBe(1);
+    expect(result.nodes[0]).toMatchObject({
       id: toGlobalId('Vault', `${TESTNET}:${VAULT}`),
       address: VAULT,
       chainId: TESTNET,

--- a/packages/api/src/graphql/sdl/schema/schema.graphql
+++ b/packages/api/src/graphql/sdl/schema/schema.graphql
@@ -2714,6 +2714,37 @@ type Vault implements Node {
   stats(filter: VaultStatsFilter): VaultStatsConnection!
 }
 
+type VaultConnection {
+  edges: [VaultEdge!]!
+  nodes: [Vault!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type VaultEdge {
+  node: Vault!
+  cursor: String!
+}
+
+"""
+Filter input for `vaultsConnection`. Vaults are a small statically
+configured set, so the filter exists primarily to support
+`vaultsConnection(filter: { address: $a })` as the by-address lookup
+pattern — the connection replaces the dedicated `vaultByAddress` query.
+"""
+input VaultFilter {
+  """
+  Restrict to a single vault address (case-insensitive). Matches both
+  the canonical vault address and any of its configured legacy aliases.
+  """
+  address: Address
+  """
+  Restrict to a single chain. Defaults to the SDK's `DEFAULT_CHAIN_ID`
+  when omitted.
+  """
+  chainId: Int
+}
+
 """
 Protocol-wide stats snapshot — no vault scoping.
 """
@@ -2908,6 +2939,12 @@ Filter input for the Relay-shaped `tradesConnection` query. Combines with AND.
 """
 input TradeFilter {
   """
+  Restrict to a single trade by execution hash. Supports the
+  by-hash single-record lookup pattern — `tradesConnection(filter: { tradeHash: $h }).nodes[0]`
+  replaces the dedicated `tradeByHash` query.
+  """
+  tradeHash: Bytes32
+  """
   Restrict to trades where the address is seller or buyer (case-insensitive). Mutually exclusive with `seller`/`buyer`.
   """
   address: String
@@ -3014,6 +3051,13 @@ Filter input for the `predictionsConnection` query. Each field is optional;
 values combine with AND.
 """
 input PredictionFilter {
+  """
+  Restrict to a single prediction by on-chain id. Supports the
+  by-predictionId single-record lookup pattern —
+  `predictionsConnection(filter: { predictionId: $p }).nodes[0]` replaces
+  the dedicated `predictionByOnchainId` query.
+  """
+  predictionId: String
   """
   Restrict to predictions where the address is predictor or counterparty (case-insensitive).
   """
@@ -3145,10 +3189,11 @@ type Query {
   """
   Refetch any `Node`-implementing entity by its opaque global id. Returns
   `null` when the id is malformed, the type is not registered, or the
-  underlying entity has been deleted. Domain-id lookups (e.g.
-  `predictionByOnchainId`, `tradeByHash`) remain the preferred entry point
-  for new traffic; `node(id:)` exists so Relay-style clients can refetch
-  cached entities polymorphically without knowing their concrete type.
+  underlying entity has been deleted. By-attribute lookups go through the
+  matching `*Connection(filter:)` — e.g. `tradesConnection(filter: { tradeHash: $h }).nodes[0]`
+  or `predictionsConnection(filter: { predictionId: $p }).nodes[0]`. `node(id:)`
+  exists so Relay-style clients can refetch cached entities polymorphically
+  without knowing their concrete type.
   """
   node(id: ID!): Node
 
@@ -3358,7 +3403,17 @@ type Query {
   """
   protocol: Protocol!
   vault(id: ID!): Vault
-  vaultByAddress(address: Address!, chainId: Int = 13374202): Vault
+  """
+  Paginated vault list, filterable by address / chain. Vaults are a
+  small statically configured set, so this exists mainly as the
+  by-address lookup pattern (`vaultsConnection(filter: { address: $a })`)
+  — replacing the dedicated `vaultByAddress` query.
+  """
+  vaultsConnection(
+    first: Int = 50
+    after: String
+    filter: VaultFilter
+  ): VaultConnection!
   accountStatsLeaderboardPage(
     filters: AccountStatsFilters
     take: Int! = 25
@@ -3432,7 +3487,6 @@ type Query {
     filter: ForecastFilter
     orderBy: ForecastOrder
   ): ForecastConnection!
-  forecastByUid(uid: String!): Forecast
   categories(
     cursor: CategoryWhereUniqueInput
     distinct: [CategoryScalarFieldEnum!]
@@ -3798,7 +3852,6 @@ type Query {
         reason: "Use `predictionId:` — same value, the new arg name disambiguates it from the `Prediction.id` (Int!) row id surfaced on `predictionsConnection` nodes."
       )
   ): Prediction
-  predictionByOnchainId(predictionId: String!): Prediction
 
   """
   Count of escrow predictions involving the given address
@@ -3980,11 +4033,6 @@ type Query {
     )
 
   """
-  Look up a single secondary market trade by its trade hash.
-  """
-  tradeByHash(hash: Bytes32!): Trade
-
-  """
   Relay-shaped connection over secondary market trades.
 
   Note: this field will be renamed to drop the `Connection` suffix
@@ -4039,7 +4087,7 @@ type Query {
       )
   ): [VaultStat!]!
     @deprecated(
-      reason: "Use `vaultByAddress(address:).stats(filter:)` — per-vault snapshots now live on Vault."
+      reason: "Use `vaultsConnection(filter: { address: $a }).nodes[0].stats(filter:)` — per-vault snapshots live on Vault."
     )
 }
 

--- a/packages/api/test/contract/__snapshots__/schema.sdl.graphql
+++ b/packages/api/test/contract/__snapshots__/schema.sdl.graphql
@@ -2380,6 +2380,38 @@ type Vault implements Node {
   stats(filter: VaultStatsFilter): VaultStatsConnection!
 }
 
+type VaultConnection {
+  edges: [VaultEdge!]!
+  nodes: [Vault!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type VaultEdge {
+  node: Vault!
+  cursor: String!
+}
+
+"""
+Filter input for `vaultsConnection`. Vaults are a small statically
+configured set, so the filter exists primarily to support
+`vaultsConnection(filter: { address: $a })` as the by-address lookup
+pattern — the connection replaces the dedicated `vaultByAddress` query.
+"""
+input VaultFilter {
+  """
+  Restrict to a single vault address (case-insensitive). Matches both
+  the canonical vault address and any of its configured legacy aliases.
+  """
+  address: Address
+
+  """
+  Restrict to a single chain. Defaults to the SDK's `DEFAULT_CHAIN_ID`
+  when omitted.
+  """
+  chainId: Int
+}
+
 """Protocol-wide stats snapshot — no vault scoping."""
 type ProtocolStat {
   """Snapshot boundary, aligned to the snapshot interval."""
@@ -2526,6 +2558,13 @@ Filter input for the Relay-shaped `tradesConnection` query. Combines with AND.
 """
 input TradeFilter {
   """
+  Restrict to a single trade by execution hash. Supports the
+  by-hash single-record lookup pattern — `tradesConnection(filter: { tradeHash: $h }).nodes[0]`
+  replaces the dedicated `tradeByHash` query.
+  """
+  tradeHash: Bytes32
+
+  """
   Restrict to trades where the address is seller or buyer (case-insensitive). Mutually exclusive with `seller`/`buyer`.
   """
   address: String
@@ -2624,6 +2663,14 @@ Filter input for the `predictionsConnection` query. Each field is optional;
 values combine with AND.
 """
 input PredictionFilter {
+  """
+  Restrict to a single prediction by on-chain id. Supports the
+  by-predictionId single-record lookup pattern —
+  `predictionsConnection(filter: { predictionId: $p }).nodes[0]` replaces
+  the dedicated `predictionByOnchainId` query.
+  """
+  predictionId: String
+
   """
   Restrict to predictions where the address is predictor or counterparty (case-insensitive).
   """
@@ -2741,10 +2788,11 @@ type Query {
   """
   Refetch any `Node`-implementing entity by its opaque global id. Returns
   `null` when the id is malformed, the type is not registered, or the
-  underlying entity has been deleted. Domain-id lookups (e.g.
-  `predictionByOnchainId`, `tradeByHash`) remain the preferred entry point
-  for new traffic; `node(id:)` exists so Relay-style clients can refetch
-  cached entities polymorphically without knowing their concrete type.
+  underlying entity has been deleted. By-attribute lookups go through the
+  matching `*Connection(filter:)` — e.g. `tradesConnection(filter: { tradeHash: $h }).nodes[0]`
+  or `predictionsConnection(filter: { predictionId: $p }).nodes[0]`. `node(id:)`
+  exists so Relay-style clients can refetch cached entities polymorphically
+  without knowing their concrete type.
   """
   node(id: ID!): Node
 
@@ -2853,7 +2901,14 @@ type Query {
   """
   protocol: Protocol!
   vault(id: ID!): Vault
-  vaultByAddress(address: Address!, chainId: Int = 13374202): Vault
+
+  """
+  Paginated vault list, filterable by address / chain. Vaults are a
+  small statically configured set, so this exists mainly as the
+  by-address lookup pattern (`vaultsConnection(filter: { address: $a })`)
+  — replacing the dedicated `vaultByAddress` query.
+  """
+  vaultsConnection(first: Int = 50, after: String, filter: VaultFilter): VaultConnection!
   accountStatsLeaderboardPage(filters: AccountStatsFilters, take: Int! = 25, skip: Int! = 0): AccountStatsLeaderboardPage! @deprecated(reason: "Use `leaderboard(metric: PNL|VOLUME|ROI, first:, after:, filter:)` — Relay-shaped pagination over the same ranked set.")
 
   """
@@ -2890,7 +2945,6 @@ type Query {
   `attestations` sibling above is removed.
   """
   forecastsConnection(first: Int = 50, after: String, filter: ForecastFilter, orderBy: ForecastOrder): ForecastConnection!
-  forecastByUid(uid: String!): Forecast
   categories(cursor: CategoryWhereUniqueInput, distinct: [CategoryScalarFieldEnum!], orderBy: [CategoryOrderByWithRelationInput!], skip: Int, take: Int, where: CategoryWhereInput): [Category!]! @deprecated(reason: "Use `categoriesConnection(first:, after:)` — Relay-shaped cursor pagination over categories.")
 
   """
@@ -3052,7 +3106,6 @@ type Query {
   callers keep working through one release.
   """
   prediction(predictionId: String, id: String @deprecated(reason: "Use `predictionId:` — same value, the new arg name disambiguates it from the `Prediction.id` (Int!) row id surfaced on `predictionsConnection` nodes.")): Prediction
-  predictionByOnchainId(predictionId: String!): Prediction
 
   """Count of escrow predictions involving the given address"""
   predictionCount(address: String!, chainId: Int): Int! @deprecated(reason: "Use `predictionsConnection(...).totalCount` — same number, available alongside the connection payload, no extra query needed.")
@@ -3139,9 +3192,6 @@ type Query {
   """
   trades(address: String, buyer: String, chainId: Int, seller: String, skip: Int! = 0, take: Int! = 50, token: String): [Trade!]! @deprecated(reason: "Use `tradesConnection` — Relay-shaped cursor pagination over the same data.")
 
-  """Look up a single secondary market trade by its trade hash."""
-  tradeByHash(hash: Bytes32!): Trade
-
   """
   Relay-shaped connection over secondary market trades.
   
@@ -3165,7 +3215,7 @@ type Query {
   trailing live candle (anchored to the *current* interval boundary) is
   appended when `toEpoch` covers now.
   """
-  vaultStats(vaultAddress: String!, from: UnixSeconds, to: UnixSeconds, fromEpoch: Int @deprecated(reason: "Use `from: UnixSeconds` — same wire format, drops the unit-suffix."), toEpoch: Int @deprecated(reason: "Use `to: UnixSeconds` — same wire format, drops the unit-suffix.")): [VaultStat!]! @deprecated(reason: "Use `vaultByAddress(address:).stats(filter:)` — per-vault snapshots now live on Vault.")
+  vaultStats(vaultAddress: String!, from: UnixSeconds, to: UnixSeconds, fromEpoch: Int @deprecated(reason: "Use `from: UnixSeconds` — same wire format, drops the unit-suffix."), toEpoch: Int @deprecated(reason: "Use `to: UnixSeconds` — same wire format, drops the unit-suffix.")): [VaultStat!]! @deprecated(reason: "Use `vaultsConnection(filter: { address: $a }).nodes[0].stats(filter:)` — per-vault snapshots live on Vault.")
 }
 
 """

--- a/packages/app/src/hooks/graphql/useSecondaryTrades.ts
+++ b/packages/app/src/hooks/graphql/useSecondaryTrades.ts
@@ -83,19 +83,21 @@ const ALL_TRADES_QUERY = /* GraphQL */ `
 
 const TRADE_QUERY = /* GraphQL */ `
   query Trade($tradeHash: Bytes32!) {
-    tradeByHash(hash: $tradeHash) {
-      id
-      tradeHash
-      chainId
-      token
-      collateral
-      seller
-      buyer
-      tokenAmount
-      price
-      txHash
-      blockNumber
-      executedAt
+    tradesConnection(filter: { tradeHash: $tradeHash }, first: 1) {
+      nodes {
+        id
+        tradeHash
+        chainId
+        token
+        collateral
+        seller
+        buyer
+        tokenAmount
+        price
+        txHash
+        blockNumber
+        executedAt
+      }
     }
   }
 `;
@@ -175,9 +177,9 @@ export function useSecondaryTrade(tradeHash?: string) {
     refetchOnReconnect: false,
     queryFn: async () => {
       const resp = await graphqlRequest<{
-        tradeByHash: SecondaryTrade | null;
+        tradesConnection: { nodes: SecondaryTrade[] };
       }>(TRADE_QUERY, { tradeHash });
-      return resp?.tradeByHash ?? null;
+      return resp?.tradesConnection?.nodes?.[0] ?? null;
     },
   });
 

--- a/packages/sdk/queries/__tests__/analytics.test.ts
+++ b/packages/sdk/queries/__tests__/analytics.test.ts
@@ -22,7 +22,9 @@ beforeEach(() => {
 describe('analytics GraphQL queries', () => {
   test('uses protocol.stats instead of legacy protocolStats root field', async () => {
     expect(GET_PROTOCOL_STATS).toContain('protocol {');
-    expect(GET_PROTOCOL_STATS).toContain('stats(filter: { timestamp: { gte: $from, lte: $to } })');
+    expect(GET_PROTOCOL_STATS).toContain(
+      'stats(filter: { timestamp: { gte: $from, lte: $to } })'
+    );
     expect(GET_PROTOCOL_STATS).not.toContain('protocolStats(');
 
     const nodes = [{ timestamp: 1, cumulativeVolume: '1' }];
@@ -30,33 +32,68 @@ describe('analytics GraphQL queries', () => {
     await expect(fetchProtocolStats()).resolves.toEqual(nodes);
   });
 
-  test('uses vaultByAddress(address:).stats instead of legacy vaultStats root field', async () => {
-    expect(GET_VAULT_STATS).toContain('vaultByAddress(address: $vaultAddress)');
-    expect(GET_VAULT_STATS).toContain('stats(filter: { timestamp: { gte: $from, lte: $to } })');
+  test('uses vaultsConnection(filter:{address:}).nodes[0].stats instead of legacy vaultStats root field', async () => {
+    expect(GET_VAULT_STATS).toContain(
+      'vaultsConnection(filter: { address: $vaultAddress }, first: 1)'
+    );
+    expect(GET_VAULT_STATS).toContain(
+      'stats(filter: { timestamp: { gte: $from, lte: $to } })'
+    );
+    expect(GET_VAULT_STATS).not.toContain('vaultByAddress(');
     expect(GET_VAULT_STATS).not.toContain('vaultStats(');
 
     const nodes = [{ timestamp: 1, balance: '1' }];
-    mockGraphqlRequest.mockResolvedValue({ vaultByAddress: { stats: { nodes } } });
+    mockGraphqlRequest.mockResolvedValue({
+      vaultsConnection: { nodes: [{ stats: { nodes } }] },
+    });
     await expect(
-      fetchVaultStats({ vaultAddress: '0x0000000000000000000000000000000000000001' })
+      fetchVaultStats({
+        vaultAddress: '0x0000000000000000000000000000000000000001',
+      })
     ).resolves.toEqual(nodes);
   });
 
+  test('vaultsConnection returns empty when no vault matches', async () => {
+    mockGraphqlRequest.mockResolvedValue({ vaultsConnection: { nodes: [] } });
+    await expect(
+      fetchVaultStats({
+        vaultAddress: '0x0000000000000000000000000000000000000001',
+      })
+    ).resolves.toEqual([]);
+  });
+
   test('uses protocol.openInterestByCategory instead of legacy root OI field', async () => {
-    expect(GET_OPEN_INTEREST_BY_CATEGORY).toMatch(/query OpenInterestByCategory \{\s*protocol \{/);
+    expect(GET_OPEN_INTEREST_BY_CATEGORY).toMatch(
+      /query OpenInterestByCategory \{\s*protocol \{/
+    );
     expect(GET_OPEN_INTEREST_BY_CATEGORY).toContain('openInterestByCategory {');
 
-    const rows = [{ category: { id: 'Q2F0ZWdvcnk6MQ==', name: 'Crypto', slug: 'crypto' }, openInterest: '1' }];
-    mockGraphqlRequest.mockResolvedValue({ protocol: { openInterestByCategory: rows } });
+    const rows = [
+      {
+        category: { id: 'Q2F0ZWdvcnk6MQ==', name: 'Crypto', slug: 'crypto' },
+        openInterest: '1',
+      },
+    ];
+    mockGraphqlRequest.mockResolvedValue({
+      protocol: { openInterestByCategory: rows },
+    });
     await expect(fetchOpenInterestByCategory()).resolves.toEqual(rows);
   });
 
   test('uses protocol.openInterestByTimeToResolution instead of legacy root OI field', async () => {
-    expect(GET_OPEN_INTEREST_BY_TIME_TO_RESOLUTION).toMatch(/query OpenInterestByTimeToResolution \{\s*protocol \{/);
-    expect(GET_OPEN_INTEREST_BY_TIME_TO_RESOLUTION).toContain('openInterestByTimeToResolution {');
+    expect(GET_OPEN_INTEREST_BY_TIME_TO_RESOLUTION).toMatch(
+      /query OpenInterestByTimeToResolution \{\s*protocol \{/
+    );
+    expect(GET_OPEN_INTEREST_BY_TIME_TO_RESOLUTION).toContain(
+      'openInterestByTimeToResolution {'
+    );
 
-    const rows = [{ bucket: 1, label: '≤1d', openInterest: '1', predictionCount: 2 }];
-    mockGraphqlRequest.mockResolvedValue({ protocol: { openInterestByTimeToResolution: rows } });
+    const rows = [
+      { bucket: 1, label: '≤1d', openInterest: '1', predictionCount: 2 },
+    ];
+    mockGraphqlRequest.mockResolvedValue({
+      protocol: { openInterestByTimeToResolution: rows },
+    });
     await expect(fetchOpenInterestByTimeToResolution()).resolves.toEqual(rows);
   });
 });

--- a/packages/sdk/queries/analytics.ts
+++ b/packages/sdk/queries/analytics.ts
@@ -50,23 +50,25 @@ export const GET_PROTOCOL_STATS = /* GraphQL */ `
 
 export const GET_VAULT_STATS = /* GraphQL */ `
   query VaultStats($vaultAddress: Address!, $from: Int, $to: Int) {
-    vaultByAddress(address: $vaultAddress) {
-      stats(filter: { timestamp: { gte: $from, lte: $to } }) {
-        nodes {
-          timestamp
-          balance
-          availableAssets
-          deployed
-          cumulativePnL
-          positionsWon
-          positionsLost
-          deposits
-          withdrawals
-          airdropGains
-          secondaryBought
-          secondarySold
-          unredeemedClaim
-          periodPnL
+    vaultsConnection(filter: { address: $vaultAddress }, first: 1) {
+      nodes {
+        stats(filter: { timestamp: { gte: $from, lte: $to } }) {
+          nodes {
+            timestamp
+            balance
+            availableAssets
+            deployed
+            cumulativePnL
+            positionsWon
+            positionsLost
+            deposits
+            withdrawals
+            airdropGains
+            secondaryBought
+            secondarySold
+            unredeemedClaim
+            periodPnL
+          }
         }
       }
     }
@@ -92,13 +94,15 @@ export async function fetchVaultStats(params: {
   to?: Date | string | number | null;
 }): Promise<VaultStat[]> {
   const data = await graphqlRequest<{
-    vaultByAddress?: { stats?: { nodes?: VaultStat[] } | null } | null;
+    vaultsConnection?: {
+      nodes?: Array<{ stats?: { nodes?: VaultStat[] } | null } | null> | null;
+    } | null;
   }>(GET_VAULT_STATS, {
     vaultAddress: params.vaultAddress,
     from: toEpochOrNull(params.from),
     to: toEpochOrNull(params.to),
   });
-  return data?.vaultByAddress?.stats?.nodes ?? [];
+  return data?.vaultsConnection?.nodes?.[0]?.stats?.nodes ?? [];
 }
 
 export interface CategoryOpenInterest {

--- a/packages/sdk/types/graphql.ts
+++ b/packages/sdk/types/graphql.ts
@@ -2533,6 +2533,13 @@ export type PredictionFilter = {
   /** Restrict to legacy (true) or non-legacy (false) predictions. */
   isLegacy?: InputMaybe<Scalars['Boolean']['input']>;
   pickConfigId?: InputMaybe<Scalars['String']['input']>;
+  /**
+   * Restrict to a single prediction by on-chain id. Supports the
+   * by-predictionId single-record lookup pattern —
+   * `predictionsConnection(filter: { predictionId: $p }).nodes[0]` replaces
+   * the dedicated `predictionByOnchainId` query.
+   */
+  predictionId?: InputMaybe<Scalars['String']['input']>;
   /** Restrict to predictions whose pickConfig settled with this result. */
   result?: InputMaybe<SettlementResult>;
   /** Restrict to settled (true) or unsettled (false) predictions. */
@@ -2828,7 +2835,6 @@ export type Query = {
    * bare-array sibling above is removed.
    */
   conditionsConnection: ConditionConnection;
-  forecastByUid?: Maybe<Forecast>;
   /**
    * Relay-style forecast list backed by EAS attestations. Defaults to attestedAt DESC.
    *
@@ -2841,10 +2847,11 @@ export type Query = {
   /**
    * Refetch any `Node`-implementing entity by its opaque global id. Returns
    * `null` when the id is malformed, the type is not registered, or the
-   * underlying entity has been deleted. Domain-id lookups (e.g.
-   * `predictionByOnchainId`, `tradeByHash`) remain the preferred entry point
-   * for new traffic; `node(id:)` exists so Relay-style clients can refetch
-   * cached entities polymorphically without knowing their concrete type.
+   * underlying entity has been deleted. By-attribute lookups go through the
+   * matching `*Connection(filter:)` — e.g. `tradesConnection(filter: { tradeHash: $h }).nodes[0]`
+   * or `predictionsConnection(filter: { predictionId: $p }).nodes[0]`. `node(id:)`
+   * exists so Relay-style clients can refetch cached entities polymorphically
+   * without knowing their concrete type.
    */
   node?: Maybe<Node>;
   /**
@@ -2912,7 +2919,6 @@ export type Query = {
    * callers keep working through one release.
    */
   prediction?: Maybe<Prediction>;
-  predictionByOnchainId?: Maybe<Prediction>;
   /**
    * Count of escrow predictions involving the given address
    * @deprecated Use `predictionsConnection(...).totalCount` — same number, available alongside the connection payload, no extra query needed.
@@ -2987,8 +2993,6 @@ export type Query = {
    * callers keep working through one release.
    */
   trade?: Maybe<Trade>;
-  /** Look up a single secondary market trade by its trade hash. */
-  tradeByHash?: Maybe<Trade>;
   /**
    * Count of secondary market trades matching the given filters
    * @deprecated Use `tradesConnection` — Relay-shaped cursor pagination over the same data.
@@ -3012,7 +3016,6 @@ export type Query = {
   /** @deprecated Unused; will be removed. No live consumers — account lookups go through `account(address:)`. */
   users: Array<User>;
   vault?: Maybe<Vault>;
-  vaultByAddress?: Maybe<Vault>;
   /**
    * Vault-specific statistics time series for a single vault address — vault
    * balance, deployed/available collateral, cumulative PnL, deposits,
@@ -3024,9 +3027,16 @@ export type Query = {
    * bars are labelled at the *start* of the interval they represent, and a
    * trailing live candle (anchored to the *current* interval boundary) is
    * appended when `toEpoch` covers now.
-   * @deprecated Use `vaultByAddress(address:).stats(filter:)` — per-vault snapshots now live on Vault.
+   * @deprecated Use `vaultsConnection(filter: { address: $a }).nodes[0].stats(filter:)` — per-vault snapshots live on Vault.
    */
   vaultStats: Array<VaultStat>;
+  /**
+   * Paginated vault list, filterable by address / chain. Vaults are a
+   * small statically configured set, so this exists mainly as the
+   * by-address lookup pattern (`vaultsConnection(filter: { address: $a })`)
+   * — replacing the dedicated `vaultByAddress` query.
+   */
+  vaultsConnection: VaultConnection;
 };
 
 
@@ -3293,11 +3303,6 @@ export type QueryConditionsConnectionArgs = {
 };
 
 
-export type QueryForecastByUidArgs = {
-  uid: Scalars['String']['input'];
-};
-
-
 export type QueryForecastsConnectionArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   filter?: InputMaybe<ForecastFilter>;
@@ -3407,11 +3412,6 @@ export type QueryPredictionArgs = {
 };
 
 
-export type QueryPredictionByOnchainIdArgs = {
-  predictionId: Scalars['String']['input'];
-};
-
-
 export type QueryPredictionCountArgs = {
   address: Scalars['String']['input'];
   chainId?: InputMaybe<Scalars['Int']['input']>;
@@ -3489,11 +3489,6 @@ export type QueryTradeArgs = {
 };
 
 
-export type QueryTradeByHashArgs = {
-  hash: Scalars['Bytes32']['input'];
-};
-
-
 export type QueryTradeCountArgs = {
   buyer?: InputMaybe<Scalars['String']['input']>;
   chainId?: InputMaybe<Scalars['Int']['input']>;
@@ -3541,18 +3536,19 @@ export type QueryVaultArgs = {
 };
 
 
-export type QueryVaultByAddressArgs = {
-  address: Scalars['Address']['input'];
-  chainId?: InputMaybe<Scalars['Int']['input']>;
-};
-
-
 export type QueryVaultStatsArgs = {
   from?: InputMaybe<Scalars['UnixSeconds']['input']>;
   fromEpoch?: InputMaybe<Scalars['Int']['input']>;
   to?: InputMaybe<Scalars['UnixSeconds']['input']>;
   toEpoch?: InputMaybe<Scalars['Int']['input']>;
   vaultAddress: Scalars['String']['input'];
+};
+
+
+export type QueryVaultsConnectionArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<VaultFilter>;
+  first?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type QueryMode =
@@ -4007,6 +4003,12 @@ export type TradeFilter = {
   /** Restrict to a single position token address (case-insensitive). */
   token?: InputMaybe<Scalars['String']['input']>;
   tokens?: InputMaybe<Array<Scalars['String']['input']>>;
+  /**
+   * Restrict to a single trade by execution hash. Supports the
+   * by-hash single-record lookup pattern — `tradesConnection(filter: { tradeHash: $h }).nodes[0]`
+   * replaces the dedicated `tradeByHash` query.
+   */
+  tradeHash?: InputMaybe<Scalars['Bytes32']['input']>;
 };
 
 /** Order input for the Relay-shaped `tradesConnection`. */
@@ -4174,6 +4176,39 @@ export type Vault = Node & {
 
 export type VaultStatsArgs = {
   filter?: InputMaybe<VaultStatsFilter>;
+};
+
+export type VaultConnection = {
+  __typename?: 'VaultConnection';
+  edges: Array<VaultEdge>;
+  nodes: Array<Vault>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type VaultEdge = {
+  __typename?: 'VaultEdge';
+  cursor: Scalars['String']['output'];
+  node: Vault;
+};
+
+/**
+ * Filter input for `vaultsConnection`. Vaults are a small statically
+ * configured set, so the filter exists primarily to support
+ * `vaultsConnection(filter: { address: $a })` as the by-address lookup
+ * pattern — the connection replaces the dedicated `vaultByAddress` query.
+ */
+export type VaultFilter = {
+  /**
+   * Restrict to a single vault address (case-insensitive). Matches both
+   * the canonical vault address and any of its configured legacy aliases.
+   */
+  address?: InputMaybe<Scalars['Address']['input']>;
+  /**
+   * Restrict to a single chain. Defaults to the SDK's `DEFAULT_CHAIN_ID`
+   * when omitted.
+   */
+  chainId?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Vault-specific stats snapshot for a single vault address. */


### PR DESCRIPTION
## Summary

Folds four standalone "by-attribute" lookups into their connection's `filter:` input — the same pattern as `account(address:)` / `accountsConnection(filter: { address })` already in the schema.

| Removed | Replacement |
|---|---|
| `vaultByAddress(address:, chainId?)` | `vaultsConnection(filter: { address, chainId })` |
| `tradeByHash(hash:)` | `tradesConnection(filter: { tradeHash })` |
| `predictionByOnchainId(predictionId:)` | `predictionsConnection(filter: { predictionId })` |
| `forecastByUid(uid:)` | `forecastsConnection(filter: { uid })` (filter field already existed) |

### Schema changes
- **New types:** `VaultConnection`, `VaultEdge`, `VaultFilter`. Connection short-circuits to a direct lookup when `filter.address` is set, so the single-record case stays O(1).
- **New filter fields:** `TradeFilter.tradeHash: Bytes32`, `PredictionFilter.predictionId: String` — threaded through `runTrades` / `mergeTradeFilters` and `buildPredictionWhere` / `runPredictions` respectively.
- **Docstring updates:** `vaultStats` deprecation reason now points at `vaultsConnection(filter: { address }).nodes[0].stats(filter:)`; `Query.node` docstring updated so the by-attribute migration path is clear.

### Consumer updates
- SDK `GET_VAULT_STATS` rewritten to use `vaultsConnection(filter:{ address: $vaultAddress }, first: 1)`. SDK test asserts both the happy path and the empty-result case.
- App `useSecondaryTrade` hook rewritten to use `tradesConnection(filter:{ tradeHash }, first: 1).nodes[0]`.

### Rationale for hard-cut (no deprecation cycle)
Same call as the recent Legacy/LimitOrder pass. No external consumers — only the SDK (vault stats) and the app (secondary trade detail) used these resolvers, both updated in this PR.

## Test plan

- [x] `pnpm --filter @sapience/api test` — 771/771 pass
- [x] `pnpm --filter @sapience/sdk test` — 665/665 pass
- [x] `pnpm --filter @sapience/app type-check` — clean
- [x] `pnpm --filter @sapience/app lint` — clean
- [x] `pnpm --filter @sapience/api test:contract` — same baseline as plain staging (10 file / 11 test pre-existing cursor/token-format failures, unrelated). Schema snapshot updated.
- [ ] Smoke-check on staging: vault analytics page still renders + secondary-trade detail page still resolves by hash
- [ ] Confirm no internal services / scripts call the dropped resolvers (a grep across keeper/relayer/market-keeper turned up zero references)

🤖 Generated with [Claude Code](https://claude.com/claude-code)