### PR TITLE
fix open-interest

### DIFF
--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -1678,14 +1678,14 @@ input QuestionOrder {
 """
 Sort fields for the Relay-shaped `questions` connection. The runner
 unions Conditions and ConditionGroups; sort values pick the column on
-each side. `OPEN_INTEREST` is intentionally omitted (symmetric with
-`ConditionOrderField`) — the Condition side would sort the varchar
-column lexicographically; restore together with raw-SQL numeric sort
-in a follow-up.
+each side. Unlike the narrower Condition/ConditionGroup connections,
+`OPEN_INTEREST` is available here because this feed uses raw SQL and
+casts the varchar-backed open-interest values numerically.
 """
 enum QuestionOrderField {
   CREATED_AT
   RESOLVES_AT
+  OPEN_INTEREST
   PREDICTION_COUNT
   SIMILAR_MARKET_VOLUME_24H
   SIMILAR_MARKET_VOLUME_7D

--- a/packages/api/src/graphql/sdl/resolvers/queries/questions.test.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/questions.test.ts
@@ -211,6 +211,24 @@ const questionsConnectionFn =
   questionsConnection as unknown as ConnectionResolverFn;
 
 describe('questionsConnection — operator filters and keyset cursors', () => {
+  it('maps OPEN_INTEREST ordering to the raw SQL open-interest sort', async () => {
+    mockPrisma.$queryRaw.mockResolvedValue([]);
+
+    await questionsConnectionFn(
+      {},
+      {
+        take: 10,
+        orderBy: { field: 'OPEN_INTEREST', direction: 'DESC' },
+      },
+      {},
+      {}
+    );
+
+    const sql = queryRawCallJson();
+    expect(sql).toContain('totalOpenInterest');
+    expect(sql).toContain('openInterest');
+  });
+
   it('maps operator gte/lte filters to the underlying SQL ranges', async () => {
     mockPrisma.$queryRaw.mockResolvedValue([]);
 

--- a/packages/api/src/graphql/sdl/resolvers/queries/questions.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/questions.ts
@@ -927,18 +927,20 @@ import { decodeCursor, encodeCursor } from '../../../relay/cursor';
 /**
  * Map the public `QuestionOrderField` enum to the internal
  * `QuestionSortField` (plus a `VolumeWindow` for windowed-volume sorts).
- * `OPEN_INTEREST` is intentionally not in `QuestionOrderField`; if the
- * enum ever grows a value not covered here, fall through to the
- * runner's `CREATED_AT DESC` default.
+ * `OPEN_INTEREST` is supported here because the questions feed already
+ * sorts via raw SQL; the narrower Condition/ConditionGroup connections
+ * still omit it because their Prisma orderBy path cannot cast varchar OI.
  */
 const mapOrderField = (
-  field: QuestionOrderField
+  field: QuestionOrderField | string
 ): { sortField: QuestionSortField; volumeWindow: VolumeWindow | null } => {
-  switch (field) {
+  switch (String(field)) {
     case QuestionOrderField.CreatedAt:
       return { sortField: QuestionSortField.CreatedAt, volumeWindow: null };
     case QuestionOrderField.ResolvesAt:
       return { sortField: QuestionSortField.EndTime, volumeWindow: null };
+    case 'OPEN_INTEREST':
+      return { sortField: QuestionSortField.OpenInterest, volumeWindow: null };
     case QuestionOrderField.PredictionCount:
       return {
         sortField: QuestionSortField.PredictionCount,

--- a/packages/api/src/graphql/sdl/schema/schema.graphql
+++ b/packages/api/src/graphql/sdl/schema/schema.graphql
@@ -1893,14 +1893,14 @@ input QuestionOrder {
 """
 Sort fields for the Relay-shaped `questions` connection. The runner
 unions Conditions and ConditionGroups; sort values pick the column on
-each side. `OPEN_INTEREST` is intentionally omitted (symmetric with
-`ConditionOrderField`) — the Condition side would sort the varchar
-column lexicographically; restore together with raw-SQL numeric sort
-in a follow-up.
+each side. Unlike the narrower Condition/ConditionGroup connections,
+`OPEN_INTEREST` is available here because this feed uses raw SQL and
+casts the varchar-backed open-interest values numerically.
 """
 enum QuestionOrderField {
   CREATED_AT
   RESOLVES_AT
+  OPEN_INTEREST
   PREDICTION_COUNT
   SIMILAR_MARKET_VOLUME_24H
   SIMILAR_MARKET_VOLUME_7D

--- a/packages/sdk/queries/__tests__/questions.test.ts
+++ b/packages/sdk/queries/__tests__/questions.test.ts
@@ -31,6 +31,18 @@ describe('fetchQuestionsSorted', () => {
     expect(call[1].orderBy).toEqual({ field: 'CREATED_AT', direction: 'DESC' });
   });
 
+  test('requests open-interest ordering when sortField is openInterest', async () => {
+    await fetchQuestionsSorted({
+      ...baseParams,
+      sortField: 'openInterest',
+    });
+    const call = mockGraphqlRequest.mock.calls[0];
+    expect(call[1].orderBy).toEqual({
+      field: 'OPEN_INTEREST',
+      direction: 'DESC',
+    });
+  });
+
   test('normalizes missing chainId to null', async () => {
     await fetchQuestionsSorted(baseParams);
     const call = mockGraphqlRequest.mock.calls[0];

--- a/packages/sdk/queries/questions.ts
+++ b/packages/sdk/queries/questions.ts
@@ -33,7 +33,7 @@ const VOLUME_WINDOW_TO_GQL: Record<VolumeWindow, string> = {
 const SORT_FIELD_TO_ORDER_FIELD: Record<SortField, string> = {
   createdAt: 'CREATED_AT',
   endTime: 'RESOLVES_AT',
-  openInterest: 'CREATED_AT',
+  openInterest: 'OPEN_INTEREST',
   predictionCount: 'PREDICTION_COUNT',
   similarMarketVolume: 'SIMILAR_MARKET_VOLUME_24H',
 };

--- a/packages/sdk/types/graphql.ts
+++ b/packages/sdk/types/graphql.ts
@@ -3706,13 +3706,13 @@ export type QuestionOrder = {
 /**
  * Sort fields for the Relay-shaped `questions` connection. The runner
  * unions Conditions and ConditionGroups; sort values pick the column on
- * each side. `OPEN_INTEREST` is intentionally omitted (symmetric with
- * `ConditionOrderField`) — the Condition side would sort the varchar
- * column lexicographically; restore together with raw-SQL numeric sort
- * in a follow-up.
+ * each side. Unlike the narrower Condition/ConditionGroup connections,
+ * `OPEN_INTEREST` is available here because this feed uses raw SQL and
+ * casts the varchar-backed open-interest values numerically.
  */
 export type QuestionOrderField =
   | 'CREATED_AT'
+  | 'OPEN_INTEREST'
   | 'PREDICTION_COUNT'
   | 'RESOLVES_AT'
   | 'SIMILAR_MARKET_VOLUME_7D'


### PR DESCRIPTION
## Summary
- Adds `OPEN_INTEREST` to `QuestionOrderField`
- Maps SDK `sortField: "openInterest"` to the new GraphQL order field
- Wires `questionsConnection` to use the existing raw-SQL numeric open-interest sort