### PR TITLE
fix(sdk): make forecast order variables non-null

### DIFF
--- a/packages/sdk/queries/__tests__/forecasts.test.ts
+++ b/packages/sdk/queries/__tests__/forecasts.test.ts
@@ -289,6 +289,8 @@ describe('fetchUserForecasts', () => {
     });
 
     const call = mockGraphqlRequest.mock.calls[0];
+    expect(call[0]).toContain('$orderBy: ForecastOrderField!');
+    expect(call[0]).toContain('$orderDirection: OrderDirection!');
     expect(call[1].orderBy).toBe('ATTESTED_AT');
     expect(call[1].orderDirection).toBe('ASC');
     expect(call[1].take).toBe(10);

--- a/packages/sdk/queries/forecasts.ts
+++ b/packages/sdk/queries/forecasts.ts
@@ -191,8 +191,8 @@ const USER_FORECASTS_QUERY = /* GraphQL */ `
     $filters: ForecastFilter
     $take: Int!
     $after: String
-    $orderBy: ForecastOrderField
-    $orderDirection: OrderDirection
+    $orderBy: ForecastOrderField!
+    $orderDirection: OrderDirection!
   ) {
     forecastsConnection(
       filter: $filters


### PR DESCRIPTION
## Why

The user forecasts SDK query declared forecast ordering variables as nullable while passing them into a non-null connection order input. GraphQL rejects that document before execution.

## What

- Declare `ForecastOrderField!` and `OrderDirection!` in the SDK user forecasts operation
- Add test coverage that the emitted query uses non-null order variables

## Verification

- Replayed the old nullable operation against live staging/prod APIs: validation failed
- Replayed the non-null operation with existing uppercase enum variables against live staging/prod APIs: succeeded
- `pnpm --filter @sapience/sdk exec vitest run queries/__tests__/forecasts.test.ts --pool=threads --poolOptions.threads.singleThread`
- `git diff --check HEAD~1..HEAD`