### PR TITLE
fix: restore staging build and market-keeper tests

### DIFF
--- a/packages/api/src/graphql/sdl/resolvers/PositionsPage.ts
+++ b/packages/api/src/graphql/sdl/resolvers/PositionsPage.ts
@@ -13,5 +13,5 @@ import prisma from '../../../core/db';
 import { lazyTotalCount } from './pageTotalCount';
 
 export const PositionsPage: PositionsPageResolvers = {
-  totalCount: lazyTotalCount(prisma.position),
+  totalCount: lazyTotalCount(() => prisma.position),
 };

--- a/packages/api/src/graphql/sdl/resolvers/pageTotalCount.ts
+++ b/packages/api/src/graphql/sdl/resolvers/pageTotalCount.ts
@@ -22,22 +22,24 @@ interface CountableModel<W> {
   count(args?: { where?: W }): Promise<number>;
 }
 
+type CountableModelGetter<W> = () => CountableModel<W>;
+
 type LazyTotalCountParent<W> = {
   totalCount?: number | null;
   _countWhere?: W;
 };
 
 /**
- * Returns a `totalCount` field resolver bound to a Prisma model. The
+ * Returns a `totalCount` field resolver bound to a Prisma model getter. The
  * concrete `*Page` resolver then becomes a single line:
  *
- *     export const PositionsPage = { totalCount: lazyTotalCount(prisma.position) };
+ *     export const PositionsPage = { totalCount: lazyTotalCount(() => prisma.position) };
  */
 export const lazyTotalCount =
-  <W, M extends CountableModel<W>>(model: M) =>
+  <W>(getModel: CountableModelGetter<W>) =>
   async (parent: unknown): Promise<number | null> => {
     const p = parent as LazyTotalCountParent<W>;
     if (typeof p.totalCount === 'number') return p.totalCount;
     if (!p._countWhere) return null;
-    return model.count({ where: p._countWhere });
+    return getModel().count({ where: p._countWhere });
   };

--- a/packages/market-keeper/src/__tests__/refresh-metadata.test.ts
+++ b/packages/market-keeper/src/__tests__/refresh-metadata.test.ts
@@ -81,12 +81,16 @@ describe('fetchAllExistingConditions', () => {
 
     expect(fetchCalls).toHaveLength(1);
     const body = JSON.parse(fetchCalls[0].init!.body as string);
-    expect(body.variables.where).toEqual({
-      public: { equals: true },
-      settled: { equals: false },
-      similarMarkets: { isEmpty: false },
+    expect(body.variables.filters).toEqual({
+      visibility: 'PUBLIC',
+      settled: false,
+      hasSimilarMarkets: true,
     });
-    expect(body.variables.orderBy).toEqual([{ id: 'asc' }]);
+    expect(body.variables.take).toBe(100);
+    expect(body.query).toContain('conditionsConnection');
+    expect(body.query).toContain(
+      'orderBy: { field: CREATED_AT, direction: ASC }'
+    );
     expect(fetchCalls[0].url.endsWith('/graphql')).toBe(true);
   });
 
@@ -111,9 +115,21 @@ describe('fetchAllExistingConditions', () => {
       },
     ];
 
-    fetchQueue.push(() => jsonResponse({ data: { conditions: page1 } }));
-    fetchQueue.push(() => jsonResponse({ data: { conditions: page2 } }));
-    fetchQueue.push(() => jsonResponse({ data: { conditions: page3 } }));
+    fetchQueue.push(() =>
+      jsonResponse({
+        data: { conditionsConnection: { nodes: page1, hasMore: true } },
+      })
+    );
+    fetchQueue.push(() =>
+      jsonResponse({
+        data: { conditionsConnection: { nodes: page2, hasMore: true } },
+      })
+    );
+    fetchQueue.push(() =>
+      jsonResponse({
+        data: { conditionsConnection: { nodes: page3, hasMore: false } },
+      })
+    );
 
     const result = await fetchAllExistingConditions('https://api.example.com');
 
@@ -134,25 +150,28 @@ describe('fetchAllExistingConditions', () => {
     fetchQueue.push(() =>
       jsonResponse({
         data: {
-          conditions: [
-            {
-              id: '0xabc',
-              endTime: 1700000000,
-              question: 'Will X happen?',
-              shortName: 'X?',
-              optionName: 'Yes side',
-              description: 'A description',
-              similarMarkets: ['https://polymarket.com/event/foo#bar'],
-              tags: ['crypto', 'btc'],
-              similarMarketVolume: 1234,
-              similarMarketImage: 'https://img.example/x.png',
-              conditionGroup: {
-                id: 7,
-                name: 'Group Name',
+          conditionsConnection: {
+            nodes: [
+              {
+                id: '0xabc',
+                endTime: 1700000000,
+                question: 'Will X happen?',
+                shortName: 'X?',
+                optionName: 'Yes side',
+                description: 'A description',
                 similarMarkets: ['https://polymarket.com/event/foo#bar'],
+                tags: ['crypto', 'btc'],
+                similarMarketVolume: 1234,
+                similarMarketImage: 'https://img.example/x.png',
+                conditionGroup: {
+                  id: 7,
+                  name: 'Group Name',
+                  similarMarkets: ['https://polymarket.com/event/foo#bar'],
+                },
               },
-            },
-          ],
+            ],
+            hasMore: false,
+          },
         },
       })
     );

--- a/packages/market-keeper/src/refresh-metadata/fetch.ts
+++ b/packages/market-keeper/src/refresh-metadata/fetch.ts
@@ -47,7 +47,7 @@ export async function fetchAllExistingConditions(
     query RefreshMetadataConditions($filters: ConditionFilter!, $take: Int!, $skip: Int!) {
       conditionsConnection(filter: $filters, first: $take, skip: $skip, orderBy: { field: CREATED_AT, direction: ASC }) {
         hasMore
-        items {
+        nodes {
           id
           endTime
           question

--- a/packages/market-keeper/src/resolver.ts
+++ b/packages/market-keeper/src/resolver.ts
@@ -18,7 +18,15 @@ function normalizeLegacy(entry: string | { address: string }): string {
   return typeof entry === 'string' ? entry : entry.address;
 }
 
-const RESOLVER_MAPS: Record<ResolverType, Record<number, { address: Address; legacy?: readonly any[] }>> = {
+type ResolverDeployment = {
+  address: Address;
+  legacy?: readonly (string | { address: string })[];
+};
+
+const RESOLVER_MAPS: Record<
+  ResolverType,
+  Record<number, ResolverDeployment>
+> = {
   ct: conditionalTokensConditionResolver,
   manual: manualConditionResolver,
 };
@@ -36,14 +44,17 @@ const RESOLVER_LABELS: Record<ResolverType, string> = {
  * @returns Resolver address and full address list (current + legacy) for DB queries
  * @throws If the resolver type has no entry for the given chain
  */
-export function getResolverConfig(chainId: number, resolverType: ResolverType): ResolverConfig {
+export function getResolverConfig(
+  chainId: number,
+  resolverType: ResolverType
+): ResolverConfig {
   const map = RESOLVER_MAPS[resolverType];
   const entry = map[chainId];
 
   if (!entry) {
     throw new Error(
       `${RESOLVER_LABELS[resolverType]} has no deployment on chain ${chainId}. ` +
-      `Set RESOLVER_TYPE to a resolver that exists on this chain.`
+        `Set RESOLVER_TYPE to a resolver that exists on this chain.`
     );
   }
 


### PR DESCRIPTION
## Summary
- Stops schema emission from touching Prisma/config at import time by making `PositionsPage.totalCount` resolve the model lazily.
- Fixes refresh-metadata to read `conditionsConnection.nodes`, matching the GraphQL query it sends.
- Updates market-keeper refresh-metadata tests for the connection-shaped response and removes a lingering explicit `any` in resolver config.

## Verification
- `pnpm --filter @sapience/api run generate-types`
- `pnpm --filter @sapience/api run lint`
- `pnpm --filter @sapience/api run type-check`
- `pnpm --filter @sapience/api run test -- src/graphql/sdl/resolvers/PositionsPage.test.ts` (Vitest ran full API suite: 67 files / 775 tests)
- `pnpm --filter @sapience/market-keeper run lint`
- `pnpm --filter @sapience/market-keeper run type-check`
- `pnpm --filter @sapience/market-keeper run test` (19 passed, 1 skipped)
