### PR TITLE
feat(api): add claimsConnection / closesConnection + harden vault(id:)

### DIFF
--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -406,6 +406,33 @@ type Claim {
   txHash: String!
 }
 
+type ClaimConnection {
+  edges: [ClaimEdge!]!
+  nodes: [Claim!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type ClaimEdge {
+  node: Claim!
+  cursor: String!
+}
+
+input ClaimFilter {
+  chainId: Int
+  holder: Address
+  predictionId: String
+}
+
+input ClaimOrder {
+  field: ClaimOrderField!
+  direction: OrderDirection!
+}
+
+enum ClaimOrderField {
+  REDEEMED_AT
+}
+
 """
 Record of a position close where both sides burn tokens and receive payouts
 """
@@ -423,6 +450,33 @@ type Close {
   predictorTokensBurned: String!
   refCode: String
   txHash: String!
+}
+
+type CloseConnection {
+  edges: [CloseEdge!]!
+  nodes: [Close!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type CloseEdge {
+  node: Close!
+  cursor: String!
+}
+
+input CloseFilter {
+  address: Address
+  chainId: Int
+  pickConfigId: String
+}
+
+input CloseOrder {
+  field: CloseOrderField!
+  direction: OrderDirection!
+}
+
+enum CloseOrderField {
+  BURNED_AT
 }
 
 type Activity {
@@ -3087,7 +3141,14 @@ type Query {
   """
   Paginated list of prediction claim (redemption) records, filterable by holder, prediction, and chain
   """
-  claims(chainId: Int, holder: String, predictionId: String, skip: Int! = 0, take: Int! = 50): [Claim!]! @deprecated(reason: "Unused; will be removed. No live consumers — claim records are reachable as a side-effect of position settlement.")
+  claims(chainId: Int, holder: String, predictionId: String, skip: Int! = 0, take: Int! = 50): [Claim!]! @deprecated(reason: "Use `claimsConnection(first:, after:, filter:, orderBy:)` — Relay-shaped cursor pagination over the same data.")
+
+  """
+  Relay-shaped connection over claim (redemption) records. Forward-only
+  cursor pagination via `first` / `after`; sorting defaults to
+  `REDEEMED_AT` / `DESC`.
+  """
+  claimsConnection(first: Int, after: String, filter: ClaimFilter, orderBy: ClaimOrder): ClaimConnection!
 
   """Look up a single close (settled position exit) record by its row id."""
   close(id: Int!): Close
@@ -3095,7 +3156,14 @@ type Query {
   """
   Paginated list of position close (burn) records, filterable by address, pick config, and chain
   """
-  closes(address: String, chainId: Int, pickConfigId: String, skip: Int! = 0, take: Int! = 50): [Close!]! @deprecated(reason: "Unused; will be removed. No live consumers — close records are reachable as a side-effect of position settlement.")
+  closes(address: String, chainId: Int, pickConfigId: String, skip: Int! = 0, take: Int! = 50): [Close!]! @deprecated(reason: "Use `closesConnection(first:, after:, filter:, orderBy:)` — Relay-shaped cursor pagination over the same data.")
+
+  """
+  Relay-shaped connection over position close (burn) records. Forward-only
+  cursor pagination via `first` / `after`; sorting defaults to
+  `BURNED_AT` / `DESC`.
+  """
+  closesConnection(first: Int, after: String, filter: CloseFilter, orderBy: CloseOrder): CloseConnection!
 
   """
   Wallet collateral balance — wUSDe holdings for the given account at

--- a/packages/api/src/graphql/sdl/resolvers/index.ts
+++ b/packages/api/src/graphql/sdl/resolvers/index.ts
@@ -87,8 +87,10 @@ import { users } from './queries/deprecated/crud';
 import {
   claim,
   claims,
+  claimsConnection,
   close,
   closes,
+  closesConnection,
   pickConfiguration,
   pickConfigurationsConnection,
   position,
@@ -169,8 +171,10 @@ export const resolvers: Resolvers = {
     // Escrow (predictions / positions / claims / closes / pick configs)
     claim,
     claims,
+    claimsConnection,
     close,
     closes,
+    closesConnection,
     pickConfiguration,
     pickConfigurations,
     pickConfigurationsConnection,

--- a/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
@@ -12,9 +12,9 @@ import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
 import { normalizeLegacyEntry } from '@sapience/sdk/contracts';
 import { collateralToken } from '@sapience/sdk/contracts/addresses';
 import {
-  fromGlobalId,
   registerNodeType,
   toGlobalId,
+  tryFromGlobalId,
 } from '../../../relay/globalId';
 import { synthesizeAccount } from '../accountSynthesis';
 import { decodeCursor, encodeCursor } from '../../../relay/cursor';
@@ -769,7 +769,9 @@ const findVaultByAddress = (chainId: number, address: string) => {
 };
 
 export const vault = (async (_parent: unknown, { id }: { id: string }) => {
-  const parsed = parseVaultDomainId(fromGlobalId(id).id);
+  const parts = tryFromGlobalId(id);
+  if (!parts) return null;
+  const parsed = parseVaultDomainId(parts.id);
   if (!parsed) return null;
   return findVaultByAddress(parsed.chainId, parsed.address);
 }) as unknown as NonNullable<QueryResolvers['vault']>;

--- a/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/escrow.ts
@@ -55,7 +55,12 @@ import prisma from '../../../../core/db';
 import { mapPickConfig } from '../pickConfigHelpers';
 import { TtlCache } from '../../../../lib/ttlCache';
 import { logDeprecatedHit } from '../../../../lib/deprecationTelemetry';
-import { clampSkip, clampTake, offsetFromCursor } from './pagination';
+import {
+  buildConnection,
+  clampSkip,
+  clampTake,
+  offsetFromCursor,
+} from './pagination';
 import { decodeCursor, encodeCursor } from '../../../relay/cursor';
 import { tryFromGlobalId } from '../../../relay/globalId';
 
@@ -1531,3 +1536,215 @@ export const claims: NonNullable<QueryResolvers['claims']> = async (
     refCode: r.refCode ?? null,
   }));
 };
+
+const mapClaimRow = (r: {
+  id: number;
+  chainId: number;
+  marketAddress: string;
+  predictionId: string;
+  holder: string;
+  positionToken: string;
+  tokensBurned: string;
+  collateralPaid: string;
+  redeemedAt: number;
+  txHash: string;
+  refCode: string | null;
+}) => ({
+  id: r.id,
+  chainId: r.chainId,
+  marketAddress: r.marketAddress,
+  predictionId: r.predictionId,
+  holder: r.holder,
+  positionToken: r.positionToken,
+  tokensBurned: r.tokensBurned,
+  collateralPaid: r.collateralPaid,
+  redeemedAt: r.redeemedAt,
+  txHash: r.txHash,
+  refCode: r.refCode ?? null,
+});
+
+const buildClaimsConnectionWhere = (
+  filter?: {
+    chainId?: number | null;
+    holder?: string | null;
+    predictionId?: string | null;
+  } | null
+): Prisma.ClaimWhereInput => {
+  const where: Prisma.ClaimWhereInput = {};
+  if (filter?.chainId != null) where.chainId = filter.chainId;
+  if (filter?.holder) where.holder = filter.holder.toLowerCase();
+  if (filter?.predictionId)
+    where.predictionId = filter.predictionId.toLowerCase();
+  return where;
+};
+
+const buildClaimCursorPredicate = (
+  k: string,
+  cursorId: string,
+  direction: 'asc' | 'desc'
+): Prisma.ClaimWhereInput => {
+  const op = direction === 'desc' ? 'lt' : 'gt';
+  const redeemedAt = Number(k);
+  const id = Number(cursorId);
+  return {
+    OR: [
+      { redeemedAt: { [op]: redeemedAt } },
+      { AND: [{ redeemedAt: { equals: redeemedAt } }, { id: { [op]: id } }] },
+    ],
+  };
+};
+
+export const claimsConnection = (async (
+  _parent: unknown,
+  args: {
+    first?: number | null;
+    after?: string | null;
+    filter?: {
+      chainId?: number | null;
+      holder?: string | null;
+      predictionId?: string | null;
+    } | null;
+    orderBy?: { field?: string | null; direction?: string | null } | null;
+  }
+) => {
+  const first = clampTake(args.first ?? undefined, {
+    defaultTake: 50,
+    maxTake: 100,
+  });
+  const direction =
+    String(args.orderBy?.direction).toLowerCase() === 'asc' ? 'asc' : 'desc';
+  const baseWhere = buildClaimsConnectionWhere(args.filter);
+  const cursor = args.after ? decodeCursor(args.after) : null;
+  const cursorWhere = cursor
+    ? buildClaimCursorPredicate(cursor.k, cursor.id, direction)
+    : null;
+  const where: Prisma.ClaimWhereInput = cursorWhere
+    ? { AND: [baseWhere, cursorWhere] }
+    : baseWhere;
+  const [rows, totalCount] = await Promise.all([
+    prisma.claim.findMany({
+      where,
+      orderBy: [{ redeemedAt: direction }, { id: direction }],
+      take: first + 1,
+    }),
+    prisma.claim.count({ where: baseWhere }),
+  ]);
+  return buildConnection({
+    rows,
+    first,
+    totalCount,
+    getNode: mapClaimRow,
+    getCursor: (row) =>
+      encodeCursor({ k: String(row.redeemedAt), id: String(row.id) }),
+  });
+}) as unknown as NonNullable<QueryResolvers['claimsConnection']>;
+
+const mapCloseRow = (r: {
+  id: number;
+  chainId: number;
+  marketAddress: string;
+  pickConfigId: string;
+  predictorHolder: string;
+  counterpartyHolder: string;
+  predictorTokensBurned: string;
+  counterpartyTokensBurned: string;
+  predictorPayout: string;
+  counterpartyPayout: string;
+  burnedAt: number;
+  txHash: string;
+  refCode: string | null;
+}) => ({
+  id: r.id,
+  chainId: r.chainId,
+  marketAddress: r.marketAddress,
+  pickConfigId: r.pickConfigId,
+  predictorHolder: r.predictorHolder,
+  counterpartyHolder: r.counterpartyHolder,
+  predictorTokensBurned: r.predictorTokensBurned,
+  counterpartyTokensBurned: r.counterpartyTokensBurned,
+  predictorPayout: r.predictorPayout,
+  counterpartyPayout: r.counterpartyPayout,
+  burnedAt: r.burnedAt,
+  txHash: r.txHash,
+  refCode: r.refCode ?? null,
+});
+
+const buildClosesConnectionWhere = (
+  filter?: {
+    address?: string | null;
+    chainId?: number | null;
+    pickConfigId?: string | null;
+  } | null
+): Prisma.CloseWhereInput => {
+  const where: Prisma.CloseWhereInput = {};
+  if (filter?.chainId != null) where.chainId = filter.chainId;
+  if (filter?.pickConfigId) {
+    where.pickConfigId = filter.pickConfigId.toLowerCase();
+  }
+  if (filter?.address) {
+    const addr = filter.address.toLowerCase();
+    where.OR = [{ predictorHolder: addr }, { counterpartyHolder: addr }];
+  }
+  return where;
+};
+
+const buildCloseCursorPredicate = (
+  k: string,
+  cursorId: string,
+  direction: 'asc' | 'desc'
+): Prisma.CloseWhereInput => {
+  const op = direction === 'desc' ? 'lt' : 'gt';
+  const burnedAt = Number(k);
+  const id = Number(cursorId);
+  return {
+    OR: [
+      { burnedAt: { [op]: burnedAt } },
+      { AND: [{ burnedAt: { equals: burnedAt } }, { id: { [op]: id } }] },
+    ],
+  };
+};
+
+export const closesConnection = (async (
+  _parent: unknown,
+  args: {
+    first?: number | null;
+    after?: string | null;
+    filter?: {
+      address?: string | null;
+      chainId?: number | null;
+      pickConfigId?: string | null;
+    } | null;
+    orderBy?: { field?: string | null; direction?: string | null } | null;
+  }
+) => {
+  const first = clampTake(args.first ?? undefined, {
+    defaultTake: 50,
+    maxTake: 100,
+  });
+  const direction =
+    String(args.orderBy?.direction).toLowerCase() === 'asc' ? 'asc' : 'desc';
+  const baseWhere = buildClosesConnectionWhere(args.filter);
+  const cursor = args.after ? decodeCursor(args.after) : null;
+  const cursorWhere = cursor
+    ? buildCloseCursorPredicate(cursor.k, cursor.id, direction)
+    : null;
+  const where: Prisma.CloseWhereInput = cursorWhere
+    ? { AND: [baseWhere, cursorWhere] }
+    : baseWhere;
+  const [rows, totalCount] = await Promise.all([
+    prisma.close.findMany({
+      where,
+      orderBy: [{ burnedAt: direction }, { id: direction }],
+      take: first + 1,
+    }),
+    prisma.close.count({ where: baseWhere }),
+  ]);
+  return buildConnection({
+    rows,
+    first,
+    totalCount,
+    getNode: mapCloseRow,
+    getCursor: (row) =>
+      encodeCursor({ k: String(row.burnedAt), id: String(row.id) }),
+  });
+}) as unknown as NonNullable<QueryResolvers['closesConnection']>;

--- a/packages/api/src/graphql/sdl/schema/schema.graphql
+++ b/packages/api/src/graphql/sdl/schema/schema.graphql
@@ -516,6 +516,33 @@ type Claim {
   txHash: String!
 }
 
+type ClaimConnection {
+  edges: [ClaimEdge!]!
+  nodes: [Claim!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type ClaimEdge {
+  node: Claim!
+  cursor: String!
+}
+
+input ClaimFilter {
+  chainId: Int
+  holder: Address
+  predictionId: String
+}
+
+input ClaimOrder {
+  field: ClaimOrderField!
+  direction: OrderDirection!
+}
+
+enum ClaimOrderField {
+  REDEEMED_AT
+}
+
 """
 Record of a position close where both sides burn tokens and receive payouts
 """
@@ -533,6 +560,33 @@ type Close {
   predictorTokensBurned: String!
   refCode: String
   txHash: String!
+}
+
+type CloseConnection {
+  edges: [CloseEdge!]!
+  nodes: [Close!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type CloseEdge {
+  node: Close!
+  cursor: String!
+}
+
+input CloseFilter {
+  address: Address
+  chainId: Int
+  pickConfigId: String
+}
+
+input CloseOrder {
+  field: CloseOrderField!
+  direction: OrderDirection!
+}
+
+enum CloseOrderField {
+  BURNED_AT
 }
 
 type Activity {
@@ -3661,8 +3715,20 @@ type Query {
     take: Int! = 50
   ): [Claim!]!
     @deprecated(
-      reason: "Unused; will be removed. No live consumers — claim records are reachable as a side-effect of position settlement."
+      reason: "Use `claimsConnection(first:, after:, filter:, orderBy:)` — Relay-shaped cursor pagination over the same data."
     )
+
+  """
+  Relay-shaped connection over claim (redemption) records. Forward-only
+  cursor pagination via `first` / `after`; sorting defaults to
+  `REDEEMED_AT` / `DESC`.
+  """
+  claimsConnection(
+    first: Int
+    after: String
+    filter: ClaimFilter
+    orderBy: ClaimOrder
+  ): ClaimConnection!
 
   """
   Look up a single close (settled position exit) record by its row id.
@@ -3680,8 +3746,20 @@ type Query {
     take: Int! = 50
   ): [Close!]!
     @deprecated(
-      reason: "Unused; will be removed. No live consumers — close records are reachable as a side-effect of position settlement."
+      reason: "Use `closesConnection(first:, after:, filter:, orderBy:)` — Relay-shaped cursor pagination over the same data."
     )
+
+  """
+  Relay-shaped connection over position close (burn) records. Forward-only
+  cursor pagination via `first` / `after`; sorting defaults to
+  `BURNED_AT` / `DESC`.
+  """
+  closesConnection(
+    first: Int
+    after: String
+    filter: CloseFilter
+    orderBy: CloseOrder
+  ): CloseConnection!
   """
   Wallet collateral balance — wUSDe holdings for the given account at
   an optional block (defaults to head). Pass `account:` (Address scalar)

--- a/packages/api/test/contract/__snapshots__/schema.sdl.graphql
+++ b/packages/api/test/contract/__snapshots__/schema.sdl.graphql
@@ -406,6 +406,33 @@ type Claim {
   txHash: String!
 }
 
+type ClaimConnection {
+  edges: [ClaimEdge!]!
+  nodes: [Claim!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type ClaimEdge {
+  node: Claim!
+  cursor: String!
+}
+
+input ClaimFilter {
+  chainId: Int
+  holder: Address
+  predictionId: String
+}
+
+input ClaimOrder {
+  field: ClaimOrderField!
+  direction: OrderDirection!
+}
+
+enum ClaimOrderField {
+  REDEEMED_AT
+}
+
 """
 Record of a position close where both sides burn tokens and receive payouts
 """
@@ -423,6 +450,33 @@ type Close {
   predictorTokensBurned: String!
   refCode: String
   txHash: String!
+}
+
+type CloseConnection {
+  edges: [CloseEdge!]!
+  nodes: [Close!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type CloseEdge {
+  node: Close!
+  cursor: String!
+}
+
+input CloseFilter {
+  address: Address
+  chainId: Int
+  pickConfigId: String
+}
+
+input CloseOrder {
+  field: CloseOrderField!
+  direction: OrderDirection!
+}
+
+enum CloseOrderField {
+  BURNED_AT
 }
 
 type Activity {
@@ -3087,7 +3141,14 @@ type Query {
   """
   Paginated list of prediction claim (redemption) records, filterable by holder, prediction, and chain
   """
-  claims(chainId: Int, holder: String, predictionId: String, skip: Int! = 0, take: Int! = 50): [Claim!]! @deprecated(reason: "Unused; will be removed. No live consumers — claim records are reachable as a side-effect of position settlement.")
+  claims(chainId: Int, holder: String, predictionId: String, skip: Int! = 0, take: Int! = 50): [Claim!]! @deprecated(reason: "Use `claimsConnection(first:, after:, filter:, orderBy:)` — Relay-shaped cursor pagination over the same data.")
+
+  """
+  Relay-shaped connection over claim (redemption) records. Forward-only
+  cursor pagination via `first` / `after`; sorting defaults to
+  `REDEEMED_AT` / `DESC`.
+  """
+  claimsConnection(first: Int, after: String, filter: ClaimFilter, orderBy: ClaimOrder): ClaimConnection!
 
   """Look up a single close (settled position exit) record by its row id."""
   close(id: Int!): Close
@@ -3095,7 +3156,14 @@ type Query {
   """
   Paginated list of position close (burn) records, filterable by address, pick config, and chain
   """
-  closes(address: String, chainId: Int, pickConfigId: String, skip: Int! = 0, take: Int! = 50): [Close!]! @deprecated(reason: "Unused; will be removed. No live consumers — close records are reachable as a side-effect of position settlement.")
+  closes(address: String, chainId: Int, pickConfigId: String, skip: Int! = 0, take: Int! = 50): [Close!]! @deprecated(reason: "Use `closesConnection(first:, after:, filter:, orderBy:)` — Relay-shaped cursor pagination over the same data.")
+
+  """
+  Relay-shaped connection over position close (burn) records. Forward-only
+  cursor pagination via `first` / `after`; sorting defaults to
+  `BURNED_AT` / `DESC`.
+  """
+  closesConnection(first: Int, after: String, filter: CloseFilter, orderBy: CloseOrder): CloseConnection!
 
   """
   Wallet collateral balance — wUSDe holdings for the given account at


### PR DESCRIPTION
## Summary
Combines two related changes for the approved-query-list goal:

1. **Relay Connection variants for Claim and Close** (supersedes #1798, rebased onto the merged #1796 + #1797). Each entity in the approved list is meant to have both a singular and plural-Connection form; this finishes the pair.
   - New types: `ClaimConnection` / `ClaimEdge` / `ClaimFilter` / `ClaimOrder` / `ClaimOrderField { REDEEMED_AT }`, same shape for `Close*` with `BURNED_AT`.
   - New top-level queries: `claimsConnection(first:, after:, filter:, orderBy:)`, `closesConnection(...)`.
   - Bare-array `claims` / `closes` deprecation reasons updated to point at the Relay replacements.

2. **`Query.vault(id:)` tolerance fix** (same as #1790, which targets main). Switches the resolver to `tryFromGlobalId` so malformed inputs return `null` instead of throwing `InvalidGlobalIdError`. Makes vault consistent with every other Node-style singular on the surface (`node`, `category`, `position`, `collateralTransfer`).

## Test plan
- [x] `pnpm --filter @sapience/api exec vitest run src/graphql/sdl` — 33 files, 315 tests pass.
- [x] `tsc --noEmit` clean.
- [ ] Contract suite — schema.sdl.graphql snapshot refreshed; introspection.json regenerates in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)