### PR TITLE
fix(api): Query.vault(id:) returns null for malformed global ids

### DIFF
--- a/packages/api/src/graphql/sdl/resolvers/queries/analytics.test.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/analytics.test.ts
@@ -31,7 +31,7 @@ vi.mock('../../../../lib/utils', () => ({
   getProviderForChain: vi.fn(),
 }));
 
-const { protocolStats, vaultStats } = await import('./analytics');
+const { protocolStats, vaultStats, vault } = await import('./analytics');
 
 type StatsArgs = {
   fromEpoch?: number | null;
@@ -172,6 +172,22 @@ describe('Query.vaultStats', () => {
     expect(result[1].periodPnL).toBe('-80');
     // Live candle: realizedPnL(-970) + unredeemed(988) + sold(7) - bought(5) = 20
     expect(result[2].cumulativePnL).toBe('20');
+  });
+});
+
+describe('Query.vault(id:) — malformed id tolerance', () => {
+  // Consumers occasionally pass a raw EVM address (e.g. the zero address)
+  // where an opaque Relay id is expected. The resolver should treat that as
+  // "not found" rather than throw — a throw becomes a logged GraphQL error
+  // even though the right semantic is null.
+  it('returns null for a malformed global id instead of throwing', async () => {
+    const vaultFn = vault as unknown as (
+      parent: unknown,
+      args: { id: string }
+    ) => Promise<unknown>;
+    await expect(
+      vaultFn({}, { id: '0x0000000000000000000000000000000000000000' })
+    ).resolves.toBeNull();
   });
 });
 

--- a/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
@@ -12,9 +12,9 @@ import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
 import { normalizeLegacyEntry } from '@sapience/sdk/contracts';
 import { collateralToken } from '@sapience/sdk/contracts/addresses';
 import {
-  fromGlobalId,
   registerNodeType,
   toGlobalId,
+  tryFromGlobalId,
 } from '../../../relay/globalId';
 import { synthesizeAccount } from '../accountSynthesis';
 import { decodeCursor, encodeCursor } from '../../../relay/cursor';
@@ -769,7 +769,9 @@ const findVaultByAddress = (chainId: number, address: string) => {
 };
 
 export const vault = (async (_parent: unknown, { id }: { id: string }) => {
-  const parsed = parseVaultDomainId(fromGlobalId(id).id);
+  const decoded = tryFromGlobalId(id);
+  if (!decoded) return null;
+  const parsed = parseVaultDomainId(decoded.id);
   if (!parsed) return null;
   return findVaultByAddress(parsed.chainId, parsed.address);
 }) as unknown as NonNullable<QueryResolvers['vault']>;


### PR DESCRIPTION
## Summary

- `Query.vault(id:)` called `fromGlobalId` directly, which throws `InvalidGlobalIdError` on inputs that don't round-trip through base64url (e.g. a raw EVM address).
- Switch to `tryFromGlobalId` so the resolver matches the already-tolerant `Query.node(id:)` path and returns `null` instead of surfacing a logged GraphQL error.
- Adds a regression test that reproduces the Sentry `malformed global id payload: 0x0000…0000` error before the fix.

## Sentry

Resolves:
> `GraphQLError: malformed global id payload: 0x0000000000000000000000000000000000000000 (decoded: �4�M4�M4�M4�M4�M4�M4�M4�M4�M4�)`

## Test plan

- [x] `pnpm --filter @sapience/api exec vitest --run src/graphql/sdl/resolvers/queries/analytics.test.ts`
- [x] type-check passes
- [ ] CI green