### PR TITLE
fix(markets): preserve question pagination hasMore

### DIFF
--- a/packages/api/src/graphql/sdl/resolvers/queries/questions.test.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/questions.test.ts
@@ -100,20 +100,88 @@ describe('runQuestions — page envelope', () => {
 
   it('hasMore=true when take + 1 raw rows came back (probe row dropped from items)', async () => {
     const rows = Array.from({ length: 11 }, (_, i) => ({
-      item_type: 'group' as const,
-      group_id: i + 1,
-      condition_id: null,
+      item_type: 'condition' as const,
+      group_id: null,
+      condition_id: `c-${i + 1}`,
       prediction_count: 0n,
+      sort_value: i + 1,
+      end_time: i + 1,
     }));
     mockPrisma.$queryRaw.mockResolvedValue(rows);
-    // hydrate returns empty arrays; we only care about the envelope shape.
     mockPrisma.conditionGroup.findMany.mockResolvedValue([]);
-    mockPrisma.condition.findMany.mockResolvedValue([]);
+    mockPrisma.condition.findMany.mockResolvedValue(
+      rows.slice(0, 10).map((row) => ({ id: row.condition_id }))
+    );
     const result = await runQuestions({ take: 10, skip: 0 });
     expect(result.hasMore).toBe(true);
+    expect(result.items).toHaveLength(10);
     // hydrate is called with the page slice (not the probe row), so the
     // findMany lookup excludes the 11th id.
-    expect(mockPrisma.conditionGroup.findMany).toHaveBeenCalled();
+    expect(mockPrisma.condition.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: { in: rows.slice(0, 10).map((r) => r.condition_id) } },
+      })
+    );
+  });
+
+  it('backfills when raw rows hydrate to fewer visible questions', async () => {
+    mockPrisma.$queryRaw
+      .mockResolvedValueOnce([
+        {
+          item_type: 'group',
+          group_id: 1,
+          condition_id: null,
+          prediction_count: 0n,
+          sort_value: 100,
+          end_time: 100,
+        },
+        {
+          item_type: 'condition',
+          group_id: null,
+          condition_id: 'c-1',
+          prediction_count: 0n,
+          sort_value: 99,
+          end_time: 99,
+        },
+        {
+          item_type: 'condition',
+          group_id: null,
+          condition_id: 'c-probe',
+          prediction_count: 0n,
+          sort_value: 98,
+          end_time: 98,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          item_type: 'condition',
+          group_id: null,
+          condition_id: 'c-2',
+          prediction_count: 0n,
+          sort_value: 97,
+          end_time: 97,
+        },
+        {
+          item_type: 'condition',
+          group_id: null,
+          condition_id: 'c-3',
+          prediction_count: 0n,
+          sort_value: 97,
+          end_time: 97,
+        },
+      ]);
+    mockPrisma.conditionGroup.findMany.mockResolvedValue([]);
+    mockPrisma.condition.findMany
+      .mockResolvedValueOnce([{ id: 'c-1' }])
+      .mockResolvedValueOnce([{ id: 'c-2' }]);
+
+    const result = await runQuestions({ take: 2, skip: 0 });
+    expect(
+      result.items.map(
+        (item) => (item as { condition?: { id?: string } }).condition?.id
+      )
+    ).toEqual(['c-1', 'c-2']);
+    expect(mockPrisma.$queryRaw).toHaveBeenCalledTimes(2);
   });
 
   it('clamps take above MAX_TAKE to 100', async () => {

--- a/packages/api/src/graphql/sdl/resolvers/queries/questions.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/questions.ts
@@ -760,10 +760,15 @@ const buildConditionWhere = (n: NormalizedArgs): Prisma.ConditionWhereInput => {
   };
 };
 
+type HydratedQuestion = {
+  item: QuestionReturn;
+  pageItem: SortedItemRow;
+};
+
 const hydrateItems = async (
   pageItems: SortedItemRow[],
   conditionWhere: Prisma.ConditionWhereInput
-): Promise<QuestionReturn[]> => {
+): Promise<HydratedQuestion[]> => {
   const groupIds = pageItems
     .filter((r) => r.item_type === 'group' && r.group_id !== null)
     .map((r) => r.group_id as number);
@@ -806,9 +811,10 @@ const hydrateItems = async (
   // `source`, `title`, `description`, etc. from this shape, so the
   // runner only needs to populate the discriminator + the wrapped row +
   // the prediction count.
-  const result: QuestionReturn[] = [];
+  const result: HydratedQuestion[] = [];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const push = (item: any) => result.push(item as QuestionReturn);
+  const push = (item: any, pageItem: SortedItemRow) =>
+    result.push({ item: item as QuestionReturn, pageItem });
   for (const item of pageItems) {
     if (item.item_type === 'group' && item.group_id !== null) {
       const group = groupMap.get(item.group_id);
@@ -816,32 +822,41 @@ const hydrateItems = async (
       if (group.condition.length === 1) {
         // Unwrap single-condition groups as standalone conditions so the
         // frontend doesn't render a group shell around a lone item.
-        push({
-          questionType: QuestionItemType.Condition,
-          group: null,
-          condition: group.condition[0] as unknown as ConditionReturn,
-          predictionCount: Number(item.prediction_count),
-        });
+        push(
+          {
+            questionType: QuestionItemType.Condition,
+            group: null,
+            condition: group.condition[0] as unknown as ConditionReturn,
+            predictionCount: Number(item.prediction_count),
+          },
+          item
+        );
       } else if (group.condition.length > 1) {
-        push({
-          questionType: QuestionItemType.Group,
-          group: {
-            ...group,
-            conditions: group.condition,
-          } as unknown as ConditionGroupReturn,
-          condition: null,
-          predictionCount: Number(item.prediction_count),
-        });
+        push(
+          {
+            questionType: QuestionItemType.Group,
+            group: {
+              ...group,
+              conditions: group.condition,
+            } as unknown as ConditionGroupReturn,
+            condition: null,
+            predictionCount: Number(item.prediction_count),
+          },
+          item
+        );
       }
     } else if (item.item_type === 'condition' && item.condition_id !== null) {
       const condition = conditionMap.get(item.condition_id);
       if (!condition) continue;
-      push({
-        questionType: QuestionItemType.Condition,
-        group: null,
-        condition: condition as unknown as ConditionReturn,
-        predictionCount: Number(item.prediction_count),
-      });
+      push(
+        {
+          questionType: QuestionItemType.Condition,
+          group: null,
+          condition: condition as unknown as ConditionReturn,
+          predictionCount: Number(item.prediction_count),
+        },
+        item
+      );
     }
   }
   return result;
@@ -855,13 +870,42 @@ const runQuestionsData = async (
   pageItems: SortedItemRow[];
 }> => {
   const n = normalizeArgs(args);
-  const sortedItems = await fetchSortedItems(n);
-  const hasMore = sortedItems.length > n.take;
-  const pageItems = sortedItems.slice(0, n.take);
-  if (pageItems.length === 0) return { items: [], hasMore, pageItems };
+  const conditionWhere = buildConditionWhere(n);
+  const hydrated: HydratedQuestion[] = [];
+  let afterCursor = n.afterCursor;
+  let skip = n.skip;
+  let hasMore = false;
 
-  const items = await hydrateItems(pageItems, buildConditionWhere(n));
-  return { items, hasMore, pageItems };
+  while (hydrated.length < n.take) {
+    const remaining = n.take - hydrated.length;
+    const sortedItems = await fetchSortedItems({
+      ...n,
+      take: remaining,
+      skip: afterCursor ? 0 : skip,
+      afterCursor,
+    });
+    hasMore = sortedItems.length > remaining;
+    const pageItems = sortedItems.slice(0, remaining);
+    if (pageItems.length === 0) break;
+
+    hydrated.push(...(await hydrateItems(pageItems, conditionWhere)));
+
+    const lastPageItem = pageItems[pageItems.length - 1];
+    afterCursor = {
+      sortValue: String(lastPageItem.sort_value),
+      ...cursorIdentity(lastPageItem),
+    };
+    skip = 0;
+
+    if (!hasMore) break;
+  }
+
+  const page = hydrated.slice(0, n.take);
+  return {
+    items: page.map((entry) => entry.item),
+    hasMore,
+    pageItems: page.map((entry) => entry.pageItem),
+  };
 };
 
 export const runQuestions = async (

--- a/packages/app/src/hooks/graphql/useInfiniteQuestions.ts
+++ b/packages/app/src/hooks/graphql/useInfiniteQuestions.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
-  fetchQuestionsSorted,
+  fetchQuestionsPage,
   type QuestionType,
   type SortField,
   type SortDirection,
@@ -108,7 +108,7 @@ export function useInfiniteQuestions(
     data: rawData,
     isFetching,
     isError,
-  } = useQuery<QuestionType[], Error>({
+  } = useQuery<{ items: QuestionType[]; hasMore: boolean }, Error>({
     queryKey: [
       'infiniteQuestions',
       pageSize,
@@ -128,8 +128,8 @@ export function useInfiniteQuestions(
       similarMarketVolumeWindow,
     ],
     queryFn: () =>
-      fetchQuestionsSorted({
-        take: pageSize + 1,
+      fetchQuestionsPage({
+        take: pageSize,
         skip,
         chainId,
         sortField,
@@ -152,10 +152,9 @@ export function useInfiniteQuestions(
       processedSkipRef.current = skip;
       lastSuccessfulSkipRef.current = skip;
 
-      const hasMoreItems = rawData.length > pageSize;
-      setHasMore(hasMoreItems);
+      setHasMore(rawData.hasMore);
 
-      const items = hasMoreItems ? rawData.slice(0, pageSize) : rawData;
+      const items = rawData.items;
 
       if (skip === 0) {
         setAllLoadedData(items);
@@ -186,7 +185,7 @@ export function useInfiniteQuestions(
         });
       }
     }
-  }, [rawData, skip, pageSize]);
+  }, [rawData, skip]);
 
   useEffect(() => {
     if (isError && skip !== lastSuccessfulSkipRef.current) {

--- a/packages/sdk/queries/__tests__/questions.test.ts
+++ b/packages/sdk/queries/__tests__/questions.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
-import { fetchQuestionsSorted } from '../questions';
+import { fetchQuestionsPage, fetchQuestionsSorted } from '../questions';
 
 const mockGraphqlRequest = vi.fn();
 vi.mock('../client/graphqlClient', () => ({
@@ -141,5 +141,56 @@ describe('fetchQuestionsSorted', () => {
     mockGraphqlRequest.mockResolvedValue({ questionsConnection: null });
     const result = await fetchQuestionsSorted(baseParams);
     expect(result).toEqual([]);
+  });
+
+  test('returns connection hasMore separately from node count', async () => {
+    const questions = Array.from({ length: 8 }, (_, i) => ({
+      questionType: 'condition',
+      condition: { id: String(i + 1) },
+      group: null,
+    }));
+    mockGraphqlRequest.mockResolvedValue({
+      questionsConnection: {
+        nodes: questions,
+        pageInfo: { hasNextPage: true, endCursor: 'cursor-8' },
+      },
+    });
+
+    const result = await fetchQuestionsPage({ ...baseParams, take: 8 });
+    expect(result.items).toEqual(questions);
+    expect(result.hasMore).toBe(true);
+  });
+
+  test('continues cursor requests when hydration returns fewer nodes than requested', async () => {
+    const firstBatch = Array.from({ length: 8 }, (_, i) => ({
+      questionType: 'condition',
+      condition: { id: String(i + 1) },
+      group: null,
+    }));
+    const secondBatch = Array.from({ length: 2 }, (_, i) => ({
+      questionType: 'condition',
+      condition: { id: String(i + 9) },
+      group: null,
+    }));
+    mockGraphqlRequest
+      .mockResolvedValueOnce({
+        questionsConnection: {
+          nodes: firstBatch,
+          pageInfo: { hasNextPage: true, endCursor: 'cursor-8' },
+        },
+      })
+      .mockResolvedValueOnce({
+        questionsConnection: {
+          nodes: secondBatch,
+          pageInfo: { hasNextPage: true, endCursor: 'cursor-10' },
+        },
+      });
+
+    const result = await fetchQuestionsPage(baseParams);
+    expect(result.items).toEqual([...firstBatch, ...secondBatch]);
+    expect(result.hasMore).toBe(true);
+    expect(mockGraphqlRequest).toHaveBeenCalledTimes(2);
+    expect(mockGraphqlRequest.mock.calls[1][1].take).toBe(2);
+    expect(mockGraphqlRequest.mock.calls[1][1].after).toBe('cursor-8');
   });
 });

--- a/packages/sdk/queries/questions.ts
+++ b/packages/sdk/queries/questions.ts
@@ -190,6 +190,11 @@ type QuestionsQueryResult = {
   } | null;
 };
 
+export interface QuestionsPageResult {
+  items: QuestionType[];
+  hasMore: boolean;
+}
+
 function buildQuestionFilter(params: FetchQuestionsSortedParams) {
   return {
     chainId: params.chainId ?? null,
@@ -231,12 +236,13 @@ function buildQuestionFilter(params: FetchQuestionsSortedParams) {
   };
 }
 
-export async function fetchQuestionsSorted(
+export async function fetchQuestionsPage(
   params: FetchQuestionsSortedParams
-): Promise<QuestionType[]> {
+): Promise<QuestionsPageResult> {
   const target = params.skip + params.take;
   const collected: QuestionType[] = [];
   let after: string | null | undefined = null;
+  let hasMore = false;
 
   while (collected.length < target) {
     const first = Math.min(100, target - collected.length);
@@ -251,10 +257,22 @@ export async function fetchQuestionsSorted(
         filter: buildQuestionFilter(params),
       });
     const conn = data.questionsConnection;
-    collected.push(...(conn?.nodes ?? []));
-    if (!conn?.pageInfo?.hasNextPage || !conn.pageInfo.endCursor) break;
+    const nodes = conn?.nodes ?? [];
+    collected.push(...nodes);
+    hasMore = Boolean(conn?.pageInfo?.hasNextPage);
+    if (!hasMore || !conn?.pageInfo?.endCursor || nodes.length === 0) break;
     after = conn.pageInfo.endCursor;
   }
 
-  return collected.slice(params.skip, target);
+  return {
+    items: collected.slice(params.skip, target),
+    hasMore,
+  };
+}
+
+export async function fetchQuestionsSorted(
+  params: FetchQuestionsSortedParams
+): Promise<QuestionType[]> {
+  const page = await fetchQuestionsPage(params);
+  return page.items;
 }


### PR DESCRIPTION
## Summary
- Backfill the `questions` runner when raw rows hydrate to fewer visible questions, so both deprecated `questions(...)` and `questionsConnection` keep returning full pages when more results exist
- Keep connection cursors aligned with the hydrated node they belong to
- Add SDK `fetchQuestionsPage` to expose server `pageInfo.hasNextPage` instead of making the app infer pagination from array length
- Update `/markets` infinite loading to use that server `hasMore` signal

## External consumers
The deprecated bare-array `questions(...)` resolver remains in the schema with the same args and return type. This fix deliberately happens in the shared runner it delegates to, so old offset/take consumers get safer page filling too. New SDK/app code uses `questionsConnection` because it can read `pageInfo.hasNextPage`; old clients are not forced onto the connection in this PR.

## Verification
- `pnpm --filter @sapience/api exec vitest run src/graphql/sdl/resolvers/queries/questions.test.ts`
- `pnpm --filter @sapience/sdk exec vitest run queries/__tests__/questions.test.ts`
- `pnpm --filter @sapience/sdk run build:lib`
- `pnpm --filter @sapience/api run type-check`
- `pnpm --filter @sapience/app run type-check`
- `pnpm --filter @sapience/api run lint`
- `pnpm --filter @sapience/sdk run lint`
- `pnpm --filter @sapience/app run lint`
