### PR TITLE
feat(api): un-deprecate approved queries (condition / conditionGroup / pickConfiguration / collateralBalance)

### DIFF
--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -3081,7 +3081,14 @@ type Query {
   Paginated list of position close (burn) records, filterable by address, pick config, and chain
   """
   closes(address: String, chainId: Int, pickConfigId: String, skip: Int! = 0, take: Int! = 50): [Close!]! @deprecated(reason: "Unused; will be removed. No live consumers — close records are reachable as a side-effect of position settlement.")
-  collateralBalance(account: Address, address: String @deprecated(reason: "Use `account`."), atBlock: Int, chainId: Int!): CollateralBalance! @deprecated(reason: "Use `collateralBalance(account:, chainId:)`; legacy `address` remains as an argument alias during migration.")
+
+  """
+  Wallet collateral balance — wUSDe holdings for the given account at
+  an optional block (defaults to head). Pass `account:` (Address scalar)
+  going forward; the legacy `address: String` arg remains as an alias
+  during migration.
+  """
+  collateralBalance(account: Address, address: String @deprecated(reason: "Use `account`."), atBlock: Int, chainId: Int!): CollateralBalance!
 
   """
   Cumulative wUSDe collateral balance for an address at `count + 1`
@@ -3138,8 +3145,21 @@ type Query {
   (→ `accounts`) in a subsequent migration.
   """
   accountsConnection(first: Int, after: String, filter: AccountFilter, orderBy: AccountOrder): AccountConnection!
-  condition(where: ConditionWhereUniqueInput!): Condition @deprecated(reason: "Pending flat-id arg flip in the final cleanup PR — single-record `condition(id:)` will replace the Prisma `where:` shape.")
-  conditionGroup(where: ConditionGroupWhereUniqueInput!): ConditionGroup @deprecated(reason: "Pending flat-id arg flip in the final cleanup PR — single-record `conditionGroup(id:)` will replace the Prisma `where:` shape.")
+
+  """
+  Look up a single condition by its on-chain condition id (the
+  CTF condition id). Pass `id:` going forward; the legacy
+  `where: ConditionWhereUniqueInput` shape remains as an alias during
+  migration.
+  """
+  condition(id: String, where: ConditionWhereUniqueInput): Condition
+
+  """
+  Look up a single condition group by its identifier. Pass `id:` going
+  forward; the legacy `where: ConditionGroupWhereUniqueInput` shape
+  remains as an alias during migration.
+  """
+  conditionGroup(id: String, where: ConditionGroupWhereUniqueInput): ConditionGroup
 
   """
   Deprecated bare-array form. Retained unchanged for the one-release
@@ -3179,7 +3199,7 @@ type Query {
   conditionsConnection(first: Int, after: String, filter: ConditionFilter, orderBy: ConditionOrder): ConditionConnection!
 
   """Look up a single pick configuration by ID"""
-  pickConfiguration(id: String!): PickConfiguration @deprecated(reason: "Unused as a top-level query. Individual configs are reachable via the embedded `pickConfig` field on positions/predictions/trades, or via `pickConfigurationsConnection` for list lookups.")
+  pickConfiguration(id: String!): PickConfiguration
 
   """
   Paginated list of pick configurations, filterable by chain, resolution status, and result

--- a/packages/api/src/graphql/sdl/resolvers/queries/conditionGroups.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/conditionGroups.ts
@@ -16,10 +16,21 @@ type Where = Prisma.ConditionGroupWhereInput;
 
 export const conditionGroup: NonNullable<
   QueryResolvers['conditionGroup']
-> = async (_parent, { where }) =>
-  prisma.conditionGroup.findUnique({
+> = async (_parent, { id, where }) => {
+  if (id != null) {
+    const numericId = Number(id);
+    if (!Number.isFinite(numericId)) return null;
+    return prisma.conditionGroup.findUnique({
+      where: { id: numericId },
+    });
+  }
+  if (where == null) {
+    throw new Error('conditionGroup: must pass `id:` or `where:`');
+  }
+  return prisma.conditionGroup.findUnique({
     where: where as unknown as Prisma.ConditionGroupWhereUniqueInput,
   });
+};
 
 // ---------------------------------------------------------------------
 // Relay-shaped `conditionGroups` connection (PR 2)

--- a/packages/api/src/graphql/sdl/resolvers/queries/crud.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/crud.ts
@@ -127,9 +127,17 @@ export const categories: NonNullable<QueryResolvers['categories']> = async (
 
 export const condition: NonNullable<QueryResolvers['condition']> = async (
   _parent,
-  { where }
+  { id, where }
 ) => {
-  logDeprecatedHit('condition');
+  if (id != null) {
+    return prisma.condition.findUnique({
+      where: { id: id.toLowerCase() },
+    });
+  }
+  if (where == null) {
+    throw new Error('condition: must pass `id:` or `where:`');
+  }
+  logDeprecatedHit('condition.where');
   return prisma.condition.findUnique({
     where: asPrismaArgs<Prisma.ConditionWhereUniqueInput>(where),
   });

--- a/packages/api/src/graphql/sdl/schema/schema.graphql
+++ b/packages/api/src/graphql/sdl/schema/schema.graphql
@@ -3661,15 +3661,18 @@ type Query {
     @deprecated(
       reason: "Unused; will be removed. No live consumers — close records are reachable as a side-effect of position settlement."
     )
+  """
+  Wallet collateral balance — wUSDe holdings for the given account at
+  an optional block (defaults to head). Pass `account:` (Address scalar)
+  going forward; the legacy `address: String` arg remains as an alias
+  during migration.
+  """
   collateralBalance(
     account: Address
     address: String @deprecated(reason: "Use `account`.")
     atBlock: Int
     chainId: Int!
   ): CollateralBalance!
-    @deprecated(
-      reason: "Use `collateralBalance(account:, chainId:)`; legacy `address` remains as an argument alias during migration."
-    )
   """
   Cumulative wUSDe collateral balance for an address at `count + 1`
   evenly-spaced snapshot boundaries going back from now. The snapshot
@@ -3745,14 +3748,23 @@ type Query {
     filter: AccountFilter
     orderBy: AccountOrder
   ): AccountConnection!
-  condition(where: ConditionWhereUniqueInput!): Condition
-    @deprecated(
-      reason: "Pending flat-id arg flip in the final cleanup PR — single-record `condition(id:)` will replace the Prisma `where:` shape."
-    )
-  conditionGroup(where: ConditionGroupWhereUniqueInput!): ConditionGroup
-    @deprecated(
-      reason: "Pending flat-id arg flip in the final cleanup PR — single-record `conditionGroup(id:)` will replace the Prisma `where:` shape."
-    )
+  """
+  Look up a single condition by its on-chain condition id (the
+  CTF condition id). Pass `id:` going forward; the legacy
+  `where: ConditionWhereUniqueInput` shape remains as an alias during
+  migration.
+  """
+  condition(id: String, where: ConditionWhereUniqueInput): Condition
+
+  """
+  Look up a single condition group by its identifier. Pass `id:` going
+  forward; the legacy `where: ConditionGroupWhereUniqueInput` shape
+  remains as an alias during migration.
+  """
+  conditionGroup(
+    id: String
+    where: ConditionGroupWhereUniqueInput
+  ): ConditionGroup
   """
   Deprecated bare-array form. Retained unchanged for the one-release
   deprecation window so pinned clients keep working. New callers
@@ -3824,9 +3836,6 @@ type Query {
   Look up a single pick configuration by ID
   """
   pickConfiguration(id: String!): PickConfiguration
-    @deprecated(
-      reason: "Unused as a top-level query. Individual configs are reachable via the embedded `pickConfig` field on positions/predictions/trades, or via `pickConfigurationsConnection` for list lookups."
-    )
 
   """
   Paginated list of pick configurations, filterable by chain, resolution status, and result

--- a/packages/api/test/contract/__snapshots__/schema.sdl.graphql
+++ b/packages/api/test/contract/__snapshots__/schema.sdl.graphql
@@ -3081,7 +3081,14 @@ type Query {
   Paginated list of position close (burn) records, filterable by address, pick config, and chain
   """
   closes(address: String, chainId: Int, pickConfigId: String, skip: Int! = 0, take: Int! = 50): [Close!]! @deprecated(reason: "Unused; will be removed. No live consumers — close records are reachable as a side-effect of position settlement.")
-  collateralBalance(account: Address, address: String @deprecated(reason: "Use `account`."), atBlock: Int, chainId: Int!): CollateralBalance! @deprecated(reason: "Use `collateralBalance(account:, chainId:)`; legacy `address` remains as an argument alias during migration.")
+
+  """
+  Wallet collateral balance — wUSDe holdings for the given account at
+  an optional block (defaults to head). Pass `account:` (Address scalar)
+  going forward; the legacy `address: String` arg remains as an alias
+  during migration.
+  """
+  collateralBalance(account: Address, address: String @deprecated(reason: "Use `account`."), atBlock: Int, chainId: Int!): CollateralBalance!
 
   """
   Cumulative wUSDe collateral balance for an address at `count + 1`
@@ -3138,8 +3145,21 @@ type Query {
   (→ `accounts`) in a subsequent migration.
   """
   accountsConnection(first: Int, after: String, filter: AccountFilter, orderBy: AccountOrder): AccountConnection!
-  condition(where: ConditionWhereUniqueInput!): Condition @deprecated(reason: "Pending flat-id arg flip in the final cleanup PR — single-record `condition(id:)` will replace the Prisma `where:` shape.")
-  conditionGroup(where: ConditionGroupWhereUniqueInput!): ConditionGroup @deprecated(reason: "Pending flat-id arg flip in the final cleanup PR — single-record `conditionGroup(id:)` will replace the Prisma `where:` shape.")
+
+  """
+  Look up a single condition by its on-chain condition id (the
+  CTF condition id). Pass `id:` going forward; the legacy
+  `where: ConditionWhereUniqueInput` shape remains as an alias during
+  migration.
+  """
+  condition(id: String, where: ConditionWhereUniqueInput): Condition
+
+  """
+  Look up a single condition group by its identifier. Pass `id:` going
+  forward; the legacy `where: ConditionGroupWhereUniqueInput` shape
+  remains as an alias during migration.
+  """
+  conditionGroup(id: String, where: ConditionGroupWhereUniqueInput): ConditionGroup
 
   """
   Deprecated bare-array form. Retained unchanged for the one-release
@@ -3179,7 +3199,7 @@ type Query {
   conditionsConnection(first: Int, after: String, filter: ConditionFilter, orderBy: ConditionOrder): ConditionConnection!
 
   """Look up a single pick configuration by ID"""
-  pickConfiguration(id: String!): PickConfiguration @deprecated(reason: "Unused as a top-level query. Individual configs are reachable via the embedded `pickConfig` field on positions/predictions/trades, or via `pickConfigurationsConnection` for list lookups.")
+  pickConfiguration(id: String!): PickConfiguration
 
   """
   Paginated list of pick configurations, filterable by chain, resolution status, and result


### PR DESCRIPTION
## Summary
- Per the approved-query list, `condition`, `conditionGroup`, `pickConfiguration`, and `collateralBalance` should remain non-deprecated; this PR drops the field-level `@deprecated` directive from each.
- Adds a flat `id:` arg to `condition` and `conditionGroup`. The existing `where:` arg is loosened from required to optional, so existing callers keep working (non-breaking) and new callers can pass `id: $hex` / `id: $numeric` directly.

## Test plan
- [x] `pnpm --filter @sapience/api exec vitest run src/graphql/sdl` — 33 files, 315 tests pass.
- [x] `tsc --noEmit` clean for the API package.
- [ ] Contract suite (`pnpm --filter @sapience/api run test:contract`) — requires Postgres; introspection.json snapshot will need a refresh in CI, but the committed `schema.sdl.graphql` snapshot is already updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)