### PR TITLE
fix(api): absorb older-client query shapes hitting staging Sentry

### DIFF
--- a/packages/api/codegen-resolvers.ts
+++ b/packages/api/codegen-resolvers.ts
@@ -74,6 +74,21 @@ const config: CodegenConfig = {
         },
         avoidOptionals: false,
         enumsAsTypes: false,
+        // Replace generated TS enums with hand-written ones for the
+        // three enums that intentionally carry both SCREAMING_SNAKE
+        // and camelCase (or lowercase/uppercase) wire values for
+        // older-client compatibility. graphql-codegen's default
+        // PascalCase transformation collides across casings; the
+        // hand-written enums in enumOverrides.ts give each member a
+        // unique TS identifier while preserving the original wire
+        // values for the canonical members so existing resolver
+        // references like `SortOrder.Asc` keep compiling.
+        enumValues: {
+          PredictionSortField:
+            '../enumOverrides#PredictionSortField',
+          PositionSortField: '../enumOverrides#PositionSortField',
+          SortOrder: '../enumOverrides#SortOrder',
+        },
         // Let `makeExecutableSchema` do the typename work at runtime
         // via prisma-model mappers; we don't need __resolveType here
         // unless we introduce a union/interface later in the port.

--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -819,6 +819,12 @@ type ConditionGroup {
   id: Int!
   name: String!
   similarMarkets: [String!]!
+
+  """
+  Compatibility alias mirroring `name`. Kept so external clients still
+  selecting `ConditionGroup.title` keep working through one release.
+  """
+  title: String! @deprecated(reason: "Use `name` — same value, the alias exists only to absorb in-flight queries from older clients.")
 }
 
 type ConditionGroupCount {
@@ -2207,6 +2213,8 @@ type Position {
 enum PositionSortField {
   CREATED_AT
   UPDATED_AT
+  createdAt @deprecated(reason: "Use `CREATED_AT` — camelCase value kept for compatibility with older clients.")
+  updatedAt @deprecated(reason: "Use `UPDATED_AT` — camelCase kept for older clients.")
 }
 
 """
@@ -2242,6 +2250,8 @@ type Prediction {
 enum PredictionSortField {
   CREATED_AT
   SETTLED_AT
+  createdAt @deprecated(reason: "Use `CREATED_AT` — camelCase value kept for compatibility with older clients.")
+  settledAt @deprecated(reason: "Use `SETTLED_AT` — camelCase kept for older clients.")
 }
 
 """Metric an account-stats leaderboard is ranked by."""
@@ -3551,6 +3561,8 @@ input SettlementResultFilter {
 enum SortOrder {
   asc
   desc
+  ASC @deprecated(reason: "Use `asc` — uppercase value kept for compatibility with older clients passing `OrderDirection`-shaped values.")
+  DESC @deprecated(reason: "Use `desc` — uppercase value kept for compatibility with older clients passing `OrderDirection`-shaped values.")
 }
 
 input SortOrderInput {

--- a/packages/api/src/graphql/sdl/enumOverrides.ts
+++ b/packages/api/src/graphql/sdl/enumOverrides.ts
@@ -1,0 +1,33 @@
+/**
+ * Hand-written TS enums for GraphQL enums that intentionally carry
+ * both canonical and legacy-cased members so older clients keep
+ * working through a deprecation window. graphql-codegen's default
+ * PascalCase transformation collides on the two casings (e.g.
+ * `CREATED_AT` and `createdAt` both become `CreatedAt`), so the
+ * affected enums are mapped to this file via codegen-resolvers.ts.
+ *
+ * Wire values match the SDL exactly; the canonical members keep
+ * their PascalCase TS names so existing resolver references like
+ * `SortOrder.Asc` and `PositionSortField.CreatedAt` compile unchanged.
+ */
+
+export enum PredictionSortField {
+  CreatedAt = 'CREATED_AT',
+  SettledAt = 'SETTLED_AT',
+  CreatedAtLegacy = 'createdAt',
+  SettledAtLegacy = 'settledAt',
+}
+
+export enum PositionSortField {
+  CreatedAt = 'CREATED_AT',
+  UpdatedAt = 'UPDATED_AT',
+  CreatedAtLegacy = 'createdAt',
+  UpdatedAtLegacy = 'updatedAt',
+}
+
+export enum SortOrder {
+  Asc = 'asc',
+  Desc = 'desc',
+  AscLegacy = 'ASC',
+  DescLegacy = 'DESC',
+}

--- a/packages/api/src/graphql/sdl/resolvers/ConditionGroup.test.ts
+++ b/packages/api/src/graphql/sdl/resolvers/ConditionGroup.test.ts
@@ -12,7 +12,7 @@ type RelationFn = (
 ) => Promise<unknown>;
 
 const callField = (
-  field: 'category' | 'conditions',
+  field: 'category' | 'conditions' | 'title',
   parent: unknown,
   args: unknown,
   ctx: unknown
@@ -61,6 +61,18 @@ describe('ConditionGroup.category', () => {
     );
     expect(result).toBe(preloaded);
     expect(helperMock.loadRelation).not.toHaveBeenCalled();
+  });
+});
+
+describe('ConditionGroup.title', () => {
+  it('mirrors `name` so older clients selecting `title` keep working', async () => {
+    const result = await callField('title', { id: 1, name: 'Crypto' }, {}, {});
+    expect(result).toBe('Crypto');
+  });
+
+  it('returns empty string when name is missing rather than null', async () => {
+    const result = await callField('title', { id: 1, name: null }, {}, {});
+    expect(result).toBe('');
   });
 });
 

--- a/packages/api/src/graphql/sdl/resolvers/ConditionGroup.ts
+++ b/packages/api/src/graphql/sdl/resolvers/ConditionGroup.ts
@@ -20,12 +20,14 @@ import { loadRelation } from './relationHelpers';
 
 type PrismaConditionGroup = {
   id: number;
+  name?: string | null;
   categoryId?: number | null;
   category?: unknown;
   [k: string]: unknown;
 };
 
 export const ConditionGroup: ConditionGroupResolvers = {
+  title: (parent) => (parent as PrismaConditionGroup).name ?? '',
   category: async (parent, args, ctx) => {
     const p = parent as PrismaConditionGroup;
     if (p.category !== undefined) return p.category as never;

--- a/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
@@ -272,13 +272,17 @@ export const runPredictions = async ({
   });
   if (empty) return { items: [], hasMore: false, totalCount: 0 };
 
-  const direction = orderDirection === 'asc' ? 'asc' : 'desc';
+  // SortOrder enum carries `asc`/`desc` plus uppercase ASC/DESC aliases
+  // for older clients; PredictionSortField carries SCREAMING_SNAKE plus
+  // camelCase aliases for the same reason.
+  const direction =
+    orderDirection === 'asc' || orderDirection === 'ASC' ? 'asc' : 'desc';
   let orderByClause: Prisma.PredictionOrderByWithRelationInput = {
     createdAt: 'desc',
   };
-  if (orderBy === 'CREATED_AT') {
+  if (orderBy === 'CREATED_AT' || orderBy === 'createdAt') {
     orderByClause = { createdAt: direction };
-  } else if (orderBy === 'SETTLED_AT') {
+  } else if (orderBy === 'SETTLED_AT' || orderBy === 'settledAt') {
     orderByClause = { settledAt: direction };
   }
 
@@ -694,9 +698,18 @@ const normalizePositionsArgs = (
   collateralMin: args.collateralMin,
   collateralMax: args.collateralMax,
   // PositionSortField SDL enum values are CREATED_AT / UPDATED_AT; map
-  // to the Prisma column name for orderBy.
-  orderField: args.orderBy === 'CREATED_AT' ? 'createdAt' : 'updatedAt',
-  orderDirection: args.orderDirection === 'asc' ? 'asc' : 'desc',
+  // to the Prisma column name for orderBy. Accept camelCase aliases kept
+  // on the enum for older clients (`createdAt`, `updatedAt`).
+  orderField:
+    args.orderBy === 'CREATED_AT' || args.orderBy === 'createdAt'
+      ? 'createdAt'
+      : 'updatedAt',
+  // SortOrder SDL enum values are `asc` / `desc`; accept uppercase
+  // ASC / DESC aliases kept on the enum for older clients.
+  orderDirection:
+    args.orderDirection === 'asc' || args.orderDirection === 'ASC'
+      ? 'asc'
+      : 'desc',
 });
 
 /**

--- a/packages/api/src/graphql/sdl/resolvers/queries/questions.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/questions.ts
@@ -281,7 +281,12 @@ const normalizeArgs = (args: RunQuestionsInput): NormalizedArgs => {
     minSimilarMarketVolume: args.minSimilarMarketVolume,
     maxSimilarMarketVolume: args.maxSimilarMarketVolume,
     sortField,
-    sortDirectionRaw: args.sortDirection === 'asc' ? 'ASC' : 'DESC',
+    // SortOrder enum carries `asc`/`desc` plus uppercase ASC/DESC aliases
+    // for older clients.
+    sortDirectionRaw:
+      args.sortDirection === 'asc' || args.sortDirection === 'ASC'
+        ? 'ASC'
+        : 'DESC',
     afterCursor: args.afterCursor ?? null,
     volumeKey,
     useWindowedSimilarMarketVolume,

--- a/packages/api/src/graphql/sdl/resolvers/queries/stagingCompatShims.test.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/stagingCompatShims.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Schema-level shims that absorb the in-flight queries surfaced in
+ * staging Sentry from older clients. These tests pin the alias
+ * presence on the SDL so a future cleanup that removes them is a
+ * loud diff, not a silent re-introduction of validation errors.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it, expect, vi } from 'vitest';
+
+const mockPrisma = vi.hoisted(() => ({
+  position: { findMany: vi.fn(), count: vi.fn() },
+  secondaryTrade: { findMany: vi.fn() },
+  pick: { findMany: vi.fn() },
+  picks: { findMany: vi.fn(), count: vi.fn() },
+  $queryRaw: vi.fn(),
+}));
+
+vi.mock('../../../../core/db', () => ({ default: mockPrisma }));
+
+import { runPositions } from './escrow';
+
+const SCHEMA = readFileSync(
+  join(__dirname, '../../schema/schema.graphql'),
+  'utf8'
+);
+
+describe('staging compat shims — SDL', () => {
+  it('ConditionGroup exposes a deprecated `title` alias for `name`', () => {
+    expect(SCHEMA).toMatch(
+      /type ConditionGroup \{[\s\S]*?title: String!\n\s*@deprecated/
+    );
+  });
+
+  it('PredictionSortField carries camelCase legacy values alongside SCREAMING_SNAKE', () => {
+    expect(SCHEMA).toMatch(
+      /enum PredictionSortField \{\n\s*CREATED_AT\n\s*SETTLED_AT\n\s*createdAt\n\s*@deprecated[\s\S]*?settledAt\n\s*@deprecated/
+    );
+  });
+
+  it('PositionSortField carries camelCase legacy values alongside SCREAMING_SNAKE', () => {
+    expect(SCHEMA).toMatch(
+      /enum PositionSortField \{\n\s*CREATED_AT\n\s*UPDATED_AT\n\s*createdAt\n\s*@deprecated[\s\S]*?updatedAt\n\s*@deprecated/
+    );
+  });
+
+  it('SortOrder carries uppercase ASC/DESC alongside the Prisma-style asc/desc', () => {
+    expect(SCHEMA).toMatch(
+      /enum SortOrder \{\n\s*asc\n\s*desc\n\s*ASC\n\s*@deprecated[\s\S]*?DESC\n\s*@deprecated/
+    );
+  });
+});
+
+describe('staging compat shims — runPositions normalization', () => {
+  it('treats camelCase `createdAt` orderBy as the canonical CREATED_AT', async () => {
+    mockPrisma.position.findMany.mockResolvedValue([]);
+    await runPositions({
+      take: 10,
+      skip: 0,
+      holder: '0xabc',
+      chainId: null,
+      conditionId: null,
+      pickConfigId: null,
+      collateralMin: null,
+      collateralMax: null,
+      endsAtMin: null,
+      endsAtMax: null,
+      holderWon: null,
+      result: null,
+      settled: null,
+      orderBy: 'createdAt',
+      orderDirection: 'DESC',
+    });
+    const call = mockPrisma.position.findMany.mock.calls.at(-1)?.[0];
+    expect(call?.orderBy).toEqual({ createdAt: 'desc' });
+  });
+
+  it('treats uppercase `DESC` orderDirection as desc on the canonical path', async () => {
+    mockPrisma.position.findMany.mockResolvedValue([]);
+    await runPositions({
+      take: 10,
+      skip: 0,
+      holder: '0xabc',
+      chainId: null,
+      conditionId: null,
+      pickConfigId: null,
+      collateralMin: null,
+      collateralMax: null,
+      endsAtMin: null,
+      endsAtMax: null,
+      holderWon: null,
+      result: null,
+      settled: null,
+      orderBy: 'CREATED_AT',
+      orderDirection: 'ASC',
+    });
+    const call = mockPrisma.position.findMany.mock.calls.at(-1)?.[0];
+    expect(call?.orderBy).toEqual({ createdAt: 'asc' });
+  });
+});

--- a/packages/api/src/graphql/sdl/schema/schema.graphql
+++ b/packages/api/src/graphql/sdl/schema/schema.graphql
@@ -967,6 +967,14 @@ type ConditionGroup {
   id: Int!
   name: String!
   similarMarkets: [String!]!
+  """
+  Compatibility alias mirroring `name`. Kept so external clients still
+  selecting `ConditionGroup.title` keep working through one release.
+  """
+  title: String!
+    @deprecated(
+      reason: "Use `name` — same value, the alias exists only to absorb in-flight queries from older clients."
+    )
 }
 
 type ConditionGroupCount {
@@ -2512,6 +2520,12 @@ Field to sort positions by
 enum PositionSortField {
   CREATED_AT
   UPDATED_AT
+  createdAt
+    @deprecated(
+      reason: "Use `CREATED_AT` — camelCase value kept for compatibility with older clients."
+    )
+  updatedAt
+    @deprecated(reason: "Use `UPDATED_AT` — camelCase kept for older clients.")
 }
 
 """
@@ -2549,6 +2563,12 @@ Field to sort predictions by
 enum PredictionSortField {
   CREATED_AT
   SETTLED_AT
+  createdAt
+    @deprecated(
+      reason: "Use `CREATED_AT` — camelCase value kept for compatibility with older clients."
+    )
+  settledAt
+    @deprecated(reason: "Use `SETTLED_AT` — camelCase kept for older clients.")
 }
 
 """
@@ -4512,6 +4532,14 @@ input SettlementResultFilter {
 enum SortOrder {
   asc
   desc
+  ASC
+    @deprecated(
+      reason: "Use `asc` — uppercase value kept for compatibility with older clients passing `OrderDirection`-shaped values."
+    )
+  DESC
+    @deprecated(
+      reason: "Use `desc` — uppercase value kept for compatibility with older clients passing `OrderDirection`-shaped values."
+    )
 }
 
 input SortOrderInput {

--- a/packages/api/test/contract/__snapshots__/schema.sdl.graphql
+++ b/packages/api/test/contract/__snapshots__/schema.sdl.graphql
@@ -819,6 +819,12 @@ type ConditionGroup {
   id: Int!
   name: String!
   similarMarkets: [String!]!
+
+  """
+  Compatibility alias mirroring `name`. Kept so external clients still
+  selecting `ConditionGroup.title` keep working through one release.
+  """
+  title: String! @deprecated(reason: "Use `name` — same value, the alias exists only to absorb in-flight queries from older clients.")
 }
 
 type ConditionGroupCount {
@@ -2207,6 +2213,8 @@ type Position {
 enum PositionSortField {
   CREATED_AT
   UPDATED_AT
+  createdAt @deprecated(reason: "Use `CREATED_AT` — camelCase value kept for compatibility with older clients.")
+  updatedAt @deprecated(reason: "Use `UPDATED_AT` — camelCase kept for older clients.")
 }
 
 """
@@ -2242,6 +2250,8 @@ type Prediction {
 enum PredictionSortField {
   CREATED_AT
   SETTLED_AT
+  createdAt @deprecated(reason: "Use `CREATED_AT` — camelCase value kept for compatibility with older clients.")
+  settledAt @deprecated(reason: "Use `SETTLED_AT` — camelCase kept for older clients.")
 }
 
 """Metric an account-stats leaderboard is ranked by."""
@@ -3551,6 +3561,8 @@ input SettlementResultFilter {
 enum SortOrder {
   asc
   desc
+  ASC @deprecated(reason: "Use `asc` — uppercase value kept for compatibility with older clients passing `OrderDirection`-shaped values.")
+  DESC @deprecated(reason: "Use `desc` — uppercase value kept for compatibility with older clients passing `OrderDirection`-shaped values.")
 }
 
 input SortOrderInput {

--- a/packages/sdk/types/graphql.ts
+++ b/packages/sdk/types/graphql.ts
@@ -1296,6 +1296,12 @@ export type ConditionGroup = {
   id: Scalars['Int']['output'];
   name: Scalars['String']['output'];
   similarMarkets: Array<Scalars['String']['output']>;
+  /**
+   * Compatibility alias mirroring `name`. Kept so external clients still
+   * selecting `ConditionGroup.title` keep working through one release.
+   * @deprecated Use `name` — same value, the alias exists only to absorb in-flight queries from older clients.
+   */
+  title: Scalars['String']['output'];
 };
 
 
@@ -2462,7 +2468,9 @@ export type PositionOrderField =
 /** Field to sort positions by */
 export type PositionSortField =
   | 'CREATED_AT'
-  | 'UPDATED_AT';
+  | 'UPDATED_AT'
+  | 'createdAt'
+  | 'updatedAt';
 
 /**
  * Paginated wrapper around Position rows with a server-truth hasMore flag.
@@ -2586,7 +2594,9 @@ export type PredictionOrderField =
 /** Field to sort predictions by */
 export type PredictionSortField =
   | 'CREATED_AT'
-  | 'SETTLED_AT';
+  | 'SETTLED_AT'
+  | 'createdAt'
+  | 'settledAt';
 
 /**
  * DEPRECATED — kept only as the return type of `accountProfitRank`, which is
@@ -3907,6 +3917,8 @@ export type SettlementResultFilter = {
 };
 
 export type SortOrder =
+  | 'ASC'
+  | 'DESC'
   | 'asc'
   | 'desc';
 


### PR DESCRIPTION
## Summary

Three GraphQL validation errors are firing repeatedly on staging from clients we can't roll forward (cached older app bundles + an external consumer per the latest query manifest):

| Sentry message | Source |
|---|---|
| `Cannot query field "title" on type "ConditionGroup"` | stale client(s) |
| `Value "createdAt" does not exist in "PredictionSortField" enum` | external `GetPredictions` |
| `Value "DESC" does not exist in "SortOrder" enum` | external `GetPredictions` / `GetPositions` / `GetQuestionsSorted` |

This PR adds **purely additive `@deprecated` compatibility shims** so those queries stop erroring at validation. The canonical wire contract for current clients (`name`, `CREATED_AT`, `asc`, etc.) is unchanged.

### Schema additions
- `ConditionGroup.title: String!` → resolves to `name`
- `PredictionSortField` adds `createdAt`, `settledAt`
- `PositionSortField` adds `createdAt`, `updatedAt` (preemptive — same client shape will hit it next)
- `SortOrder` adds `ASC`, `DESC`

All four marked `@deprecated` with a reason pointing to the canonical value.

### Resolvers
- `runPredictions`, `normalizePositionsArgs`, `runQuestionsData` accept both casings before dispatching to Prisma's lowercase column names.

### Codegen wrinkle
graphql-codegen's PascalCase rule collides on the two casings (`'CREATED_AT'` and `'createdAt'` both want to become `CreatedAt`). Routed the three affected enums through a hand-written `enumOverrides.ts` via the `enumValues` config so each member gets a unique TS identifier while wire values stay 1:1 with the SDL — existing resolver references like `SortOrder.Asc` keep compiling.

### Out of scope
The fourth Sentry error (`Cannot query field "outcomes" on type "Prediction"`) isn't addressed: it isn't in the external query manifest, there is no historical `Prediction.outcomes` shape to safely alias, and guessing the field type risks breaking the client's sub-selection in a new way.

## Test plan

- [x] `pnpm --filter @sapience/api run test` — 779 passing (was 771; added 8 in `stagingCompatShims.test.ts` + `ConditionGroup.test.ts`)
- [x] `pnpm --filter @sapience/sdk run test` — 665 passing
- [x] `pnpm --filter @sapience/api run type-check`
- [x] `pnpm --filter @sapience/app run type-check`
- [x] `pnpm --filter @sapience/api run test:contract` — same 10 pre-existing failures as `staging` baseline; schema snapshot regenerated; no new failures
- [ ] After deploy, verify the three Sentry signatures stop firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)