### PR TITLE
fix(api): restore back-compat for positions order + protocolStats(vaultAddress)

### DIFF
--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -1759,10 +1759,16 @@ enum TradeOrderField {
   BLOCK_NUMBER
 }
 
-"""Order input for the Relay-shaped `positionsConnection`."""
+"""
+Order input for the Relay-shaped `positionsConnection`.
+Both `field` and `direction` are nullable so external clients passing
+nullable `$orderDirection: OrderDirection` / `$orderBy: PositionOrderField`
+variables continue to validate against this schema. Resolver defaults to
+`UPDATED_AT` / `DESC`.
+"""
 input PositionOrder {
-  field: PositionOrderField!
-  direction: OrderDirection!
+  field: PositionOrderField
+  direction: OrderDirection
 }
 
 """Sort fields for the Relay-shaped `positionsConnection`."""
@@ -2467,7 +2473,11 @@ input VaultFilter {
   chainId: Int
 }
 
-"""Protocol-wide stats snapshot — no vault scoping."""
+"""
+Protocol-wide stats snapshot. When the deprecated `Query.protocolStats(vaultAddress:)`
+arg is set, vault-scoped fields (the `vault*` block below) are populated alongside the
+protocol-wide counters from the same fat-row pipeline that backs `vaultStats`.
+"""
 type ProtocolStat {
   """Snapshot boundary, aligned to the snapshot interval."""
   timestamp: UnixSeconds!
@@ -2483,6 +2493,35 @@ type ProtocolStat {
   periodVolume: String!
   openInterest: String!
   escrowBalance: String!
+
+  """
+  DEPRECATED — pre-split alias for `cumulativeTradeCount`. Kept so pinned external
+  queries keep validating; new callers should read `cumulativeTradeCount`.
+  """
+  totalTradeCount: Int @deprecated(reason: "Use `cumulativeTradeCount`.")
+
+  """
+  DEPRECATED — realized PnL delta. Lives on `VaultStat.periodPnL` now and is
+  only populated here when the row is vault-scoped (`protocolStats(vaultAddress:)`).
+  """
+  periodPnL: String @deprecated(reason: "Use `vaultStats(vaultAddress:).periodPnL` — only populated on vault-scoped rows.")
+
+  """
+  DEPRECATED — vault collateral balance. Only populated when the row is vault-scoped
+  via `protocolStats(vaultAddress:)`.
+  """
+  vaultBalance: String @deprecated(reason: "Use `vaultStats(vaultAddress:).balance`.")
+  vaultAvailableAssets: String @deprecated(reason: "Use `vaultStats(vaultAddress:).availableAssets`.")
+  vaultDeployed: String @deprecated(reason: "Use `vaultStats(vaultAddress:).deployed`.")
+  vaultCumulativePnL: String @deprecated(reason: "Use `vaultStats(vaultAddress:).cumulativePnL`.")
+  vaultPositionsWon: Int @deprecated(reason: "Use `vaultStats(vaultAddress:).positionsWon`.")
+  vaultPositionsLost: Int @deprecated(reason: "Use `vaultStats(vaultAddress:).positionsLost`.")
+  vaultDeposits: String @deprecated(reason: "Use `vaultStats(vaultAddress:).deposits`.")
+  vaultWithdrawals: String @deprecated(reason: "Use `vaultStats(vaultAddress:).withdrawals`.")
+  vaultAirdropGains: String @deprecated(reason: "Use `vaultStats(vaultAddress:).airdropGains`.")
+  vaultSecondaryBought: String @deprecated(reason: "Use `vaultStats(vaultAddress:).secondaryBought`.")
+  vaultSecondarySold: String @deprecated(reason: "Use `vaultStats(vaultAddress:).secondarySold`.")
+  vaultUnredeemedClaim: String @deprecated(reason: "Use `vaultStats(vaultAddress:).unredeemedClaim`.")
 }
 
 """
@@ -3201,7 +3240,7 @@ type Query {
   back), so callers can distinguish it as `points[points.length - 1]
   .timestamp >= floor(now / interval) * interval`.
   """
-  protocolStats(from: UnixSeconds, to: UnixSeconds, fromEpoch: Int @deprecated(reason: "Use `from: UnixSeconds` — same wire format, drops the unit-suffix."), toEpoch: Int @deprecated(reason: "Use `to: UnixSeconds` — same wire format, drops the unit-suffix.")): [ProtocolStat!]! @deprecated(reason: "Use `protocol.stats(filter:)` — Relay-shaped stats connection under the protocol namespace.")
+  protocolStats(from: UnixSeconds, to: UnixSeconds, fromEpoch: Int @deprecated(reason: "Use `from: UnixSeconds` — same wire format, drops the unit-suffix."), toEpoch: Int @deprecated(reason: "Use `to: UnixSeconds` — same wire format, drops the unit-suffix."), vaultAddress: String @deprecated(reason: "Use `vaultStats(vaultAddress:)` — per-vault snapshots live on Vault. When set here, the legacy vault* fields on ProtocolStat are populated for backwards compatibility.")): [ProtocolStat!]! @deprecated(reason: "Use `protocol.stats(filter:)` — Relay-shaped stats connection under the protocol namespace.")
 
   """
   Time-bucketed total protocol trading volume across all users. DEPRECATED:

--- a/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
@@ -452,6 +452,7 @@ type ProtocolStatsArgs = {
   to?: number | null;
   fromEpoch?: number | null;
   toEpoch?: number | null;
+  vaultAddress?: string | null;
 };
 
 type VaultStatsArgs = ProtocolStatsArgs & {
@@ -460,9 +461,14 @@ type VaultStatsArgs = ProtocolStatsArgs & {
 
 const protocolStatsImpl = async (
   _parent: unknown,
-  { from, to, fromEpoch, toEpoch }: ProtocolStatsArgs
+  { from, to, fromEpoch, toEpoch, vaultAddress }: ProtocolStatsArgs
 ): Promise<ProtocolStat[]> => {
-  const fat = await runFatStats(undefined, from ?? fromEpoch, to ?? toEpoch);
+  const fat = await runFatStats(
+    vaultAddress ?? undefined,
+    from ?? fromEpoch,
+    to ?? toEpoch
+  );
+  const isVaultScoped = vaultAddress != null;
   return fat.map(
     (s): ProtocolStat => ({
       timestamp: s.timestamp,
@@ -472,6 +478,20 @@ const protocolStatsImpl = async (
       periodVolume: s.periodVolume,
       openInterest: s.openInterest,
       escrowBalance: s.escrowBalance,
+      totalTradeCount: s.cumulativeTradeCount,
+      periodPnL: isVaultScoped ? s.periodPnL : null,
+      vaultBalance: isVaultScoped ? s.balance : null,
+      vaultAvailableAssets: isVaultScoped ? s.availableAssets : null,
+      vaultDeployed: isVaultScoped ? s.deployed : null,
+      vaultCumulativePnL: isVaultScoped ? s.cumulativePnL : null,
+      vaultPositionsWon: isVaultScoped ? s.positionsWon : null,
+      vaultPositionsLost: isVaultScoped ? s.positionsLost : null,
+      vaultDeposits: isVaultScoped ? s.deposits : null,
+      vaultWithdrawals: isVaultScoped ? s.withdrawals : null,
+      vaultAirdropGains: isVaultScoped ? s.airdropGains : null,
+      vaultSecondaryBought: isVaultScoped ? s.secondaryBought : null,
+      vaultSecondarySold: isVaultScoped ? s.secondarySold : null,
+      vaultUnredeemedClaim: isVaultScoped ? s.unredeemedClaim : null,
     })
   );
 };

--- a/packages/api/src/graphql/sdl/schema/schema.graphql
+++ b/packages/api/src/graphql/sdl/schema/schema.graphql
@@ -1989,10 +1989,14 @@ enum TradeOrderField {
 
 """
 Order input for the Relay-shaped `positionsConnection`.
+Both `field` and `direction` are nullable so external clients passing
+nullable `$orderDirection: OrderDirection` / `$orderBy: PositionOrderField`
+variables continue to validate against this schema. Resolver defaults to
+`UPDATED_AT` / `DESC`.
 """
 input PositionOrder {
-  field: PositionOrderField!
-  direction: OrderDirection!
+  field: PositionOrderField
+  direction: OrderDirection
 }
 
 """
@@ -2799,7 +2803,9 @@ input VaultFilter {
 }
 
 """
-Protocol-wide stats snapshot — no vault scoping.
+Protocol-wide stats snapshot. When the deprecated `Query.protocolStats(vaultAddress:)`
+arg is set, vault-scoped fields (the `vault*` block below) are populated alongside the
+protocol-wide counters from the same fat-row pipeline that backs `vaultStats`.
 """
 type ProtocolStat {
   """
@@ -2824,6 +2830,49 @@ type ProtocolStat {
   periodVolume: String!
   openInterest: String!
   escrowBalance: String!
+
+  """
+  DEPRECATED — pre-split alias for `cumulativeTradeCount`. Kept so pinned external
+  queries keep validating; new callers should read `cumulativeTradeCount`.
+  """
+  totalTradeCount: Int
+    @deprecated(reason: "Use `cumulativeTradeCount`.")
+
+  """
+  DEPRECATED — realized PnL delta. Lives on `VaultStat.periodPnL` now and is
+  only populated here when the row is vault-scoped (`protocolStats(vaultAddress:)`).
+  """
+  periodPnL: String
+    @deprecated(reason: "Use `vaultStats(vaultAddress:).periodPnL` — only populated on vault-scoped rows.")
+
+  """
+  DEPRECATED — vault collateral balance. Only populated when the row is vault-scoped
+  via `protocolStats(vaultAddress:)`.
+  """
+  vaultBalance: String
+    @deprecated(reason: "Use `vaultStats(vaultAddress:).balance`.")
+  vaultAvailableAssets: String
+    @deprecated(reason: "Use `vaultStats(vaultAddress:).availableAssets`.")
+  vaultDeployed: String
+    @deprecated(reason: "Use `vaultStats(vaultAddress:).deployed`.")
+  vaultCumulativePnL: String
+    @deprecated(reason: "Use `vaultStats(vaultAddress:).cumulativePnL`.")
+  vaultPositionsWon: Int
+    @deprecated(reason: "Use `vaultStats(vaultAddress:).positionsWon`.")
+  vaultPositionsLost: Int
+    @deprecated(reason: "Use `vaultStats(vaultAddress:).positionsLost`.")
+  vaultDeposits: String
+    @deprecated(reason: "Use `vaultStats(vaultAddress:).deposits`.")
+  vaultWithdrawals: String
+    @deprecated(reason: "Use `vaultStats(vaultAddress:).withdrawals`.")
+  vaultAirdropGains: String
+    @deprecated(reason: "Use `vaultStats(vaultAddress:).airdropGains`.")
+  vaultSecondaryBought: String
+    @deprecated(reason: "Use `vaultStats(vaultAddress:).secondaryBought`.")
+  vaultSecondarySold: String
+    @deprecated(reason: "Use `vaultStats(vaultAddress:).secondarySold`.")
+  vaultUnredeemedClaim: String
+    @deprecated(reason: "Use `vaultStats(vaultAddress:).unredeemedClaim`.")
 }
 
 """
@@ -3969,6 +4018,10 @@ type Query {
     toEpoch: Int
       @deprecated(
         reason: "Use `to: UnixSeconds` — same wire format, drops the unit-suffix."
+      )
+    vaultAddress: String
+      @deprecated(
+        reason: "Use `vaultStats(vaultAddress:)` — per-vault snapshots live on Vault. When set here, the legacy vault* fields on ProtocolStat are populated for backwards compatibility."
       )
   ): [ProtocolStat!]!
     @deprecated(

--- a/packages/api/test/contract/__snapshots__/introspection.json
+++ b/packages/api/test/contract/__snapshots__/introspection.json
@@ -15569,20 +15569,16 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "PositionOrder",
-        "description": "Order input for the Relay-shaped `positionsConnection`.",
+        "description": "Order input for the Relay-shaped `positionsConnection`.\nBoth `field` and `direction` are nullable so external clients passing\nnullable `$orderDirection: OrderDirection` / `$orderBy: PositionOrderField`\nvariables continue to validate against this schema. Resolver defaults to\n`UPDATED_AT` / `DESC`.",
         "fields": null,
         "inputFields": [
           {
             "name": "field",
             "description": null,
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "PositionOrderField",
-                "ofType": null
-              }
+              "kind": "ENUM",
+              "name": "PositionOrderField",
+              "ofType": null
             },
             "defaultValue": null
           },
@@ -15590,13 +15586,9 @@
             "name": "direction",
             "description": null,
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "OrderDirection",
-                "ofType": null
-              }
+              "kind": "ENUM",
+              "name": "OrderDirection",
+              "ofType": null
             },
             "defaultValue": null
           }
@@ -16690,7 +16682,7 @@
       {
         "kind": "OBJECT",
         "name": "ProtocolStat",
-        "description": "Protocol-wide stats snapshot — no vault scoping.",
+        "description": "Protocol-wide stats snapshot. When the deprecated `Query.protocolStats(vaultAddress:)`\narg is set, vault-scoped fields (the `vault*` block below) are populated alongside the\nprotocol-wide counters from the same fat-row pipeline that backs `vaultStats`.",
         "fields": [
           {
             "name": "timestamp",
@@ -16803,6 +16795,174 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "totalTradeCount",
+            "description": "DEPRECATED — pre-split alias for `cumulativeTradeCount`. Kept so pinned external\nqueries keep validating; new callers should read `cumulativeTradeCount`.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use `cumulativeTradeCount`."
+          },
+          {
+            "name": "periodPnL",
+            "description": "DEPRECATED — realized PnL delta. Lives on `VaultStat.periodPnL` now and is\nonly populated here when the row is vault-scoped (`protocolStats(vaultAddress:)`).",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use `vaultStats(vaultAddress:).periodPnL` — only populated on vault-scoped rows."
+          },
+          {
+            "name": "vaultBalance",
+            "description": "DEPRECATED — vault collateral balance. Only populated when the row is vault-scoped\nvia `protocolStats(vaultAddress:)`.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use `vaultStats(vaultAddress:).balance`."
+          },
+          {
+            "name": "vaultAvailableAssets",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use `vaultStats(vaultAddress:).availableAssets`."
+          },
+          {
+            "name": "vaultDeployed",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use `vaultStats(vaultAddress:).deployed`."
+          },
+          {
+            "name": "vaultCumulativePnL",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use `vaultStats(vaultAddress:).cumulativePnL`."
+          },
+          {
+            "name": "vaultPositionsWon",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use `vaultStats(vaultAddress:).positionsWon`."
+          },
+          {
+            "name": "vaultPositionsLost",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use `vaultStats(vaultAddress:).positionsLost`."
+          },
+          {
+            "name": "vaultDeposits",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use `vaultStats(vaultAddress:).deposits`."
+          },
+          {
+            "name": "vaultWithdrawals",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use `vaultStats(vaultAddress:).withdrawals`."
+          },
+          {
+            "name": "vaultAirdropGains",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use `vaultStats(vaultAddress:).airdropGains`."
+          },
+          {
+            "name": "vaultSecondaryBought",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use `vaultStats(vaultAddress:).secondaryBought`."
+          },
+          {
+            "name": "vaultSecondarySold",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use `vaultStats(vaultAddress:).secondarySold`."
+          },
+          {
+            "name": "vaultUnredeemedClaim",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use `vaultStats(vaultAddress:).unredeemedClaim`."
           }
         ],
         "inputFields": null,

--- a/packages/api/test/contract/__snapshots__/schema.sdl.graphql
+++ b/packages/api/test/contract/__snapshots__/schema.sdl.graphql
@@ -1759,10 +1759,16 @@ enum TradeOrderField {
   BLOCK_NUMBER
 }
 
-"""Order input for the Relay-shaped `positionsConnection`."""
+"""
+Order input for the Relay-shaped `positionsConnection`.
+Both `field` and `direction` are nullable so external clients passing
+nullable `$orderDirection: OrderDirection` / `$orderBy: PositionOrderField`
+variables continue to validate against this schema. Resolver defaults to
+`UPDATED_AT` / `DESC`.
+"""
 input PositionOrder {
-  field: PositionOrderField!
-  direction: OrderDirection!
+  field: PositionOrderField
+  direction: OrderDirection
 }
 
 """Sort fields for the Relay-shaped `positionsConnection`."""
@@ -2467,7 +2473,11 @@ input VaultFilter {
   chainId: Int
 }
 
-"""Protocol-wide stats snapshot — no vault scoping."""
+"""
+Protocol-wide stats snapshot. When the deprecated `Query.protocolStats(vaultAddress:)`
+arg is set, vault-scoped fields (the `vault*` block below) are populated alongside the
+protocol-wide counters from the same fat-row pipeline that backs `vaultStats`.
+"""
 type ProtocolStat {
   """Snapshot boundary, aligned to the snapshot interval."""
   timestamp: UnixSeconds!
@@ -2483,6 +2493,35 @@ type ProtocolStat {
   periodVolume: String!
   openInterest: String!
   escrowBalance: String!
+
+  """
+  DEPRECATED — pre-split alias for `cumulativeTradeCount`. Kept so pinned external
+  queries keep validating; new callers should read `cumulativeTradeCount`.
+  """
+  totalTradeCount: Int @deprecated(reason: "Use `cumulativeTradeCount`.")
+
+  """
+  DEPRECATED — realized PnL delta. Lives on `VaultStat.periodPnL` now and is
+  only populated here when the row is vault-scoped (`protocolStats(vaultAddress:)`).
+  """
+  periodPnL: String @deprecated(reason: "Use `vaultStats(vaultAddress:).periodPnL` — only populated on vault-scoped rows.")
+
+  """
+  DEPRECATED — vault collateral balance. Only populated when the row is vault-scoped
+  via `protocolStats(vaultAddress:)`.
+  """
+  vaultBalance: String @deprecated(reason: "Use `vaultStats(vaultAddress:).balance`.")
+  vaultAvailableAssets: String @deprecated(reason: "Use `vaultStats(vaultAddress:).availableAssets`.")
+  vaultDeployed: String @deprecated(reason: "Use `vaultStats(vaultAddress:).deployed`.")
+  vaultCumulativePnL: String @deprecated(reason: "Use `vaultStats(vaultAddress:).cumulativePnL`.")
+  vaultPositionsWon: Int @deprecated(reason: "Use `vaultStats(vaultAddress:).positionsWon`.")
+  vaultPositionsLost: Int @deprecated(reason: "Use `vaultStats(vaultAddress:).positionsLost`.")
+  vaultDeposits: String @deprecated(reason: "Use `vaultStats(vaultAddress:).deposits`.")
+  vaultWithdrawals: String @deprecated(reason: "Use `vaultStats(vaultAddress:).withdrawals`.")
+  vaultAirdropGains: String @deprecated(reason: "Use `vaultStats(vaultAddress:).airdropGains`.")
+  vaultSecondaryBought: String @deprecated(reason: "Use `vaultStats(vaultAddress:).secondaryBought`.")
+  vaultSecondarySold: String @deprecated(reason: "Use `vaultStats(vaultAddress:).secondarySold`.")
+  vaultUnredeemedClaim: String @deprecated(reason: "Use `vaultStats(vaultAddress:).unredeemedClaim`.")
 }
 
 """
@@ -3201,7 +3240,7 @@ type Query {
   back), so callers can distinguish it as `points[points.length - 1]
   .timestamp >= floor(now / interval) * interval`.
   """
-  protocolStats(from: UnixSeconds, to: UnixSeconds, fromEpoch: Int @deprecated(reason: "Use `from: UnixSeconds` — same wire format, drops the unit-suffix."), toEpoch: Int @deprecated(reason: "Use `to: UnixSeconds` — same wire format, drops the unit-suffix.")): [ProtocolStat!]! @deprecated(reason: "Use `protocol.stats(filter:)` — Relay-shaped stats connection under the protocol namespace.")
+  protocolStats(from: UnixSeconds, to: UnixSeconds, fromEpoch: Int @deprecated(reason: "Use `from: UnixSeconds` — same wire format, drops the unit-suffix."), toEpoch: Int @deprecated(reason: "Use `to: UnixSeconds` — same wire format, drops the unit-suffix."), vaultAddress: String @deprecated(reason: "Use `vaultStats(vaultAddress:)` — per-vault snapshots live on Vault. When set here, the legacy vault* fields on ProtocolStat are populated for backwards compatibility.")): [ProtocolStat!]! @deprecated(reason: "Use `protocol.stats(filter:)` — Relay-shaped stats connection under the protocol namespace.")
 
   """
   Time-bucketed total protocol trading volume across all users. DEPRECATED:

--- a/packages/sdk/types/graphql.ts
+++ b/packages/sdk/types/graphql.ts
@@ -2457,10 +2457,16 @@ export type PositionFilters = {
   settled?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
-/** Order input for the Relay-shaped `positionsConnection`. */
+/**
+ * Order input for the Relay-shaped `positionsConnection`.
+ * Both `field` and `direction` are nullable so external clients passing
+ * nullable `$orderDirection: OrderDirection` / `$orderBy: PositionOrderField`
+ * variables continue to validate against this schema. Resolver defaults to
+ * `UPDATED_AT` / `DESC`.
+ */
 export type PositionOrder = {
-  direction: OrderDirection;
-  field: PositionOrderField;
+  direction?: InputMaybe<OrderDirection>;
+  field?: InputMaybe<PositionOrderField>;
 };
 
 /** Sort fields for the Relay-shaped `positionsConnection`. */
@@ -2636,7 +2642,11 @@ export type ProtocolStatsArgs = {
   filter?: InputMaybe<ProtocolStatFilter>;
 };
 
-/** Protocol-wide stats snapshot — no vault scoping. */
+/**
+ * Protocol-wide stats snapshot. When the deprecated `Query.protocolStats(vaultAddress:)`
+ * arg is set, vault-scoped fields (the `vault*` block below) are populated alongside the
+ * protocol-wide counters from the same fat-row pipeline that backs `vaultStats`.
+ */
 export type ProtocolStat = {
   __typename?: 'ProtocolStat';
   /** Cumulative count of predictions and secondary trades/sales */
@@ -2644,12 +2654,52 @@ export type ProtocolStat = {
   cumulativeVolume: Scalars['String']['output'];
   escrowBalance: Scalars['String']['output'];
   openInterest: Scalars['String']['output'];
+  /**
+   * DEPRECATED — realized PnL delta. Lives on `VaultStat.periodPnL` now and is
+   * only populated here when the row is vault-scoped (`protocolStats(vaultAddress:)`).
+   * @deprecated Use `vaultStats(vaultAddress:).periodPnL` — only populated on vault-scoped rows.
+   */
+  periodPnL?: Maybe<Scalars['String']['output']>;
   /** Trade-count delta over the snapshot interval */
   periodTradeCount: Scalars['Int']['output'];
   /** Cumulative-volume delta over the snapshot interval */
   periodVolume: Scalars['String']['output'];
   /** Snapshot boundary, aligned to the snapshot interval. */
   timestamp: Scalars['UnixSeconds']['output'];
+  /**
+   * DEPRECATED — pre-split alias for `cumulativeTradeCount`. Kept so pinned external
+   * queries keep validating; new callers should read `cumulativeTradeCount`.
+   * @deprecated Use `cumulativeTradeCount`.
+   */
+  totalTradeCount?: Maybe<Scalars['Int']['output']>;
+  /** @deprecated Use `vaultStats(vaultAddress:).airdropGains`. */
+  vaultAirdropGains?: Maybe<Scalars['String']['output']>;
+  /** @deprecated Use `vaultStats(vaultAddress:).availableAssets`. */
+  vaultAvailableAssets?: Maybe<Scalars['String']['output']>;
+  /**
+   * DEPRECATED — vault collateral balance. Only populated when the row is vault-scoped
+   * via `protocolStats(vaultAddress:)`.
+   * @deprecated Use `vaultStats(vaultAddress:).balance`.
+   */
+  vaultBalance?: Maybe<Scalars['String']['output']>;
+  /** @deprecated Use `vaultStats(vaultAddress:).cumulativePnL`. */
+  vaultCumulativePnL?: Maybe<Scalars['String']['output']>;
+  /** @deprecated Use `vaultStats(vaultAddress:).deployed`. */
+  vaultDeployed?: Maybe<Scalars['String']['output']>;
+  /** @deprecated Use `vaultStats(vaultAddress:).deposits`. */
+  vaultDeposits?: Maybe<Scalars['String']['output']>;
+  /** @deprecated Use `vaultStats(vaultAddress:).positionsLost`. */
+  vaultPositionsLost?: Maybe<Scalars['Int']['output']>;
+  /** @deprecated Use `vaultStats(vaultAddress:).positionsWon`. */
+  vaultPositionsWon?: Maybe<Scalars['Int']['output']>;
+  /** @deprecated Use `vaultStats(vaultAddress:).secondaryBought`. */
+  vaultSecondaryBought?: Maybe<Scalars['String']['output']>;
+  /** @deprecated Use `vaultStats(vaultAddress:).secondarySold`. */
+  vaultSecondarySold?: Maybe<Scalars['String']['output']>;
+  /** @deprecated Use `vaultStats(vaultAddress:).unredeemedClaim`. */
+  vaultUnredeemedClaim?: Maybe<Scalars['String']['output']>;
+  /** @deprecated Use `vaultStats(vaultAddress:).withdrawals`. */
+  vaultWithdrawals?: Maybe<Scalars['String']['output']>;
 };
 
 export type ProtocolStatConnection = {
@@ -3482,6 +3532,7 @@ export type QueryProtocolStatsArgs = {
   fromEpoch?: InputMaybe<Scalars['Int']['input']>;
   to?: InputMaybe<Scalars['UnixSeconds']['input']>;
   toEpoch?: InputMaybe<Scalars['Int']['input']>;
+  vaultAddress?: InputMaybe<Scalars['String']['input']>;
 };
 
 


### PR DESCRIPTION
## Summary

External API consumers started hitting Sentry validation errors after the recent main update that introduced the Relay-shaped GraphQL surface. Three related issues:

- `Variable "$orderDirection" of type "OrderDirection" used in position expecting type "OrderDirection!"` — `PositionOrder.direction` was non-null, so consumers passing nullable `$orderDirection: OrderDirection` into `Account.positions(orderBy:)` (a non-Connection-suffix resolver) failed schema validation.
- `Cannot query field "vaultWithdrawals" on type "ProtocolStat"` — vault-scoped columns were dropped from `ProtocolStat` when it was split into `ProtocolStat` / `VaultStat`.
- `Unknown argument "vaultAddress" on field "Query.protocolStats"` — the `vaultAddress` arg was removed when `protocolStats` and `vaultStats` were split into two resolvers.

### Changes

- `PositionOrder.field` / `PositionOrder.direction`: relaxed to nullable. Resolver already defaults to `UPDATED_AT` / `DESC` via optional chaining, no behavior change for non-null callers.
- `ProtocolStat`: re-added deprecated nullable `vaultWithdrawals`, `vaultDeposits`, `vaultBalance`, `vaultAvailableAssets`, `vaultDeployed`, `vaultCumulativePnL`, `vaultPositionsWon`, `vaultPositionsLost`, `vaultAirdropGains`, `vaultSecondaryBought`, `vaultSecondarySold`, `vaultUnredeemedClaim`, plus `totalTradeCount` and `periodPnL`. Each deprecation message points at the `vaultStats(vaultAddress:)` replacement.
- `Query.protocolStats(vaultAddress: String)`: re-added as deprecated arg. When set, the resolver passes it to the same fat-row pipeline that backs `vaultStats` and populates the legacy vault* fields on the returned `ProtocolStat` rows. When omitted, vault* fields are `null` and the resolver behavior matches today's.

### Why not just ask the consumer to update?

We don't control their query; they're failing in prod right now. These are all additive/widening schema changes (nullable widening, deprecated arg/field restoration) — non-breaking for any current caller, load-bearing for the external one.

## Test plan

- [x] `pnpm --filter @sapience/api run type-check` — clean
- [x] `pnpm --filter @sapience/api exec vitest run src/graphql` — 412 tests pass, including `analytics.test.ts` and `escrow.test.ts`
- [ ] Confirm Sentry validation errors stop after deploy
- [ ] Manual GraphiQL: `{ protocolStats(vaultAddress: "0x...") { vaultWithdrawals timestamp } }` returns populated rows
- [ ] Manual GraphiQL: `query ($d: OrderDirection) { account(address: "0x...") { positions(orderBy: { field: CREATED_AT, direction: $d }) { totalCount } } }` validates with `$d` left null

🤖 Generated with [Claude Code](https://claude.com/claude-code)