### PR TITLE
fix(docs): correct GraphQL examples to match strict Relay schema

### DIFF
--- a/packages/docs/docs/pages/builder-guide/api/graphql.mdx
+++ b/packages/docs/docs/pages/builder-guide/api/graphql.mdx
@@ -44,8 +44,11 @@ const client = new ApolloClient({
 const { data } = await client.query({
   query: gql`
     query Questions {
-      questionsConnection(first: 10, sortField: endTime, sortDirection: desc) {
-        items {
+      questionsConnection(
+        first: 10
+        orderBy: { field: RESOLVES_AT, direction: DESC }
+      ) {
+        nodes {
           questionType
           predictionCount
           condition {
@@ -56,7 +59,10 @@ const { data } = await client.query({
             id
           }
         }
-        hasMore
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
       }
     }
   `,
@@ -69,5 +75,5 @@ console.log(data.questionsConnection.nodes);
 
 - The API is currently public; please be considerate and cache when possible.
 - Use `slug` (not `id`) when you need a stable, human-friendly identifier — most ID fields on Sapience entities are `Int!` and shift between environments.
-- Prefer the paginated list queries (`questionsConnection`, `conditionsConnection`, `conditionGroupsConnection`, `categoriesConnection`, `predictionsPage`, `positionsPage`, etc.) for list reads. Newer `*Connection` fields use cursor pagination (`first`/`after`) and expose `nodes`, `edges`, and `pageInfo`; older shipped `*Page` fields use `take`/`skip` with `{ items, hasMore, totalCount }`. The bare-array equivalents (`questions`, `conditions`, …) still respond but are `@deprecated` and will be removed.
+- Prefer the paginated list queries (`questionsConnection`, `conditionsConnection`, `conditionGroupsConnection`, `categoriesConnection`, `predictionsPage`, `positionsPage`, etc.) for list reads. The `*Connection` fields use cursor pagination (`first`/`after`) and expose `nodes`, `edges`, and `pageInfo` (Relay shape); pass sort via `orderBy: { field: <FIELD>, direction: ASC | DESC }`. The older shipped `*Page` fields use `take`/`skip` with `{ items, hasMore, totalCount }`. The bare-array equivalents (`questions`, `conditions`, …) still respond but are `@deprecated` and will be removed.
 - Some queries are marked `@deprecated` in the schema (`claims`, `closes`, `conditionGroup`, `pickConfiguration`, `tradeCount`, `users`, plus the bare-array list queries listed above). They still respond, but rely on them at your own risk — read the schema before depending on one.

--- a/packages/docs/docs/pages/builder-guide/guides/_forecasting-agent-typescript.mdx
+++ b/packages/docs/docs/pages/builder-guide/guides/_forecasting-agent-typescript.mdx
@@ -41,10 +41,10 @@ async function fetchRandomCondition() {
   const query = gql`
     query Conditions($nowSec: Int!) {
       conditionsConnection(
-        filters: { visibility: PUBLIC, minEndTime: $nowSec }
+        filter: { visibility: PUBLIC, resolvesAt: { gte: $nowSec } }
         first: 50
       ) {
-        items {
+        nodes {
           id
           question
           shortName

--- a/packages/docs/docs/pages/builder-guide/guides/_trading-agent-typescript.mdx
+++ b/packages/docs/docs/pages/builder-guide/guides/_trading-agent-typescript.mdx
@@ -80,11 +80,15 @@ async function fetchCondition() {
   const query = gql`
     query Conditions($chainId: Int!, $nowSec: Int!) {
       conditionsConnection(
-        filters: { chainId: $chainId, visibility: PUBLIC, minEndTime: $nowSec }
+        filter: {
+          chainId: $chainId
+          visibility: PUBLIC
+          resolvesAt: { gte: $nowSec }
+        }
         orderBy: { field: RESOLVES_AT, direction: ASC }
         first: 1
       ) {
-        items {
+        nodes {
           id
           question
           shortName

--- a/packages/docs/docs/pages/builder-guide/guides/prediction-market-app.mdx
+++ b/packages/docs/docs/pages/builder-guide/guides/prediction-market-app.mdx
@@ -150,8 +150,10 @@ const client = new GraphQLClient('https://api.sapience.xyz/graphql');
 
 const QuestionsQuery = gql`
   query Questions {
-    questionsConnection(first: 10, sortField: endTime, sortDirection: desc) {
-      hasMore
+    questionsConnection(
+      first: 10
+      orderBy: { field: RESOLVES_AT, direction: DESC }
+    ) {
       nodes {
         questionType
         predictionCount
@@ -162,6 +164,10 @@ const QuestionsQuery = gql`
         group {
           id
         }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
       }
     }
   }


### PR DESCRIPTION
## Summary

The example queries shipped in the public docs were emitting the same
`ConditionConnection` / `QuestionConnection` validation errors that are
currently firing in staging Sentry (`Cannot query field 'hasMore'`,
`Unknown argument 'skip'`, etc.).

Brought four files into line with the strict Relay-shaped schema that
landed in #1774 and the `ConditionFilter` shape we ship today.

- `api/graphql.mdx` — `questionsConnection` example: dropped
  `sortField`/`sortDirection`/`items`/`hasMore` (none of which exist on
  the Connection field); now uses `orderBy: { field, direction }`,
  `nodes`, and `pageInfo.hasNextPage`. Reworked the trailing note so it
  no longer implies `*Connection` and `*Page` share a pagination shape.
- `guides/prediction-market-app.mdx` — same `questionsConnection` fix.
- `guides/_forecasting-agent-typescript.mdx`,
  `guides/_trading-agent-typescript.mdx` — `conditionsConnection`
  examples: `filters:` → `filter:`, `items` → `nodes`, and
  `minEndTime` → `resolvesAt: { gte: ... }` (the real `ConditionFilter`
  field).

## Why now

Tracing the staging Sentry validation errors:

> `Cannot query field "hasMore" on type "ConditionConnection"`
> `Variable "$resolver" of type "String!" used in position expecting type "Address"`
> `Unknown argument "skip" on field "Query.conditionsConnection"`

…the exact pattern that triggers all three lived in
`packages/market-keeper/scripts/settle-{manual,polymarket}.ts` before
commit `733649f20` ("fix keeper") replaced those inline queries with the
shared `fetchResolverConditions` helper using `$resolver: Address!`,
`first`/`after`, and `nodes`/`pageInfo`. The deployed keeper on Railway
needs to be redeployed to pick that up — the source is fixed.

These doc updates close the *other* path that would keep generating the
same errors: anyone copying the old examples into their own integration.

## Test plan

- [ ] Render docs locally and confirm the GraphQL examples now match the
      schema in `packages/api/src/graphql/sdl/schema/schema.graphql`.
- [ ] Spot-check the four updated files for any other lingering `items`
      / `hasMore` / `sortField` references on `*Connection` queries.