### PR TITLE
fix: build market keeper for railway backend deploys

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "pnpm run build:backend",
-    "build:backend": "pnpm --filter @sapience/sdk run build:lib && pnpm --filter @sapience/api run prisma:generate",
+    "build:backend": "pnpm --filter @sapience/sdk run build:lib && pnpm --filter @sapience/api run prisma:generate && pnpm --filter @sapience/market-keeper run build",
     "build:web": "pnpm --filter @sapience/app run build && pnpm --filter docs run build",
     "test": "pnpm run test --recursive",
     "dev:app": "pnpm --filter @sapience/app run dev",


### PR DESCRIPTION
## Summary
- include `@sapience/market-keeper` in the root backend build path
- ensures Railway builds `packages/market-keeper/dist/scripts/*` before the Keeper service runs `node scripts/start.js`

## Why
Keeper runtime logs show `MODULE_NOT_FOUND` for `/app/packages/market-keeper/dist/scripts/refresh-metadata.js`. The source script exists; the compiled `dist` output is missing because root `pnpm run build` only built the SDK and generated API Prisma.

## Verification
- `rm -rf packages/market-keeper/dist && pnpm run build`
- verified `packages/market-keeper/dist/scripts/refresh-metadata.js` exists after build
