### PR TITLE
fix(api): repair questions connection resolver export

### DIFF
--- a/packages/api/src/graphql/sdl/resolvers/queries/questions.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/questions.ts
@@ -1003,9 +1003,10 @@ const rangeMin = (filter: ScalarRangeFilter | null | undefined) =>
 const rangeMax = (filter: ScalarRangeFilter | null | undefined) =>
   filter?.lte ?? filter?.lt ?? filter?.equals ?? null;
 
-export const questionsConnection: NonNullable<
-  QueryResolvers['questionsConnection']
-> = async (_parent, { first, after, filter, orderBy }) => {
+const questionsConnectionResolver = async (
+  _parent: unknown,
+  { first, after, filter, orderBy }: Partial<QueryQuestionsConnectionArgs>
+) => {
   const cappedFirst = clampTake(first ?? 50, {
     defaultTake: 50,
     maxTake: 100,
@@ -1068,4 +1069,9 @@ export const questionsConnection: NonNullable<
       endCursor: edges[edges.length - 1]?.cursor ?? null,
     },
   };
-}) as unknown as NonNullable<QueryResolvers['questionsConnection']>;
+};
+
+export const questionsConnection =
+  questionsConnectionResolver as unknown as NonNullable<
+    QueryResolvers['questionsConnection']
+  >;


### PR DESCRIPTION
## Summary
- Fix `questionsConnection` resolver export syntax introduced on staging
- Keep the lazy `_totalCount` runtime shape while moving the generated resolver cast to the exported symbol

## Verification
- `pnpm --filter @sapience/api exec tsx -e "import('./src/graphql/sdl/resolvers/queries/questions.ts').then(()=>console.log('tsx import ok'))"`
- `pnpm --filter @sapience/api run type-check`
