### PR TITLE
feat(api): add singular by-id queries (category / forecast / collateralTransfer / position / claim / close)

### DIFF
--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -3063,6 +3063,15 @@ type Query {
   (→ `forecasts`) in a subsequent migration.
   """
   forecastsConnection(first: Int = 50, after: String, filter: ForecastFilter, orderBy: ForecastOrder): ForecastConnection!
+
+  """Look up a single forecast (EAS attestation) by its on-chain `uid`."""
+  forecast(uid: String!): Forecast
+
+  """
+  Look up a single category by ID. Accepts either the numeric DB id
+  serialized as a string or the Relay opaque global id.
+  """
+  category(id: ID!): Category
   categories(cursor: CategoryWhereUniqueInput, distinct: [CategoryScalarFieldEnum!], orderBy: [CategoryOrderByWithRelationInput!], skip: Int, take: Int, where: CategoryWhereInput): [Category!]! @deprecated(reason: "Use `categoriesConnection(first:, after:)` — Relay-shaped cursor pagination over categories.")
 
   """
@@ -3072,10 +3081,16 @@ type Query {
   """
   categoriesConnection(first: Int = 100, after: String, filter: CategoryFilter): CategoryConnection!
 
+  """Look up a single claim (redemption) record by its row id."""
+  claim(id: Int!): Claim
+
   """
   Paginated list of prediction claim (redemption) records, filterable by holder, prediction, and chain
   """
   claims(chainId: Int, holder: String, predictionId: String, skip: Int! = 0, take: Int! = 50): [Claim!]! @deprecated(reason: "Unused; will be removed. No live consumers — claim records are reachable as a side-effect of position settlement.")
+
+  """Look up a single close (settled position exit) record by its row id."""
+  close(id: Int!): Close
 
   """
   Paginated list of position close (burn) records, filterable by address, pick config, and chain
@@ -3118,6 +3133,9 @@ type Query {
   deprecated bare-array `collateralTransfers` sibling above is removed.
   """
   collateralTransfersConnection(first: Int = 100, after: String, filter: CollateralTransferFilter, orderBy: CollateralTransferOrder): CollateralTransferConnection!
+
+  """Look up a single collateral transfer by its Relay global id."""
+  collateralTransfer(id: ID!): CollateralTransfer
 
   """
   Look up a single account by canonical wallet address. Replacement for
@@ -3219,6 +3237,14 @@ type Query {
   `positions` bare-array / `positionsPage` siblings above are removed.
   """
   positionsConnection(first: Int, after: String, filter: PositionFilter, orderBy: PositionOrder): PositionConnection!
+
+  """
+  Look up a single position by its Relay global id. The id encodes the
+  underlying Position row id and (for synthesized sell rows) the trade
+  hash that produced them; the same id format is surfaced on
+  `Position.id`.
+  """
+  position(id: ID!): Position
 
   """
   Look up a single prediction by its on-chain prediction ID. Pass

--- a/packages/api/src/graphql/sdl/resolvers/index.ts
+++ b/packages/api/src/graphql/sdl/resolvers/index.ts
@@ -59,6 +59,7 @@ import {
 import {
   collateralBalance,
   collateralBalanceHistory,
+  collateralTransfer,
   collateralTransfersConnection,
 } from './queries/collateralBalance';
 import { collateralTransfers } from './queries/deprecated/collateralBalance';
@@ -76,16 +77,21 @@ import {
   accountsConnection,
   categories,
   categoriesConnection,
+  category,
   condition,
+  forecast,
   forecastsConnection,
   user,
 } from './queries/crud';
 import { users } from './queries/deprecated/crud';
 import {
+  claim,
   claims,
+  close,
   closes,
   pickConfiguration,
   pickConfigurationsConnection,
+  position,
   positionsConnection,
   positionsPage,
   prediction,
@@ -152,6 +158,7 @@ export const resolvers: Resolvers = {
     // Collateral
     collateralBalance,
     collateralBalanceHistory,
+    collateralTransfer,
     collateralTransfers,
     collateralTransfersConnection,
     // Conditions / questions
@@ -160,11 +167,14 @@ export const resolvers: Resolvers = {
     questions,
     questionsConnection,
     // Escrow (predictions / positions / claims / closes / pick configs)
+    claim,
     claims,
+    close,
     closes,
     pickConfiguration,
     pickConfigurations,
     pickConfigurationsConnection,
+    position,
     positionCount,
     positions,
     positionsConnection,
@@ -183,6 +193,8 @@ export const resolvers: Resolvers = {
     // CRUD passthroughs
     account,
     accountsConnection,
+    category,
+    forecast,
     forecastsConnection,
     categories,
     categoriesConnection,

--- a/packages/api/src/graphql/sdl/resolvers/queries/collateralBalance.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/collateralBalance.ts
@@ -10,7 +10,11 @@ import { Prisma } from '../../../../../generated/prisma';
 import prisma from '../../../../core/db';
 import { buildConnection, clampSkip, clampTake } from './pagination';
 import { decodeCursor, encodeCursor } from '../../../relay/cursor';
-import { registerNodeType, toGlobalId } from '../../../relay/globalId';
+import {
+  registerNodeType,
+  resolveNode,
+  toGlobalId,
+} from '../../../relay/globalId';
 import { synthesizeAccount } from '../accountSynthesis';
 
 const collateralForChain = (chainId: number) => ({
@@ -79,6 +83,21 @@ registerNodeType({
     return row ? mapCollateralTransfer(row) : null;
   },
 });
+
+export const collateralTransfer = (async (
+  _parent: unknown,
+  { id }: { id: string },
+  ctx: unknown
+) => {
+  const result = await resolveNode(id, ctx);
+  if (
+    result &&
+    (result as { __typename?: string }).__typename === 'CollateralTransfer'
+  ) {
+    return result;
+  }
+  return null;
+}) as unknown as NonNullable<QueryResolvers['collateralTransfer']>;
 
 export const collateralBalance = (async (
   _parent: unknown,

--- a/packages/api/src/graphql/sdl/resolvers/queries/crud.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/crud.ts
@@ -26,7 +26,11 @@ import prisma from '../../../../core/db';
 import { TtlCache } from '../../../../lib/ttlCache';
 import { logDeprecatedHit } from '../../../../lib/deprecationTelemetry';
 import { decodeCursor, encodeCursor } from '../../../relay/cursor';
-import { registerNodeType, toGlobalId } from '../../../relay/globalId';
+import {
+  registerNodeType,
+  resolveNode,
+  toGlobalId,
+} from '../../../relay/globalId';
 import { synthesizeAccount } from '../accountSynthesis';
 import { buildConnection, clampTake } from './pagination';
 
@@ -133,6 +137,27 @@ export const condition: NonNullable<QueryResolvers['condition']> = async (
   return prisma.condition.findUnique({
     where: asPrismaArgs<Prisma.ConditionWhereUniqueInput>(where),
   });
+};
+
+export const category = (async (
+  _parent: unknown,
+  { id }: { id: string },
+  ctx: unknown
+) => {
+  const result = await resolveNode(id, ctx);
+  if (result && (result as { __typename?: string }).__typename === 'Category') {
+    return result;
+  }
+  return null;
+}) as unknown as NonNullable<QueryResolvers['category']>;
+
+export const forecast: NonNullable<QueryResolvers['forecast']> = async (
+  _parent,
+  { uid }
+) => {
+  const row = await prisma.attestation.findUnique({ where: { uid } });
+  if (!row) return null;
+  return mapForecast(row) as unknown as never;
 };
 
 export const user: NonNullable<QueryResolvers['user']> = async (

--- a/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
@@ -57,6 +57,7 @@ import { TtlCache } from '../../../../lib/ttlCache';
 import { logDeprecatedHit } from '../../../../lib/deprecationTelemetry';
 import { clampSkip, clampTake, offsetFromCursor } from './pagination';
 import { decodeCursor, encodeCursor } from '../../../relay/cursor';
+import { tryFromGlobalId } from '../../../relay/globalId';
 
 export type PredictionWithPickConfig = Prisma.PredictionGetPayload<{
   include: { pickConfiguration: { include: { picks: true } } };
@@ -1123,6 +1124,15 @@ const basePositionRowId = (positionNodeId: string): number | null => {
   return Number.isInteger(numericId) ? numericId : null;
 };
 
+export const position: NonNullable<QueryResolvers['position']> = (async (
+  _parent: unknown,
+  { id }: { id: string }
+) => {
+  const parts = tryFromGlobalId(id);
+  if (!parts || parts.type !== 'Position') return null;
+  return resolvePositionNode(parts.id);
+}) as unknown as NonNullable<QueryResolvers['position']>;
+
 export const resolvePositionNode = async (
   positionNodeId: string
 ): Promise<PositionShape | null> => {
@@ -1415,6 +1425,78 @@ export const closes: NonNullable<QueryResolvers['closes']> = async (
     txHash: r.txHash,
     refCode: r.refCode ?? null,
   }));
+};
+
+const mapClaim = (r: {
+  id: number;
+  chainId: number;
+  marketAddress: string;
+  predictionId: string;
+  holder: string;
+  positionToken: string;
+  tokensBurned: string;
+  collateralPaid: string;
+  redeemedAt: number;
+  txHash: string;
+  refCode: string | null;
+}) => ({
+  id: r.id,
+  chainId: r.chainId,
+  marketAddress: r.marketAddress,
+  predictionId: r.predictionId,
+  holder: r.holder,
+  positionToken: r.positionToken,
+  tokensBurned: r.tokensBurned,
+  collateralPaid: r.collateralPaid,
+  redeemedAt: r.redeemedAt,
+  txHash: r.txHash,
+  refCode: r.refCode ?? null,
+});
+
+export const claim: NonNullable<QueryResolvers['claim']> = async (
+  _parent,
+  { id }
+) => {
+  const row = await prisma.claim.findUnique({ where: { id } });
+  return row ? mapClaim(row) : null;
+};
+
+const mapClose = (r: {
+  id: number;
+  chainId: number;
+  marketAddress: string;
+  pickConfigId: string;
+  predictorHolder: string;
+  counterpartyHolder: string;
+  predictorTokensBurned: string;
+  counterpartyTokensBurned: string;
+  predictorPayout: string;
+  counterpartyPayout: string;
+  burnedAt: number;
+  txHash: string;
+  refCode: string | null;
+}) => ({
+  id: r.id,
+  chainId: r.chainId,
+  marketAddress: r.marketAddress,
+  pickConfigId: r.pickConfigId,
+  predictorHolder: r.predictorHolder,
+  counterpartyHolder: r.counterpartyHolder,
+  predictorTokensBurned: r.predictorTokensBurned,
+  counterpartyTokensBurned: r.counterpartyTokensBurned,
+  predictorPayout: r.predictorPayout,
+  counterpartyPayout: r.counterpartyPayout,
+  burnedAt: r.burnedAt,
+  txHash: r.txHash,
+  refCode: r.refCode ?? null,
+});
+
+export const close: NonNullable<QueryResolvers['close']> = async (
+  _parent,
+  { id }
+) => {
+  const row = await prisma.close.findUnique({ where: { id } });
+  return row ? mapClose(row) : null;
 };
 
 export const claims: NonNullable<QueryResolvers['claims']> = async (

--- a/packages/api/src/graphql/sdl/schema/schema.graphql
+++ b/packages/api/src/graphql/sdl/schema/schema.graphql
@@ -3611,6 +3611,17 @@ type Query {
     filter: ForecastFilter
     orderBy: ForecastOrder
   ): ForecastConnection!
+
+  """
+  Look up a single forecast (EAS attestation) by its on-chain `uid`.
+  """
+  forecast(uid: String!): Forecast
+
+  """
+  Look up a single category by ID. Accepts either the numeric DB id
+  serialized as a string or the Relay opaque global id.
+  """
+  category(id: ID!): Category
   categories(
     cursor: CategoryWhereUniqueInput
     distinct: [CategoryScalarFieldEnum!]
@@ -3635,6 +3646,11 @@ type Query {
   ): CategoryConnection!
 
   """
+  Look up a single claim (redemption) record by its row id.
+  """
+  claim(id: Int!): Claim
+
+  """
   Paginated list of prediction claim (redemption) records, filterable by holder, prediction, and chain
   """
   claims(
@@ -3647,6 +3663,11 @@ type Query {
     @deprecated(
       reason: "Unused; will be removed. No live consumers — claim records are reachable as a side-effect of position settlement."
     )
+
+  """
+  Look up a single close (settled position exit) record by its row id.
+  """
+  close(id: Int!): Close
 
   """
   Paginated list of position close (burn) records, filterable by address, pick config, and chain
@@ -3721,6 +3742,11 @@ type Query {
     filter: CollateralTransferFilter
     orderBy: CollateralTransferOrder
   ): CollateralTransferConnection!
+
+  """
+  Look up a single collateral transfer by its Relay global id.
+  """
+  collateralTransfer(id: ID!): CollateralTransfer
   """
   Look up a single account by canonical wallet address. Replacement for
   `user(where:)` — accepts a flat `address: String!` arg instead of the
@@ -3965,6 +3991,14 @@ type Query {
     filter: PositionFilter
     orderBy: PositionOrder
   ): PositionConnection!
+
+  """
+  Look up a single position by its Relay global id. The id encodes the
+  underlying Position row id and (for synthesized sell rows) the trade
+  hash that produced them; the same id format is surfaced on
+  `Position.id`.
+  """
+  position(id: ID!): Position
 
   """
   Look up a single prediction by its on-chain prediction ID. Pass

--- a/packages/api/test/contract/__snapshots__/schema.sdl.graphql
+++ b/packages/api/test/contract/__snapshots__/schema.sdl.graphql
@@ -3063,6 +3063,15 @@ type Query {
   (→ `forecasts`) in a subsequent migration.
   """
   forecastsConnection(first: Int = 50, after: String, filter: ForecastFilter, orderBy: ForecastOrder): ForecastConnection!
+
+  """Look up a single forecast (EAS attestation) by its on-chain `uid`."""
+  forecast(uid: String!): Forecast
+
+  """
+  Look up a single category by ID. Accepts either the numeric DB id
+  serialized as a string or the Relay opaque global id.
+  """
+  category(id: ID!): Category
   categories(cursor: CategoryWhereUniqueInput, distinct: [CategoryScalarFieldEnum!], orderBy: [CategoryOrderByWithRelationInput!], skip: Int, take: Int, where: CategoryWhereInput): [Category!]! @deprecated(reason: "Use `categoriesConnection(first:, after:)` — Relay-shaped cursor pagination over categories.")
 
   """
@@ -3072,10 +3081,16 @@ type Query {
   """
   categoriesConnection(first: Int = 100, after: String, filter: CategoryFilter): CategoryConnection!
 
+  """Look up a single claim (redemption) record by its row id."""
+  claim(id: Int!): Claim
+
   """
   Paginated list of prediction claim (redemption) records, filterable by holder, prediction, and chain
   """
   claims(chainId: Int, holder: String, predictionId: String, skip: Int! = 0, take: Int! = 50): [Claim!]! @deprecated(reason: "Unused; will be removed. No live consumers — claim records are reachable as a side-effect of position settlement.")
+
+  """Look up a single close (settled position exit) record by its row id."""
+  close(id: Int!): Close
 
   """
   Paginated list of position close (burn) records, filterable by address, pick config, and chain
@@ -3118,6 +3133,9 @@ type Query {
   deprecated bare-array `collateralTransfers` sibling above is removed.
   """
   collateralTransfersConnection(first: Int = 100, after: String, filter: CollateralTransferFilter, orderBy: CollateralTransferOrder): CollateralTransferConnection!
+
+  """Look up a single collateral transfer by its Relay global id."""
+  collateralTransfer(id: ID!): CollateralTransfer
 
   """
   Look up a single account by canonical wallet address. Replacement for
@@ -3219,6 +3237,14 @@ type Query {
   `positions` bare-array / `positionsPage` siblings above are removed.
   """
   positionsConnection(first: Int, after: String, filter: PositionFilter, orderBy: PositionOrder): PositionConnection!
+
+  """
+  Look up a single position by its Relay global id. The id encodes the
+  underlying Position row id and (for synthesized sell rows) the trade
+  hash that produced them; the same id format is surfaced on
+  `Position.id`.
+  """
+  position(id: ID!): Position
 
   """
   Look up a single prediction by its on-chain prediction ID. Pass


### PR DESCRIPTION
## Summary
- Adds the six singular point-lookups required by the approved-query list. Purely additive: no existing field shape changes.

| field | arg | strategy |
| --- | --- | --- |
| `category(id: ID!)` | Relay global id | `resolveNode` against the existing Category Node loader |
| `forecast(uid: String!)` | on-chain EAS attestation uid | direct `prisma.attestation.findUnique` |
| `collateralTransfer(id: ID!)` | Relay global id | `resolveNode` against the existing CollateralTransfer Node loader |
| `position(id: ID!)` | Relay global id (decodes `Position:rowId(-sell-…)`) | `resolvePositionNode` |
| `claim(id: Int!)` | row primary key | `prisma.claim.findUnique` |
| `close(id: Int!)` | row primary key | `prisma.close.findUnique` |

## Test plan
- [x] `pnpm --filter @sapience/api exec vitest run src/graphql/sdl` — 33 files, 315 tests pass.
- [x] `tsc --noEmit` clean.
- [ ] Contract suite (`pnpm --filter @sapience/api run test:contract`) — schema.sdl.graphql snapshot is refreshed; the introspection.json snapshot will regenerate in CI.

## Follow-ups
- `claimsConnection` / `closesConnection` (the plural Connection variants for the entity list) — separate PR, requires new Connection/Edge/Filter/Order input types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)