### PR TITLE
fix(api): revert input-position Address args back to String on pre-existing fields

### DIFF
--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -1990,13 +1990,16 @@ input ConditionFilter {
 
   """
   Deprecated alias for `resolverAddress`; kept during the rename window for older clients.
+  Typed as `String` (not `Address`) so existing queries passing nullable `$marketAddress: String`
+  variables continue to validate — the strict `Address` scalar lives on the canonical `resolverAddress`.
   """
-  marketAddress: Address @deprecated(reason: "Use `resolverAddress` — same resolver/oracle contract address, accurately named.")
+  marketAddress: String @deprecated(reason: "Use `resolverAddress` — same resolver/oracle contract address, accurately named.")
 
   """
   Deprecated alias for `resolverAddressIn`; kept during the rename window for older clients.
+  Typed as `[String!]` for the same back-compat reason as `marketAddress` above.
   """
-  marketAddressIn: [Address!] @deprecated(reason: "Use `resolverAddressIn` — same resolver/oracle contract addresses, accurately named.")
+  marketAddressIn: [String!] @deprecated(reason: "Use `resolverAddressIn` — same resolver/oracle contract addresses, accurately named.")
 
   """
   Visibility filter. Defaults to PUBLIC when omitted; ID filters bypass the default for direct lookups.
@@ -2108,13 +2111,16 @@ input QuestionFilter {
 
   """
   Deprecated alias for `resolverAddress`; kept during the rename window for older clients.
+  Typed as `String` (not `Address`) so existing queries passing nullable `$marketAddress: String`
+  variables continue to validate — the strict `Address` scalar lives on the canonical `resolverAddress`.
   """
-  marketAddress: Address @deprecated(reason: "Use `resolverAddress` — same resolver/oracle contract address, accurately named.")
+  marketAddress: String @deprecated(reason: "Use `resolverAddress` — same resolver/oracle contract address, accurately named.")
 
   """
   Deprecated alias for `resolverAddressIn`; kept during the rename window for older clients.
+  Typed as `[String!]` for the same back-compat reason as `marketAddress` above.
   """
-  marketAddressIn: [Address!] @deprecated(reason: "Use `resolverAddressIn` — same resolver/oracle contract addresses, accurately named.")
+  marketAddressIn: [String!] @deprecated(reason: "Use `resolverAddressIn` — same resolver/oracle contract addresses, accurately named.")
 
   """Restrict to questions whose category slug is in this set."""
   categorySlugs: [String!]
@@ -2671,18 +2677,26 @@ input TradeFilter {
 
   """
   Restrict to trades where the address is seller or buyer. Mutually exclusive with `seller`/`buyer`.
+  Typed as `String` (not `Address`) so existing queries passing nullable `String` variables
+  keep validating against the pre-existing input shape.
   """
-  address: Address
+  address: String
 
-  """Restrict to a single seller address."""
-  seller: Address
+  """
+  Restrict to a single seller address. Typed as `String` for back-compat — see `address` above.
+  """
+  seller: String
 
-  """Restrict to a single buyer address."""
-  buyer: Address
+  """
+  Restrict to a single buyer address. Typed as `String` for back-compat — see `address` above.
+  """
+  buyer: String
 
-  """Restrict to a single position token address."""
-  token: Address
-  tokens: [Address!]
+  """
+  Restrict to a single position token address. Typed as `String` for back-compat — see `address` above.
+  """
+  token: String
+  tokens: [String!]
 
   """Restrict to a single chain."""
   chainId: Int
@@ -2778,8 +2792,10 @@ input PredictionFilter {
 
   """
   Restrict to predictions where the address is predictor or counterparty.
+  Typed as `String` (not `Address`) so existing queries passing nullable `String` variables
+  keep validating against the pre-existing input shape.
   """
-  address: Address
+  address: String
 
   """Restrict to a single chain."""
   chainId: Int
@@ -3106,10 +3122,12 @@ type Query {
 
   """
   Look up a single account by canonical wallet address. Replacement for
-  `user(where:)` — accepts a flat `address: Address!` arg instead of the
-  Prisma-shaped `UserWhereUniqueInput`.
+  `user(where:)` — accepts a flat `address: String!` arg instead of the
+  Prisma-shaped `UserWhereUniqueInput`. The arg is typed as `String` (not
+  `Address`) so existing external queries passing `$wallet: String!`
+  variables continue to validate.
   """
-  account(address: Address!): Account
+  account(address: String!): Account
 
   """
   Relay-shaped connection over accounts (User-table rows). Single-address

--- a/packages/api/src/graphql/sdl/schema/schema.graphql
+++ b/packages/api/src/graphql/sdl/schema/schema.graphql
@@ -2245,13 +2245,16 @@ input ConditionFilter {
 
   """
   Deprecated alias for `resolverAddress`; kept during the rename window for older clients.
+  Typed as `String` (not `Address`) so existing queries passing nullable `$marketAddress: String`
+  variables continue to validate — the strict `Address` scalar lives on the canonical `resolverAddress`.
   """
-  marketAddress: Address @deprecated(reason: "Use `resolverAddress` — same resolver/oracle contract address, accurately named.")
+  marketAddress: String @deprecated(reason: "Use `resolverAddress` — same resolver/oracle contract address, accurately named.")
 
   """
   Deprecated alias for `resolverAddressIn`; kept during the rename window for older clients.
+  Typed as `[String!]` for the same back-compat reason as `marketAddress` above.
   """
-  marketAddressIn: [Address!] @deprecated(reason: "Use `resolverAddressIn` — same resolver/oracle contract addresses, accurately named.")
+  marketAddressIn: [String!] @deprecated(reason: "Use `resolverAddressIn` — same resolver/oracle contract addresses, accurately named.")
 
   """
   Visibility filter. Defaults to PUBLIC when omitted; ID filters bypass the default for direct lookups.
@@ -2397,13 +2400,16 @@ input QuestionFilter {
 
   """
   Deprecated alias for `resolverAddress`; kept during the rename window for older clients.
+  Typed as `String` (not `Address`) so existing queries passing nullable `$marketAddress: String`
+  variables continue to validate — the strict `Address` scalar lives on the canonical `resolverAddress`.
   """
-  marketAddress: Address @deprecated(reason: "Use `resolverAddress` — same resolver/oracle contract address, accurately named.")
+  marketAddress: String @deprecated(reason: "Use `resolverAddress` — same resolver/oracle contract address, accurately named.")
 
   """
   Deprecated alias for `resolverAddressIn`; kept during the rename window for older clients.
+  Typed as `[String!]` for the same back-compat reason as `marketAddress` above.
   """
-  marketAddressIn: [Address!] @deprecated(reason: "Use `resolverAddressIn` — same resolver/oracle contract addresses, accurately named.")
+  marketAddressIn: [String!] @deprecated(reason: "Use `resolverAddressIn` — same resolver/oracle contract addresses, accurately named.")
 
   """
   Restrict to questions whose category slug is in this set.
@@ -3059,21 +3065,23 @@ input TradeFilter {
   tradeHash: Bytes32
   """
   Restrict to trades where the address is seller or buyer. Mutually exclusive with `seller`/`buyer`.
+  Typed as `String` (not `Address`) so existing queries passing nullable `String` variables
+  keep validating against the pre-existing input shape.
   """
-  address: Address
+  address: String
   """
-  Restrict to a single seller address.
+  Restrict to a single seller address. Typed as `String` for back-compat — see `address` above.
   """
-  seller: Address
+  seller: String
   """
-  Restrict to a single buyer address.
+  Restrict to a single buyer address. Typed as `String` for back-compat — see `address` above.
   """
-  buyer: Address
+  buyer: String
   """
-  Restrict to a single position token address.
+  Restrict to a single position token address. Typed as `String` for back-compat — see `address` above.
   """
-  token: Address
-  tokens: [Address!]
+  token: String
+  tokens: [String!]
   """
   Restrict to a single chain.
   """
@@ -3173,8 +3181,10 @@ input PredictionFilter {
   predictionId: String
   """
   Restrict to predictions where the address is predictor or counterparty.
+  Typed as `String` (not `Address`) so existing queries passing nullable `String` variables
+  keep validating against the pre-existing input shape.
   """
-  address: Address
+  address: String
   """
   Restrict to a single chain.
   """
@@ -3699,10 +3709,12 @@ type Query {
   ): CollateralTransferConnection!
   """
   Look up a single account by canonical wallet address. Replacement for
-  `user(where:)` — accepts a flat `address: Address!` arg instead of the
-  Prisma-shaped `UserWhereUniqueInput`.
+  `user(where:)` — accepts a flat `address: String!` arg instead of the
+  Prisma-shaped `UserWhereUniqueInput`. The arg is typed as `String` (not
+  `Address`) so existing external queries passing `$wallet: String!`
+  variables continue to validate.
   """
-  account(address: Address!): Account
+  account(address: String!): Account
 
   """
   Relay-shaped connection over accounts (User-table rows). Single-address

--- a/packages/api/test/contract/__snapshots__/introspection.json
+++ b/packages/api/test/contract/__snapshots__/introspection.json
@@ -16369,10 +16369,10 @@
           },
           {
             "name": "address",
-            "description": "Restrict to predictions where the address is predictor or counterparty.",
+            "description": "Restrict to predictions where the address is predictor or counterparty.\nTyped as `String` (not `Address`) so existing queries passing nullable `String` variables\nkeep validating against the pre-existing input shape.",
             "type": {
               "kind": "SCALAR",
-              "name": "Address",
+              "name": "String",
               "ofType": null
             },
             "defaultValue": null
@@ -18993,7 +18993,7 @@
           },
           {
             "name": "account",
-            "description": "Look up a single account by canonical wallet address. Replacement for\n`user(where:)` — accepts a flat `address: Address!` arg instead of the\nPrisma-shaped `UserWhereUniqueInput`.",
+            "description": "Look up a single account by canonical wallet address. Replacement for\n`user(where:)` — accepts a flat `address: String!` arg instead of the\nPrisma-shaped `UserWhereUniqueInput`. The arg is typed as `String` (not\n`Address`) so existing external queries passing `$wallet: String!`\nvariables continue to validate.",
             "args": [
               {
                 "name": "address",
@@ -19003,7 +19003,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "SCALAR",
-                    "name": "Address",
+                    "name": "String",
                     "ofType": null
                   }
                 },
@@ -23606,40 +23606,40 @@
           },
           {
             "name": "address",
-            "description": "Restrict to trades where the address is seller or buyer. Mutually exclusive with `seller`/`buyer`.",
+            "description": "Restrict to trades where the address is seller or buyer. Mutually exclusive with `seller`/`buyer`.\nTyped as `String` (not `Address`) so existing queries passing nullable `String` variables\nkeep validating against the pre-existing input shape.",
             "type": {
               "kind": "SCALAR",
-              "name": "Address",
+              "name": "String",
               "ofType": null
             },
             "defaultValue": null
           },
           {
             "name": "seller",
-            "description": "Restrict to a single seller address.",
+            "description": "Restrict to a single seller address. Typed as `String` for back-compat — see `address` above.",
             "type": {
               "kind": "SCALAR",
-              "name": "Address",
+              "name": "String",
               "ofType": null
             },
             "defaultValue": null
           },
           {
             "name": "buyer",
-            "description": "Restrict to a single buyer address.",
+            "description": "Restrict to a single buyer address. Typed as `String` for back-compat — see `address` above.",
             "type": {
               "kind": "SCALAR",
-              "name": "Address",
+              "name": "String",
               "ofType": null
             },
             "defaultValue": null
           },
           {
             "name": "token",
-            "description": "Restrict to a single position token address.",
+            "description": "Restrict to a single position token address. Typed as `String` for back-compat — see `address` above.",
             "type": {
               "kind": "SCALAR",
-              "name": "Address",
+              "name": "String",
               "ofType": null
             },
             "defaultValue": null
@@ -23655,7 +23655,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Address",
+                  "name": "String",
                   "ofType": null
                 }
               }

--- a/packages/api/test/contract/__snapshots__/schema.sdl.graphql
+++ b/packages/api/test/contract/__snapshots__/schema.sdl.graphql
@@ -1990,13 +1990,16 @@ input ConditionFilter {
 
   """
   Deprecated alias for `resolverAddress`; kept during the rename window for older clients.
+  Typed as `String` (not `Address`) so existing queries passing nullable `$marketAddress: String`
+  variables continue to validate — the strict `Address` scalar lives on the canonical `resolverAddress`.
   """
-  marketAddress: Address @deprecated(reason: "Use `resolverAddress` — same resolver/oracle contract address, accurately named.")
+  marketAddress: String @deprecated(reason: "Use `resolverAddress` — same resolver/oracle contract address, accurately named.")
 
   """
   Deprecated alias for `resolverAddressIn`; kept during the rename window for older clients.
+  Typed as `[String!]` for the same back-compat reason as `marketAddress` above.
   """
-  marketAddressIn: [Address!] @deprecated(reason: "Use `resolverAddressIn` — same resolver/oracle contract addresses, accurately named.")
+  marketAddressIn: [String!] @deprecated(reason: "Use `resolverAddressIn` — same resolver/oracle contract addresses, accurately named.")
 
   """
   Visibility filter. Defaults to PUBLIC when omitted; ID filters bypass the default for direct lookups.
@@ -2108,13 +2111,16 @@ input QuestionFilter {
 
   """
   Deprecated alias for `resolverAddress`; kept during the rename window for older clients.
+  Typed as `String` (not `Address`) so existing queries passing nullable `$marketAddress: String`
+  variables continue to validate — the strict `Address` scalar lives on the canonical `resolverAddress`.
   """
-  marketAddress: Address @deprecated(reason: "Use `resolverAddress` — same resolver/oracle contract address, accurately named.")
+  marketAddress: String @deprecated(reason: "Use `resolverAddress` — same resolver/oracle contract address, accurately named.")
 
   """
   Deprecated alias for `resolverAddressIn`; kept during the rename window for older clients.
+  Typed as `[String!]` for the same back-compat reason as `marketAddress` above.
   """
-  marketAddressIn: [Address!] @deprecated(reason: "Use `resolverAddressIn` — same resolver/oracle contract addresses, accurately named.")
+  marketAddressIn: [String!] @deprecated(reason: "Use `resolverAddressIn` — same resolver/oracle contract addresses, accurately named.")
 
   """Restrict to questions whose category slug is in this set."""
   categorySlugs: [String!]
@@ -2671,18 +2677,26 @@ input TradeFilter {
 
   """
   Restrict to trades where the address is seller or buyer. Mutually exclusive with `seller`/`buyer`.
+  Typed as `String` (not `Address`) so existing queries passing nullable `String` variables
+  keep validating against the pre-existing input shape.
   """
-  address: Address
+  address: String
 
-  """Restrict to a single seller address."""
-  seller: Address
+  """
+  Restrict to a single seller address. Typed as `String` for back-compat — see `address` above.
+  """
+  seller: String
 
-  """Restrict to a single buyer address."""
-  buyer: Address
+  """
+  Restrict to a single buyer address. Typed as `String` for back-compat — see `address` above.
+  """
+  buyer: String
 
-  """Restrict to a single position token address."""
-  token: Address
-  tokens: [Address!]
+  """
+  Restrict to a single position token address. Typed as `String` for back-compat — see `address` above.
+  """
+  token: String
+  tokens: [String!]
 
   """Restrict to a single chain."""
   chainId: Int
@@ -2778,8 +2792,10 @@ input PredictionFilter {
 
   """
   Restrict to predictions where the address is predictor or counterparty.
+  Typed as `String` (not `Address`) so existing queries passing nullable `String` variables
+  keep validating against the pre-existing input shape.
   """
-  address: Address
+  address: String
 
   """Restrict to a single chain."""
   chainId: Int
@@ -3106,10 +3122,12 @@ type Query {
 
   """
   Look up a single account by canonical wallet address. Replacement for
-  `user(where:)` — accepts a flat `address: Address!` arg instead of the
-  Prisma-shaped `UserWhereUniqueInput`.
+  `user(where:)` — accepts a flat `address: String!` arg instead of the
+  Prisma-shaped `UserWhereUniqueInput`. The arg is typed as `String` (not
+  `Address`) so existing external queries passing `$wallet: String!`
+  variables continue to validate.
   """
-  account(address: Address!): Account
+  account(address: String!): Account
 
   """
   Relay-shaped connection over accounts (User-table rows). Single-address

--- a/packages/sdk/types/graphql.ts
+++ b/packages/sdk/types/graphql.ts
@@ -1037,14 +1037,17 @@ export type ConditionFilter = {
   ids?: InputMaybe<Array<Scalars['ID']['input']>>;
   /**
    * Deprecated alias for `resolverAddress`; kept during the rename window for older clients.
+   * Typed as `String` (not `Address`) so existing queries passing nullable `$marketAddress: String`
+   * variables continue to validate — the strict `Address` scalar lives on the canonical `resolverAddress`.
    * @deprecated Use `resolverAddress` — same resolver/oracle contract address, accurately named.
    */
-  marketAddress?: InputMaybe<Scalars['Address']['input']>;
+  marketAddress?: InputMaybe<Scalars['String']['input']>;
   /**
    * Deprecated alias for `resolverAddressIn`; kept during the rename window for older clients.
+   * Typed as `[String!]` for the same back-compat reason as `marketAddress` above.
    * @deprecated Use `resolverAddressIn` — same resolver/oracle contract addresses, accurately named.
    */
-  marketAddressIn?: InputMaybe<Array<Scalars['Address']['input']>>;
+  marketAddressIn?: InputMaybe<Array<Scalars['String']['input']>>;
   /**
    * Filter by resolution state. `{ isNull: true }` selects unsettled
    * conditions; `{ isNull: false }` selects settled (any outcome);
@@ -2579,8 +2582,12 @@ export type PredictionEdge = {
  * values combine with AND.
  */
 export type PredictionFilter = {
-  /** Restrict to predictions where the address is predictor or counterparty. */
-  address?: InputMaybe<Scalars['Address']['input']>;
+  /**
+   * Restrict to predictions where the address is predictor or counterparty.
+   * Typed as `String` (not `Address`) so existing queries passing nullable `String` variables
+   * keep validating against the pre-existing input shape.
+   */
+  address?: InputMaybe<Scalars['String']['input']>;
   /** Restrict to a single chain. */
   chainId?: InputMaybe<Scalars['Int']['input']>;
   /** Restrict to predictions on a single condition (via the pickConfig join). */
@@ -2740,8 +2747,10 @@ export type Query = {
   __typename?: 'Query';
   /**
    * Look up a single account by canonical wallet address. Replacement for
-   * `user(where:)` — accepts a flat `address: Address!` arg instead of the
-   * Prisma-shaped `UserWhereUniqueInput`.
+   * `user(where:)` — accepts a flat `address: String!` arg instead of the
+   * Prisma-shaped `UserWhereUniqueInput`. The arg is typed as `String` (not
+   * `Address`) so existing external queries passing `$wallet: String!`
+   * variables continue to validate.
    */
   account?: Maybe<Account>;
   /**
@@ -3153,7 +3162,7 @@ export type Query = {
 
 
 export type QueryAccountArgs = {
-  address: Scalars['Address']['input'];
+  address: Scalars['String']['input'];
 };
 
 
@@ -3792,14 +3801,17 @@ export type QuestionFilter = {
   estimatedPrice?: InputMaybe<FloatFilter>;
   /**
    * Deprecated alias for `resolverAddress`; kept during the rename window for older clients.
+   * Typed as `String` (not `Address`) so existing queries passing nullable `$marketAddress: String`
+   * variables continue to validate — the strict `Address` scalar lives on the canonical `resolverAddress`.
    * @deprecated Use `resolverAddress` — same resolver/oracle contract address, accurately named.
    */
-  marketAddress?: InputMaybe<Scalars['Address']['input']>;
+  marketAddress?: InputMaybe<Scalars['String']['input']>;
   /**
    * Deprecated alias for `resolverAddressIn`; kept during the rename window for older clients.
+   * Typed as `[String!]` for the same back-compat reason as `marketAddress` above.
    * @deprecated Use `resolverAddressIn` — same resolver/oracle contract addresses, accurately named.
    */
-  marketAddressIn?: InputMaybe<Array<Scalars['Address']['input']>>;
+  marketAddressIn?: InputMaybe<Array<Scalars['String']['input']>>;
   /** Resolution-status filter; defaults to all when omitted. */
   resolutionStatus?: InputMaybe<ResolutionStatus>;
   /**
@@ -4114,19 +4126,23 @@ export type TradeEdge = {
 
 /** Filter input for the Relay-shaped `tradesConnection` query. Combines with AND. */
 export type TradeFilter = {
-  /** Restrict to trades where the address is seller or buyer. Mutually exclusive with `seller`/`buyer`. */
-  address?: InputMaybe<Scalars['Address']['input']>;
-  /** Restrict to a single buyer address. */
-  buyer?: InputMaybe<Scalars['Address']['input']>;
+  /**
+   * Restrict to trades where the address is seller or buyer. Mutually exclusive with `seller`/`buyer`.
+   * Typed as `String` (not `Address`) so existing queries passing nullable `String` variables
+   * keep validating against the pre-existing input shape.
+   */
+  address?: InputMaybe<Scalars['String']['input']>;
+  /** Restrict to a single buyer address. Typed as `String` for back-compat — see `address` above. */
+  buyer?: InputMaybe<Scalars['String']['input']>;
   /** Restrict to a single chain. */
   chainId?: InputMaybe<Scalars['Int']['input']>;
   /** Filter by execution epoch seconds, e.g. `{ gte: 1770000000, lt: 1770086400 }`. */
   executedAt?: InputMaybe<IntFilter>;
-  /** Restrict to a single seller address. */
-  seller?: InputMaybe<Scalars['Address']['input']>;
-  /** Restrict to a single position token address. */
-  token?: InputMaybe<Scalars['Address']['input']>;
-  tokens?: InputMaybe<Array<Scalars['Address']['input']>>;
+  /** Restrict to a single seller address. Typed as `String` for back-compat — see `address` above. */
+  seller?: InputMaybe<Scalars['String']['input']>;
+  /** Restrict to a single position token address. Typed as `String` for back-compat — see `address` above. */
+  token?: InputMaybe<Scalars['String']['input']>;
+  tokens?: InputMaybe<Array<Scalars['String']['input']>>;
   /**
    * Restrict to a single trade by execution hash. Supports the
    * by-hash single-record lookup pattern — `tradesConnection(filter: { tradeHash: $h }).nodes[0]`


### PR DESCRIPTION
## Summary

#1776 tightened a handful of pre-existing field args and filter-input fields from `String` to `Address`. The wire format is identical, but GraphQL validates variable types **nominally** (per `IsVariableUsageAllowed` in the spec) — `$wallet: String!` is rejected against an arg expecting `Address!` even though both serialize as a JSON string. External consumers started hitting Sentry errors like:

> `Variable "$wallet" of type "String!" used in position expecting type "Address!"`

## Changes

Revert just the **input/arg positions** on fields that existed before #1776:

- `Query.account(address: Address! → String!)`
- `ConditionFilter.marketAddress` / `marketAddressIn` (deprecated aliases) → `String` / `[String!]`
- `QuestionFilter.marketAddress` / `marketAddressIn` (deprecated aliases) → `String` / `[String!]`
- `TradeFilter.address` / `seller` / `buyer` / `token` / `tokens` → `String` / `[String!]`
- `PredictionFilter.address` → `String`

## What stays `Address`

- **Newly introduced inputs** (`resolverAddress`, `resolverAddressIn`) keep `Address` — nobody could have been passing `String` variables into a field name that did not exist before #1776, so there is no back-compat to preserve.
- **Output fields** (`Condition.resolverAddress`, `Burn.holder`, `Pick.conditionResolverAddress`, etc.) keep `Address` since output return types do not trigger variable-validation errors.

## Test plan

- [x] `pnpm --filter @sapience/api run type-check` — clean
- [x] `pnpm --filter @sapience/api exec vitest run src/graphql` — 412 / 412 pass
- [x] `pnpm --filter @sapience/api exec vitest --config vitest.contract.config.ts --run` — 19 / 19 pass, snapshots refreshed
- [ ] Confirm Sentry `Variable "..." of type "String!" used in position expecting type "Address!"` errors stop after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)