### PR TITLE
fix: restore staging keeper deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "pnpm run build:backend",
-    "build:backend": "pnpm --filter @sapience/sdk run build:lib && pnpm --filter @sapience/api run prisma:generate",
+    "build:backend": "pnpm --filter @sapience/sdk run build:lib && pnpm --filter @sapience/api run prisma:generate && pnpm --filter @sapience/market-keeper run build",
     "build:web": "pnpm --filter @sapience/app run build && pnpm --filter docs run build",
     "test": "pnpm run test --recursive",
     "dev:app": "pnpm --filter @sapience/app run dev",

--- a/packages/market-keeper/scripts/start.js
+++ b/packages/market-keeper/scripts/start.js
@@ -9,9 +9,6 @@ run('node dist/scripts/relist.js');
 run('node dist/scripts/prices-and-1d-7d-volume.js');
 run('node dist/scripts/refresh-volume.js');
 run('node dist/scripts/cleanup-polymarket.js --execute');
-// "today" tag runs AFTER refresh-metadata so we own the tag value last
-// (refresh-metadata can rewrite tags from Polymarket event data).
-run('node dist/scripts/refresh-imminent-tag.js');
 
 if (process.env.DEFAULT_CHAIN_ID === '5064014') {
   run('node dist/scripts/settle-polymarket.js --execute --wait');


### PR DESCRIPTION
## Summary
- build `@sapience/market-keeper` as part of the backend Railpack build path
- stop `scripts/start.js` from invoking `dist/scripts/refresh-imminent-tag.js`, whose source was removed by the GraphQL-surface rollback

## Why
Current `origin/staging` deploy status has only `sapience-core - Keeper` failing. The repo had two keeper deployment footguns:
1. root `build:backend` emitted SDK/API artifacts but not market-keeper `dist/scripts/*`;
2. `packages/market-keeper/scripts/start.js` still called a deleted script after #1802.

## Verification
- `pnpm install --frozen-lockfile --prefer-offline --filter @sapience/market-keeper...`
- `rm -rf packages/market-keeper/dist && pnpm --filter @sapience/market-keeper run build`
- verified required `dist/scripts/*.js` files exist and `refresh-imminent-tag` is no longer called
