### PR TITLE
fix(graphql): restore order input compatibility

### DIFF
--- a/packages/api/codegen-resolvers.ts
+++ b/packages/api/codegen-resolvers.ts
@@ -84,10 +84,10 @@ const config: CodegenConfig = {
         // values for the canonical members so existing resolver
         // references like `SortOrder.Asc` keep compiling.
         enumValues: {
-          PredictionSortField:
-            '../enumOverrides#PredictionSortField',
+          PredictionSortField: '../enumOverrides#PredictionSortField',
           PositionSortField: '../enumOverrides#PositionSortField',
           SortOrder: '../enumOverrides#SortOrder',
+          OrderDirection: '../enumOverrides#OrderDirection',
         },
         // Let `makeExecutableSchema` do the typename work at runtime
         // via prisma-model mappers; we don't need __resolveType here

--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -1759,10 +1759,7 @@ enum TradeOrderField {
   BLOCK_NUMBER
 }
 
-"""
-Order input for the Relay-shaped `positionsConnection`. Strict: both fields are
-required so canonical Relay clients self-document the sort they intend.
-"""
+"""Order input for the Relay-shaped `positionsConnection`."""
 input PositionOrder {
   field: PositionOrderField!
   direction: OrderDirection!
@@ -2356,6 +2353,8 @@ Sort order shared across every `orderBy` input on the redesigned surface.
 enum OrderDirection {
   ASC
   DESC
+  asc
+  desc
 }
 
 """

--- a/packages/api/src/graphql/sdl/enumOverrides.ts
+++ b/packages/api/src/graphql/sdl/enumOverrides.ts
@@ -31,3 +31,10 @@ export enum SortOrder {
   AscLegacy = 'ASC',
   DescLegacy = 'DESC',
 }
+
+export enum OrderDirection {
+  Asc = 'ASC',
+  Desc = 'DESC',
+  AscLegacy = 'asc',
+  DescLegacy = 'desc',
+}

--- a/packages/api/src/graphql/sdl/resolvers/queries/collateralBalance.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/collateralBalance.ts
@@ -332,7 +332,8 @@ export const collateralTransfersConnection = (async (
   });
   const cursor = args.after ? decodeCursor(args.after) : null;
   const baseWhere = buildConnectionWhere(args.filter);
-  const direction = args.orderBy?.direction === 'ASC' ? 'asc' : 'desc';
+  const direction =
+    String(args.orderBy?.direction).toLowerCase() === 'asc' ? 'asc' : 'desc';
   const cursorWhere = cursor
     ? buildTransferCursorPredicate(cursor.k, cursor.id, direction)
     : null;

--- a/packages/api/src/graphql/sdl/resolvers/queries/conditionGroups.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/conditionGroups.ts
@@ -153,7 +153,7 @@ export const conditionGroupsConnection: NonNullable<
   const orderField: ConditionGroupOrderField =
     orderBy?.field ?? ConditionGroupOrderField.CreatedAt;
   const direction: OrderDirection = orderBy?.direction ?? OrderDirection.Desc;
-  const prismaDir = direction === OrderDirection.Asc ? 'asc' : 'desc';
+  const prismaDir = String(direction).toLowerCase() === 'asc' ? 'asc' : 'desc';
   const prismaOrderField = CONNECTION_ORDER_FIELD_MAP[orderField];
 
   const filterWhere = buildConditionGroupsConnectionWhere(filter);

--- a/packages/api/src/graphql/sdl/resolvers/queries/conditions.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/conditions.ts
@@ -346,7 +346,7 @@ export const conditionsConnection: NonNullable<
   const orderField: ConditionOrderField =
     orderBy?.field ?? ConditionOrderField.CreatedAt;
   const direction: OrderDirection = orderBy?.direction ?? OrderDirection.Desc;
-  const prismaDir = direction === OrderDirection.Asc ? 'asc' : 'desc';
+  const prismaDir = String(direction).toLowerCase() === 'asc' ? 'asc' : 'desc';
   const prismaOrderField = CONNECTION_ORDER_FIELD_MAP[orderField];
 
   const filterWhere = buildConditionsConnectionWhere(filter);

--- a/packages/api/src/graphql/sdl/resolvers/queries/crud.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/crud.ts
@@ -192,7 +192,7 @@ export const accountsConnection = (async (
 ) => {
   const cappedFirst = clampTake(first ?? 50, { defaultTake: 50, maxTake: 100 });
   const direction: 'asc' | 'desc' =
-    orderBy?.direction === 'ASC' ? 'asc' : 'desc';
+    String(orderBy?.direction).toLowerCase() === 'asc' ? 'asc' : 'desc';
   const search = (filter?.search as string | null | undefined)?.trim();
   const baseWhere: Prisma.UserWhereInput = search
     ? { address: { contains: search.toLowerCase(), mode: 'insensitive' } }
@@ -311,7 +311,7 @@ export const forecastsConnection: NonNullable<
 
   const orderField = orderBy?.field ?? ForecastOrderField.AttestedAt;
   const direction = orderBy?.direction ?? OrderDirection.Desc;
-  const prismaDir = direction === OrderDirection.Asc ? 'asc' : 'desc';
+  const prismaDir = String(direction).toLowerCase() === 'asc' ? 'asc' : 'desc';
   const prismaOrderField =
     orderField === ForecastOrderField.CreatedAt ? 'createdAt' : 'time';
   const cursorPayload = after ? decodeCursor(after) : null;

--- a/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
@@ -328,7 +328,7 @@ export const predictionsConnection: NonNullable<
 ) => {
   const cappedFirst = clampTake(first ?? 50, { defaultTake: 50, maxTake: 100 });
   const direction = orderBy?.direction ?? OrderDirection.Desc;
-  const prismaDir = direction === OrderDirection.Asc ? 'asc' : 'desc';
+  const prismaDir = String(direction).toLowerCase() === 'asc' ? 'asc' : 'desc';
 
   const { where: filterWhere, empty } = await buildPredictionWhere({
     predictionId:
@@ -548,7 +548,7 @@ const mergePickConfigurationFilters = (
           ? 'RESOLVED_AT'
           : 'CREATED_AT',
     orderDirection:
-      args.orderBy?.direction === OrderDirection.Asc ? 'asc' : 'desc',
+      String(args.orderBy?.direction).toLowerCase() === 'asc' ? 'asc' : 'desc',
   };
 };
 
@@ -1335,7 +1335,7 @@ const mergePositionConnectionFilter = (
         ? PositionSortField.CreatedAt
         : PositionSortField.UpdatedAt,
     orderDirection:
-      args.orderBy?.direction === OrderDirection.Asc
+      String(args.orderBy?.direction).toLowerCase() === 'asc'
         ? SortOrder.Asc
         : SortOrder.Desc,
     holder: f?.holder ?? null,

--- a/packages/api/src/graphql/sdl/resolvers/queries/questions.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/questions.ts
@@ -44,7 +44,6 @@ import type {
 import {
   QuestionItemType,
   QuestionOrderField,
-  OrderDirection,
   QuestionSortField,
   SortOrder,
   VolumeWindow,
@@ -1017,11 +1016,11 @@ const questionsConnectionResolver = async (
     ? mapOrderField(orderBy.field)
     : { sortField: null, volumeWindow: null };
   const sortDirection: SortOrder | null =
-    orderBy?.direction === OrderDirection.Asc
-      ? SortOrder.Asc
-      : orderBy?.direction === OrderDirection.Desc
-        ? SortOrder.Desc
-        : null;
+    orderBy?.direction == null
+      ? null
+      : String(orderBy.direction).toLowerCase() === 'asc'
+        ? SortOrder.Asc
+        : SortOrder.Desc;
   const operatorFilter = filter as typeof filter & {
     resolvesAt?: ScalarRangeFilter | null;
     estimatedPrice?: ScalarRangeFilter | null;

--- a/packages/api/src/graphql/sdl/resolvers/queries/trade.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/trade.ts
@@ -15,7 +15,7 @@ import type {
   QueryTradesArgs,
   QueryTradesConnectionArgs,
 } from '../../__generated__/resolvers';
-import { OrderDirection, TradeOrderField } from '../../__generated__/resolvers';
+import { TradeOrderField } from '../../__generated__/resolvers';
 import { Prisma } from '../../../../../generated/prisma';
 import prisma from '../../../../core/db';
 import { clampSkip, clampTake, offsetFromCursor } from './pagination';
@@ -189,7 +189,7 @@ const mergeTradeFilters = (args: QueryTradesConnectionArgs): RunTradesArgs => {
         ? 'BLOCK_NUMBER'
         : 'EXECUTED_AT',
     orderDirection:
-      args.orderBy?.direction === OrderDirection.Asc ? 'asc' : 'desc',
+      String(args.orderBy?.direction).toLowerCase() === 'asc' ? 'asc' : 'desc',
   };
 };
 

--- a/packages/api/src/graphql/sdl/schema/schema.graphql
+++ b/packages/api/src/graphql/sdl/schema/schema.graphql
@@ -1988,8 +1988,7 @@ enum TradeOrderField {
 }
 
 """
-Order input for the Relay-shaped `positionsConnection`. Strict: both fields are
-required so canonical Relay clients self-document the sort they intend.
+Order input for the Relay-shaped `positionsConnection`.
 """
 input PositionOrder {
   field: PositionOrderField!
@@ -2248,13 +2247,19 @@ input ConditionFilter {
   Typed as `String` (not `Address`) so existing queries passing nullable `$marketAddress: String`
   variables continue to validate — the strict `Address` scalar lives on the canonical `resolverAddress`.
   """
-  marketAddress: String @deprecated(reason: "Use `resolverAddress` — same resolver/oracle contract address, accurately named.")
+  marketAddress: String
+    @deprecated(
+      reason: "Use `resolverAddress` — same resolver/oracle contract address, accurately named."
+    )
 
   """
   Deprecated alias for `resolverAddressIn`; kept during the rename window for older clients.
   Typed as `[String!]` for the same back-compat reason as `marketAddress` above.
   """
-  marketAddressIn: [String!] @deprecated(reason: "Use `resolverAddressIn` — same resolver/oracle contract addresses, accurately named.")
+  marketAddressIn: [String!]
+    @deprecated(
+      reason: "Use `resolverAddressIn` — same resolver/oracle contract addresses, accurately named."
+    )
 
   """
   Visibility filter. Defaults to PUBLIC when omitted; ID filters bypass the default for direct lookups.
@@ -2403,13 +2408,19 @@ input QuestionFilter {
   Typed as `String` (not `Address`) so existing queries passing nullable `$marketAddress: String`
   variables continue to validate — the strict `Address` scalar lives on the canonical `resolverAddress`.
   """
-  marketAddress: String @deprecated(reason: "Use `resolverAddress` — same resolver/oracle contract address, accurately named.")
+  marketAddress: String
+    @deprecated(
+      reason: "Use `resolverAddress` — same resolver/oracle contract address, accurately named."
+    )
 
   """
   Deprecated alias for `resolverAddressIn`; kept during the rename window for older clients.
   Typed as `[String!]` for the same back-compat reason as `marketAddress` above.
   """
-  marketAddressIn: [String!] @deprecated(reason: "Use `resolverAddressIn` — same resolver/oracle contract addresses, accurately named.")
+  marketAddressIn: [String!]
+    @deprecated(
+      reason: "Use `resolverAddressIn` — same resolver/oracle contract addresses, accurately named."
+    )
 
   """
   Restrict to questions whose category slug is in this set.
@@ -2677,6 +2688,8 @@ Sort order shared across every `orderBy` input on the redesigned surface.
 enum OrderDirection {
   ASC
   DESC
+  asc
+  desc
 }
 
 """
@@ -2852,15 +2865,16 @@ type ProtocolStat {
   DEPRECATED — pre-split alias for `cumulativeTradeCount`. Kept so pinned external
   queries keep validating; new callers should read `cumulativeTradeCount`.
   """
-  totalTradeCount: Int
-    @deprecated(reason: "Use `cumulativeTradeCount`.")
+  totalTradeCount: Int @deprecated(reason: "Use `cumulativeTradeCount`.")
 
   """
   DEPRECATED — realized PnL delta. Lives on `VaultStat.periodPnL` now and is
   only populated here when the row is vault-scoped (`protocolStats(vaultAddress:)`).
   """
   periodPnL: String
-    @deprecated(reason: "Use `vaultStats(vaultAddress:).periodPnL` — only populated on vault-scoped rows.")
+    @deprecated(
+      reason: "Use `vaultStats(vaultAddress:).periodPnL` — only populated on vault-scoped rows."
+    )
 
   """
   DEPRECATED — vault collateral balance. Only populated when the row is vault-scoped

--- a/packages/api/src/graphql/sdl/schema/schema.test.ts
+++ b/packages/api/src/graphql/sdl/schema/schema.test.ts
@@ -15,7 +15,7 @@
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { parse, Kind } from 'graphql';
+import { buildSchema, graphql, parse, Kind } from 'graphql';
 import type {
   ObjectTypeDefinitionNode,
   ObjectTypeExtensionNode,
@@ -26,7 +26,8 @@ import type {
 import { describe, it, expect } from 'vitest';
 
 const SDL_PATH = join(__dirname, 'schema.graphql');
-const doc = parse(readFileSync(SDL_PATH, 'utf8'));
+const schemaText = readFileSync(SDL_PATH, 'utf8');
+const doc = parse(schemaText);
 
 type QueryFieldEntry = {
   typeName: string;
@@ -178,5 +179,49 @@ describe('SDL contract: *Page fields', () => {
     expect(offenders, '*Page types with non-canonical field shapes').toEqual(
       []
     );
+  });
+});
+
+describe('SDL contract: external order compatibility', () => {
+  it('accepts legacy lowercase direction values without changing order input nullability', async () => {
+    const schema = buildSchema(schemaText);
+    const result = await graphql({
+      schema,
+      source: `
+        query UserForecasts(
+          $filters: ForecastFilter
+          $take: Int!
+          $after: String
+          $orderBy: ForecastOrderField!
+          $orderDirection: OrderDirection!
+        ) {
+          forecastsConnection(
+            filter: $filters
+            first: $take
+            after: $after
+            orderBy: { field: $orderBy, direction: $orderDirection }
+          ) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+          }
+        }
+      `,
+      rootValue: {
+        forecastsConnection: () => ({
+          pageInfo: { hasNextPage: false, endCursor: null },
+        }),
+      },
+      variableValues: {
+        filters: {},
+        take: 1,
+        after: null,
+        orderBy: 'ATTESTED_AT',
+        orderDirection: 'desc',
+      },
+    });
+
+    expect(result.errors).toBeUndefined();
   });
 });

--- a/packages/api/test/contract/__snapshots__/introspection.json
+++ b/packages/api/test/contract/__snapshots__/introspection.json
@@ -13998,6 +13998,18 @@
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "asc",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "desc",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "possibleTypes": null
@@ -15600,7 +15612,7 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "PositionOrder",
-        "description": "Order input for the Relay-shaped `positionsConnection`. Strict: both fields are\nrequired so canonical Relay clients self-document the sort they intend.",
+        "description": "Order input for the Relay-shaped `positionsConnection`.",
         "fields": null,
         "inputFields": [
           {

--- a/packages/api/test/contract/__snapshots__/schema.sdl.graphql
+++ b/packages/api/test/contract/__snapshots__/schema.sdl.graphql
@@ -1759,10 +1759,7 @@ enum TradeOrderField {
   BLOCK_NUMBER
 }
 
-"""
-Order input for the Relay-shaped `positionsConnection`. Strict: both fields are
-required so canonical Relay clients self-document the sort they intend.
-"""
+"""Order input for the Relay-shaped `positionsConnection`."""
 input PositionOrder {
   field: PositionOrderField!
   direction: OrderDirection!
@@ -2356,6 +2353,8 @@ Sort order shared across every `orderBy` input on the redesigned surface.
 enum OrderDirection {
   ASC
   DESC
+  asc
+  desc
 }
 
 """

--- a/packages/sdk/queries/forecasts.ts
+++ b/packages/sdk/queries/forecasts.ts
@@ -191,8 +191,8 @@ const USER_FORECASTS_QUERY = /* GraphQL */ `
     $filters: ForecastFilter
     $take: Int!
     $after: String
-    $orderBy: ForecastOrderField
-    $orderDirection: OrderDirection
+    $orderBy: ForecastOrderField!
+    $orderDirection: OrderDirection!
   ) {
     forecastsConnection(
       filter: $filters

--- a/packages/sdk/types/graphql.ts
+++ b/packages/sdk/types/graphql.ts
@@ -2164,7 +2164,9 @@ export type NullsOrder =
 /** Sort order shared across every `orderBy` input on the redesigned surface. */
 export type OrderDirection =
   | 'ASC'
-  | 'DESC';
+  | 'DESC'
+  | 'asc'
+  | 'desc';
 
 /**
  * Shared shape for `*Page` paginated wrappers. Concrete types add their own
@@ -2474,10 +2476,7 @@ export type PositionFilters = {
   settled?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
-/**
- * Order input for the Relay-shaped `positionsConnection`. Strict: both fields are
- * required so canonical Relay clients self-document the sort they intend.
- */
+/** Order input for the Relay-shaped `positionsConnection`. */
 export type PositionOrder = {
   direction: OrderDirection;
   field: PositionOrderField;


### PR DESCRIPTION
## Summary
- restores the pre-existing order input nullability: strict `*Order.field` / `.direction` stay non-null, while the existing legacy position bridge remains nullable
- accepts legacy lowercase `asc` / `desc` on `OrderDirection` so external consumers sending lowercase enum values validate again
- normalizes resolver direction handling so `ASC` and `asc` behave identically
- updates the in-repo SDK forecast query to use non-null order variables and uppercase-safe values
- regenerates GraphQL schema/types and contract schema/introspection snapshots

## Verification
- `pnpm --filter @sapience/api exec vitest run src/graphql/sdl/schema/schema.test.ts --pool=threads --poolOptions.threads.singleThread`
- `pnpm --filter @sapience/sdk exec vitest run queries/__tests__/forecasts.test.ts --pool=threads --poolOptions.threads.singleThread`
- `pnpm --filter @sapience/api run type-check`
- `pnpm --filter @sapience/sdk run type-check`
- `pnpm --filter @sapience/sdk run build:lib`
- `CONTRACT_SKIP_SERVER=1 pnpm --filter @sapience/api exec vitest --config vitest.contract.config.ts --run test/contract/schema.snapshot.test.ts test/contract/introspection.test.ts`
