### PR TITLE
fix(api): split PositionOrder into strict + LegacyPositionOrder

### DIFF
--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -86,7 +86,7 @@ type Account implements Node {
   predictions(first: Int = 50, after: String, filter: PredictionFilter, orderBy: PredictionOrder): PredictionConnection!
   trades(first: Int = 50, after: String, filter: TradeFilter, orderBy: TradeOrder): TradeConnection!
   forecasts(first: Int = 50, after: String, filter: ForecastFilter, orderBy: ForecastOrder): ForecastConnection!
-  positions(first: Int = 50, after: String, filter: PositionFilter, orderBy: PositionOrder): PositionConnection!
+  positions(first: Int = 50, after: String, filter: PositionFilter, orderBy: LegacyPositionOrder): PositionConnection!
   collateralBalance(chainId: Int!, atBlock: BigInt): CollateralBalance!
 }
 
@@ -1382,7 +1382,7 @@ type PickConfiguration implements Node {
   picks: [Pick!]!
   predictions(first: Int = 50, after: String, filter: PredictionFilter, orderBy: PredictionOrder): PredictionConnection!
   trades(first: Int = 50, after: String, filter: TradeFilter, orderBy: TradeOrder): TradeConnection!
-  positions(first: Int = 50, after: String, filter: PositionFilter, orderBy: PositionOrder): PositionConnection!
+  positions(first: Int = 50, after: String, filter: PositionFilter, orderBy: LegacyPositionOrder): PositionConnection!
   predictionId: String
   predictorToken: String
   resolved: Boolean!
@@ -1760,13 +1760,24 @@ enum TradeOrderField {
 }
 
 """
-Order input for the Relay-shaped `positionsConnection`.
-Both `field` and `direction` are nullable so external clients passing
-nullable `$orderDirection: OrderDirection` / `$orderBy: PositionOrderField`
-variables continue to validate against this schema. Resolver defaults to
-`UPDATED_AT` / `DESC`.
+Order input for the Relay-shaped `positionsConnection`. Strict: both fields are
+required so canonical Relay clients self-document the sort they intend.
 """
 input PositionOrder {
+  field: PositionOrderField!
+  direction: OrderDirection!
+}
+
+"""
+Order input for the non-Connection-suffix `Account.positions` /
+`PickConfiguration.positions` access paths. Both fields are nullable so
+pre-existing external queries that wire nullable variables into the
+`orderBy` shape (`{ field: $f, direction: $d }`) keep validating; the
+resolver defaults to `UPDATED_AT` / `DESC` when either field is omitted.
+New callers should prefer `positionsConnection(orderBy: PositionOrder!)`,
+which is the canonical Relay surface.
+"""
+input LegacyPositionOrder {
   field: PositionOrderField
   direction: OrderDirection
 }

--- a/packages/api/src/graphql/sdl/schema/schema.graphql
+++ b/packages/api/src/graphql/sdl/schema/schema.graphql
@@ -159,7 +159,7 @@ type Account implements Node {
     first: Int = 50
     after: String
     filter: PositionFilter
-    orderBy: PositionOrder
+    orderBy: LegacyPositionOrder
   ): PositionConnection!
   collateralBalance(chainId: Int!, atBlock: BigInt): CollateralBalance!
 }
@@ -1554,7 +1554,7 @@ type PickConfiguration implements Node {
     first: Int = 50
     after: String
     filter: PositionFilter
-    orderBy: PositionOrder
+    orderBy: LegacyPositionOrder
   ): PositionConnection!
   predictionId: String
   predictorToken: String
@@ -1988,13 +1988,24 @@ enum TradeOrderField {
 }
 
 """
-Order input for the Relay-shaped `positionsConnection`.
-Both `field` and `direction` are nullable so external clients passing
-nullable `$orderDirection: OrderDirection` / `$orderBy: PositionOrderField`
-variables continue to validate against this schema. Resolver defaults to
-`UPDATED_AT` / `DESC`.
+Order input for the Relay-shaped `positionsConnection`. Strict: both fields are
+required so canonical Relay clients self-document the sort they intend.
 """
 input PositionOrder {
+  field: PositionOrderField!
+  direction: OrderDirection!
+}
+
+"""
+Order input for the non-Connection-suffix `Account.positions` /
+`PickConfiguration.positions` access paths. Both fields are nullable so
+pre-existing external queries that wire nullable variables into the
+`orderBy` shape (`{ field: $f, direction: $d }`) keep validating; the
+resolver defaults to `UPDATED_AT` / `DESC` when either field is omitted.
+New callers should prefer `positionsConnection(orderBy: PositionOrder!)`,
+which is the canonical Relay surface.
+"""
+input LegacyPositionOrder {
   field: PositionOrderField
   direction: OrderDirection
 }

--- a/packages/api/test/contract/__snapshots__/introspection.json
+++ b/packages/api/test/contract/__snapshots__/introspection.json
@@ -545,7 +545,7 @@
                 "description": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "PositionOrder",
+                  "name": "LegacyPositionOrder",
                   "ofType": null
                 },
                 "defaultValue": null
@@ -12672,6 +12672,37 @@
       },
       {
         "kind": "INPUT_OBJECT",
+        "name": "LegacyPositionOrder",
+        "description": "Order input for the non-Connection-suffix `Account.positions` /\n`PickConfiguration.positions` access paths. Both fields are nullable so\npre-existing external queries that wire nullable variables into the\n`orderBy` shape (`{ field: $f, direction: $d }`) keep validating; the\nresolver defaults to `UPDATED_AT` / `DESC` when either field is omitted.\nNew callers should prefer `positionsConnection(orderBy: PositionOrder!)`,\nwhich is the canonical Relay surface.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "field",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "PositionOrderField",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "direction",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderDirection",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
         "name": "NestedBigIntFilter",
         "description": null,
         "fields": null,
@@ -14535,7 +14566,7 @@
                 "description": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "PositionOrder",
+                  "name": "LegacyPositionOrder",
                   "ofType": null
                 },
                 "defaultValue": null
@@ -15569,16 +15600,20 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "PositionOrder",
-        "description": "Order input for the Relay-shaped `positionsConnection`.\nBoth `field` and `direction` are nullable so external clients passing\nnullable `$orderDirection: OrderDirection` / `$orderBy: PositionOrderField`\nvariables continue to validate against this schema. Resolver defaults to\n`UPDATED_AT` / `DESC`.",
+        "description": "Order input for the Relay-shaped `positionsConnection`. Strict: both fields are\nrequired so canonical Relay clients self-document the sort they intend.",
         "fields": null,
         "inputFields": [
           {
             "name": "field",
             "description": null,
             "type": {
-              "kind": "ENUM",
-              "name": "PositionOrderField",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "PositionOrderField",
+                "ofType": null
+              }
             },
             "defaultValue": null
           },
@@ -15586,9 +15621,13 @@
             "name": "direction",
             "description": null,
             "type": {
-              "kind": "ENUM",
-              "name": "OrderDirection",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "OrderDirection",
+                "ofType": null
+              }
             },
             "defaultValue": null
           }

--- a/packages/api/test/contract/__snapshots__/schema.sdl.graphql
+++ b/packages/api/test/contract/__snapshots__/schema.sdl.graphql
@@ -86,7 +86,7 @@ type Account implements Node {
   predictions(first: Int = 50, after: String, filter: PredictionFilter, orderBy: PredictionOrder): PredictionConnection!
   trades(first: Int = 50, after: String, filter: TradeFilter, orderBy: TradeOrder): TradeConnection!
   forecasts(first: Int = 50, after: String, filter: ForecastFilter, orderBy: ForecastOrder): ForecastConnection!
-  positions(first: Int = 50, after: String, filter: PositionFilter, orderBy: PositionOrder): PositionConnection!
+  positions(first: Int = 50, after: String, filter: PositionFilter, orderBy: LegacyPositionOrder): PositionConnection!
   collateralBalance(chainId: Int!, atBlock: BigInt): CollateralBalance!
 }
 
@@ -1382,7 +1382,7 @@ type PickConfiguration implements Node {
   picks: [Pick!]!
   predictions(first: Int = 50, after: String, filter: PredictionFilter, orderBy: PredictionOrder): PredictionConnection!
   trades(first: Int = 50, after: String, filter: TradeFilter, orderBy: TradeOrder): TradeConnection!
-  positions(first: Int = 50, after: String, filter: PositionFilter, orderBy: PositionOrder): PositionConnection!
+  positions(first: Int = 50, after: String, filter: PositionFilter, orderBy: LegacyPositionOrder): PositionConnection!
   predictionId: String
   predictorToken: String
   resolved: Boolean!
@@ -1760,13 +1760,24 @@ enum TradeOrderField {
 }
 
 """
-Order input for the Relay-shaped `positionsConnection`.
-Both `field` and `direction` are nullable so external clients passing
-nullable `$orderDirection: OrderDirection` / `$orderBy: PositionOrderField`
-variables continue to validate against this schema. Resolver defaults to
-`UPDATED_AT` / `DESC`.
+Order input for the Relay-shaped `positionsConnection`. Strict: both fields are
+required so canonical Relay clients self-document the sort they intend.
 """
 input PositionOrder {
+  field: PositionOrderField!
+  direction: OrderDirection!
+}
+
+"""
+Order input for the non-Connection-suffix `Account.positions` /
+`PickConfiguration.positions` access paths. Both fields are nullable so
+pre-existing external queries that wire nullable variables into the
+`orderBy` shape (`{ field: $f, direction: $d }`) keep validating; the
+resolver defaults to `UPDATED_AT` / `DESC` when either field is omitted.
+New callers should prefer `positionsConnection(orderBy: PositionOrder!)`,
+which is the canonical Relay surface.
+"""
+input LegacyPositionOrder {
   field: PositionOrderField
   direction: OrderDirection
 }

--- a/packages/sdk/types/graphql.ts
+++ b/packages/sdk/types/graphql.ts
@@ -107,7 +107,7 @@ export type AccountPositionsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   filter?: InputMaybe<PositionFilter>;
   first?: InputMaybe<Scalars['Int']['input']>;
-  orderBy?: InputMaybe<PositionOrder>;
+  orderBy?: InputMaybe<LegacyPositionOrder>;
 };
 
 
@@ -1997,6 +1997,20 @@ export type LeaderboardMetric =
   | 'ROI'
   | 'VOLUME';
 
+/**
+ * Order input for the non-Connection-suffix `Account.positions` /
+ * `PickConfiguration.positions` access paths. Both fields are nullable so
+ * pre-existing external queries that wire nullable variables into the
+ * `orderBy` shape (`{ field: $f, direction: $d }`) keep validating; the
+ * resolver defaults to `UPDATED_AT` / `DESC` when either field is omitted.
+ * New callers should prefer `positionsConnection(orderBy: PositionOrder!)`,
+ * which is the canonical Relay surface.
+ */
+export type LegacyPositionOrder = {
+  direction?: InputMaybe<OrderDirection>;
+  field?: InputMaybe<PositionOrderField>;
+};
+
 export type NestedBigIntFilter = {
   equals?: InputMaybe<Scalars['BigInt']['input']>;
   gt?: InputMaybe<Scalars['BigInt']['input']>;
@@ -2252,7 +2266,7 @@ export type PickConfigurationPositionsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   filter?: InputMaybe<PositionFilter>;
   first?: InputMaybe<Scalars['Int']['input']>;
-  orderBy?: InputMaybe<PositionOrder>;
+  orderBy?: InputMaybe<LegacyPositionOrder>;
 };
 
 
@@ -2458,15 +2472,12 @@ export type PositionFilters = {
 };
 
 /**
- * Order input for the Relay-shaped `positionsConnection`.
- * Both `field` and `direction` are nullable so external clients passing
- * nullable `$orderDirection: OrderDirection` / `$orderBy: PositionOrderField`
- * variables continue to validate against this schema. Resolver defaults to
- * `UPDATED_AT` / `DESC`.
+ * Order input for the Relay-shaped `positionsConnection`. Strict: both fields are
+ * required so canonical Relay clients self-document the sort they intend.
  */
 export type PositionOrder = {
-  direction?: InputMaybe<OrderDirection>;
-  field?: InputMaybe<PositionOrderField>;
+  direction: OrderDirection;
+  field: PositionOrderField;
 };
 
 /** Sort fields for the Relay-shaped `positionsConnection`. */


### PR DESCRIPTION
## Summary

Follow-up to #1785 (now merged). That PR relaxed `PositionOrder.field` / `direction` to nullable so external consumers could keep using their existing queries. That worked, but it also weakened the canonical Relay surface (`Query.positionsConnection`) — Relay best practice is non-null sort field + direction so the intended ordering is self-documented in the schema.

Split into two input types:

| Input | Shape | Used by |
|---|---|---|
| `PositionOrder` | non-null `field` / `direction` | `Query.positionsConnection` (canonical Relay) |
| `LegacyPositionOrder` | nullable `field` / `direction` | `Account.positions`, `PickConfiguration.positions` (non-Connection-suffix parent fields) |

Resolver wiring is unchanged: parent.positions delegates to the same `positionsConnection` function via `(positionsConnection as any)`, which already handles null `orderBy?.field` / `orderBy?.direction` via optional chaining (defaults `UPDATED_AT` / `DESC`).

## Why this shape

- **External clients that hit `Account.positions`** (the variant flagged in Sentry as the urgent break) keep validating with their existing nullable-variable queries.
- **New Relay callers using `positionsConnection`** get the strict surface back. The schema encodes which sort was intended, no implicit defaults.
- **No runtime behavior change** — the legacy path defaults the same way the previous nullable shared input did.

## Test plan

- [x] `pnpm --filter @sapience/api run type-check` — clean
- [x] `pnpm --filter @sapience/api exec vitest run src/graphql` — 412 / 412 pass
- [x] `pnpm --filter @sapience/api exec vitest --config vitest.contract.config.ts --run` — 19 / 19 pass, snapshots refreshed
- [ ] Confirm Sentry validation errors stay quiet after deploy
- [ ] Manual GraphiQL: `positionsConnection(orderBy: { field: $f, direction: $d })` with `$f: PositionOrderField` (nullable) → fails validation pointing at `PositionOrderField!` (expected, this is the tightened canonical surface)
- [ ] Manual GraphiQL: `account(...) { positions(orderBy: { field: $f, direction: $d }) { ... } }` with both nullable → validates ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)