### PR TITLE
ui(app): collapse Custom date range into a calendar-icon tab

### DIFF
--- a/packages/app/src/components/shared/TimeRangeFilter.tsx
+++ b/packages/app/src/components/shared/TimeRangeFilter.tsx
@@ -8,9 +8,10 @@ import {
 } from '@sapience/ui/components/ui/popover';
 import { Tabs, TabsTrigger } from '@sapience/ui/components/ui/tabs';
 import { cn } from '@sapience/ui/lib/utils';
-import { format } from 'date-fns';
 import { CalendarDays } from 'lucide-react';
 import { useState } from 'react';
+
+type DateRange = { from: Date | undefined; to?: Date };
 
 import { presetRange, type FixedPreset, type TimeRange } from './timeRange';
 import SegmentedTabsList from '~/components/shared/SegmentedTabsList';
@@ -18,12 +19,6 @@ import SegmentedTabsList from '~/components/shared/SegmentedTabsList';
 export * from './timeRange';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-
-function customLabel(range: TimeRange): string {
-  if (range.preset !== 'CUSTOM' || !range.from) return 'Custom';
-  const to = range.to ?? new Date();
-  return `${format(range.from, 'MMM d')} – ${format(to, 'MMM d')}`;
-}
 
 interface Props {
   value: TimeRange;
@@ -33,57 +28,66 @@ interface Props {
 
 export default function TimeRangeFilter({ value, onChange, className }: Props) {
   const [open, setOpen] = useState(false);
+  const [pending, setPending] = useState<DateRange | undefined>();
   const isCustom = value.preset === 'CUSTOM';
 
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (next) {
+      setPending(value.from ? { from: value.from, to: value.to } : undefined);
+    }
+  };
+
   return (
-    <div className={cn('flex items-center gap-1.5', className)}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <Tabs
         value={isCustom ? '' : value.preset}
         onValueChange={(v) => {
           if (v) onChange(presetRange(v as FixedPreset));
         }}
+        className={className}
       >
         <SegmentedTabsList triggerClassName="text-xs px-2 h-7">
           <TabsTrigger value="1W">1W</TabsTrigger>
           <TabsTrigger value="1M">1M</TabsTrigger>
           <TabsTrigger value="3M">3M</TabsTrigger>
           <TabsTrigger value="ALL">ALL</TabsTrigger>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              aria-label="Custom date range"
+              title="Custom range"
+              className={cn(
+                'inline-flex items-center justify-center transition-colors',
+                isCustom
+                  ? 'bg-[var(--seg-active)] text-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              <CalendarDays className="w-3 h-3" />
+            </button>
+          </PopoverTrigger>
         </SegmentedTabsList>
       </Tabs>
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>
-          <button
-            type="button"
-            className={cn(
-              'inline-flex items-center gap-1 rounded-md border px-2 h-7 text-xs transition-colors',
-              isCustom
-                ? 'border-brand-white/30 text-foreground'
-                : 'border-brand-white/10 text-muted-foreground hover:text-foreground'
-            )}
-          >
-            <CalendarDays className="w-3 h-3" />
-            {customLabel(value)}
-          </button>
-        </PopoverTrigger>
-        <PopoverContent className="w-auto p-0" align="end">
-          <Calendar
-            mode="range"
-            numberOfMonths={2}
-            defaultMonth={value.from ?? new Date(Date.now() - 30 * DAY_MS)}
-            selected={{ from: value.from, to: value.to }}
-            onSelect={(r) => {
-              // Only commit once both ends are picked, so a click-then-click
-              // selection fires a single state change (and a single network
-              // request downstream) instead of two.
-              if (r?.from && r.to) {
-                onChange({ preset: 'CUSTOM', from: r.from, to: r.to });
-                setOpen(false);
-              }
-            }}
-            disabled={{ after: new Date() }}
-          />
-        </PopoverContent>
-      </Popover>
-    </div>
+      <PopoverContent className="w-auto p-0" align="end">
+        <Calendar
+          mode="range"
+          numberOfMonths={2}
+          defaultMonth={value.from ?? new Date(Date.now() - 30 * DAY_MS)}
+          selected={pending}
+          onSelect={(r) => {
+            // react-day-picker's range mode returns {from: date, to: date}
+            // on the first click (same date on both ends). Only commit and
+            // close once the user picks a real second endpoint.
+            setPending(r);
+            if (r?.from && r.to && r.from.getTime() !== r.to.getTime()) {
+              onChange({ preset: 'CUSTOM', from: r.from, to: r.to });
+              setOpen(false);
+            }
+          }}
+          disabled={{ after: new Date() }}
+        />
+      </PopoverContent>
+    </Popover>
   );
 }


### PR DESCRIPTION
## Summary
- Move the **Custom** date-range option into the same segmented tab group as `1W` / `1M` / `3M` / `ALL`, rendered as a calendar-icon-only tab. Previously it was a separate bordered \"Custom\" pill-button to the right of the group.
- When a custom range is active, the icon tab gets the same active-tab background as the other tabs (via the shared `--seg-active` token), so the control reads consistently.
- Fix two long-standing UX issues with the range-pick popover that surfaced while wiring up the new tab:
  - **First click no longer closes the popover.** react-day-picker v9's range mode returns `{ from: date, to: date }` on the initial click (same date on both endpoints, when `min=0` — the default). The old `r.from && r.to` close condition therefore fired immediately. Now we only commit + close once `from` and `to` are different days.
  - **First click visibly highlights immediately.** Pending selection is now tracked in local state inside `TimeRangeFilter` and seeded from `value` whenever the popover opens, so the Calendar shows the in-progress range without needing the parent state to update first.
- No callsite changes: `TimeRangeFilter` keeps the same `{ value, onChange, className }` props. Consumers in `AnalyticsPageContent`, `AccountsLeaderboardCard`, and `VaultPnlChart` are unaffected.

Caveat worth flagging: with this logic you can no longer pick a same-day range (clicking the same date twice toggles selection off per day-picker's semantics rather than committing). That seems fine for the kind of windowed filtering this control drives, but easy to revisit if needed.

## Test plan
- [ ] `pnpm --filter app run type-check` passes
- [ ] On `/analytics`, the four preset tabs + calendar-icon tab render in a single segmented group
- [ ] Clicking the calendar tab opens the popover; clicking one date keeps the popover open and highlights the date
- [ ] Clicking a second (different) date commits the range and closes the popover
- [ ] When a custom range is active, the calendar-icon tab shows the active background; switching back to a preset clears it
- [ ] Same checks on `/vaults` (VaultPnlChart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)