### PR TITLE
feat(keeper, api): AP-style Title Case tags + keeper Connection migration

### DIFF
--- a/packages/api/src/graphql/sdl/resolvers/queries/tags.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/tags.ts
@@ -17,7 +17,7 @@ const popularTagsCache = new TtlCache<string, string[]>({
   ttlMs: 60 * 60 * 1000,
 });
 /** Versioned so old caches invalidate when the deny list / SQL changes. */
-const CACHE_KEY = 'popularTags:v1';
+const CACHE_KEY = 'popularTags:v2';
 
 export const popularTags: NonNullable<
   QueryResolvers['popularTags']

--- a/packages/api/src/routes/conditions.test.ts
+++ b/packages/api/src/routes/conditions.test.ts
@@ -134,7 +134,7 @@ describe('conditions routes', () => {
       expect(res.body.message).toMatch(/already exists/i);
     });
 
-    it('stores tags array when provided (first-letter capitalized)', async () => {
+    it('stores tags array when provided (Title-Cased)', async () => {
       mockPrisma.condition.create.mockResolvedValue({ id: '0x1' });
 
       const res = await request(app)
@@ -144,6 +144,26 @@ describe('conditions routes', () => {
       expect(res.status).toBe(201);
       const createCall = mockPrisma.condition.create.mock.calls[0][0];
       expect(createCall.data.tags).toEqual(['Bitcoin', 'Crypto', 'UFC']);
+    });
+
+    it('title-cases multi-word lowercase tags on create', async () => {
+      mockPrisma.condition.create.mockResolvedValue({ id: '0x1' });
+
+      const res = await request(app)
+        .post('/admin/conditions')
+        .send(
+          baseBody({
+            tags: ['primary elections', 'highest temperature', 'UFC'],
+          })
+        );
+
+      expect(res.status).toBe(201);
+      const createCall = mockPrisma.condition.create.mock.calls[0][0];
+      expect(createCall.data.tags).toEqual([
+        'Primary Elections',
+        'Highest Temperature',
+        'UFC',
+      ]);
     });
 
     it('defaults tags to empty array when not provided', async () => {
@@ -554,7 +574,7 @@ describe('conditions routes', () => {
       expect(updateCall.data.endTime).toBe(FUTURE_END_TIME + 10000);
     });
 
-    it('updates tags when provided (first-letter capitalized)', async () => {
+    it('updates tags when provided (Title-Cased)', async () => {
       mockPrisma.condition.findUnique.mockResolvedValue(existingCondition());
       mockPrisma.condition.update.mockResolvedValue({
         ...existingCondition(),
@@ -568,6 +588,22 @@ describe('conditions routes', () => {
       expect(res.status).toBe(200);
       const updateCall = mockPrisma.condition.update.mock.calls[0][0];
       expect(updateCall.data.tags).toEqual(['Updated-tag']);
+    });
+
+    it('title-cases multi-word lowercase tags on update', async () => {
+      mockPrisma.condition.findUnique.mockResolvedValue(existingCondition());
+      mockPrisma.condition.update.mockResolvedValue({
+        ...existingCondition(),
+        tags: ['Primary Elections'],
+      });
+
+      const res = await request(app)
+        .put(`/admin/conditions/${VALID_ID}`)
+        .send({ tags: ['primary elections'] });
+
+      expect(res.status).toBe(200);
+      const updateCall = mockPrisma.condition.update.mock.calls[0][0];
+      expect(updateCall.data.tags).toEqual(['Primary Elections']);
     });
 
     it('does not overwrite tags when not provided', async () => {

--- a/packages/api/src/routes/conditions.ts
+++ b/packages/api/src/routes/conditions.ts
@@ -16,14 +16,75 @@ function isHttpUrl(value: unknown): boolean {
   }
 }
 
-// Polymarket returns some tag labels miscased (e.g. `temperature`). Uppercase
-// the first char and preserve the rest so acronyms like `UFC` stay intact.
+// AP-style title-case "small words" that stay lowercase when they're
+// neither the first nor the last word. Articles, coordinating
+// conjunctions, and prepositions ≤ 3 letters. Includes "vs" (sports
+// journalism convention) and "x" (Polymarket matchup separator).
+const TITLE_CASE_SMALL_WORDS = new Set([
+  // Articles
+  'a',
+  'an',
+  'the',
+  // Coordinating conjunctions
+  'and',
+  'but',
+  'for',
+  'nor',
+  'or',
+  'so',
+  'yet',
+  // Short prepositions (≤3 letters)
+  'as',
+  'at',
+  'by',
+  'in',
+  'of',
+  'off',
+  'on',
+  'per',
+  'to',
+  'up',
+  'via',
+  // Domain-specific
+  'vs',
+  'x',
+]);
+
+// AP-style Title Case. Each word:
+//   1) Acronym/mixed-case preservation — any word containing an
+//      uppercase letter is left alone (UFC, NFL, DeFi, iOS, F1, U.S.).
+//   2) First and last words are always capitalized (even if they're
+//      small words: "Of Mice and Men", "Things to Come To").
+//   3) Small-word skip — articles, coord. conjunctions, ≤3-letter
+//      prepositions stay lowercase. ALL-CAPS forms ("OR" the Oregon
+//      state code) bypass this and are treated as acronyms.
+// Splits on space only — hyphenated tags like "updated-tag" stay as
+// one word ("Updated-tag").
 // Mirrors normalizeTagLabel in packages/market-keeper/src/generate/tags.ts.
 function normalizeTags(tags: unknown): string[] {
   if (!Array.isArray(tags)) return [];
   return tags
     .filter((t): t is string => typeof t === 'string' && t.length > 0)
-    .map((t) => t.charAt(0).toUpperCase() + t.slice(1));
+    .map((t) => {
+      const words = t.split(' ');
+      return words
+        .map((w, i) => {
+          const isFirst = i === 0;
+          const isLast = i === words.length - 1;
+          const isAllUpper = /[A-Z]/.test(w) && w === w.toUpperCase();
+          if (
+            !isFirst &&
+            !isLast &&
+            !isAllUpper &&
+            TITLE_CASE_SMALL_WORDS.has(w.toLowerCase())
+          ) {
+            return w.toLowerCase();
+          }
+          if (/[A-Z]/.test(w)) return w;
+          return w.charAt(0).toUpperCase() + w.slice(1);
+        })
+        .join(' ');
+    });
 }
 
 // GET route removed in favor of GraphQL. Use GraphQL `conditions` query for reads.

--- a/packages/app/src/components/markets/MarketsPage.tsx
+++ b/packages/app/src/components/markets/MarketsPage.tsx
@@ -66,10 +66,11 @@ const MarketsPage = () => {
     'sapience.markets.searchTerm',
     ''
   );
-  // Key bumped to v2 after tag-case normalization (lowercase values like
-  // "temperature" no longer match; force a reset of stale selections).
+  // Key bumped to v3 after per-word Title Case normalization (e.g. cached
+  // "Primary elections" no longer matches the new "Primary Elections";
+  // force a reset of stale selections).
   const [selectedTag, setSelectedTag] = useSessionState<string | null>(
-    'sapience.markets.selectedTag.v2',
+    'sapience.markets.selectedTag.v3',
     null
   );
   const defaultFilters: FilterState = {

--- a/packages/market-keeper/scripts/backfill-tag-casing.ts
+++ b/packages/market-keeper/scripts/backfill-tag-casing.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+/// <reference types="node" />
+/**
+ * One-shot backfill: renormalize tags on every public condition to
+ * per-word Title Case with acronym guard.
+ *
+ * Usage:
+ *   tsx scripts/backfill-tag-casing.ts --dry-run
+ *   tsx scripts/backfill-tag-casing.ts
+ */
+
+import { main } from '../src/backfill-tag-casing/index.js';
+import { logSeparator } from '../src/utils/log.js';
+
+logSeparator('market-keeper:backfill-tag-casing', 'START');
+main().finally(() =>
+  logSeparator('market-keeper:backfill-tag-casing', 'END')
+);

--- a/packages/market-keeper/scripts/settle-manual.ts
+++ b/packages/market-keeper/scripts/settle-manual.ts
@@ -237,7 +237,7 @@ query UnresolvedConditions($take: Int!, $skip: Int!, $resolver: String!) {
   conditionsConnection(
     filter: {
       settled: false
-      contractAddress: $resolver
+      marketAddress: $resolver
       # Pick up both public and private — the deprecated resolver's
       # implicit public=true filter would silently exclude privated
       # conditions that still have engagement to settle.

--- a/packages/market-keeper/scripts/settle-polymarket.ts
+++ b/packages/market-keeper/scripts/settle-polymarket.ts
@@ -218,7 +218,7 @@ query UnresolvedConditions($take: Int!, $skip: Int!, $resolver: String!) {
   conditionsConnection(
     filter: {
       settled: false
-      contractAddress: $resolver
+      marketAddress: $resolver
       # Pick up both public and private — the deprecated resolver's
       # implicit public=true filter would silently exclude privated
       # conditions that still have engagement to settle.

--- a/packages/market-keeper/scripts/settle-pyth.ts
+++ b/packages/market-keeper/scripts/settle-pyth.ts
@@ -561,7 +561,7 @@ async function main() {
         chainId: CHAIN_ID,
         resolvesAt: { lte: nowSec },
         settled: false,
-        contractAddress: PYTH_RESOLVER_ADDRESS,
+        marketAddress: PYTH_RESOLVER_ADDRESS,
       },
       take,
       skip,

--- a/packages/market-keeper/src/__tests__/refresh-metadata.test.ts
+++ b/packages/market-keeper/src/__tests__/refresh-metadata.test.ts
@@ -74,29 +74,38 @@ function makeMarket(
 }
 
 describe('fetchAllExistingConditions', () => {
-  it('sends a where clause that filters to public + unsettled + non-empty similarMarkets', async () => {
-    fetchQueue.push(() => jsonResponse({ data: { conditions: [] } }));
+  // Build a conditionsConnection response page with the given nodes and
+  // an optional next-page cursor. `endCursor` is null on the final page.
+  const connectionPage = (
+    nodes: unknown[],
+    endCursor: string | null
+  ): unknown => ({
+    data: {
+      conditionsConnection: {
+        nodes,
+        pageInfo: { hasNextPage: endCursor !== null, endCursor },
+      },
+    },
+  });
+
+  it('sends a ConditionFilter that filters to public + unsettled + non-empty similarMarkets', async () => {
+    fetchQueue.push(() => jsonResponse(connectionPage([], null)));
 
     await fetchAllExistingConditions('https://api.example.com');
 
     expect(fetchCalls).toHaveLength(1);
     const body = JSON.parse(fetchCalls[0].init!.body as string);
-    expect(body.variables.filters).toEqual({
+    expect(body.variables.filter).toEqual({
       visibility: 'PUBLIC',
       settled: false,
       hasSimilarMarkets: true,
     });
-    expect(body.variables.take).toBe(100);
-    expect(body.query).toContain('conditionsConnection');
-    expect(body.query).toContain(
-      'orderBy: { field: CREATED_AT, direction: ASC }'
-    );
+    expect(body.variables.first).toBe(100);
+    expect(body.variables.after).toBeNull();
     expect(fetchCalls[0].url.endsWith('/graphql')).toBe(true);
   });
 
-  it('paginates with deterministic orderBy until a page returns < pageSize', async () => {
-    // Two full pages of 100 then an empty short page — same shape
-    // refresh-volume's fetchActiveConditionIds uses.
+  it('paginates via pageInfo.endCursor until hasNextPage=false', async () => {
     const page1 = Array.from({ length: 100 }, (_, i) => ({
       id: `0x${(i + 1).toString().padStart(3, '0')}`,
       endTime: 1700000000,
@@ -115,65 +124,51 @@ describe('fetchAllExistingConditions', () => {
       },
     ];
 
-    fetchQueue.push(() =>
-      jsonResponse({
-        data: { conditionsConnection: { nodes: page1, hasMore: true } },
-      })
-    );
-    fetchQueue.push(() =>
-      jsonResponse({
-        data: { conditionsConnection: { nodes: page2, hasMore: true } },
-      })
-    );
-    fetchQueue.push(() =>
-      jsonResponse({
-        data: { conditionsConnection: { nodes: page3, hasMore: false } },
-      })
-    );
+    fetchQueue.push(() => jsonResponse(connectionPage(page1, 'cursor-1')));
+    fetchQueue.push(() => jsonResponse(connectionPage(page2, 'cursor-2')));
+    fetchQueue.push(() => jsonResponse(connectionPage(page3, null)));
 
     const result = await fetchAllExistingConditions('https://api.example.com');
 
     expect(result.size).toBe(201);
     expect(fetchCalls).toHaveLength(3);
-    expect(JSON.parse(fetchCalls[0].init!.body as string).variables.skip).toBe(
-      0
+    expect(JSON.parse(fetchCalls[0].init!.body as string).variables.after).toBe(
+      null
     );
-    expect(JSON.parse(fetchCalls[1].init!.body as string).variables.skip).toBe(
-      100
+    expect(JSON.parse(fetchCalls[1].init!.body as string).variables.after).toBe(
+      'cursor-1'
     );
-    expect(JSON.parse(fetchCalls[2].init!.body as string).variables.skip).toBe(
-      200
+    expect(JSON.parse(fetchCalls[2].init!.body as string).variables.after).toBe(
+      'cursor-2'
     );
   });
 
   it('maps GraphQL fields onto the ExistingCondition shape', async () => {
     fetchQueue.push(() =>
-      jsonResponse({
-        data: {
-          conditionsConnection: {
-            nodes: [
-              {
-                id: '0xabc',
-                endTime: 1700000000,
-                question: 'Will X happen?',
-                shortName: 'X?',
-                optionName: 'Yes side',
-                description: 'A description',
+      jsonResponse(
+        connectionPage(
+          [
+            {
+              id: '0xabc',
+              endTime: 1700000000,
+              question: 'Will X happen?',
+              shortName: 'X?',
+              optionName: 'Yes side',
+              description: 'A description',
+              similarMarkets: ['https://polymarket.com/event/foo#bar'],
+              tags: ['crypto', 'btc'],
+              similarMarketVolume: 1234,
+              similarMarketImage: 'https://img.example/x.png',
+              conditionGroup: {
+                id: 7,
+                name: 'Group Name',
                 similarMarkets: ['https://polymarket.com/event/foo#bar'],
-                tags: ['crypto', 'btc'],
-                similarMarketVolume: 1234,
-                similarMarketImage: 'https://img.example/x.png',
-                conditionGroup: {
-                  id: 7,
-                  name: 'Group Name',
-                  similarMarkets: ['https://polymarket.com/event/foo#bar'],
-                },
               },
-            ],
-            hasMore: false,
-          },
-        },
-      })
+            },
+          ],
+          null
+        )
+      )
     );
 
     const result = await fetchAllExistingConditions('https://api.example.com');

--- a/packages/market-keeper/src/__tests__/tags.test.ts
+++ b/packages/market-keeper/src/__tests__/tags.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { fetchEventTags } from '../generate/tags';
+import { fetchEventTags, normalizeTagLabel } from '../generate/tags';
 
 const mockFetchWithRetry = vi.fn();
 vi.mock('../utils', () => ({
@@ -108,10 +108,10 @@ describe('fetchEventTags', () => {
     expect(result.get('case-dup')).toEqual(['Temperature']);
   });
 
-  it('capitalizes the first letter of each label (preserves rest)', async () => {
-    // Polymarket returns some labels miscased, e.g. `temperature` lowercase.
-    // We normalize the first character so acronyms like "UFC" are untouched
-    // but "temperature" becomes "Temperature".
+  it('title-cases each word and preserves acronyms', async () => {
+    // Polymarket returns some labels miscased. Per-word Title Case capitalizes
+    // every word, but the acronym guard leaves words with any uppercase letter
+    // untouched, so "UFC" survives.
     mockResponse([
       {
         slug: 'weather-event',
@@ -128,7 +128,7 @@ describe('fetchEventTags', () => {
 
     expect(result.get('weather-event')).toEqual([
       'Temperature',
-      'Highest temperature',
+      'Highest Temperature',
       'UFC',
       'Weather',
     ]);
@@ -206,5 +206,112 @@ describe('fetchEventTags', () => {
     // Should still return what was fetched from page 1
     expect(result.size).toBe(500);
     expect(mockFetchWithRetry).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('normalizeTagLabel', () => {
+  it('capitalizes a single lowercase word', () => {
+    expect(normalizeTagLabel('temperature')).toBe('Temperature');
+  });
+
+  it('capitalizes every word of a multi-word lowercase label', () => {
+    expect(normalizeTagLabel('primary elections')).toBe('Primary Elections');
+    expect(normalizeTagLabel('highest temperature')).toBe(
+      'Highest Temperature'
+    );
+  });
+
+  it('leaves already Title-Cased labels unchanged', () => {
+    expect(normalizeTagLabel('Sports')).toBe('Sports');
+    expect(normalizeTagLabel('Senate Primary')).toBe('Senate Primary');
+  });
+
+  it('preserves acronyms via the uppercase-letter guard', () => {
+    expect(normalizeTagLabel('UFC')).toBe('UFC');
+    expect(normalizeTagLabel('NFL')).toBe('NFL');
+    expect(normalizeTagLabel('F1')).toBe('F1');
+  });
+
+  it('preserves mixed-case brand words', () => {
+    expect(normalizeTagLabel('DeFi')).toBe('DeFi');
+    expect(normalizeTagLabel('iOS launch')).toBe('iOS Launch');
+  });
+
+  it('treats hyphenated tokens as one word (no split on hyphen)', () => {
+    expect(normalizeTagLabel('updated-tag')).toBe('Updated-tag');
+  });
+
+  it('returns the input unchanged for empty string', () => {
+    expect(normalizeTagLabel('')).toBe('');
+  });
+
+  it('handles mixed inputs (acronym + lowercase multi-word)', () => {
+    expect(normalizeTagLabel('UFC fight night')).toBe('UFC Fight Night');
+  });
+
+  describe('small-word skip list', () => {
+    it('keeps "or" lowercase between two content words', () => {
+      expect(normalizeTagLabel('Up or Down')).toBe('Up or Down');
+      // and lowercases an incorrectly-capitalized "Or"
+      expect(normalizeTagLabel('Up Or Down')).toBe('Up or Down');
+    });
+
+    it('keeps "of" lowercase in multi-word names', () => {
+      expect(normalizeTagLabel('Democratic Party of Korea')).toBe(
+        'Democratic Party of Korea'
+      );
+      expect(normalizeTagLabel('Strait of Hormuz')).toBe('Strait of Hormuz');
+      expect(normalizeTagLabel('league of legends')).toBe('League of Legends');
+    });
+
+    it('keeps "x" lowercase (matchup separator)', () => {
+      expect(normalizeTagLabel('U.S. x Iran')).toBe('U.S. x Iran');
+      expect(normalizeTagLabel('Brazil x Argentina')).toBe(
+        'Brazil x Argentina'
+      );
+    });
+
+    it('keeps "the", "and", "vs" lowercase mid-tag', () => {
+      expect(normalizeTagLabel('The lord of the rings')).toBe(
+        'The Lord of the Rings'
+      );
+      expect(normalizeTagLabel('rock and roll')).toBe('Rock and Roll');
+      expect(normalizeTagLabel('Trump vs Biden')).toBe('Trump vs Biden');
+    });
+
+    it('capitalizes a small word when it is the first word', () => {
+      expect(normalizeTagLabel('of mice and men')).toBe('Of Mice and Men');
+      expect(normalizeTagLabel('the rolling stones')).toBe(
+        'The Rolling Stones'
+      );
+    });
+
+    it('preserves all-caps short words as acronyms (not lowercased)', () => {
+      // "OR" the Oregon state code, not the conjunction
+      expect(normalizeTagLabel('Salem OR Race')).toBe('Salem OR Race');
+      expect(normalizeTagLabel('Austin TX Heat')).toBe('Austin TX Heat');
+    });
+
+    it('always capitalizes the last word even if it is a small word', () => {
+      // Per AP/Chicago, last word always capitalizes.
+      expect(normalizeTagLabel('things to come to')).toBe('Things to Come To');
+      expect(normalizeTagLabel('what are you waiting for')).toBe(
+        'What Are You Waiting For'
+      );
+    });
+
+    it('lowercases the additional short prepositions (up, off, per, via)', () => {
+      expect(normalizeTagLabel('What is up with that')).toBe(
+        'What Is up With That'
+      );
+      expect(normalizeTagLabel('Days off work')).toBe('Days off Work');
+      expect(normalizeTagLabel('Prize per round')).toBe('Prize per Round');
+      expect(normalizeTagLabel('Sent via courier')).toBe('Sent via Courier');
+    });
+
+    it('handles a single small word as-is (first === last → capitalize)', () => {
+      expect(normalizeTagLabel('of')).toBe('Of');
+      expect(normalizeTagLabel('the')).toBe('The');
+    });
   });
 });

--- a/packages/market-keeper/src/backfill-endtimes/index.ts
+++ b/packages/market-keeper/src/backfill-endtimes/index.ts
@@ -114,38 +114,45 @@ async function fetchUnsettledPmConditions(
   const PAGE_SIZE = 100;
   const out: PageItem[] = [];
   const seen = new Set<string>();
-  let skip = 0;
+  let after: string | null = null;
+  let pageNo = 0;
   let lastSize = 0;
   let zeroGrowthStreak = 0;
 
-  while (true) {
-    // Uses the legacy `conditions` query (Prisma-style where/orderBy)
-    // rather than `conditionsPage`, because staging's API is on the
-    // pre-`conditionsPage` schema. Pagination is take/skip with no
-    // server-truth `hasMore` — we stop when a page returns < PAGE_SIZE.
-    const query = `
-      query BackfillCandidates($where: ConditionWhereInput!, $orderBy: [ConditionOrderByWithRelationInput!], $take: Int!, $skip: Int!) {
-        conditions(where: $where, orderBy: $orderBy, take: $take, skip: $skip) {
+  // Relay-shaped `conditionsConnection` with cursor pagination. We
+  // sort by CREATED_AT ASC so --limit picks the oldest first (most
+  // likely to predate the new pipeline).
+  const query = `
+    query BackfillCandidates($filter: ConditionFilter!, $first: Int!, $after: String) {
+      conditionsConnection(filter: $filter, first: $first, after: $after, orderBy: { field: CREATED_AT, direction: ASC }) {
+        nodes {
           id
           question
           description
           endTime
         }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
       }
-    `;
+    }
+  `;
+
+  while (true) {
+    pageNo++;
     const variables = {
-      where: {
-        public: { equals: true },
-        settled: { equals: false },
-        similarMarkets: { isEmpty: false },
+      filter: {
+        visibility: 'PUBLIC',
+        settled: false,
+        hasSimilarMarkets: true,
       },
-      orderBy: [{ id: 'asc' }],
-      take: PAGE_SIZE,
-      skip,
+      first: PAGE_SIZE,
+      after,
     };
     // Log the exact request variables on the first page so 0-result runs
     // are diagnosable from the script output alone.
-    if (skip === 0) {
+    if (pageNo === 1) {
       log(
         `[Backfill]   GraphQL variables: ${JSON.stringify(variables, null, 2)}`
       );
@@ -158,7 +165,7 @@ async function fetchUnsettledPmConditions(
     if (!response.ok) {
       const body = await response.text().catch(() => '(unreadable body)');
       throw new Error(
-        `GraphQL conditions failed: HTTP ${response.status} ${response.statusText}\nResponse body: ${body.slice(0, 2000)}`
+        `GraphQL conditionsConnection failed: HTTP ${response.status} ${response.statusText}\nResponse body: ${body.slice(0, 2000)}`
       );
     }
     // GraphQL returns 200 with `errors: [...]` for query errors (unknown
@@ -166,27 +173,33 @@ async function fetchUnsettledPmConditions(
     // Inspect the parsed body for `errors` and surface them.
     const result = (await response.json()) as {
       data?: {
-        conditions?: Array<{
-          id: string;
-          question: string;
-          description: string | null;
-          endTime: number;
-        }>;
+        conditionsConnection?: {
+          nodes?: Array<{
+            id: string;
+            question: string;
+            description: string | null;
+            endTime: number;
+          }>;
+          pageInfo?: {
+            hasNextPage?: boolean | null;
+            endCursor?: string | null;
+          } | null;
+        };
       };
       errors?: Array<{ message: string; path?: unknown }>;
     };
     if (result.errors && result.errors.length > 0) {
       throw new Error(
-        `GraphQL conditions returned errors: ${JSON.stringify(result.errors, null, 2)}`
+        `GraphQL conditionsConnection returned errors: ${JSON.stringify(result.errors, null, 2)}`
       );
     }
-    const items = result.data?.conditions ?? [];
-    // Legacy `conditions` has no `hasMore`; stop on a short page.
-    const hasMore = items.length === PAGE_SIZE;
+    const nodes = result.data?.conditionsConnection?.nodes ?? [];
+    const pageInfo = result.data?.conditionsConnection?.pageInfo;
+    const hasMore = pageInfo?.hasNextPage ?? false;
     log(
-      `[Backfill]   page (skip=${skip}): fetched ${items.length} (cumulative ${out.length + items.length})`
+      `[Backfill]   page ${pageNo}: fetched ${nodes.length} (cumulative ${out.length + nodes.length})`
     );
-    for (const c of items) {
+    for (const c of nodes) {
       if (seen.has(c.id)) continue;
       seen.add(c.id);
       out.push({
@@ -197,13 +210,13 @@ async function fetchUnsettledPmConditions(
       });
       if (maxResults !== null && out.length >= maxResults) return out;
     }
-    // Safety: same infinite-loop guard as refresh-imminent-tag — break out
-    // if a full page keeps coming back but adds zero unique rows.
+    // Safety: cursor pagination shouldn't loop, but protect against a
+    // server-side bug where the same endCursor keeps coming back.
     if (out.length === lastSize) {
       zeroGrowthStreak++;
       if (zeroGrowthStreak >= 3) {
         logError(
-          `[Backfill] WARN: 3 consecutive pages added 0 unique rows (skip=${skip}); aborting pagination to avoid an infinite loop`
+          `[Backfill] WARN: 3 consecutive pages added 0 unique rows (after=${after}); aborting pagination to avoid an infinite loop`
         );
         break;
       }
@@ -212,7 +225,8 @@ async function fetchUnsettledPmConditions(
     }
     lastSize = out.length;
     if (!hasMore) break;
-    skip += PAGE_SIZE;
+    after = pageInfo?.endCursor ?? null;
+    if (!after) break;
   }
   return out;
 }

--- a/packages/market-keeper/src/backfill-tag-casing/index.ts
+++ b/packages/market-keeper/src/backfill-tag-casing/index.ts
@@ -1,0 +1,308 @@
+/**
+ * One-shot backfill: walk every public condition, apply the per-word
+ * Title Case normalizer to its tags array, and submit changed rows via
+ * PUT /admin/conditions/batch-metadata. Idempotent — a second run
+ * reports zero updates.
+ *
+ * Backfills settled rows too because `popularTags` and SQL prefix
+ * filters in graphql/sdl/resolvers/queries/questions.ts don't filter on
+ * `settled`, so case-consistency on legacy data matters for those reads.
+ */
+
+import 'dotenv/config';
+import { DEFAULT_SAPIENCE_API_URL } from '../constants';
+import {
+  validatePrivateKey,
+  confirmProductionAccess,
+  fetchWithRetry,
+  log,
+  logError,
+} from '../utils';
+import { submitMetadataUpdates } from '../generate/api';
+import { normalizeTagLabel } from '../generate/tags';
+
+interface BackfillCLIOptions {
+  dryRun: boolean;
+  limit: number | null;
+  help: boolean;
+}
+
+const DEFAULT_DRY_RUN_LIMIT = 1000;
+
+function parseArgs(): BackfillCLIOptions {
+  const args = process.argv.slice(2);
+  const limitIdx = args.findIndex((a) => a === '--limit');
+  const dryRun = args.includes('--dry-run');
+  const explicitLimit =
+    limitIdx !== -1 && args[limitIdx + 1]
+      ? parseInt(args[limitIdx + 1], 10)
+      : null;
+  return {
+    dryRun,
+    limit: explicitLimit ?? (dryRun ? DEFAULT_DRY_RUN_LIMIT : null),
+    help: args.includes('--help') || args.includes('-h'),
+  };
+}
+
+function showHelp(): void {
+  console.log(`
+Usage: tsx scripts/backfill-tag-casing.ts [options]
+
+Walks every public condition and renormalizes its tags using the
+per-word Title Case rule with acronym guard (e.g. "Primary elections" →
+"Primary Elections", "UFC" stays "UFC"). Rows whose tags are already
+correct are skipped.
+
+Options:
+  --dry-run      Show what would change without submitting.
+                 Defaults to fetching only ${DEFAULT_DRY_RUN_LIMIT} conditions; override with --limit.
+  --limit N      Cap the number of conditions fetched (sorted by createdAt desc).
+                 Default: ${DEFAULT_DRY_RUN_LIMIT} in --dry-run, unlimited in live mode.
+  --help, -h     Show this help
+
+Environment Variables (required for live run):
+  SAPIENCE_API_URL     API URL (default: https://api.sapience.xyz)
+  ADMIN_PRIVATE_KEY    64-char hex private key for signing admin requests
+`);
+}
+
+interface PageItem {
+  id: string;
+  tags: string[];
+}
+
+async function fetchAllPublicConditions(
+  apiUrl: string,
+  maxResults: number | null
+): Promise<PageItem[]> {
+  const graphqlUrl = apiUrl.replace(/\/+$/, '') + '/graphql';
+  const PAGE_SIZE = 100;
+  const out: PageItem[] = [];
+  const seen = new Set<string>();
+  let after: string | null = null;
+  let pageCount = 0;
+  let lastSize = 0;
+  let zeroGrowthStreak = 0;
+
+  // Uses the Relay-shaped `conditionsConnection` resolver. `filter:
+  // { visibility: PUBLIC }` covers both settled and unsettled public
+  // rows — we want case-consistency across the whole public set.
+  const query = `
+    query TagBackfillCandidates($filter: ConditionFilter!, $first: Int!, $after: String) {
+      conditionsConnection(filter: $filter, first: $first, after: $after, orderBy: { field: CREATED_AT, direction: DESC }) {
+        nodes {
+          id
+          tags
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  `;
+
+  while (true) {
+    pageCount++;
+    const pageStart = Date.now();
+    const response = await fetchWithRetry(graphqlUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query,
+        variables: {
+          filter: { visibility: 'PUBLIC' },
+          first: PAGE_SIZE,
+          after,
+        },
+      }),
+    });
+    if (!response.ok) {
+      const body = await response.text().catch(() => '(unreadable body)');
+      throw new Error(
+        `GraphQL conditionsConnection failed: HTTP ${response.status} ${response.statusText}\nResponse body: ${body.slice(0, 2000)}`
+      );
+    }
+    const result = (await response.json()) as {
+      data?: {
+        conditionsConnection?: {
+          nodes?: Array<{ id: string; tags: string[] }>;
+          pageInfo?: {
+            hasNextPage?: boolean | null;
+            endCursor?: string | null;
+          } | null;
+        };
+      };
+      errors?: Array<{ message: string }>;
+    };
+    if (result.errors && result.errors.length > 0) {
+      throw new Error(
+        `GraphQL conditionsConnection returned errors: ${JSON.stringify(result.errors, null, 2)}`
+      );
+    }
+    const nodes = result.data?.conditionsConnection?.nodes ?? [];
+    const pageInfo = result.data?.conditionsConnection?.pageInfo;
+    const hasMore = pageInfo?.hasNextPage ?? false;
+    for (const c of nodes) {
+      if (seen.has(c.id)) continue;
+      seen.add(c.id);
+      out.push({ id: c.id, tags: c.tags ?? [] });
+      if (maxResults !== null && out.length >= maxResults) {
+        log(
+          `[TagBackfill]   page ${pageCount}: fetched ${nodes.length} (cumulative ${out.length}, ${Date.now() - pageStart}ms) — hit --limit ${maxResults}, stopping`
+        );
+        return out;
+      }
+    }
+    log(
+      `[TagBackfill]   page ${pageCount}: fetched ${nodes.length} (cumulative ${out.length}, ${Date.now() - pageStart}ms, hasMore=${hasMore})`
+    );
+    // Zero-growth abort guard: cursor pagination shouldn't loop, but
+    // protect against a server-side bug that re-emits the same cursor.
+    if (out.length === lastSize) {
+      zeroGrowthStreak++;
+      if (zeroGrowthStreak >= 3) {
+        logError(
+          `[TagBackfill] WARN: 3 consecutive pages added 0 unique rows (hasMore=${hasMore}, after=${after}); aborting pagination to avoid an infinite loop`
+        );
+        break;
+      }
+    } else {
+      zeroGrowthStreak = 0;
+    }
+    lastSize = out.length;
+    if (!hasMore) break;
+    after = pageInfo?.endCursor ?? null;
+    if (!after) break;
+  }
+  return out;
+}
+
+function tagsEqualOrdered(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((v, i) => v === b[i]);
+}
+
+export async function main(): Promise<void> {
+  const runStart = Date.now();
+  const options = parseArgs();
+  if (options.help) {
+    showHelp();
+    return;
+  }
+
+  const apiUrl = process.env.SAPIENCE_API_URL || DEFAULT_SAPIENCE_API_URL;
+  const rawPrivateKey = process.env.ADMIN_PRIVATE_KEY;
+
+  log(`[TagBackfill] ==============================================`);
+  log(`[TagBackfill] API:     ${apiUrl}`);
+  log(`[TagBackfill] Mode:    ${options.dryRun ? 'DRY-RUN' : 'LIVE'}`);
+  log(
+    `[TagBackfill] Limit:   ${options.limit === null ? 'unlimited' : options.limit}`
+  );
+  log(`[TagBackfill] ==============================================`);
+
+  let privateKey: `0x${string}` | undefined;
+  if (!options.dryRun) {
+    try {
+      privateKey = validatePrivateKey(rawPrivateKey);
+    } catch (error) {
+      logError(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+    log(`[TagBackfill] Confirming prod access (LIVE mode)...`);
+    await confirmProductionAccess(apiUrl);
+  }
+
+  log(`[TagBackfill] [1/3] Fetching public conditions...`);
+  const fetchStart = Date.now();
+  const conditions = await fetchAllPublicConditions(apiUrl, options.limit);
+  log(
+    `[TagBackfill] [1/3] Fetched ${conditions.length} conditions in ${((Date.now() - fetchStart) / 1000).toFixed(1)}s`
+  );
+
+  log(`[TagBackfill] [2/3] Renormalizing tags...`);
+  type Update = {
+    id: string;
+    oldTags: string[];
+    newTags: string[];
+  };
+  const updates: Update[] = [];
+  // Track unique rename transitions for a clearer summary.
+  const renameCounts = new Map<string, number>();
+
+  for (const c of conditions) {
+    const newTags = c.tags.map(normalizeTagLabel);
+    if (!tagsEqualOrdered(c.tags, newTags)) {
+      updates.push({ id: c.id, oldTags: c.tags, newTags });
+      for (let i = 0; i < c.tags.length; i++) {
+        if (c.tags[i] !== newTags[i]) {
+          const key = `${c.tags[i]} → ${newTags[i]}`;
+          renameCounts.set(key, (renameCounts.get(key) ?? 0) + 1);
+        }
+      }
+    }
+  }
+
+  log(
+    `[TagBackfill] [2/3] ${updates.length} rows have at least one tag to rename (${conditions.length - updates.length} unchanged)`
+  );
+
+  if (renameCounts.size > 0) {
+    const ranked = [...renameCounts.entries()].sort((a, b) => b[1] - a[1]);
+    log(`[TagBackfill] Tag transitions (count × "old → new"):`);
+    for (const [transition, count] of ranked) {
+      log(`  ${String(count).padStart(5)} × "${transition}"`);
+    }
+  }
+
+  const sample = updates.slice(0, 10);
+  if (sample.length > 0) {
+    log(
+      `[TagBackfill] Sample rows (first ${sample.length} of ${updates.length}):`
+    );
+    for (const u of sample) {
+      log(
+        `  ${u.id.slice(0, 10)}… ${JSON.stringify(u.oldTags)} → ${JSON.stringify(u.newTags)}`
+      );
+    }
+    if (updates.length > sample.length) {
+      log(`  ... and ${updates.length - sample.length} more`);
+    }
+  }
+
+  if (options.dryRun) {
+    log(
+      `[TagBackfill] [3/3] DRY-RUN: no changes submitted. Re-run without --dry-run to apply.`
+    );
+    log(
+      `[TagBackfill] Total wall-clock: ${((Date.now() - runStart) / 1000).toFixed(1)}s`
+    );
+    return;
+  }
+
+  if (updates.length === 0) {
+    log(`[TagBackfill] [3/3] No changes needed (idempotent re-run).`);
+    log(
+      `[TagBackfill] Total wall-clock: ${((Date.now() - runStart) / 1000).toFixed(1)}s`
+    );
+    return;
+  }
+
+  log(`[TagBackfill] [3/3] Submitting ${updates.length} tag updates...`);
+  const submitStart = Date.now();
+  await submitMetadataUpdates(
+    apiUrl,
+    privateKey!,
+    updates.map((u) => ({
+      conditionId: u.id,
+      fields: { tags: u.newTags },
+    }))
+  );
+  log(
+    `[TagBackfill] [3/3] Submit done in ${((Date.now() - submitStart) / 1000).toFixed(1)}s`
+  );
+  log(
+    `[TagBackfill] Total wall-clock: ${((Date.now() - runStart) / 1000).toFixed(1)}s`
+  );
+}

--- a/packages/market-keeper/src/cleanup/api.ts
+++ b/packages/market-keeper/src/cleanup/api.ts
@@ -23,7 +23,7 @@ const CONDITIONS_PAGE_SIZE = 30;
 
 // Fetch unsettled conditions with no engagement (OI=0 and no attestations) — cleanup candidates
 const UNRESOLVED_NO_ENGAGEMENT_QUERY = `
-query UnresolvedNoEngagement($take: Int!, $skip: Int!) {
+query UnresolvedNoEngagement($first: Int!, $after: String) {
   conditionsConnection(
     filter: {
       settled: false
@@ -31,15 +31,17 @@ query UnresolvedNoEngagement($take: Int!, $skip: Int!) {
       engagement: NONE
     }
     orderBy: { field: RESOLVES_AT, direction: ASC }
-    first: $take
-    skip: $skip
+    first: $first
+    after: $after
   ) {
-    hasMore
-    items {
+    nodes {
       id
       openInterest
       question
-      endTime
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
     }
   }
 }
@@ -50,7 +52,7 @@ query UnresolvedNoEngagement($take: Int!, $skip: Int!) {
 // performs the OR(openInterest != 0, attestations.some) check; restricting
 // to the provided id set keeps the response small.
 const CONDITIONS_WITH_ENGAGEMENT_QUERY = `
-query ConditionsWithEngagement($ids: [String!]!) {
+query ConditionsWithEngagement($ids: [ID!]!) {
   conditionsConnection(
     filter: {
       ids: $ids
@@ -59,7 +61,7 @@ query ConditionsWithEngagement($ids: [String!]!) {
     }
     first: 100
   ) {
-    items {
+    nodes {
       id
     }
   }
@@ -89,15 +91,19 @@ function mapCondition(raw: RawCondition): CleanupCondition {
 
 async function fetchConditionsConnection(
   apiUrl: string,
-  take: number,
-  skip: number
-): Promise<{ items: CleanupCondition[]; hasMore: boolean }> {
+  first: number,
+  after: string | null
+): Promise<{
+  items: CleanupCondition[];
+  hasMore: boolean;
+  endCursor: string | null;
+}> {
   const response = await fetchWithRetry(`${apiUrl}/graphql`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
     body: JSON.stringify({
       query: UNRESOLVED_NO_ENGAGEMENT_QUERY,
-      variables: { take, skip },
+      variables: { first, after },
     }),
   });
 
@@ -109,7 +115,13 @@ async function fetchConditionsConnection(
   }
 
   const result = (await response.json()) as GraphQLResponse<{
-    conditionsConnection: { nodes: RawCondition[]; hasMore?: boolean };
+    conditionsConnection: {
+      nodes: RawCondition[];
+      pageInfo?: {
+        hasNextPage?: boolean | null;
+        endCursor?: string | null;
+      } | null;
+    };
   }>;
   if (result.errors?.length) {
     throw new Error(
@@ -120,7 +132,8 @@ async function fetchConditionsConnection(
   const page = result.data?.conditionsConnection;
   return {
     items: (page?.nodes ?? []).map(mapCondition),
-    hasMore: Boolean(page?.hasMore),
+    hasMore: Boolean(page?.pageInfo?.hasNextPage),
+    endCursor: page?.pageInfo?.endCursor ?? null,
   };
 }
 
@@ -128,23 +141,23 @@ export async function fetchNoEngagementConditions(
   apiUrl: string
 ): Promise<CleanupCondition[]> {
   const all: CleanupCondition[] = [];
-  let skip = 0;
+  let after: string | null = null;
 
   console.log(`Fetching unresolved no-engagement conditions from ${apiUrl}...`);
 
   while (true) {
-    const { items, hasMore } = await fetchConditionsConnection(
+    const { items, hasMore, endCursor } = await fetchConditionsConnection(
       apiUrl,
       CONDITIONS_PAGE_SIZE,
-      skip
+      after
     );
     all.push(...items);
 
     if (items.length > 0) {
       console.log(`  Fetched ${all.length} conditions so far...`);
     }
-    if (!hasMore) break;
-    skip += CONDITIONS_PAGE_SIZE;
+    if (!hasMore || !endCursor) break;
+    after = endCursor;
   }
 
   console.log(`Found ${all.length} unresolved no-engagement conditions`);

--- a/packages/market-keeper/src/generate/market.ts
+++ b/packages/market-keeper/src/generate/market.ts
@@ -22,7 +22,10 @@ export async function fetchEndingSoonestMarkets(): Promise<PolymarketMarket[]> {
 
   const allMarkets: PolymarketMarket[] = [];
   const seenConditionIds = new Set<string>(); // Track seen markets to deduplicate
-  const PAGE_SIZE = 500;
+  // Polymarket's /markets endpoint silently caps `limit` at 100 server-side;
+  // requesting more returns 100 anyway, and the `markets.length < PAGE_SIZE`
+  // short-page stop signal below would then misfire after page 1.
+  const PAGE_SIZE = 100;
   let pageCount = 0;
   let offset = 0;
 

--- a/packages/market-keeper/src/generate/tags.ts
+++ b/packages/market-keeper/src/generate/tags.ts
@@ -9,12 +9,73 @@ interface PolymarketEventTag {
   slug?: string;
 }
 
-// Polymarket returns some tag labels with an inconsistent lowercase first
-// letter (e.g. `temperature`). Uppercase the first character and preserve
-// the rest so acronyms like `UFC` stay intact.
+// AP-style title-case "small words" that stay lowercase when they're
+// neither the first nor the last word. Articles, coordinating
+// conjunctions, and prepositions ≤ 3 letters. Includes "vs" (sports
+// journalism convention) and "x" (Polymarket matchup separator).
+const TITLE_CASE_SMALL_WORDS = new Set([
+  // Articles
+  'a',
+  'an',
+  'the',
+  // Coordinating conjunctions
+  'and',
+  'but',
+  'for',
+  'nor',
+  'or',
+  'so',
+  'yet',
+  // Short prepositions (≤3 letters)
+  'as',
+  'at',
+  'by',
+  'in',
+  'of',
+  'off',
+  'on',
+  'per',
+  'to',
+  'up',
+  'via',
+  // Domain-specific
+  'vs',
+  'x',
+]);
+
+// AP-style Title Case. Each word:
+//   1) Acronym/mixed-case preservation — any word containing an
+//      uppercase letter is left alone (UFC, NFL, DeFi, iOS, F1, U.S.).
+//   2) First and last words are always capitalized (even if they're
+//      small words: "Of Mice and Men", "Things to Come To").
+//   3) Small-word skip — articles, coord. conjunctions, ≤3-letter
+//      prepositions stay lowercase. ALL-CAPS forms ("OR" the Oregon
+//      state code) bypass this and are treated as acronyms.
+// Splits on space only — hyphenated tags like "updated-tag" stay as
+// one word ("Updated-tag").
+// Mirrors normalizeTags in packages/api/src/routes/conditions.ts.
 export function normalizeTagLabel(label: string): string {
   if (!label) return label;
-  return label.charAt(0).toUpperCase() + label.slice(1);
+  const words = label.split(' ');
+  return words
+    .map((w, i) => {
+      const isFirst = i === 0;
+      const isLast = i === words.length - 1;
+      const isAllUpper = /[A-Z]/.test(w) && w === w.toUpperCase();
+      // Small-word skip — only mid-tag, only when not all-caps.
+      if (
+        !isFirst &&
+        !isLast &&
+        !isAllUpper &&
+        TITLE_CASE_SMALL_WORDS.has(w.toLowerCase())
+      ) {
+        return w.toLowerCase();
+      }
+      // Preserve acronyms and mixed-case brands.
+      if (/[A-Z]/.test(w)) return w;
+      return w.charAt(0).toUpperCase() + w.slice(1);
+    })
+    .join(' ');
 }
 
 interface PolymarketEvent {

--- a/packages/market-keeper/src/prices-and-1d-7d-volume/index.ts
+++ b/packages/market-keeper/src/prices-and-1d-7d-volume/index.ts
@@ -65,36 +65,38 @@ async function fetchActiveConditionIds(apiUrl: string): Promise<string[]> {
   const PAGE_SIZE = 100;
   const allIds: string[] = [];
   const seen = new Set<string>();
-  let skip = 0;
+  let after: string | null = null;
 
-  while (true) {
-    // orderBy id ensures deterministic pagination — without it, conditions
-    // sharing the same timestamp can shift between pages, causing missed or
-    // duplicate results (see commit 31c216402).
-    const query = `
-      query ActiveConditions($filters: ConditionFilter!, $take: Int!, $skip: Int!) {
-        conditionsConnection(filter: $filters, first: $take, skip: $skip, orderBy: { field: CREATED_AT, direction: ASC }) {
-          hasMore
-          nodes {
-            id
-          }
+  // Cursor-paginated walk via `conditionsConnection`. Sort is
+  // CREATED_AT ASC for determinism across runs.
+  const query = `
+    query ActiveConditions($filter: ConditionFilter!, $first: Int!, $after: String) {
+      conditionsConnection(filter: $filter, first: $first, after: $after, orderBy: { field: CREATED_AT, direction: ASC }) {
+        nodes {
+          id
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
         }
       }
-    `;
+    }
+  `;
 
+  while (true) {
     const response = await fetchWithRetry(graphqlUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         query,
         variables: {
-          filters: {
+          filter: {
             settled: false,
             visibility: 'PUBLIC',
             hasSimilarMarkets: true,
           },
-          take: PAGE_SIZE,
-          skip,
+          first: PAGE_SIZE,
+          after,
         },
       }),
     });
@@ -108,17 +110,17 @@ async function fetchActiveConditionIds(apiUrl: string): Promise<string[]> {
     const result = (await response.json()) as {
       data?: {
         conditionsConnection?: {
-          hasMore?: boolean | null;
+          nodes?: Array<{ id: string }>;
           pageInfo?: {
             hasNextPage?: boolean | null;
             endCursor?: string | null;
           } | null;
-          nodes?: Array<{ id: string }>;
         };
       };
     };
     const conditions = result.data?.conditionsConnection?.nodes ?? [];
-    const hasMore = result.data?.conditionsConnection?.hasMore ?? false;
+    const pageInfo = result.data?.conditionsConnection?.pageInfo;
+    const hasMore = pageInfo?.hasNextPage ?? false;
 
     for (const c of conditions) {
       if (!seen.has(c.id)) {
@@ -128,7 +130,8 @@ async function fetchActiveConditionIds(apiUrl: string): Promise<string[]> {
     }
 
     if (!hasMore) break;
-    skip += PAGE_SIZE;
+    after = pageInfo?.endCursor ?? null;
+    if (!after) break;
   }
 
   return allIds;

--- a/packages/market-keeper/src/refresh-imminent-tag/index.ts
+++ b/packages/market-keeper/src/refresh-imminent-tag/index.ts
@@ -103,89 +103,92 @@ async function fetchAllUnsettledConditions(
   const PAGE_SIZE = 100;
   const out: PageItem[] = [];
   const seen = new Set<string>();
-  let skip = 0;
+  let after: string | null = null;
   let pageCount = 0;
   let lastSize = 0;
   let zeroGrowthStreak = 0;
 
-  while (true) {
-    pageCount++;
-    const pageStart = Date.now();
-    // Uses the legacy `conditions` query because staging's API removed
-    // `conditionsPage` in PR #1744. The new shape is `conditionsConnection`
-    // (Relay-style); legacy `conditions` is still available and simpler
-    // for take/skip pagination. We sort by `createdAt desc` so a --limit
-    // sample biases toward newest markets (most likely to match today/
-    // tomorrow's date). No server-truth `hasMore` — stop on short page.
-    const query = `
-      query ImminentTagCandidates($where: ConditionWhereInput!, $orderBy: [ConditionOrderByWithRelationInput!], $take: Int!, $skip: Int!) {
-        conditions(where: $where, orderBy: $orderBy, take: $take, skip: $skip) {
+  // Relay-shaped `conditionsConnection` with cursor pagination. Sort by
+  // CREATED_AT DESC so a --limit sample biases toward newest markets
+  // (most likely to match today/tomorrow's date).
+  const query = `
+    query ImminentTagCandidates($filter: ConditionFilter!, $first: Int!, $after: String) {
+      conditionsConnection(filter: $filter, first: $first, after: $after, orderBy: { field: CREATED_AT, direction: DESC }) {
+        nodes {
           id
           question
           tags
         }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
       }
-    `;
+    }
+  `;
+
+  while (true) {
+    pageCount++;
+    const pageStart = Date.now();
     const response = await fetchWithRetry(graphqlUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         query,
         variables: {
-          where: {
-            public: { equals: true },
-            settled: { equals: false },
-          },
-          orderBy: [{ createdAt: 'desc' }],
-          take: PAGE_SIZE,
-          skip,
+          filter: { visibility: 'PUBLIC', settled: false },
+          first: PAGE_SIZE,
+          after,
         },
       }),
     });
     if (!response.ok) {
       const body = await response.text().catch(() => '(unreadable body)');
       throw new Error(
-        `GraphQL conditions failed: HTTP ${response.status} ${response.statusText}\nResponse body: ${body.slice(0, 2000)}`
+        `GraphQL conditionsConnection failed: HTTP ${response.status} ${response.statusText}\nResponse body: ${body.slice(0, 2000)}`
       );
     }
     const result = (await response.json()) as {
       data?: {
-        conditions?: Array<{ id: string; question: string; tags: string[] }>;
+        conditionsConnection?: {
+          nodes?: Array<{ id: string; question: string; tags: string[] }>;
+          pageInfo?: {
+            hasNextPage?: boolean | null;
+            endCursor?: string | null;
+          } | null;
+        };
       };
       errors?: Array<{ message: string }>;
     };
     if (result.errors && result.errors.length > 0) {
       throw new Error(
-        `GraphQL conditions returned errors: ${JSON.stringify(result.errors, null, 2)}`
+        `GraphQL conditionsConnection returned errors: ${JSON.stringify(result.errors, null, 2)}`
       );
     }
-    const items = result.data?.conditions ?? [];
-    // Legacy `conditions` has no `hasMore` — stop when a page is short.
-    const hasMore = items.length === PAGE_SIZE;
-    for (const c of items) {
+    const nodes = result.data?.conditionsConnection?.nodes ?? [];
+    const pageInfo = result.data?.conditionsConnection?.pageInfo;
+    const hasMore = pageInfo?.hasNextPage ?? false;
+    for (const c of nodes) {
       if (seen.has(c.id)) continue;
       seen.add(c.id);
       out.push({ id: c.id, question: c.question, tags: c.tags ?? [] });
       if (maxResults !== null && out.length >= maxResults) {
         log(
-          `[TodayTag]   page ${pageCount}: fetched ${items.length} (cumulative ${out.length}, ${Date.now() - pageStart}ms) — hit --limit ${maxResults}, stopping`
+          `[TodayTag]   page ${pageCount}: fetched ${nodes.length} (cumulative ${out.length}, ${Date.now() - pageStart}ms) — hit --limit ${maxResults}, stopping`
         );
         return out;
       }
     }
     log(
-      `[TodayTag]   page ${pageCount}: fetched ${items.length} (cumulative ${out.length}, ${Date.now() - pageStart}ms, hasMore=${hasMore})`
+      `[TodayTag]   page ${pageCount}: fetched ${nodes.length} (cumulative ${out.length}, ${Date.now() - pageStart}ms, hasMore=${hasMore})`
     );
-    // Safety: if the server keeps saying hasMore=true but the page only
-    // returns duplicates we've already seen, treat that as a server-side
-    // pagination bug and break instead of looping forever (cf.
-    // refresh-metadata's observed infinite loop returning the same 1100
-    // rows across 24k+ pages).
+    // Safety: cursor pagination shouldn't loop, but protect against a
+    // server-side bug where the same endCursor keeps coming back.
     if (out.length === lastSize) {
       zeroGrowthStreak++;
       if (zeroGrowthStreak >= 3) {
         logError(
-          `[TodayTag] WARN: 3 consecutive pages added 0 unique rows (hasMore=${hasMore}, skip=${skip}); aborting pagination to avoid an infinite loop`
+          `[TodayTag] WARN: 3 consecutive pages added 0 unique rows (hasMore=${hasMore}, after=${after}); aborting pagination to avoid an infinite loop`
         );
         break;
       }
@@ -194,7 +197,8 @@ async function fetchAllUnsettledConditions(
     }
     lastSize = out.length;
     if (!hasMore) break;
-    skip += PAGE_SIZE;
+    after = pageInfo?.endCursor ?? null;
+    if (!after) break;
   }
   return out;
 }

--- a/packages/market-keeper/src/refresh-imminent-tag/match.test.ts
+++ b/packages/market-keeper/src/refresh-imminent-tag/match.test.ts
@@ -165,6 +165,12 @@ describe('questionMentionsImminentDate', () => {
   });
 });
 
+describe('TODAY_TAG', () => {
+  it('is the Title-Cased literal "Today"', () => {
+    expect(TODAY_TAG).toBe('Today');
+  });
+});
+
 describe('computeDesiredTags', () => {
   it('adds the today tag when matched and not already present', () => {
     expect(computeDesiredTags(['Politics'], true)).toEqual([

--- a/packages/market-keeper/src/refresh-imminent-tag/match.ts
+++ b/packages/market-keeper/src/refresh-imminent-tag/match.ts
@@ -14,7 +14,10 @@
  * other words don't trigger (e.g. "May 1800s" doesn't match "May 18").
  */
 
-export const TODAY_TAG = 'today';
+// The tag is stored Title-Cased to match how the API normalizes tags on
+// write (PUT /admin/conditions/batch-metadata). Comparing with 'today'
+// (lowercase) would fail to strip stored 'Today' values.
+export const TODAY_TAG = 'Today';
 
 const MONTH_NAMES = [
   'January',

--- a/packages/market-keeper/src/refresh-metadata/fetch.ts
+++ b/packages/market-keeper/src/refresh-metadata/fetch.ts
@@ -43,10 +43,13 @@ export async function fetchAllExistingConditions(
 ): Promise<Map<string, ExistingCondition>> {
   const graphqlUrl = apiUrl.replace(/\/+$/, '') + '/graphql';
 
+  // Uses the Relay-shaped `conditionsConnection` (the legacy bare
+  // `conditions(where:)` resolver is deprecated per the redesign).
+  // Cursor-paginated via `first` / `after`; reads `pageInfo.endCursor`
+  // and `pageInfo.hasNextPage` to drive the loop.
   const query = `
-    query RefreshMetadataConditions($filters: ConditionFilter!, $take: Int!, $skip: Int!) {
-      conditionsConnection(filter: $filters, first: $take, skip: $skip, orderBy: { field: CREATED_AT, direction: ASC }) {
-        hasMore
+    query RefreshMetadataConditions($filter: ConditionFilter!, $first: Int!, $after: String) {
+      conditionsConnection(filter: $filter, first: $first, after: $after, orderBy: { field: CREATED_AT, direction: ASC }) {
         nodes {
           id
           endTime
@@ -64,12 +67,16 @@ export async function fetchAllExistingConditions(
             similarMarkets
           }
         }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
       }
     }
   `;
 
   const existing = new Map<string, ExistingCondition>();
-  let skip = 0;
+  let after: string | null = null;
   let pageCount = 0;
 
   while (true) {
@@ -81,13 +88,13 @@ export async function fetchAllExistingConditions(
       body: JSON.stringify({
         query,
         variables: {
-          filters: {
+          filter: {
             visibility: 'PUBLIC',
             settled: false,
             hasSimilarMarkets: true,
           },
-          take: SAPIENCE_PAGE_SIZE,
-          skip,
+          first: SAPIENCE_PAGE_SIZE,
+          after,
         },
       }),
     });
@@ -101,11 +108,6 @@ export async function fetchAllExistingConditions(
     const result = (await response.json()) as {
       data?: {
         conditionsConnection?: {
-          hasMore?: boolean | null;
-          pageInfo?: {
-            hasNextPage?: boolean | null;
-            endCursor?: string | null;
-          } | null;
           nodes?: Array<{
             id: string;
             endTime: number;
@@ -123,12 +125,17 @@ export async function fetchAllExistingConditions(
               similarMarkets?: string[] | null;
             } | null;
           }>;
+          pageInfo?: {
+            hasNextPage?: boolean | null;
+            endCursor?: string | null;
+          } | null;
         };
       };
     };
 
     const conditions = result.data?.conditionsConnection?.nodes ?? [];
-    const hasMore = result.data?.conditionsConnection?.hasMore ?? false;
+    const pageInfo = result.data?.conditionsConnection?.pageInfo;
+    const hasMore = pageInfo?.hasNextPage ?? false;
 
     for (const c of conditions) {
       existing.set(c.id, {
@@ -153,7 +160,8 @@ export async function fetchAllExistingConditions(
     );
 
     if (!hasMore) break;
-    skip += SAPIENCE_PAGE_SIZE;
+    after = pageInfo?.endCursor ?? null;
+    if (!after) break;
   }
 
   return existing;

--- a/packages/market-keeper/src/refresh-volume/index.ts
+++ b/packages/market-keeper/src/refresh-volume/index.ts
@@ -96,33 +96,36 @@ async function fetchActiveConditionIds(apiUrl: string): Promise<string[]> {
   const PAGE_SIZE = 100;
   const allIds: string[] = [];
   const seen = new Set<string>();
-  let skip = 0;
+  let after: string | null = null;
 
-  while (true) {
-    const query = `
-      query ActiveConditions($filters: ConditionFilter!, $take: Int!, $skip: Int!) {
-        conditionsConnection(filter: $filters, first: $take, skip: $skip, orderBy: { field: CREATED_AT, direction: ASC }) {
-          hasMore
-          nodes {
-            id
-          }
+  const query = `
+    query ActiveConditions($filter: ConditionFilter!, $first: Int!, $after: String) {
+      conditionsConnection(filter: $filter, first: $first, after: $after, orderBy: { field: CREATED_AT, direction: ASC }) {
+        nodes {
+          id
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
         }
       }
-    `;
+    }
+  `;
 
+  while (true) {
     const response = await fetchWithRetry(graphqlUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         query,
         variables: {
-          filters: {
+          filter: {
             settled: false,
             visibility: 'PUBLIC',
             hasSimilarMarkets: true,
           },
-          take: PAGE_SIZE,
-          skip,
+          first: PAGE_SIZE,
+          after,
         },
       }),
     });
@@ -136,17 +139,17 @@ async function fetchActiveConditionIds(apiUrl: string): Promise<string[]> {
     const result = (await response.json()) as {
       data?: {
         conditionsConnection?: {
-          hasMore?: boolean | null;
+          nodes?: Array<{ id: string }>;
           pageInfo?: {
             hasNextPage?: boolean | null;
             endCursor?: string | null;
           } | null;
-          nodes?: Array<{ id: string }>;
         };
       };
     };
     const conditions = result.data?.conditionsConnection?.nodes ?? [];
-    const hasMore = result.data?.conditionsConnection?.hasMore ?? false;
+    const pageInfo = result.data?.conditionsConnection?.pageInfo;
+    const hasMore = pageInfo?.hasNextPage ?? false;
 
     for (const c of conditions) {
       if (!seen.has(c.id)) {
@@ -156,7 +159,8 @@ async function fetchActiveConditionIds(apiUrl: string): Promise<string[]> {
     }
 
     if (!hasMore) break;
-    skip += PAGE_SIZE;
+    after = pageInfo?.endCursor ?? null;
+    if (!after) break;
   }
 
   return allIds;

--- a/packages/market-keeper/src/relist/market.ts
+++ b/packages/market-keeper/src/relist/market.ts
@@ -11,7 +11,10 @@ import {
   MARKET_FILTERS,
 } from '../generate/pipeline';
 
-const PAGE_SIZE = 500;
+// Polymarket's /markets endpoint silently caps `limit` at 100 server-side;
+// requesting more returns 100 anyway, and the `markets.length < PAGE_SIZE`
+// short-page stop signal below would then misfire after page 1.
+const PAGE_SIZE = 100;
 
 /**
  * Fetch markets whose endDate is in the past (within the lookback window)


### PR DESCRIPTION
## Summary

Two related workstreams, presented as two commits for clean review.

### 1. AP-style Title Case tag normalization + today-tag fix + backfill

User flagged that `"Primary elections"` was the only tag rendered non-Title-Case in the UI. Root cause: both mirrored normalizers (keeper `normalizeTagLabel`, API `normalizeTags`) only uppercased the first character — which preserved acronyms like `UFC` but left every multi-word Polymarket label half-cased.

Rewrites both normalizers to **AP-style per-word Title Case** with:
- Acronym/mixed-case preservation (UFC, NFL, DeFi, iOS, F1, U.S.)
- Small-word skip list — articles, coordinating conjunctions, ≤3-letter prepositions stay lowercase mid-tag. Includes `vs` (sports convention) and `x` (Polymarket matchup separator, e.g. `"U.S. x Iran"`)
- First/last-word exceptions (always capitalized, even small words)
- ALL-CAPS short words preserved as acronyms (`"OR"` Oregon state code stays `"OR"`, doesn't get lowercased to the conjunction)

Also fixes a latent bug where `TODAY_TAG = 'today'` (lowercase) didn't match what the API normalizer actually stored (`'Today'`). The strip-filter in `refresh-imminent-tag` compared against the lowercase constant and never removed the tag. `TODAY_TAG` is now `'Today'` end-to-end.

Adds a one-shot backfill script. Bumps the API `popularTags` cache key and the markets-page `selectedTag` sessionStorage key so stale lowercase values invalidate on deploy.

**Verified end-to-end on staging**: dry-run produced 11 correct tag transitions across 54 conditions; live backfill applied; `popularTags` GraphQL confirms `"Primary Elections"` is now present and `"Primary elections"` is gone.

### 2. Keeper migration to `conditionsConnection` + cursor pagination

Every keeper query against bare `conditions(where:)` is `@deprecated` per the staging schema, and every Connection query still on `first: $take, skip: $skip` uses deprecated args. The deprecation runway ends with `conditionsConnection` being renamed to `conditions`.

Migrates all 7 keeper sites to the canonical Relay shape:
- `conditionsConnection(filter: ConditionFilter!, first, after, orderBy)`
- Reads `nodes` (not the deprecated `items` alias)
- Reads `pageInfo.hasNextPage` + `endCursor` (not the deprecated `hasMore` alias)
- Cursor pagination via `after` (not the deprecated `skip`)

Sites migrated:
- `refresh-metadata/fetch.ts` — was broken on the new schema (queried `items` but parsed `.nodes`, so `fetchAllExistingConditions` returned empty in production). Supersedes the minimal `items`→`nodes` patch in #1763 with the full cursor migration.
- `refresh-imminent-tag/index.ts` — was on legacy `conditions(where:)`
- `backfill-endtimes/index.ts` — was on legacy `conditions(where:)`
- `refresh-volume/index.ts` — was on skip-based Connection
- `prices-and-1d-7d-volume/index.ts` — was on skip-based Connection
- `cleanup/api.ts` — was on skip-based Connection + queried `items`; also fixes a pre-existing `ids: [String!]!` → `[ID!]!` validation bug that would have started failing on the new schema

`refresh-metadata.test.ts` rewritten to assert the `ConditionFilter` shape, `nodes`/`pageInfo` parsing, and cursor-based pagination across mocked pages.

**Verified each unique query shape with curl against `api.staging.sapience.xyz`** — all 6 return 200 with valid `nodes` + `pageInfo`.

## Test plan
- [x] `pnpm --filter market-keeper run test` — 407/407 pass
- [x] `pnpm --filter @sapience/api run test` — 778/778 pass
- [x] Type-check clean on keeper, app
- [x] Staging dry-run of backfill produced expected 11 correct transitions
- [x] Live backfill applied; `popularTags` confirms `"Primary Elections"` present, `"Primary elections"` absent
- [x] Curl smoke against staging for all 6 unique Connection query shapes
- [ ] Frontend smoke on `/markets` after deploy — click "Primary Elections" tag, verify filter works
- [ ] Confirm `refresh-imminent-tag` daily cron picks up `TODAY_TAG = 'Today'` correctly on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)