### PR TITLE
ci: deepen checkout so paths-filter can diff without fetching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
       - uses: dorny/paths-filter@v3
         id: filter
         with:


### PR DESCRIPTION
## Summary
- On push to `main`, `dorny/paths-filter@v3` needs the previous commit to compute its diff. With the default shallow checkout (depth 1) it has to `git fetch` that commit, and the fetch intermittently fails with `fatal: could not read Username for 'https://github.com'`, taking the whole `changes` job (and therefore all of CI) down with it.
- Most recent occurrence: run [26334396564](https://github.com/sapiencexyz/sapience/actions/runs/26334396564) on commit 3ba0b49a9 — same commit had passed CI as PR #1788 because the `pull_request` event uses the PR base ref instead of a follow-up fetch.
- Setting `fetch-depth: 2` keeps the parent locally so `paths-filter` never needs to make a network call.

## Test plan
- [ ] CI passes on this PR
- [ ] Once merged, the next push to `main` exercises the same `paths-filter` step without the credential error

🤖 Generated with [Claude Code](https://claude.com/claude-code)