### PR TITLE
fix(market-keeper): use marketAddress in settlement filters

### DIFF
--- a/packages/market-keeper/scripts/settle-manual.ts
+++ b/packages/market-keeper/scripts/settle-manual.ts
@@ -237,7 +237,7 @@ query UnresolvedConditions($take: Int!, $skip: Int!, $resolver: String!) {
   conditionsConnection(
     filter: {
       settled: false
-      contractAddress: $resolver
+      marketAddress: $resolver
       # Pick up both public and private — the deprecated resolver's
       # implicit public=true filter would silently exclude privated
       # conditions that still have engagement to settle.

--- a/packages/market-keeper/scripts/settle-polymarket.ts
+++ b/packages/market-keeper/scripts/settle-polymarket.ts
@@ -218,7 +218,7 @@ query UnresolvedConditions($take: Int!, $skip: Int!, $resolver: String!) {
   conditionsConnection(
     filter: {
       settled: false
-      contractAddress: $resolver
+      marketAddress: $resolver
       # Pick up both public and private — the deprecated resolver's
       # implicit public=true filter would silently exclude privated
       # conditions that still have engagement to settle.

--- a/packages/market-keeper/scripts/settle-pyth.ts
+++ b/packages/market-keeper/scripts/settle-pyth.ts
@@ -561,7 +561,7 @@ async function main() {
         chainId: CHAIN_ID,
         resolvesAt: { lte: nowSec },
         settled: false,
-        contractAddress: PYTH_RESOLVER_ADDRESS,
+        marketAddress: PYTH_RESOLVER_ADDRESS,
       },
       take,
       skip,

--- a/packages/market-keeper/src/__tests__/settlement-query-fields.test.ts
+++ b/packages/market-keeper/src/__tests__/settlement-query-fields.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const packageRoot = resolve(__dirname, '../..');
+
+function readScript(relativePath: string): string {
+  return readFileSync(resolve(packageRoot, relativePath), 'utf8');
+}
+
+describe('settlement GraphQL filters', () => {
+  it.each([
+    'scripts/settle-manual.ts',
+    'scripts/settle-polymarket.ts',
+    'scripts/settle-pyth.ts',
+  ])('uses ConditionFilter.marketAddress in %s', (scriptPath) => {
+    const source = readScript(scriptPath);
+
+    expect(source).toContain('marketAddress');
+    expect(source).not.toContain('contractAddress');
+  });
+});


### PR DESCRIPTION
## Summary
- update all market-keeper settlement GraphQL condition filters from removed `contractAddress` to `marketAddress`
- cover manual, Polymarket, and Pyth settlement scripts
- add a regression test so this field-name drift trips locally instead of crashing keeper

## Verification
- `pnpm --filter @sapience/market-keeper exec vitest run src/__tests__/settlement-query-fields.test.ts`
- `pnpm --filter @sapience/market-keeper run type-check`
- `pnpm --filter @sapience/market-keeper run lint`
- `pnpm --filter @sapience/market-keeper run test`
- live staging GraphQL smoke query against `conditionsConnection(filter: { marketAddress: ... })` returned 200

Note: full `format:check` still fails on pre-existing formatting drift in unrelated market-keeper files; touched files pass targeted Prettier check.