### PR TITLE
refactor(api): dry GraphQL connection pagination

### DIFF
--- a/packages/api/src/graphql/sdl/resolvers/queries/collateralBalance.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/collateralBalance.ts
@@ -8,7 +8,7 @@ import { collateralToken } from '@sapience/sdk/contracts/addresses';
 import type { QueryResolvers } from '../../__generated__/resolvers';
 import { Prisma } from '../../../../../generated/prisma';
 import prisma from '../../../../core/db';
-import { clampSkip, clampTake } from './pagination';
+import { buildConnection, clampSkip, clampTake } from './pagination';
 import { decodeCursor, encodeCursor } from '../../../relay/cursor';
 import { registerNodeType, toGlobalId } from '../../../relay/globalId';
 import { synthesizeAccount } from '../accountSynthesis';
@@ -347,26 +347,16 @@ export const collateralTransfersConnection = (async (
     }),
     prisma.collateralTransfer.count({ where: baseWhere }),
   ]);
-  const pageRows = rows.slice(0, first);
-  const nodes = pageRows.map((row) =>
-    mapCollateralTransfer(row, args.filter?.account ?? undefined)
-  );
-  const edges = nodes.map((node, i) => ({
-    node,
-    cursor: encodeCursor({
-      k: String(pageRows[i].blockNumber),
-      id: String(pageRows[i].id),
-    }),
-  }));
-  return {
-    edges,
-    nodes,
+  return buildConnection({
+    rows,
+    first,
     totalCount,
-    pageInfo: {
-      hasNextPage: rows.length > first,
-      hasPreviousPage: false,
-      startCursor: edges[0]?.cursor ?? null,
-      endCursor: edges.at(-1)?.cursor ?? null,
-    },
-  };
+    getNode: (row) =>
+      mapCollateralTransfer(row, args.filter?.account ?? undefined),
+    getCursor: (row) =>
+      encodeCursor({
+        k: String(row.blockNumber),
+        id: String(row.id),
+      }),
+  });
 }) as unknown as NonNullable<QueryResolvers['collateralTransfersConnection']>;

--- a/packages/api/src/graphql/sdl/resolvers/queries/conditions.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/conditions.ts
@@ -31,7 +31,7 @@ import {
   OrderDirection,
 } from '../../__generated__/resolvers';
 import prisma from '../../../../core/db';
-import { clampTake } from './pagination';
+import { buildConnection, clampTake } from './pagination';
 import { decodeCursor, encodeCursor } from '../../../relay/cursor';
 
 type Where = Prisma.ConditionWhereInput;
@@ -373,25 +373,17 @@ export const conditionsConnection: NonNullable<
     prisma.condition.count({ where: filterWhere }),
   ]);
 
-  const hasNextPage = rawRows.length > cappedFirst;
-  const pageRows = hasNextPage ? rawRows.slice(0, cappedFirst) : rawRows;
-
-  const edges = pageRows.map((row) => ({
-    node: row,
-    cursor: encodeCursor({ k: readOrderKey(row, orderField), id: row.id }),
-  }));
+  const connection = buildConnection({
+    rows: rawRows,
+    first: cappedFirst,
+    totalCount,
+    getCursor: (row) =>
+      encodeCursor({ k: readOrderKey(row, orderField), id: row.id }),
+  });
 
   return {
-    items: pageRows,
-    hasMore: hasNextPage,
-    edges,
-    nodes: pageRows,
-    totalCount,
-    pageInfo: {
-      hasNextPage,
-      hasPreviousPage: false,
-      startCursor: edges[0]?.cursor ?? null,
-      endCursor: edges[edges.length - 1]?.cursor ?? null,
-    },
+    items: connection.nodes,
+    hasMore: connection.pageInfo.hasNextPage,
+    ...connection,
   };
 };

--- a/packages/api/src/graphql/sdl/resolvers/queries/crud.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/crud.ts
@@ -28,7 +28,7 @@ import { logDeprecatedHit } from '../../../../lib/deprecationTelemetry';
 import { decodeCursor, encodeCursor } from '../../../relay/cursor';
 import { registerNodeType, toGlobalId } from '../../../relay/globalId';
 import { synthesizeAccount } from '../accountSynthesis';
-import { clampTake } from './pagination';
+import { buildConnection, clampTake } from './pagination';
 
 /**
  * Cache only the no-args call (the dominant public path: integrator's
@@ -214,26 +214,16 @@ export const accountsConnection = (async (
     prisma.user.count({ where: baseWhere }),
   ]);
 
-  const hasNextPage = rows.length > cappedFirst;
-  const pageRows = hasNextPage ? rows.slice(0, cappedFirst) : rows;
-  const edges = pageRows.map((row) => ({
-    node: row,
-    cursor: encodeCursor({
-      k: row.createdAt.toISOString(),
-      id: String(row.id),
-    }),
-  }));
-  return {
-    edges,
-    nodes: pageRows,
+  return buildConnection({
+    rows,
+    first: cappedFirst,
     totalCount,
-    pageInfo: {
-      hasNextPage,
-      hasPreviousPage: false,
-      startCursor: edges[0]?.cursor ?? null,
-      endCursor: edges.at(-1)?.cursor ?? null,
-    },
-  };
+    getCursor: (row) =>
+      encodeCursor({
+        k: row.createdAt.toISOString(),
+        id: String(row.id),
+      }),
+  });
 }) as any as NonNullable<QueryResolvers['accountsConnection']>;
 
 const buildForecastCursorPredicate = (
@@ -351,31 +341,20 @@ export const forecastsConnection: NonNullable<
     prisma.attestation.count({ where }),
   ]);
 
-  const hasNextPage = rawRows.length > cappedFirst;
-  const pageRows = hasNextPage ? rawRows.slice(0, cappedFirst) : rawRows;
-  const nodes = pageRows.map(mapForecast);
-  const edges = nodes.map((node, index) => ({
-    node,
-    cursor: encodeCursor({
-      k:
-        orderField === ForecastOrderField.CreatedAt
-          ? pageRows[index].createdAt.toISOString()
-          : String(pageRows[index].time),
-      id: pageRows[index].uid,
-    }),
-  }));
-
-  return {
-    edges,
-    nodes,
+  return buildConnection({
+    rows: rawRows,
+    first: cappedFirst,
     totalCount,
-    pageInfo: {
-      hasNextPage,
-      hasPreviousPage: false,
-      startCursor: edges[0]?.cursor ?? null,
-      endCursor: edges[edges.length - 1]?.cursor ?? null,
-    },
-  };
+    getNode: mapForecast,
+    getCursor: (row) =>
+      encodeCursor({
+        k:
+          orderField === ForecastOrderField.CreatedAt
+            ? row.createdAt.toISOString()
+            : String(row.time),
+        id: row.uid,
+      }),
+  });
 };
 
 const buildCategoryCursorPredicate = (
@@ -420,24 +399,14 @@ export const categoriesConnection = (async (
     }),
     prisma.category.count({ where: searchWhere }),
   ]);
-  const pageRows = rawRows.slice(0, cappedTake);
-  const nodes = pageRows.map((row) => ({
-    ...row,
-    id: toGlobalId('Category', row.id),
-  }));
-  const edges = nodes.map((node, i) => ({
-    node,
-    cursor: encodeCursor({ k: pageRows[i].name, id: String(pageRows[i].id) }),
-  }));
-  return {
-    edges,
-    nodes,
+  return buildConnection({
+    rows: rawRows,
+    first: cappedTake,
     totalCount,
-    pageInfo: {
-      hasNextPage: rawRows.length > cappedTake,
-      hasPreviousPage: false,
-      startCursor: edges[0]?.cursor ?? null,
-      endCursor: edges.at(-1)?.cursor ?? null,
-    },
-  };
+    getNode: (row) => ({
+      ...row,
+      id: toGlobalId('Category', row.id),
+    }),
+    getCursor: (row) => encodeCursor({ k: row.name, id: String(row.id) }),
+  });
 }) as unknown as NonNullable<QueryResolvers['categoriesConnection']>;

--- a/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
@@ -55,18 +55,12 @@ import prisma from '../../../../core/db';
 import { mapPickConfig } from '../pickConfigHelpers';
 import { TtlCache } from '../../../../lib/ttlCache';
 import { logDeprecatedHit } from '../../../../lib/deprecationTelemetry';
-import { clampSkip, clampTake } from './pagination';
+import { clampSkip, clampTake, offsetFromCursor } from './pagination';
 import { decodeCursor, encodeCursor } from '../../../relay/cursor';
 
 export type PredictionWithPickConfig = Prisma.PredictionGetPayload<{
   include: { pickConfiguration: { include: { picks: true } } };
 }>;
-
-const offsetFromCursor = (cursor: string | null | undefined): number => {
-  const payload = cursor ? decodeCursor(cursor) : null;
-  const offset = payload ? Number(payload.k) : Number.NaN;
-  return Number.isInteger(offset) && offset >= 0 ? offset + 1 : 0;
-};
 
 export const mapPrediction = (
   r: PredictionWithPickConfig

--- a/packages/api/src/graphql/sdl/resolvers/queries/pagination.test.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/pagination.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { MAX_SKIP, MAX_TAKE, clampSkip, clampTake } from './pagination';
+import {
+  MAX_SKIP,
+  MAX_TAKE,
+  buildConnection,
+  clampSkip,
+  clampTake,
+  offsetFromCursor,
+} from './pagination';
 
 describe('clampTake', () => {
   it('returns defaultTake when value is null', () => {
@@ -95,6 +102,64 @@ describe('clampSkip', () => {
 
   it('passes through 0', () => {
     expect(clampSkip(0)).toBe(0);
+  });
+});
+
+describe('offsetFromCursor', () => {
+  it('returns 0 when after is missing or malformed', () => {
+    expect(offsetFromCursor(undefined)).toBe(0);
+    expect(offsetFromCursor(null)).toBe(0);
+    expect(offsetFromCursor('not-a-cursor')).toBe(0);
+  });
+
+  it('advances one row past an offset cursor payload', () => {
+    expect(
+      offsetFromCursor(
+        Buffer.from('{"k":"41","id":"ignored"}').toString('base64url')
+      )
+    ).toBe(42);
+  });
+});
+
+describe('buildConnection', () => {
+  it('slices first-plus-one rows and wires nodes, edges, and pageInfo', () => {
+    const result = buildConnection({
+      rows: [
+        { id: 1, name: 'first' },
+        { id: 2, name: 'second' },
+        { id: 3, name: 'third' },
+      ],
+      first: 2,
+      totalCount: 3,
+      hasPreviousPage: true,
+      getCursor: (row) => `cursor-${row.id}`,
+    });
+
+    expect(result.nodes).toEqual([
+      { id: 1, name: 'first' },
+      { id: 2, name: 'second' },
+    ]);
+    expect(result.edges).toEqual([
+      { node: { id: 1, name: 'first' }, cursor: 'cursor-1' },
+      { node: { id: 2, name: 'second' }, cursor: 'cursor-2' },
+    ]);
+    expect(result.pageInfo).toEqual({
+      hasNextPage: true,
+      hasPreviousPage: true,
+      startCursor: 'cursor-1',
+      endCursor: 'cursor-2',
+    });
+  });
+
+  it('preserves totalCount on connection envelopes', () => {
+    expect(
+      buildConnection({
+        rows: [{ id: 1 }],
+        first: 10,
+        totalCount: 7,
+        getCursor: (row) => String(row.id),
+      }).totalCount
+    ).toBe(7);
   });
 });
 

--- a/packages/api/src/graphql/sdl/resolvers/queries/pagination.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/pagination.ts
@@ -21,6 +21,8 @@
  * items total" UI badges without paying the offset cost.
  */
 
+import { decodeCursor } from '../../../relay/cursor';
+
 export const MAX_TAKE = 100;
 export const MAX_SKIP = 1000;
 
@@ -41,4 +43,62 @@ export const clampSkip = (
   const value = skip ?? 0;
   if (!Number.isFinite(value) || value <= 0) return 0;
   return Math.min(Math.floor(value), maxSkip);
+};
+
+export const offsetFromCursor = (cursor: string | null | undefined): number => {
+  const payload = cursor ? decodeCursor(cursor) : null;
+  const offset = payload ? Number(payload.k) : Number.NaN;
+  return Number.isInteger(offset) && offset >= 0 ? offset + 1 : 0;
+};
+
+type BuildConnectionArgs<TRow, TNode = TRow> = {
+  rows: readonly TRow[];
+  first: number;
+  getCursor: (row: TRow, index: number) => string;
+  getNode?: (row: TRow, index: number) => TNode;
+  totalCount: number;
+  hasPreviousPage?: boolean;
+};
+
+type ConnectionEdge<TNode> = { node: TNode; cursor: string };
+
+export const buildConnection = <TRow, TNode = TRow>({
+  rows,
+  first,
+  getCursor,
+  getNode,
+  totalCount,
+  hasPreviousPage = false,
+}: BuildConnectionArgs<TRow, TNode>): {
+  edges: ConnectionEdge<TNode>[];
+  nodes: TNode[];
+  totalCount: number;
+  pageInfo: {
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+    startCursor: string | null;
+    endCursor: string | null;
+  };
+} => {
+  const hasNextPage = rows.length > first;
+  const pageRows = hasNextPage ? rows.slice(0, first) : rows;
+  const nodes = pageRows.map((row, index) =>
+    getNode ? getNode(row, index) : (row as unknown as TNode)
+  );
+  const edges = pageRows.map((row, index) => ({
+    node: nodes[index],
+    cursor: getCursor(row, index),
+  }));
+
+  return {
+    edges,
+    nodes,
+    totalCount,
+    pageInfo: {
+      hasNextPage,
+      hasPreviousPage,
+      startCursor: edges[0]?.cursor ?? null,
+      endCursor: edges.at(-1)?.cursor ?? null,
+    },
+  };
 };

--- a/packages/api/src/graphql/sdl/resolvers/queries/stagingCompatShims.test.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/stagingCompatShims.test.ts
@@ -69,8 +69,8 @@ describe('staging compat shims — runPositions normalization', () => {
       holderWon: null,
       result: null,
       settled: null,
-      orderBy: 'createdAt',
-      orderDirection: 'DESC',
+      orderBy: 'createdAt' as never,
+      orderDirection: 'DESC' as never,
     });
     const call = mockPrisma.position.findMany.mock.calls.at(-1)?.[0];
     expect(call?.orderBy).toEqual({ createdAt: 'desc' });
@@ -92,8 +92,8 @@ describe('staging compat shims — runPositions normalization', () => {
       holderWon: null,
       result: null,
       settled: null,
-      orderBy: 'CREATED_AT',
-      orderDirection: 'ASC',
+      orderBy: 'CREATED_AT' as never,
+      orderDirection: 'ASC' as never,
     });
     const call = mockPrisma.position.findMany.mock.calls.at(-1)?.[0];
     expect(call?.orderBy).toEqual({ createdAt: 'asc' });

--- a/packages/api/src/graphql/sdl/resolvers/queries/trade.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/trade.ts
@@ -18,8 +18,8 @@ import type {
 import { OrderDirection, TradeOrderField } from '../../__generated__/resolvers';
 import { Prisma } from '../../../../../generated/prisma';
 import prisma from '../../../../core/db';
-import { clampSkip, clampTake } from './pagination';
-import { decodeCursor, encodeCursor } from '../../../relay/cursor';
+import { clampSkip, clampTake, offsetFromCursor } from './pagination';
+import { encodeCursor } from '../../../relay/cursor';
 
 export type Trade = NonNullable<
   Awaited<ReturnType<typeof prisma.secondaryTrade.findUnique>>
@@ -191,12 +191,6 @@ const mergeTradeFilters = (args: QueryTradesConnectionArgs): RunTradesArgs => {
     orderDirection:
       args.orderBy?.direction === OrderDirection.Asc ? 'asc' : 'desc',
   };
-};
-
-const offsetFromCursor = (cursor: string | null | undefined): number => {
-  const payload = cursor ? decodeCursor(cursor) : null;
-  const offset = payload ? Number(payload.k) : Number.NaN;
-  return Number.isInteger(offset) && offset >= 0 ? offset + 1 : 0;
 };
 
 export const tradesConnection: NonNullable<


### PR DESCRIPTION
## Summary
- add shared GraphQL connection helpers for first+1 slicing, edges/nodes, pageInfo, and totalCount envelopes
- move offset-backed cursor decoding into the shared pagination module
- refactor accounts, forecasts, categories, conditions, and collateral transfer connections to use the shared helper
- keep staging compat tests compiling against intentionally legacy enum strings

## Verification
- `PATH=/opt/data/tools/node-v22.12.0-linux-x64/bin:$PATH pnpm --filter @sapience/api exec vitest run src/graphql/sdl/resolvers/queries/pagination.test.ts src/graphql/sdl/resolvers/queries/crud.test.ts src/graphql/sdl/resolvers/queries/conditions.test.ts src/graphql/sdl/resolvers/queries/trade.test.ts src/graphql/sdl/resolvers/queries/escrow.test.ts src/graphql/sdl/resolvers/queries/collateralBalance.test.ts src/graphql/sdl/resolvers/queries/stagingCompatShims.test.ts --pool=threads --poolOptions.threads.singleThread`
- `PATH=/opt/data/tools/node-v22.12.0-linux-x64/bin:$PATH pnpm --filter @sapience/api run type-check`
- `PATH=/opt/data/tools/node-v22.12.0-linux-x64/bin:$PATH pnpm --filter @sapience/api run lint`
- `git diff --check`
