### PR TITLE
chore(market-keeper): LLM endTime smoke + silence per-market debug logs

### DIFF
--- a/packages/market-keeper/package.json
+++ b/packages/market-keeper/package.json
@@ -28,6 +28,7 @@
     "refresh-volume:dry-run": "tsx scripts/refresh-volume.ts --dry-run",
     "refresh-metadata": "tsx scripts/refresh-metadata.ts",
     "refresh-metadata:dry-run": "tsx scripts/refresh-metadata.ts --dry-run",
+    "smoke-endtime-llm": "tsx scripts/smoke-endtime-llm.ts",
     "cleanup-polymarket": "tsx scripts/cleanup-polymarket.ts",
     "cleanup-polymarket:dry-run": "tsx scripts/cleanup-polymarket.ts --dry-run",
     "cleanup-polymarket:execute": "tsx scripts/cleanup-polymarket.ts --execute",

--- a/packages/market-keeper/scripts/smoke-endtime-llm.ts
+++ b/packages/market-keeper/scripts/smoke-endtime-llm.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+/// <reference types="node" />
+/**
+ * Deploy-gate smoke for the LLM endTime path.
+ *
+ * Usage:
+ *   tsx scripts/smoke-endtime-llm.ts
+ *
+ * Env:
+ *   OPENROUTER_API_KEY  (required) — real key, smoke fires one paid call
+ *   LLM_ENDTIME_MODEL   (optional) — defaults to constants.ts default
+ *
+ * Exit codes:
+ *   0  LLM endTime path alive end-to-end
+ *   1  Sonar errored, returned UNKNOWN, or decideEndTime regressed
+ */
+
+import 'dotenv/config';
+import { main } from '../src/smoke-endtime-llm/index.js';
+import { logSeparator } from '../src/utils/log.js';
+
+logSeparator('market-keeper:smoke-endtime-llm', 'START');
+main().finally(() =>
+  logSeparator('market-keeper:smoke-endtime-llm', 'END')
+);

--- a/packages/market-keeper/src/generate/transform.ts
+++ b/packages/market-keeper/src/generate/transform.ts
@@ -70,7 +70,6 @@ export function transformMatchQuestion(market: PolymarketMarket): string {
     const [, team1, team2, period, total] = ouMatch;
     const periodText = period ? `${period} ` : '';
     const transformed = `Will ${team1} vs ${team2} ${periodText}total be over ${total}?`;
-    console.log(`[Transform O/U] "${market.question}" -> "${transformed}"`);
     return transformed;
   }
 
@@ -87,9 +86,6 @@ export function transformMatchQuestion(market: PolymarketMarket): string {
     else if (statLower === 'assists') verb = 'record';
     else if (statLower === 'rebounds') verb = 'grab';
     const transformed = `Will ${player} ${verb} over ${value} ${statLower}?`;
-    console.log(
-      `[Transform Player Prop] "${market.question}" -> "${transformed}"`
-    );
     return transformed;
   }
 
@@ -101,9 +97,6 @@ export function transformMatchQuestion(market: PolymarketMarket): string {
   if (totalRoundsMatch) {
     const [, total] = totalRoundsMatch;
     const transformed = `Will total rounds be over ${total}?`;
-    console.log(
-      `[Transform Total Rounds] "${market.question}" -> "${transformed}"`
-    );
     return transformed;
   }
 
@@ -115,9 +108,6 @@ export function transformMatchQuestion(market: PolymarketMarket): string {
   if (gamesTotalMatch) {
     const [, total] = gamesTotalMatch;
     const transformed = `Will total games be over ${total}?`;
-    console.log(
-      `[Transform Games Total] "${market.question}" -> "${transformed}"`
-    );
     return transformed;
   }
 
@@ -130,9 +120,6 @@ export function transformMatchQuestion(market: PolymarketMarket): string {
     const [, team, count] = mapsWinMatch;
     const mapWord = count === '1' ? 'map' : 'maps';
     const transformed = `Will ${team} win at least ${count} ${mapWord}?`;
-    console.log(
-      `[Transform Maps Win] "${market.question}" -> "${transformed}"`
-    );
     return transformed;
   }
 
@@ -144,7 +131,6 @@ export function transformMatchQuestion(market: PolymarketMarket): string {
   if (bttsMatch) {
     const [, team1, team2] = bttsMatch;
     const transformed = `Will both ${team1} and ${team2} score?`;
-    console.log(`[Transform BTTS] "${market.question}" -> "${transformed}"`);
     return transformed;
   }
 
@@ -157,7 +143,6 @@ export function transformMatchQuestion(market: PolymarketMarket): string {
   if (upDownMatch) {
     const [, asset, dateTime] = upDownMatch;
     const transformed = `Will ${asset} go up on ${dateTime}?`;
-    console.log(`[Transform Up/Down] "${market.question}" -> "${transformed}"`);
     return transformed;
   }
 
@@ -181,7 +166,6 @@ export function transformMatchQuestion(market: PolymarketMarket): string {
     const [, prefix, spread] = spreadMatch;
     const context = prefix ? ` (${prefix})` : '';
     const transformed = `${outcomes[0]} covers ${spread} spread vs ${outcomes[1]}?${context}`;
-    console.log(`[Transform Spread] "${market.question}" -> "${transformed}"`);
     return transformed;
   }
 
@@ -204,9 +188,6 @@ export function transformMatchQuestion(market: PolymarketMarket): string {
     const context =
       contextParts.length > 0 ? ` (${contextParts.join(', ')})` : '';
     const transformed = `${outcomes[0]} covers ${handicap} handicap vs ${outcomes[1]}?${context}`;
-    console.log(
-      `[Transform Handicap] "${market.question}" -> "${transformed}"`
-    );
     return transformed;
   }
 
@@ -219,9 +200,6 @@ export function transformMatchQuestion(market: PolymarketMarket): string {
   if (seriesHandicapMatch) {
     const [, team, handicapType, handicap] = seriesHandicapMatch;
     const transformed = `Will ${team} cover the ${handicap} ${handicapType.toLowerCase()} handicap vs ${outcomes[1]}?`;
-    console.log(
-      `[Transform Series Handicap] "${market.question}" -> "${transformed}"`
-    );
     return transformed;
   }
 
@@ -230,7 +208,6 @@ export function transformMatchQuestion(market: PolymarketMarket): string {
   if (mostMatch) {
     const [, metric] = mostMatch;
     const transformed = `${outcomes[0]} gets most ${metric}?`;
-    console.log(`[Transform Most] "${market.question}" -> "${transformed}"`);
     return transformed;
   }
 
@@ -257,9 +234,7 @@ export function transformMatchQuestion(market: PolymarketMarket): string {
   const context =
     contextParts.length > 0 ? ` (${contextParts.join(', ')})` : '';
 
-  // Log transformation for debugging
   const transformed = `${outcomes[0]} beats ${outcomes[1]}?${context}`;
-  console.log(`[Transform] "${market.question}" -> "${transformed}"`);
 
   // Rephrase: first outcome (Yes) beats second outcome (No)
   return transformed;

--- a/packages/market-keeper/src/llm/enrichment.ts
+++ b/packages/market-keeper/src/llm/enrichment.ts
@@ -320,12 +320,7 @@ export async function enrichMarketsWithLLM(
     const results = new Map<string, MarketEnrichmentOutput>();
     let deterministicCount = 0;
     for (const market of markets) {
-      const shortName = resolveShortName(market);
-      if (shortName) {
-        deterministicCount++;
-      } else {
-        console.log(`[LLM] No pattern for short name: "${market.question}"`);
-      }
+      if (resolveShortName(market)) deterministicCount++;
       results.set(market.conditionId, getFallbackEnrichment(market));
     }
     console.log(

--- a/packages/market-keeper/src/smoke-endtime-llm/index.ts
+++ b/packages/market-keeper/src/smoke-endtime-llm/index.ts
@@ -1,0 +1,142 @@
+/**
+ * Smoke test for the LLM endTime path.
+ *
+ * Fires one Perplexity Sonar call against a synthetic Polymarket market,
+ * runs the result through `decideEndTime`, and asserts the combiner picked
+ * the LLM branch. Exit 0 means the LLM wiring (auth, model id, prompt,
+ * citations parse, combiner) is alive end-to-end; exit 1 means something
+ * regressed.
+ *
+ * Where this runs: two Railway services, both invoking this same script.
+ *   - Daily heartbeat: catches external regressions between deploys
+ *     (OpenRouter API shape change, model deprecation, auth rotation).
+ *   - Per-deploy gate: runs after a keeper deploy completes; failing
+ *     deploy is marked unhealthy before traffic is taken.
+ * Keeping OPENROUTER_API_KEY in Railway (not GitHub Actions) blocks the
+ * credit-drain vector of PR-spam abuse via CI workflows.
+ *
+ * Why a synthetic market: the smoke is testing the call path, not endTime
+ * quality. A fixed input keeps the assertion deterministic across runs.
+ * The GraphQL fetch path is exercised by every cron tick — no need to
+ * double-test it here. No DB writes either; smoke is fully read-only.
+ *
+ * Model default is `perplexity/sonar` (cheap) rather than inheriting the
+ * keeper's `perplexity/sonar-pro` default. The smoke proves the *call
+ * path*, not the prod model's hallucination profile — prod model quality
+ * is verified by daily generate output, not by a fixed synthetic market.
+ * Override via LLM_ENDTIME_MODEL=perplexity/sonar-pro if you want to
+ * smoke the prod model explicitly.
+ *
+ * Cost: ~$0.005 per invocation at sonar pricing (dominated by the $5/1000
+ * web-search charge, not tokens). Daily + per-deploy = rounding error.
+ */
+
+import { enrichEndTimesWithLLM } from '../llm';
+import { decideEndTime } from '../generate/api';
+import type { PolymarketMarket, SapienceCondition } from '../types';
+import { log, logError } from '../utils';
+
+const SMOKE_MARKET: PolymarketMarket = {
+  id: 'smoke',
+  conditionId: '0xsmoke',
+  question:
+    'Will the men’s singles final of the 2027 Australian Open be played on or before January 31, 2027?',
+  description:
+    'Resolves YES if the men’s singles final of the 2027 Australian Open is played at any point on or before 11:59 PM AET on January 31, 2027.',
+  events: [{ title: '2027 Australian Open' }],
+  outcomes: ['Yes', 'No'],
+  outcomePrices: [0.5, 0.5],
+  endDate: '2027-01-31T12:59:00Z',
+  volume: '0',
+  liquidity: '0',
+  slug: 'smoke-ao-2027',
+  active: true,
+  closed: false,
+};
+
+// Cheap by default — see file header rationale.
+const SMOKE_DEFAULT_MODEL = 'perplexity/sonar';
+
+export async function runSmoke(): Promise<number> {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  const model = process.env.LLM_ENDTIME_MODEL || SMOKE_DEFAULT_MODEL;
+
+  if (!apiKey) {
+    logError(
+      '[smoke-endtime-llm] FAIL: OPENROUTER_API_KEY not set. The smoke must be invoked with the key wired in from Railway env, never from CI secrets.'
+    );
+    return 1;
+  }
+
+  log(`[smoke-endtime-llm] Calling Sonar with model=${model} ...`);
+
+  let llmMap;
+  try {
+    // Force enabled:true — staging keeper runs with LLM_ENABLED=false at
+    // runtime, and we explicitly want to bypass that gate here.
+    llmMap = await enrichEndTimesWithLLM([SMOKE_MARKET], {
+      enabled: true,
+      apiKey,
+      model,
+    });
+  } catch (err) {
+    logError(
+      `[smoke-endtime-llm] FAIL: Sonar call threw — ${err instanceof Error ? err.message : String(err)}`
+    );
+    return 1;
+  }
+
+  const llmResult = llmMap.get(SMOKE_MARKET.conditionId);
+  if (!llmResult) {
+    logError(
+      '[smoke-endtime-llm] FAIL: Sonar returned no entry for the smoke market — see [LLM:endTime] error logs above.'
+    );
+    return 1;
+  }
+
+  log(
+    `[smoke-endtime-llm] Sonar result: ts=${llmResult.ts}, confidence=${llmResult.confidence}`
+  );
+
+  if (llmResult.ts === null) {
+    logError(
+      `[smoke-endtime-llm] FAIL: Sonar returned a null timestamp (confidence=${llmResult.confidence}). The prompt parses but Sonar refused to commit — investigate the prompt or model.`
+    );
+    return 1;
+  }
+
+  // Run the combiner. With a non-null LLM ts, decideEndTime MUST pick the
+  // LLM branch — anything else is a regression in decideEndTime itself.
+  const condition: SapienceCondition = {
+    conditionHash: SMOKE_MARKET.conditionId,
+    question: SMOKE_MARKET.question,
+    shortName: 'AO 2027 final?',
+    categorySlug: 'sports',
+    endDate: SMOKE_MARKET.endDate,
+    description: SMOKE_MARKET.description,
+    similarMarkets: [],
+    tags: [],
+    chainId: 5064014,
+    llmEndTime: llmResult,
+  };
+
+  const decision = decideEndTime(condition);
+  log(
+    `[smoke-endtime-llm] decideEndTime: source=${decision.source}, ts=${decision.ts}`
+  );
+
+  if (!decision.source.startsWith('llm-')) {
+    logError(
+      `[smoke-endtime-llm] FAIL: combiner picked source=${decision.source} despite a non-null Sonar ts. decideEndTime priority is broken.`
+    );
+    return 1;
+  }
+
+  log('[smoke-endtime-llm] OK: LLM endTime path alive end-to-end.');
+  return 0;
+}
+
+export async function main(): Promise<void> {
+  const code = await runSmoke();
+  process.exit(code);
+}


### PR DESCRIPTION
## Summary

- **New `smoke-endtime-llm` script** — fires one Perplexity Sonar call against a synthetic market and asserts `decideEndTime` picked the `llm-*` branch. Exit 0 = LLM path alive end-to-end.
  - Intended to run from **two Railway services** sharing the same command:
    - Daily cron heartbeat — catches external regressions (OpenRouter API shape change, model deprecation, auth rotation)
    - Per-deploy gate — fails the keeper rollout if a code change broke the LLM call path
  - Keeps `OPENROUTER_API_KEY` out of GitHub Actions secrets so PR-spam can't drain credits.
  - Defaults to cheap `perplexity/sonar`; override via `LLM_ENDTIME_MODEL=perplexity/sonar-pro` to smoke the prod model. Cost ~\$0.005 per call.
  - Read-only: synthetic in-memory market, no DB writes, no admin signing.

- **Silence per-market debug logs**: drop 12 `[Transform ...]` console.logs in `generate/transform.ts` (comment-marked "for debugging") and the per-market `[LLM] No pattern for short name` line in `llm/enrichment.ts`. Aggregate summary lines on either side already capture the same signal; per-market detail was log noise at a few hundred markets per cron tick.

## Test plan

- [x] `pnpm --filter market-keeper run type-check`
- [x] `pnpm --filter market-keeper run test` (407 pass)
- [ ] Smoke locally with a real key: `OPENROUTER_API_KEY=<key> pnpm --filter market-keeper run smoke-endtime-llm` — expect exit 0 + `[smoke-endtime-llm] OK` line
- [ ] Wire as two Railway services after merge (daily cron + post-deploy hook) — out of repo scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)