### PR TITLE
Fix Polymarket paging for crowded NBA market times

### DIFF
--- a/packages/market-keeper/src/__tests__/market-fetch.test.ts
+++ b/packages/market-keeper/src/__tests__/market-fetch.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PolymarketMarket } from '../types';
+import { fetchEndingSoonestMarkets } from '../generate/market';
+import { fetchWithRetry } from '../utils';
+
+vi.mock('../utils', () => ({
+  fetchWithRetry: vi.fn(),
+}));
+
+function makeMarket(
+  id: number | string,
+  endDate = '2026-05-21T00:30:00.000Z',
+  overrides: Partial<PolymarketMarket> = {}
+): PolymarketMarket {
+  return {
+    id: String(id),
+    question: `Market ${id}`,
+    conditionId: `0x${String(id).padStart(64, '0')}`,
+    outcomes: '["Yes","No"]',
+    volume: '1000',
+    liquidity: '1000',
+    endDate,
+    description: 'Test market',
+    slug: `market-${id}`,
+    active: true,
+    closed: false,
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    json: vi.fn().mockResolvedValue(body),
+  };
+}
+
+describe('fetchEndingSoonestMarkets', () => {
+  beforeEach(() => {
+    vi.setSystemTime(new Date('2026-05-20T23:25:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('continues paging when inclusive end_date_min returns a duplicate full page', async () => {
+    const firstPage = Array.from({ length: 100 }, (_, i) => makeMarket(i));
+    const spursThunderProps = [
+      makeMarket('101', '2026-05-21T00:30:00.000Z', {
+        question: 'Victor Wembanyama: Points O/U 24.5',
+        slug: 'nba-sas-okc-2026-05-20-points-victor-wembanyama-24pt5',
+        sportsMarketType: 'points',
+      }),
+      makeMarket('102', '2026-05-21T00:30:00.000Z', {
+        question: 'Shai Gilgeous-Alexander: Rebounds O/U 4.5',
+        slug: 'nba-sas-okc-2026-05-20-rebounds-shai-gilgeous-alexander-4pt5',
+        sportsMarketType: 'rebounds',
+      }),
+    ];
+
+    vi.mocked(fetchWithRetry)
+      // Initial page advances the cursor to the crowded game start timestamp.
+      .mockResolvedValueOnce(jsonResponse(firstPage) as never)
+      // Gamma's inclusive end_date_min can return the same full page again.
+      .mockResolvedValueOnce(jsonResponse(firstPage) as never)
+      // The offset page contains later siblings at that same timestamp.
+      .mockResolvedValueOnce(jsonResponse(spursThunderProps) as never)
+      // Supplementary event tag fetch.
+      .mockResolvedValueOnce(jsonResponse([]) as never);
+
+    const markets = await fetchEndingSoonestMarkets();
+
+    expect(markets.map((m) => m.slug)).toContain(
+      'nba-sas-okc-2026-05-20-points-victor-wembanyama-24pt5'
+    );
+    expect(markets.map((m) => m.slug)).toContain(
+      'nba-sas-okc-2026-05-20-rebounds-shai-gilgeous-alexander-4pt5'
+    );
+    expect(fetchWithRetry).toHaveBeenCalledTimes(4);
+    expect(vi.mocked(fetchWithRetry).mock.calls[2][0]).toContain('offset=100');
+  });
+});

--- a/packages/market-keeper/src/__tests__/resolve-short-name.test.ts
+++ b/packages/market-keeper/src/__tests__/resolve-short-name.test.ts
@@ -55,6 +55,15 @@ describe('resolveShortName', () => {
     expect(result).toContain('BTC');
   });
 
+  it('returns regex inference for O/U player props', () => {
+    const market = makeMarket({
+      question: 'Victor Wembanyama: Points O/U 24.5',
+      outcomes: ['Yes', 'No'],
+      sportsMarketType: 'points',
+    });
+    expect(resolveShortName(market)).toBe('Wembanyama O24.5pts');
+  });
+
   it('returns null when no regex rule matches (LLM fallback path)', () => {
     const market = makeMarket({
       question: 'Some obscure question with no pattern?',

--- a/packages/market-keeper/src/generate/market.ts
+++ b/packages/market-keeper/src/generate/market.ts
@@ -85,23 +85,21 @@ export async function fetchEndingSoonestMarkets(): Promise<PolymarketMarket[]> {
       }
     }
 
+    const newMinEndDate = maxEndDateInBatch.toISOString();
+
     // Stop conditions:
     // 1. Got less than PAGE_SIZE markets (no more pages)
     // 2. Max endDate in batch exceeds our window (all remaining markets are beyond our window)
-    // 3. No new markets added (we've seen all markets at this endDate)
-    if (
-      markets.length < PAGE_SIZE ||
-      maxEndDateInBatch >= maxEndDate ||
-      newMarketsCount === 0
-    ) {
+    if (markets.length < PAGE_SIZE || maxEndDateInBatch >= maxEndDate) {
       break;
     }
 
-    // Move the cursor to fetch next page
-    const newMinEndDate = maxEndDateInBatch.toISOString();
-    if (newMinEndDate === currentMinEndDate) {
-      // Cursor didn't advance — many markets share the same endDate.
-      // Use offset to page through them.
+    // Move the cursor to fetch next page. Gamma's end_date_min is inclusive,
+    // so the first request after advancing to a crowded timestamp can return
+    // the exact same PAGE_SIZE markets we just saw. Do not stop on that
+    // duplicate page — advance offset within the timestamp so later siblings
+    // (e.g. player props sharing the game start time) are not skipped.
+    if (newMinEndDate === currentMinEndDate || newMarketsCount === 0) {
       offset += PAGE_SIZE;
     } else {
       currentMinEndDate = newMinEndDate;

--- a/packages/market-keeper/src/generate/shortName.ts
+++ b/packages/market-keeper/src/generate/shortName.ts
@@ -257,9 +257,9 @@ export function inferShortName(market: PolymarketMarket): string | null {
   const question = market.question;
   const outcomes = parseOutcomes(market.outcomes);
 
-  // Rule 1: Player props - "Player: Stat Over X.X"
+  // Rule 1: Player props - "Player: Stat Over X.X" or "Player: Stat O/U X.X"
   const playerPropMatch = question.match(
-    /^(.+?):\s+(Points|Rebounds|Assists|Steals|Blocks|Turnovers|3-Pointers|Fantasy Points)\s+Over\s+(\d+(?:\.\d+)?)$/i
+    /^(.+?):\s+(Points|Rebounds|Assists|Steals|Blocks|Turnovers|3-Pointers|Fantasy Points)\s+(?:Over|O\/U)\s+(\d+(?:\.\d+)?)$/i
   );
   if (playerPropMatch) {
     const [, player, stat, value] = playerPropMatch;


### PR DESCRIPTION
## Summary
- keep paging when Gamma returns a duplicate full page for an inclusive `end_date_min` cursor
- adds regression coverage for Spurs/Thunder player props sharing the same game timestamp
- recognizes Polymarket `Player: Stat O/U X.X` props for deterministic short names

## Verification
- `pnpm --filter @sapience/market-keeper exec prettier --check src/generate/market.ts src/generate/shortName.ts src/__tests__/market-fetch.test.ts src/__tests__/resolve-short-name.test.ts`
- `pnpm --filter @sapience/market-keeper exec vitest run src/__tests__/market-fetch.test.ts src/__tests__/resolve-short-name.test.ts`
- `pnpm --filter @sapience/market-keeper run type-check`
- `pnpm --filter @sapience/market-keeper run lint`
- `pnpm --filter @sapience/market-keeper generate:dry-run` → includes `Spurs vs. Thunder` with 37 conditions, including player props

Root cause: Gamma `end_date_min` is inclusive. When many markets share the same start/end timestamp, the next cursor request can return the previous full page again. The old `newMarketsCount === 0` stop condition treated that duplicate page as EOF, so later siblings at the same timestamp were skipped. 🔮