### PR TITLE
ci: deepen checkout so paths-filter can diff without fetching (staging)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
       - uses: dorny/paths-filter@v3
         id: filter
         with:


### PR DESCRIPTION
## Summary
Mirrors #1789 (which targets main) for staging. Pure CI plumbing.

On push events, `dorny/paths-filter@v3` needs the previous commit to compute its diff. With the default shallow checkout (depth 1) it has to `git fetch` that commit, and the fetch intermittently fails with `fatal: could not read Username for 'https://github.com'`, taking the whole `changes` job — and therefore all of CI — down with it.

Setting `fetch-depth: 2` keeps the parent locally so paths-filter never needs to make a network call.

## Why a duplicate PR
#1789 targets main; staging needs the same fix and the `ci.yml` file is currently identical on both branches. Repointing #1789 itself failed due to a GitHub Projects-classic deprecation issue blocking the base-branch edit.

## Test plan
- [ ] CI passes on this PR
- [ ] Once merged, the next push to staging exercises the same paths-filter step without the credential error

🤖 Generated with [Claude Code](https://claude.com/claude-code)