### PR TITLE
v2: Vault.stats + statsHistory (Option A) + Protocol.tvl

### DIFF
--- a/packages/api/schema.v2.graphql
+++ b/packages/api/schema.v2.graphql
@@ -165,19 +165,27 @@ historical legacy aliases. The small total count means the connection
 exists primarily for enumeration; per-vault refetch goes through
 `vault(address:)`.
 """
-type Vault implements Node & AddressEntity {
+type Vault implements Node {
   id: ID!
 
-  """Canonical lowercase vault contract address (current primary)."""
-  address: Address!
-
-  """Chain the vault is deployed on."""
-  chainId: Int!
+  """
+  The vault's on-chain identity as an account: address, chainId, live wallet
+  balance, ranking, and balance history. A vault *is* an account (by
+  composition); its address and chain live here rather than being duplicated
+  onto `Vault`.
+  """
+  account: Account!
 
   """
   Latest economic snapshot for this vault (balance, deployed/undeployed
   collateral, realized PnL, flows). `null` until the stats writer has
   recorded a first snapshot for the vault.
+
+  DEFERRED — not built yet: this is currently the latest *recorded*
+  snapshot. The target is a live, non-null chain read computed at query time
+  (reusing v1's live-candle helpers in `sdl/resolvers/queries/analytics.ts`)
+  so `/vaults` can drop its own `usePassiveLiquidityVault` RPC reads. Big
+  lift: needs per-request chain reads, not just a snapshot lookup.
   """
   stats: VaultStat
 
@@ -214,6 +222,18 @@ type VaultStat {
   Settlement PnL: gross payouts to the vault minus its primary-creation collateral.
   """
   realizedPnl: BigInt!
+
+  """
+  Cumulative trading PnL the vault dashboard plots: settlement PnL, plus
+  wUSDe earmarked from resolved-but-unredeemed wins, plus net secondary-
+  market flow (`realizedPnl + unredeemedClaim + secondarySold −
+  secondaryBought`). This is the *same* numerator the account behind the
+  vault carries; the vault presents it as a return on total assets
+  (`balance + deployedCollateral`), where the account measures it against
+  deployed capital. The unredeemed term cancels the transient phantom loss
+  between a position resolving and its redeem being indexed.
+  """
+  cumulativePnl: BigInt!
   deposits: BigInt!
   withdrawals: BigInt!
   positionsWon: Int!
@@ -1161,7 +1181,21 @@ breakdowns the dashboard renders. Lookup is via `protocol { … }`; no
 arguments needed.
 """
 type Protocol {
-  stats(first: Int = 100, after: String, filter: ProtocolStatFilter): ProtocolStatConnection!
+  """
+  Live, current protocol-wide stats — a single `ProtocolStat` with
+  `timestamp = now`. Volume / trade-count / open-interest reflect the
+  in-progress period and `totalValueLocked` is read across every configured
+  vault at query time. Use `statsHistory` for the recorded daily series.
+  """
+  stats: ProtocolStat!
+
+  """
+  Recorded protocol-wide snapshots, oldest first — backs the analytics
+  volume / TVL / open-interest time-series charts. (Previously named
+  `stats`; renamed to `statsHistory` so `stats` can be the live singular,
+  matching the `Vault` access pattern.)
+  """
+  statsHistory(first: Int = 100, after: String, filter: ProtocolStatFilter): ProtocolStatConnection!
   openInterestByCategory: [CategoryOpenInterest!]!
 
   """
@@ -1174,21 +1208,14 @@ type Protocol {
   re-key when granularity becomes configurable.
   """
   openInterestByTimeToResolution: [TimeToResolutionBucket!]!
-
-  """
-  Total value locked across the protocol, wei. Escrow collateral (which
-  includes settled-but-unclaimed winnings) plus undeployed available
-  assets summed across **every** configured vault — not just the default
-  one. Computed server-side from the latest per-vault stats snapshots.
-  """
-  tvl: BigInt!
 }
 
 """
 Protocol-wide snapshot of cumulative + period metrics. v2 drops the
-vault-scoped fields v1 carried (`vault*`, `periodPnL`); protocol-level
-TVL is exposed directly as `Protocol.tvl`, and per-vault stat breakdowns
-live on `Vault.stats` / `Vault.statsHistory`.
+vault-scoped fields v1 carried (`vault*`, `periodPnL`); per-vault stat
+breakdowns live on `Vault.stats` / `Vault.statsHistory`. Protocol-level
+TVL is carried here as `totalValueLocked` (read live on `Protocol.stats`,
+aggregated per snapshot on `Protocol.statsHistory`).
 """
 type ProtocolStat {
   timestamp: UnixSeconds!
@@ -1198,6 +1225,15 @@ type ProtocolStat {
   periodTradeCount: Int!
   openInterest: BigInt!
   escrowBalance: BigInt!
+
+  """
+  Total value locked across the protocol, wei: escrow collateral (which
+  includes settled-but-unclaimed winnings) plus undeployed available assets
+  summed across **every** configured vault family — not just the default
+  one (the v1 series under-counted by scoping to a single family). Computed
+  by read-time aggregation, so history and the live `Protocol.stats` agree.
+  """
+  totalValueLocked: BigInt!
 }
 
 type ProtocolStatEdge {

--- a/packages/api/schema.v2.graphql
+++ b/packages/api/schema.v2.graphql
@@ -42,9 +42,14 @@ interface Node {
 """
 Anything addressable on-chain. Both wallet-keyed accounts and
 contract-controlled vaults expose an `address` and a Node identity, so
-v2 unifies them under one interface. Address-scoped fields shared by
-both kinds (`stats`, `collateralBalance`, `rank`, …) attach here in the
-phases that introduce them; this stub starts the interface narrow.
+v2 unifies them under one interface.
+
+The interface is intentionally narrow: `id` + `address`. Account-scoped
+analytics (`ranking`, `collateralBalance`, …) live on `Account`
+directly rather than the interface, because the vault equivalents are
+different metrics (a vault's balance is its on-chain `availableAssets` /
+`deployed`, not a wallet transfer-sum). If a genuinely shared
+address-scoped field emerges, promote it here then.
 """
 interface AddressEntity implements Node {
   id: ID!
@@ -168,6 +173,70 @@ type Vault implements Node & AddressEntity {
 
   """Chain the vault is deployed on."""
   chainId: Int!
+
+  """
+  Latest economic snapshot for this vault (balance, deployed/undeployed
+  collateral, realized PnL, flows). `null` until the stats writer has
+  recorded a first snapshot for the vault.
+  """
+  stats: VaultStat
+
+  """
+  Time-series of this vault's economic snapshots, newest first. Backs the
+  vault dashboard's TVL / PnL charts. Defaults to `TIMESTAMP DESC`.
+  """
+  statsHistory(first: Int = 30, after: String, filter: VaultStatFilter): VaultStatConnection!
+}
+
+"""
+One economic snapshot of a vault, taken by the stats writer. Amounts are
+wUSDe wei. Field names drop the leaked `vault*` Prisma column prefixes
+(redundant under `Vault`) and use the schema's collateral vocabulary.
+"""
+type VaultStat {
+  timestamp: UnixSeconds!
+
+  """
+  Raw wUSDe held by the vault contract (`balanceOf`), excludes deployed
+  funds.
+  """
+  balance: BigInt!
+
+  """Collateral deployed into escrow (backing open positions)."""
+  deployedCollateral: BigInt!
+
+  """
+  Liquid collateral not yet deployed to escrow. `balance + deployed` is AUM.
+  """
+  undeployedCollateral: BigInt!
+
+  """
+  Settlement PnL: gross payouts to the vault minus its primary-creation collateral.
+  """
+  realizedPnl: BigInt!
+  deposits: BigInt!
+  withdrawals: BigInt!
+  positionsWon: Int!
+  positionsLost: Int!
+  collateralWon: BigInt!
+  collateralLost: BigInt!
+}
+
+type VaultStatEdge {
+  cursor: String!
+  node: VaultStat!
+}
+
+type VaultStatConnection {
+  edges: [VaultStatEdge!]!
+  nodes: [VaultStat!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+input VaultStatFilter {
+  """Snapshot timestamp window in epoch seconds (inclusive)."""
+  timestamp: IntRangeFilter
 }
 
 type VaultEdge {
@@ -1105,12 +1174,21 @@ type Protocol {
   re-key when granularity becomes configurable.
   """
   openInterestByTimeToResolution: [TimeToResolutionBucket!]!
+
+  """
+  Total value locked across the protocol, wei. Escrow collateral (which
+  includes settled-but-unclaimed winnings) plus undeployed available
+  assets summed across **every** configured vault — not just the default
+  one. Computed server-side from the latest per-vault stats snapshots.
+  """
+  tvl: BigInt!
 }
 
 """
 Protocol-wide snapshot of cumulative + period metrics. v2 drops the
-vault-scoped fields v1 carried (`vault*`, `periodPnL`) — vault-specific
-stats live on `Vault.stats` in the same shape.
+vault-scoped fields v1 carried (`vault*`, `periodPnL`); protocol-level
+TVL is exposed directly as `Protocol.tvl`, and per-vault stat breakdowns
+live on `Vault.stats` / `Vault.statsHistory`.
 """
 type ProtocolStat {
   timestamp: UnixSeconds!

--- a/packages/api/src/graphql/v2/resolvers/Account.ts
+++ b/packages/api/src/graphql/v2/resolvers/Account.ts
@@ -79,4 +79,11 @@ export const Account: AccountResolvers = {
 
   collateralBalance: collateralBalanceField,
   collateralBalanceHistory: collateralBalanceHistoryField,
+
+  // DEFERRED — not built yet: `stats` / `statsHistory` (AccountStat), the
+  // account's return-on-deployed PnL series (same numerator a vault plots
+  // on-total). No per-account time-series source exists yet — accountStats.ts
+  // is a windowed leaderboard aggregate, not a bucketed series — so this needs
+  // a new per-account snapshot writer/table. No consumer today. See the
+  // matching note on the `Account` type in schema.graphql.
 };

--- a/packages/api/src/graphql/v2/resolvers/Protocol.test.ts
+++ b/packages/api/src/graphql/v2/resolvers/Protocol.test.ts
@@ -143,6 +143,23 @@ describe('Protocol (v2)', () => {
     expect(conn.nodes.map((n) => n.cumulativeTradeCount)).toEqual([5, 9]);
   });
 
+  it('statsHistory honors the filter.timestamp window (display-ts, inclusive)', async () => {
+    // History display timestamps are 913_600 and 1_000_000 (live candle aside).
+    // gte = 1_000_000 should keep only the later row.
+    const conn = await callResolver<{
+      nodes: { timestamp: number; cumulativeVolume: string }[];
+      totalCount: number;
+    }>(Protocol.statsHistory)(
+      null,
+      { filter: { timestamp: { gte: 1_000_000 } } },
+      {},
+      null
+    );
+    expect(conn.totalCount).toBe(1);
+    expect(conn.nodes.map((n) => n.timestamp)).toEqual([1_000_000]);
+    expect(conn.nodes[0].cumulativeVolume).toBe('2000');
+  });
+
   it('stats returns the live candle with live cross-vault TVL', async () => {
     const stat = await callResolver<{
       cumulativeVolume: string;

--- a/packages/api/src/graphql/v2/resolvers/Protocol.test.ts
+++ b/packages/api/src/graphql/v2/resolvers/Protocol.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const INTERVAL = 86400;
+
+// Two configured vault families; legacy lists empty.
+const mockGetConfiguredVaults = vi.hoisted(() =>
+  vi.fn(() => [
+    { kind: 'protocol', address: '0xAAAA', config: { legacy: [] } },
+    { kind: 'pyth', address: '0xBBBB', config: { legacy: [] } },
+  ])
+);
+
+// All-vault raw snapshots at two daily timestamps. Per timestamp, available
+// assets sum across families: 1_000_000 -> 100+200=300, 1_086_400 -> 150+250=400.
+const mockGetProtocolStatsTimeSeries = vi.hoisted(() =>
+  vi.fn(async () => [
+    {
+      vaultAddress: '0xaaaa',
+      timestamp: 1_000_000,
+      vaultAvailableAssets: '100',
+      escrowBalance: '50',
+    },
+    {
+      vaultAddress: '0xbbbb',
+      timestamp: 1_000_000,
+      vaultAvailableAssets: '200',
+      escrowBalance: '50',
+    },
+    {
+      vaultAddress: '0xaaaa',
+      timestamp: 1_086_400,
+      vaultAvailableAssets: '150',
+      escrowBalance: '60',
+    },
+    {
+      vaultAddress: '0xbbbb',
+      timestamp: 1_086_400,
+      vaultAvailableAssets: '250',
+      escrowBalance: '60',
+    },
+  ])
+);
+
+const mockGetLatestProtocolStats = vi.hoisted(() =>
+  vi.fn(async (_chainId: number, address: string) => ({
+    timestamp: 1_086_400,
+    vaultAvailableAssets: address === '0xaaaa' ? '150' : '250',
+    escrowBalance: '60',
+  }))
+);
+
+// v1 protocolStats: two recorded rows (display ts = rawTs − interval) plus the
+// appended in-progress live candle (labelled far in the future, no raw match).
+const mockV1ProtocolStats = vi.hoisted(() =>
+  vi.fn(async () => [
+    {
+      timestamp: 1_000_000 - INTERVAL,
+      cumulativeVolume: '1000',
+      totalTradeCount: 5,
+      periodVolume: '100',
+      periodTradeCount: 2,
+      openInterest: '10',
+      escrowBalance: '50',
+    },
+    {
+      timestamp: 1_086_400 - INTERVAL,
+      cumulativeVolume: '2000',
+      totalTradeCount: 9,
+      periodVolume: '200',
+      periodTradeCount: 4,
+      openInterest: '20',
+      escrowBalance: '60',
+    },
+    {
+      timestamp: 1_700_000_000,
+      cumulativeVolume: '2500',
+      totalTradeCount: 12,
+      periodVolume: '500',
+      periodTradeCount: 3,
+      openInterest: '25',
+      escrowBalance: '70',
+    },
+  ])
+);
+
+vi.mock('../../../services/protocolStats', () => ({
+  getConfiguredVaults: mockGetConfiguredVaults,
+  getLatestProtocolStats: mockGetLatestProtocolStats,
+  getProtocolStatsTimeSeries: mockGetProtocolStatsTimeSeries,
+  resolveSnapshotIntervalSeconds: () => INTERVAL,
+}));
+
+vi.mock('@sapience/sdk/constants', () => ({ DEFAULT_CHAIN_ID: 13374202 }));
+
+vi.mock('@sapience/sdk/contracts', () => ({
+  normalizeLegacyEntry: (le: { address?: string } | string) =>
+    typeof le === 'string' ? { address: le } : { address: le.address ?? '' },
+}));
+
+vi.mock('../../sdl/resolvers/queries/analytics', () => ({
+  protocolStats: mockV1ProtocolStats,
+  openInterestByCategory: vi.fn(),
+  openInterestByTimeToResolution: vi.fn(),
+}));
+
+vi.mock('../cacheHints', () => ({
+  CACHE_HINTS: { SNAPSHOT_MINUTE: {} },
+  setCacheHint: vi.fn(),
+}));
+
+import { Protocol } from './Protocol';
+
+const callResolver = <TResult = unknown>(resolver: unknown) =>
+  resolver as (
+    parent: unknown,
+    args: Record<string, unknown>,
+    ctx: unknown,
+    info: unknown
+  ) => Promise<TResult>;
+
+describe('Protocol (v2)', () => {
+  it('statsHistory drops the live candle and aggregates TVL across all vaults', async () => {
+    const conn = await callResolver<{
+      nodes: {
+        timestamp: number;
+        cumulativeVolume: string;
+        cumulativeTradeCount: number;
+        totalValueLocked: bigint;
+      }[];
+      totalCount: number;
+    }>(Protocol.statsHistory)(null, {}, {}, null);
+
+    // 3 v1 rows in, live candle (cumulativeVolume '2500') filtered out.
+    expect(conn.totalCount).toBe(2);
+    expect(conn.nodes.map((n) => n.cumulativeVolume)).toEqual(['1000', '2000']);
+
+    // totalValueLocked = chain-wide escrow + Σ available across families:
+    //   row1: 50 + 300 = 350 ; row2: 60 + 400 = 460
+    expect(conn.nodes[0].totalValueLocked).toBe(350n);
+    expect(conn.nodes[1].totalValueLocked).toBe(460n);
+
+    // v1's `totalTradeCount` is surfaced as `cumulativeTradeCount`.
+    expect(conn.nodes.map((n) => n.cumulativeTradeCount)).toEqual([5, 9]);
+  });
+
+  it('stats returns the live candle with live cross-vault TVL', async () => {
+    const stat = await callResolver<{
+      cumulativeVolume: string;
+      cumulativeTradeCount: number;
+      totalValueLocked: bigint;
+    }>(Protocol.stats)(null, {}, {}, null);
+
+    expect(stat.cumulativeVolume).toBe('2500');
+    expect(stat.cumulativeTradeCount).toBe(12);
+    // computeProtocolTvl: latest escrow 60 + (150 + 250) = 460
+    expect(stat.totalValueLocked).toBe(460n);
+  });
+});

--- a/packages/api/src/graphql/v2/resolvers/Protocol.ts
+++ b/packages/api/src/graphql/v2/resolvers/Protocol.ts
@@ -1,8 +1,15 @@
 /**
  * `Query.protocol` — singleton entry point for protocol-wide stats and
- * breakdowns. Delegates to v1's stats helpers; v2's `Protocol.stats`
+ * breakdowns. Delegates to v1's stats helpers; `Protocol.statsHistory`
  * wraps the same fat-row pipeline in a forward-only Relay connection
- * with offset cursors (the rows are already materialized in memory).
+ * (offset cursors; rows are already materialized in memory), while
+ * `Protocol.stats` returns the single live/current `ProtocolStat`.
+ *
+ * `totalValueLocked` is computed by read-time aggregation across every
+ * configured vault family (escrow + Σ undeployed available assets). The v1
+ * `protocolStats` series scoped TVL to a single family and under-counted;
+ * here both the live `stats` and each `statsHistory` row sum all families so
+ * they agree.
  */
 
 import type {
@@ -16,6 +23,7 @@ import {
   encodeCursor,
 } from '../relay/connection';
 import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
+import { normalizeLegacyEntry } from '@sapience/sdk/contracts';
 import {
   protocolStats as v1ProtocolStats,
   openInterestByCategory as v1OIByCategory,
@@ -24,10 +32,14 @@ import {
 import {
   getConfiguredVaults,
   getLatestProtocolStats,
+  getProtocolStatsTimeSeries,
+  resolveSnapshotIntervalSeconds,
 } from '../../../services/protocolStats';
 import { CACHE_HINTS, setCacheHint } from '../cacheHints';
 
 type V1Resolver = (parent: null, args: unknown, ctx: unknown) => unknown;
+
+type V1StatRow = Record<string, unknown>;
 
 const DAY = 86400;
 
@@ -49,64 +61,161 @@ const TTR_BUCKET_BOUNDS: Record<
   7: { minSecondsFromNow: 180 * DAY, maxSecondsFromNow: null },
 };
 
+/**
+ * Map a v1 protocolStats row to the public `ProtocolStat` wire shape. The
+ * BigInt-typed volume / open-interest fields are passed through as their
+ * source strings (the BigInt scalar serializes them); `totalValueLocked`
+ * is supplied by the caller as an already-aggregated bigint. Renames v1's
+ * `totalTradeCount` to the schema's `cumulativeTradeCount`.
+ */
+const mapProtocolStat = (row: V1StatRow, totalValueLocked: bigint) => ({
+  timestamp: Number(row.timestamp ?? Math.floor(Date.now() / 1000)),
+  cumulativeVolume: (row.cumulativeVolume as string) ?? '0',
+  cumulativeTradeCount: Number(row.totalTradeCount ?? 0),
+  periodVolume: (row.periodVolume as string) ?? '0',
+  periodTradeCount: Number(row.periodTradeCount ?? 0),
+  openInterest: (row.openInterest as string) ?? '0',
+  escrowBalance: (row.escrowBalance as string) ?? '0',
+  totalValueLocked,
+});
+
+/**
+ * Live protocol TVL = chain-wide escrow + Σ undeployed available assets
+ * across every configured vault family. escrowBalance is denormalized onto
+ * each vault's snapshot, so take it once from the most-recent snapshot.
+ */
+const computeProtocolTvl = async (chainId: number): Promise<bigint> => {
+  const snapshots = await Promise.all(
+    getConfiguredVaults(chainId).map((v) =>
+      getLatestProtocolStats(chainId, v.address.toLowerCase())
+    )
+  );
+  let availableAssetsSum = 0n;
+  let latestEscrow = 0n;
+  let latestTimestamp = -1;
+  for (const snapshot of snapshots) {
+    if (!snapshot) continue;
+    availableAssetsSum += BigInt(snapshot.vaultAvailableAssets || '0');
+    if (snapshot.timestamp > latestTimestamp) {
+      latestTimestamp = snapshot.timestamp;
+      latestEscrow = BigInt(snapshot.escrowBalance || '0');
+    }
+  }
+  return latestEscrow + availableAssetsSum;
+};
+
+/**
+ * Per-(raw)-timestamp sum of undeployed available assets across every vault
+ * family, for the historical TVL series. Rows are deduped per family (a
+ * single timestamp can carry both a current-primary and a since-demoted
+ * legacy row; the primary wins) so a family is never double-counted — the
+ * same guard v1 applies before its per-family series.
+ */
+const crossFamilyAvailableByRawTs = async (
+  chainId: number
+): Promise<Map<number, bigint>> => {
+  const addressToFamily = new Map<string, string>();
+  for (const v of getConfiguredVaults(chainId)) {
+    const primary = v.address.toLowerCase();
+    addressToFamily.set(primary, primary);
+    for (const le of v.config.legacy ?? []) {
+      addressToFamily.set(
+        normalizeLegacyEntry(le).address.toLowerCase(),
+        primary
+      );
+    }
+  }
+
+  const allRows = await getProtocolStatsTimeSeries(undefined, chainId);
+  const deduped = new Map<string, (typeof allRows)[number]>();
+  for (const row of allRows) {
+    const family = addressToFamily.get(row.vaultAddress.toLowerCase());
+    if (!family) continue;
+    const key = `${family}:${row.timestamp}`;
+    const existing = deduped.get(key);
+    if (!existing || row.vaultAddress.toLowerCase() === family) {
+      deduped.set(key, row);
+    }
+  }
+
+  const byTs = new Map<number, bigint>();
+  for (const row of deduped.values()) {
+    byTs.set(
+      row.timestamp,
+      (byTs.get(row.timestamp) ?? 0n) + BigInt(row.vaultAvailableAssets || '0')
+    );
+  }
+  return byTs;
+};
+
 export const protocol: NonNullable<QueryResolvers['protocol']> = () =>
   ({}) as never;
 
 export const Protocol: ProtocolResolvers = {
-  stats: async (_parent, args, _ctx, info) => {
-    // Stats are materialized by a once-per-minute snapshot writer.
+  stats: async (_parent, _args, _ctx, info) => {
     setCacheHint(info, CACHE_HINTS.SNAPSHOT_MINUTE);
-    const rows = (await (v1ProtocolStats as unknown as V1Resolver)(
-      null,
-      {
-        from: args.filter?.timestamp?.gte ?? undefined,
-        to: args.filter?.timestamp?.lte ?? undefined,
-      },
-      null
-    )) as Array<Record<string, unknown>>;
-    const first = clampTake(args.first ?? rows.length, {
-      defaultTake: rows.length || 100,
+    const chainId = DEFAULT_CHAIN_ID;
+    const [rows, totalValueLocked] = await Promise.all([
+      (v1ProtocolStats as unknown as V1Resolver)(null, {}, null) as Promise<
+        V1StatRow[]
+      >,
+      computeProtocolTvl(chainId),
+    ]);
+    // v1 appends the in-progress (live) candle as the last row; fall back to
+    // a zero-valued current snapshot when no snapshots exist at all.
+    const live = rows.length > 0 ? rows[rows.length - 1] : {};
+    return mapProtocolStat(live, totalValueLocked) as never;
+  },
+
+  statsHistory: async (_parent, args, _ctx, info) => {
+    setCacheHint(info, CACHE_HINTS.SNAPSHOT_MINUTE);
+    const chainId = DEFAULT_CHAIN_ID;
+    const interval = resolveSnapshotIntervalSeconds();
+    const [allRows, availableByRawTs] = await Promise.all([
+      (v1ProtocolStats as unknown as V1Resolver)(
+        null,
+        {
+          from: args.filter?.timestamp?.gte ?? undefined,
+          to: args.filter?.timestamp?.lte ?? undefined,
+        },
+        null
+      ) as Promise<V1StatRow[]>,
+      crossFamilyAvailableByRawTs(chainId),
+    ]);
+
+    // Keep only recorded snapshots: a v1 row's display timestamp is
+    // `rawTimestamp − interval`, so a recorded row maps back to a known raw
+    // snapshot. The appended live candle (labelled at the current boundary)
+    // has no matching raw snapshot and is dropped — it's served by `stats`.
+    const rawTsOf = (row: V1StatRow) => Number(row.timestamp ?? 0) + interval;
+    const historyRows = allRows.filter((row) =>
+      availableByRawTs.has(rawTsOf(row))
+    );
+
+    const first = clampTake(args.first ?? historyRows.length, {
+      defaultTake: historyRows.length || 100,
       maxTake: 1000,
     });
     const after = args.after ? decodeCursor(args.after) : null;
     const start = after && /^\d+$/.test(after.k) ? Number(after.k) + 1 : 0;
-    const slice = rows.slice(start, start + first + 1);
+    const slice = historyRows.slice(start, start + first + 1);
 
     return buildConnection({
-      rows: slice as never[],
+      rows: slice,
       first,
-      totalCount: rows.length,
+      totalCount: historyRows.length,
+      getNode: (row) =>
+        mapProtocolStat(
+          row,
+          BigInt((row.escrowBalance as string) ?? '0') +
+            (availableByRawTs.get(rawTsOf(row)) ?? 0n)
+        ),
       getCursor: (row, idx) =>
         encodeCursor({
           k: String(start + idx),
-          id: String((row as { timestamp?: unknown }).timestamp ?? ''),
+          id: String(row.timestamp ?? ''),
         }),
-    });
-  },
-
-  tvl: async () => {
-    const chainId = DEFAULT_CHAIN_ID;
-    // TVL = chain-wide escrow balance + undeployed available assets summed
-    // across every configured vault family (protocol / pyth / single-leg /
-    // strategy-b), not just the default. escrowBalance is denormalized onto
-    // each vault's snapshot, so take it once from the most-recent snapshot.
-    const snapshots = await Promise.all(
-      getConfiguredVaults(chainId).map((v) =>
-        getLatestProtocolStats(chainId, v.address.toLowerCase())
-      )
-    );
-    let availableAssetsSum = 0n;
-    let latestEscrow = 0n;
-    let latestTimestamp = -1;
-    for (const snapshot of snapshots) {
-      if (!snapshot) continue;
-      availableAssetsSum += BigInt(snapshot.vaultAvailableAssets || '0');
-      if (snapshot.timestamp > latestTimestamp) {
-        latestTimestamp = snapshot.timestamp;
-        latestEscrow = BigInt(snapshot.escrowBalance || '0');
-      }
-    }
-    return (latestEscrow + availableAssetsSum) as never;
+    }) as never;
   },
 
   openInterestByCategory: () =>

--- a/packages/api/src/graphql/v2/resolvers/Protocol.ts
+++ b/packages/api/src/graphql/v2/resolvers/Protocol.ts
@@ -15,11 +15,16 @@ import {
   decodeCursor,
   encodeCursor,
 } from '../relay/connection';
+import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
 import {
   protocolStats as v1ProtocolStats,
   openInterestByCategory as v1OIByCategory,
   openInterestByTimeToResolution as v1OIByTTR,
 } from '../../sdl/resolvers/queries/analytics';
+import {
+  getConfiguredVaults,
+  getLatestProtocolStats,
+} from '../../../services/protocolStats';
 import { CACHE_HINTS, setCacheHint } from '../cacheHints';
 
 type V1Resolver = (parent: null, args: unknown, ctx: unknown) => unknown;
@@ -77,6 +82,31 @@ export const Protocol: ProtocolResolvers = {
           id: String((row as { timestamp?: unknown }).timestamp ?? ''),
         }),
     });
+  },
+
+  tvl: async () => {
+    const chainId = DEFAULT_CHAIN_ID;
+    // TVL = chain-wide escrow balance + undeployed available assets summed
+    // across every configured vault family (protocol / pyth / single-leg /
+    // strategy-b), not just the default. escrowBalance is denormalized onto
+    // each vault's snapshot, so take it once from the most-recent snapshot.
+    const snapshots = await Promise.all(
+      getConfiguredVaults(chainId).map((v) =>
+        getLatestProtocolStats(chainId, v.address.toLowerCase())
+      )
+    );
+    let availableAssetsSum = 0n;
+    let latestEscrow = 0n;
+    let latestTimestamp = -1;
+    for (const snapshot of snapshots) {
+      if (!snapshot) continue;
+      availableAssetsSum += BigInt(snapshot.vaultAvailableAssets || '0');
+      if (snapshot.timestamp > latestTimestamp) {
+        latestTimestamp = snapshot.timestamp;
+        latestEscrow = BigInt(snapshot.escrowBalance || '0');
+      }
+    }
+    return (latestEscrow + availableAssetsSum) as never;
   },
 
   openInterestByCategory: () =>

--- a/packages/api/src/graphql/v2/resolvers/Protocol.ts
+++ b/packages/api/src/graphql/v2/resolvers/Protocol.ts
@@ -172,25 +172,30 @@ export const Protocol: ProtocolResolvers = {
     const chainId = DEFAULT_CHAIN_ID;
     const interval = resolveSnapshotIntervalSeconds();
     const [allRows, availableByRawTs] = await Promise.all([
-      (v1ProtocolStats as unknown as V1Resolver)(
-        null,
-        {
-          from: args.filter?.timestamp?.gte ?? undefined,
-          to: args.filter?.timestamp?.lte ?? undefined,
-        },
-        null
-      ) as Promise<V1StatRow[]>,
+      // v1 `protocolStats` takes only `vaultAddress` (defaults to the protocol
+      // family) — it has no time-window args, so `filter.timestamp` is applied
+      // here, in-resolver, against each row's (display) timestamp.
+      (v1ProtocolStats as unknown as V1Resolver)(null, {}, null) as Promise<
+        V1StatRow[]
+      >,
       crossFamilyAvailableByRawTs(chainId),
     ]);
 
-    // Keep only recorded snapshots: a v1 row's display timestamp is
-    // `rawTimestamp − interval`, so a recorded row maps back to a known raw
-    // snapshot. The appended live candle (labelled at the current boundary)
-    // has no matching raw snapshot and is dropped — it's served by `stats`.
+    // Keep only recorded snapshots within the requested window. A v1 row's
+    // display timestamp is `rawTimestamp − interval`, so a recorded row maps
+    // back to a known raw snapshot; the appended live candle (labelled at the
+    // current boundary) has no matching raw snapshot and is dropped — it's
+    // served by `stats`. The `filter.timestamp` bounds are inclusive and match
+    // the node's surfaced (display) `timestamp`.
     const rawTsOf = (row: V1StatRow) => Number(row.timestamp ?? 0) + interval;
-    const historyRows = allRows.filter((row) =>
-      availableByRawTs.has(rawTsOf(row))
-    );
+    const window = args.filter?.timestamp;
+    const historyRows = allRows.filter((row) => {
+      if (!availableByRawTs.has(rawTsOf(row))) return false;
+      const ts = Number(row.timestamp ?? 0);
+      if (window?.gte != null && ts < window.gte) return false;
+      if (window?.lte != null && ts > window.lte) return false;
+      return true;
+    });
 
     const first = clampTake(args.first ?? historyRows.length, {
       defaultTake: historyRows.length || 100,

--- a/packages/api/src/graphql/v2/resolvers/Vault.test.ts
+++ b/packages/api/src/graphql/v2/resolvers/Vault.test.ts
@@ -31,7 +31,15 @@ vi.mock('@sapience/sdk/constants', () => ({
 vi.mock('../../../core/db', () => ({
   default: {
     protocolStatsSnapshot: { findMany: vi.fn(), count: vi.fn() },
+    user: { findUnique: vi.fn().mockResolvedValue(null) },
   },
+}));
+
+vi.mock('../accountSynthesis', () => ({
+  synthesizeAccount: (address: string) => ({
+    address,
+    createdAt: new Date(0),
+  }),
 }));
 
 // Vault.ts registers `Vault` in the v2 Node registry at module import.
@@ -91,6 +99,14 @@ describe('Vault (v2)', () => {
     ]);
   });
 
+  it('account composes a chain-scoped Account from the vault row', async () => {
+    const acct = await callResolver<{ address: string; chainId: number }>(
+      Vault.account
+    )({ id: 'x', address: '0xAAAA', chainId: 13374202 }, {}, {}, null);
+    expect(acct.address).toBe('0xaaaa');
+    expect(acct.chainId).toBe(13374202);
+  });
+
   it('stats maps the latest snapshot to the VaultStat wire shape', async () => {
     mockGetLatestProtocolStats.mockResolvedValue({
       timestamp: 1700000000,
@@ -98,6 +114,9 @@ describe('Vault (v2)', () => {
       vaultDeployed: '500',
       vaultAvailableAssets: '1500',
       vaultRealizedPnL: '42',
+      vaultUnredeemedClaim: '10',
+      vaultSecondarySold: '5',
+      vaultSecondaryBought: '3',
       vaultDeposits: '2000',
       vaultWithdrawals: '300',
       vaultPositionsWon: 7,
@@ -110,12 +129,15 @@ describe('Vault (v2)', () => {
       undeployedCollateral: bigint;
       balance: bigint;
       realizedPnl: bigint;
+      cumulativePnl: bigint;
       positionsWon: number;
     }>(Vault.stats)({ chainId: 13374202, address: '0xAAAA' }, {}, {}, null);
     expect(stat.deployedCollateral).toBe(500n);
     expect(stat.undeployedCollateral).toBe(1500n);
     expect(stat.balance).toBe(1000n);
     expect(stat.realizedPnl).toBe(42n);
+    // cumulativePnl = realized + unredeemed + secondarySold − secondaryBought
+    expect(stat.cumulativePnl).toBe(54n);
     expect(stat.positionsWon).toBe(7);
   });
 

--- a/packages/api/src/graphql/v2/resolvers/Vault.test.ts
+++ b/packages/api/src/graphql/v2/resolvers/Vault.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import { fromGlobalIdV2 } from '../relay/nodeRegistry';
 
+const mockGetLatestProtocolStats = vi.hoisted(() => vi.fn());
+
 vi.mock('../../../services/protocolStats', () => ({
   getConfiguredVaults: vi.fn(() => [
     {
@@ -14,6 +16,7 @@ vi.mock('../../../services/protocolStats', () => ({
       config: { legacy: [] },
     },
   ]),
+  getLatestProtocolStats: mockGetLatestProtocolStats,
 }));
 
 vi.mock('@sapience/sdk/contracts', () => ({
@@ -25,8 +28,14 @@ vi.mock('@sapience/sdk/constants', () => ({
   DEFAULT_CHAIN_ID: 13374202,
 }));
 
+vi.mock('../../../core/db', () => ({
+  default: {
+    protocolStatsSnapshot: { findMany: vi.fn(), count: vi.fn() },
+  },
+}));
+
 // Vault.ts registers `Vault` in the v2 Node registry at module import.
-import { findVaultByAddress } from './Vault';
+import { findVaultByAddress, Vault } from './Vault';
 import { vault, vaults } from './queries/vault';
 
 const callResolver = <TResult = unknown>(resolver: unknown) =>
@@ -80,5 +89,44 @@ describe('Vault (v2)', () => {
       '0x000000000000000000000000000000000000aaaa',
       '0x000000000000000000000000000000000000bbbb',
     ]);
+  });
+
+  it('stats maps the latest snapshot to the VaultStat wire shape', async () => {
+    mockGetLatestProtocolStats.mockResolvedValue({
+      timestamp: 1700000000,
+      vaultBalance: '1000',
+      vaultDeployed: '500',
+      vaultAvailableAssets: '1500',
+      vaultRealizedPnL: '42',
+      vaultDeposits: '2000',
+      vaultWithdrawals: '300',
+      vaultPositionsWon: 7,
+      vaultPositionsLost: 2,
+      vaultCollateralWon: '800',
+      vaultCollateralLost: '100',
+    });
+    const stat = await callResolver<{
+      deployedCollateral: bigint;
+      undeployedCollateral: bigint;
+      balance: bigint;
+      realizedPnl: bigint;
+      positionsWon: number;
+    }>(Vault.stats)({ chainId: 13374202, address: '0xAAAA' }, {}, {}, null);
+    expect(stat.deployedCollateral).toBe(500n);
+    expect(stat.undeployedCollateral).toBe(1500n);
+    expect(stat.balance).toBe(1000n);
+    expect(stat.realizedPnl).toBe(42n);
+    expect(stat.positionsWon).toBe(7);
+  });
+
+  it('stats returns null when no snapshot exists', async () => {
+    mockGetLatestProtocolStats.mockResolvedValue(null);
+    const stat = await callResolver<unknown>(Vault.stats)(
+      { chainId: 13374202, address: '0xAAAA' },
+      {},
+      {},
+      null
+    );
+    expect(stat).toBeNull();
   });
 });

--- a/packages/api/src/graphql/v2/resolvers/Vault.ts
+++ b/packages/api/src/graphql/v2/resolvers/Vault.ts
@@ -1,11 +1,11 @@
 /**
- * v2 Vault — implements Node & AddressEntity.
+ * v2 Vault — implements Node.
  *
  * The configured-vault catalog comes from `services/protocolStats/vaultConfig`,
- * the same source v1 reads from. v2's wire shape drops the leaked
- * `Account` relation and the `collateral` value type; both can be
- * derived (account by address, collateral via chainId mapping) and
- * neither is part of the "what is a vault" surface.
+ * the same source v1 reads from. A vault is an account by composition:
+ * `Vault.account` exposes its address, chainId, balance, and ranking, so the
+ * `Vault` type itself carries no `address`/`chainId` fields (the mapped row
+ * still holds them internally to key snapshot lookups).
  *
  * Global id encoding is `(Vault, "<chainId>:<address>")` because a
  * vault is uniquely identified by its (chainId, address) pair — two
@@ -26,6 +26,7 @@ import {
   decodeCursor,
   encodeCursor,
 } from '../relay/connection';
+import { loadAccount } from './queries/account';
 import type { VaultResolvers } from '../__generated__/resolvers';
 
 export type VaultRow = {
@@ -117,6 +118,14 @@ const mapVaultStat = (row: SnapshotRow) => ({
   deployedCollateral: BigInt(row.vaultDeployed ?? '0'),
   undeployedCollateral: BigInt(row.vaultAvailableAssets ?? '0'),
   realizedPnl: BigInt(row.vaultRealizedPnL ?? '0'),
+  // Cumulative trading PnL — same roll-up v1's analytics chart uses
+  // (settlement + unredeemed wins + net secondary flow). Sourced entirely
+  // from existing snapshot columns; no live recomputation here.
+  cumulativePnl:
+    BigInt(row.vaultRealizedPnL ?? '0') +
+    BigInt(row.vaultUnredeemedClaim ?? '0') +
+    BigInt(row.vaultSecondarySold ?? '0') -
+    BigInt(row.vaultSecondaryBought ?? '0'),
   deposits: BigInt(row.vaultDeposits ?? '0'),
   withdrawals: BigInt(row.vaultWithdrawals ?? '0'),
   positionsWon: row.vaultPositionsWon,
@@ -133,15 +142,34 @@ const mapVaultStat = (row: SnapshotRow) => ({
  * stays a plain property read off the mapped row.
  */
 export const Vault: VaultResolvers = {
-  stats: async (parent) => {
-    const snapshot = await getLatestProtocolStats(
+  // A vault is an account by composition. Resolve the same Account parent
+  // shape the `account(address:)` query produces, scoped to the vault's chain.
+  account: ((parent: VaultRow, _args: unknown, ctx: unknown) =>
+    loadAccount(
+      parent.address,
       parent.chainId,
-      parent.address.toLowerCase()
+      ctx as Parameters<typeof loadAccount>[2]
+    )) as never,
+
+  stats: async (parent) => {
+    // DEFERRED — not built yet: returns the latest *recorded* snapshot. The
+    // target is a live, non-null query-time chain read (reuse v1's live-candle
+    // helpers in sdl/resolvers/queries/analytics.ts) so /vaults can drop
+    // usePassiveLiquidityVault. Big lift — per-request RPC, not a snapshot map.
+    //
+    // The runtime parent is the mapped VaultRow (carries address/chainId for
+    // snapshot lookups); the generated parent type no longer surfaces them
+    // now that the public `Vault` reaches identity through `account`.
+    const row = parent as unknown as VaultRow;
+    const snapshot = await getLatestProtocolStats(
+      row.chainId,
+      row.address.toLowerCase()
     );
     return snapshot ? (mapVaultStat(snapshot) as never) : null;
   },
 
   statsHistory: async (parent, args) => {
+    const row = parent as unknown as VaultRow;
     const first = clampTake(args.first ?? 30, {
       defaultTake: 30,
       maxTake: 365,
@@ -150,8 +178,8 @@ export const Vault: VaultResolvers = {
     const skip = after && /^\d+$/.test(after.k) ? Number(after.k) + 1 : 0;
 
     const where = {
-      chainId: parent.chainId,
-      vaultAddress: parent.address.toLowerCase(),
+      chainId: row.chainId,
+      vaultAddress: row.address.toLowerCase(),
       ...(args.filter?.timestamp
         ? {
             timestamp: {

--- a/packages/api/src/graphql/v2/resolvers/Vault.ts
+++ b/packages/api/src/graphql/v2/resolvers/Vault.ts
@@ -14,8 +14,19 @@
 
 import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
 import { normalizeLegacyEntry } from '@sapience/sdk/contracts';
-import { getConfiguredVaults } from '../../../services/protocolStats';
+import prisma from '../../../core/db';
+import {
+  getConfiguredVaults,
+  getLatestProtocolStats,
+} from '../../../services/protocolStats';
 import { registerNodeTypeV2, toGlobalIdV2 } from '../relay/nodeRegistry';
+import {
+  buildConnection,
+  clampTake,
+  decodeCursor,
+  encodeCursor,
+} from '../relay/connection';
+import type { VaultResolvers } from '../__generated__/resolvers';
 
 export type VaultRow = {
   id: string; // pre-encoded global id
@@ -91,11 +102,88 @@ registerNodeTypeV2({
   },
 });
 
+type SnapshotRow = NonNullable<
+  Awaited<ReturnType<typeof getLatestProtocolStats>>
+>;
+
 /**
- * No custom field resolvers — every Vault field is a plain property on
- * the mapped row. The map lives in this module so resolvers and the
- * Node loader stay in sync.
+ * Map a `protocol_stats_snapshot` row to the public `VaultStat` wire
+ * shape — drops the `vault*` column prefixes (redundant under `Vault`)
+ * and coerces the VarChar-stored bigints.
  */
-export const Vault = {};
+const mapVaultStat = (row: SnapshotRow) => ({
+  timestamp: row.timestamp,
+  balance: BigInt(row.vaultBalance ?? '0'),
+  deployedCollateral: BigInt(row.vaultDeployed ?? '0'),
+  undeployedCollateral: BigInt(row.vaultAvailableAssets ?? '0'),
+  realizedPnl: BigInt(row.vaultRealizedPnL ?? '0'),
+  deposits: BigInt(row.vaultDeposits ?? '0'),
+  withdrawals: BigInt(row.vaultWithdrawals ?? '0'),
+  positionsWon: row.vaultPositionsWon,
+  positionsLost: row.vaultPositionsLost,
+  collateralWon: BigInt(row.vaultCollateralWon ?? '0'),
+  collateralLost: BigInt(row.vaultCollateralLost ?? '0'),
+});
+
+/**
+ * `stats` reads the vault's latest snapshot; `statsHistory` pages the
+ * time series newest-first with an offset cursor (snapshots are a
+ * bounded daily series). Both key on `(chainId, vaultAddress)`, indexed
+ * on `protocol_stats_snapshot`. Identity (`id`, `address`, `chainId`)
+ * stays a plain property read off the mapped row.
+ */
+export const Vault: VaultResolvers = {
+  stats: async (parent) => {
+    const snapshot = await getLatestProtocolStats(
+      parent.chainId,
+      parent.address.toLowerCase()
+    );
+    return snapshot ? (mapVaultStat(snapshot) as never) : null;
+  },
+
+  statsHistory: async (parent, args) => {
+    const first = clampTake(args.first ?? 30, {
+      defaultTake: 30,
+      maxTake: 365,
+    });
+    const after = args.after ? decodeCursor(args.after) : null;
+    const skip = after && /^\d+$/.test(after.k) ? Number(after.k) + 1 : 0;
+
+    const where = {
+      chainId: parent.chainId,
+      vaultAddress: parent.address.toLowerCase(),
+      ...(args.filter?.timestamp
+        ? {
+            timestamp: {
+              ...(args.filter.timestamp.gte != null
+                ? { gte: args.filter.timestamp.gte }
+                : {}),
+              ...(args.filter.timestamp.lte != null
+                ? { lte: args.filter.timestamp.lte }
+                : {}),
+            },
+          }
+        : {}),
+    };
+
+    const [rows, totalCount] = await Promise.all([
+      prisma.protocolStatsSnapshot.findMany({
+        where,
+        orderBy: { timestamp: 'desc' },
+        skip,
+        take: first + 1,
+      }),
+      prisma.protocolStatsSnapshot.count({ where }),
+    ]);
+
+    return buildConnection({
+      rows,
+      first,
+      totalCount,
+      getNode: (row) => mapVaultStat(row),
+      getCursor: (_row, idx) => encodeCursor({ k: String(skip + idx), id: '' }),
+    }) as never;
+  },
+};
 
 export { DEFAULT_CHAIN_ID };

--- a/packages/api/src/graphql/v2/resolvers/queries/account.ts
+++ b/packages/api/src/graphql/v2/resolvers/queries/account.ts
@@ -19,27 +19,44 @@ import {
   withCursorWhere,
 } from '../../relay/connection';
 
-export const account: NonNullable<QueryResolvers['account']> = async (
-  _parent,
-  { address, chainId },
-  ctx
-) => {
+type AccountCtx = {
+  loaders?: { userByAddress?: { load: (a: string) => Promise<unknown> } };
+};
+
+type ResolvedAccount = NonNullable<
+  Awaited<ReturnType<typeof prisma.user.findUnique>>
+>;
+
+/**
+ * Resolve a chain-scoped account view for an address: load the persisted
+ * User row (via the request loader when available) or synthesize one, then
+ * attach the resolved `chainId`. Shared by the `account(address:)` query
+ * and `Vault.account` so both produce the identical Account parent shape.
+ * `chainId` defaults to the deployment's chain when the caller omits it.
+ */
+export const loadAccount = async (
+  address: string,
+  chainId: number | null | undefined,
+  ctx: AccountCtx | null | undefined
+): Promise<ResolvedAccount> => {
   const addressLc = address.toLowerCase();
-  const row = ctx.loaders?.userByAddress
+  const row = ctx?.loaders?.userByAddress
     ? await ctx.loaders.userByAddress.load(addressLc)
     : await prisma.user.findUnique({ where: { address: addressLc } });
   // synthesizeAccount returns a v1-typed Account; the runtime shape matches
-  // the Prisma row mapper used here, so the cast is purely a name-level fix.
-  // Schema declares this as non-null (`account(...): Account!`) — the
-  // synthesis path guarantees a value, never returns null. `chainId` scopes
-  // the account view; it defaults server-side when the caller omits it.
+  // the Prisma row mapper, so the cast is purely a name-level fix. The
+  // synthesis path guarantees a value, never null.
   return {
-    ...((row ?? synthesizeAccount(addressLc)) as NonNullable<
-      Awaited<ReturnType<typeof prisma.user.findUnique>>
-    >),
+    ...((row ?? synthesizeAccount(addressLc)) as ResolvedAccount),
     chainId: chainId ?? DEFAULT_CHAIN_ID,
-  } as NonNullable<Awaited<ReturnType<typeof prisma.user.findUnique>>>;
+  } as ResolvedAccount;
 };
+
+export const account: NonNullable<QueryResolvers['account']> = (
+  _parent,
+  { address, chainId },
+  ctx
+) => loadAccount(address, chainId, ctx);
 
 export const accounts: NonNullable<QueryResolvers['accounts']> = async (
   _parent,

--- a/packages/api/src/graphql/v2/schema/schema.graphql
+++ b/packages/api/src/graphql/v2/schema/schema.graphql
@@ -149,6 +149,17 @@ type Account implements Node & AddressEntity {
     after: String
     intervalSeconds: Int
   ): CollateralBalanceConnection!
+
+  # DEFERRED — not built yet: an account PnL surface mirroring the vault's:
+  #   stats: AccountStat!
+  #   statsHistory(first, after, filter): AccountStatConnection!
+  # This is the "return on deployed" (trading-performance) home — the same
+  # cumulative-PnL numerator a vault plots against total assets, but measured
+  # against the account's deployed capital (collateral in open positions).
+  # Big lift: no per-account time-series source exists today (accountStats.ts
+  # produces only a windowed leaderboard aggregate, not a bucketed series),
+  # and per-account deployed-collateral-over-time isn't tracked at all — it
+  # would need a new per-account snapshot writer + table. No consumer yet.
 }
 
 type AccountEdge {
@@ -207,23 +218,27 @@ historical legacy aliases. The small total count means the connection
 exists primarily for enumeration; per-vault refetch goes through
 `vault(address:)`.
 """
-type Vault implements Node & AddressEntity {
+type Vault implements Node {
   id: ID!
 
   """
-  Canonical lowercase vault contract address (current primary).
+  The vault's on-chain identity as an account: address, chainId, live wallet
+  balance, ranking, and balance history. A vault *is* an account (by
+  composition); its address and chain live here rather than being duplicated
+  onto `Vault`.
   """
-  address: Address!
-
-  """
-  Chain the vault is deployed on.
-  """
-  chainId: Int!
+  account: Account!
 
   """
   Latest economic snapshot for this vault (balance, deployed/undeployed
   collateral, realized PnL, flows). `null` until the stats writer has
   recorded a first snapshot for the vault.
+
+  DEFERRED — not built yet: this is currently the latest *recorded*
+  snapshot. The target is a live, non-null chain read computed at query time
+  (reusing v1's live-candle helpers in `sdl/resolvers/queries/analytics.ts`)
+  so `/vaults` can drop its own `usePassiveLiquidityVault` RPC reads. Big
+  lift: needs per-request chain reads, not just a snapshot lookup.
   """
   stats: VaultStat
 
@@ -256,6 +271,17 @@ type VaultStat {
   undeployedCollateral: BigInt!
   """Settlement PnL: gross payouts to the vault minus its primary-creation collateral."""
   realizedPnl: BigInt!
+  """
+  Cumulative trading PnL the vault dashboard plots: settlement PnL, plus
+  wUSDe earmarked from resolved-but-unredeemed wins, plus net secondary-
+  market flow (`realizedPnl + unredeemedClaim + secondarySold −
+  secondaryBought`). This is the *same* numerator the account behind the
+  vault carries; the vault presents it as a return on total assets
+  (`balance + deployedCollateral`), where the account measures it against
+  deployed capital. The unredeemed term cancels the transient phantom loss
+  between a position resolving and its redeem being indexed.
+  """
+  cumulativePnl: BigInt!
   deposits: BigInt!
   withdrawals: BigInt!
   positionsWon: Int!
@@ -1298,7 +1324,21 @@ breakdowns the dashboard renders. Lookup is via `protocol { … }`; no
 arguments needed.
 """
 type Protocol {
-  stats(
+  """
+  Live, current protocol-wide stats — a single `ProtocolStat` with
+  `timestamp = now`. Volume / trade-count / open-interest reflect the
+  in-progress period and `totalValueLocked` is read across every configured
+  vault at query time. Use `statsHistory` for the recorded daily series.
+  """
+  stats: ProtocolStat!
+
+  """
+  Recorded protocol-wide snapshots, oldest first — backs the analytics
+  volume / TVL / open-interest time-series charts. (Previously named
+  `stats`; renamed to `statsHistory` so `stats` can be the live singular,
+  matching the `Vault` access pattern.)
+  """
+  statsHistory(
     first: Int = 100
     after: String
     filter: ProtocolStatFilter
@@ -1314,21 +1354,14 @@ type Protocol {
   re-key when granularity becomes configurable.
   """
   openInterestByTimeToResolution: [TimeToResolutionBucket!]!
-
-  """
-  Total value locked across the protocol, wei. Escrow collateral (which
-  includes settled-but-unclaimed winnings) plus undeployed available
-  assets summed across **every** configured vault — not just the default
-  one. Computed server-side from the latest per-vault stats snapshots.
-  """
-  tvl: BigInt!
 }
 
 """
 Protocol-wide snapshot of cumulative + period metrics. v2 drops the
-vault-scoped fields v1 carried (`vault*`, `periodPnL`); protocol-level
-TVL is exposed directly as `Protocol.tvl`, and per-vault stat breakdowns
-live on `Vault.stats` / `Vault.statsHistory`.
+vault-scoped fields v1 carried (`vault*`, `periodPnL`); per-vault stat
+breakdowns live on `Vault.stats` / `Vault.statsHistory`. Protocol-level
+TVL is carried here as `totalValueLocked` (read live on `Protocol.stats`,
+aggregated per snapshot on `Protocol.statsHistory`).
 """
 type ProtocolStat {
   timestamp: UnixSeconds!
@@ -1338,6 +1371,14 @@ type ProtocolStat {
   periodTradeCount: Int!
   openInterest: BigInt!
   escrowBalance: BigInt!
+  """
+  Total value locked across the protocol, wei: escrow collateral (which
+  includes settled-but-unclaimed winnings) plus undeployed available assets
+  summed across **every** configured vault family — not just the default
+  one (the v1 series under-counted by scoping to a single family). Computed
+  by read-time aggregation, so history and the live `Protocol.stats` agree.
+  """
+  totalValueLocked: BigInt!
 }
 
 type ProtocolStatEdge {

--- a/packages/api/src/graphql/v2/schema/schema.graphql
+++ b/packages/api/src/graphql/v2/schema/schema.graphql
@@ -62,9 +62,14 @@ interface Node {
 """
 Anything addressable on-chain. Both wallet-keyed accounts and
 contract-controlled vaults expose an `address` and a Node identity, so
-v2 unifies them under one interface. Address-scoped fields shared by
-both kinds (`stats`, `collateralBalance`, `rank`, …) attach here in the
-phases that introduce them; this stub starts the interface narrow.
+v2 unifies them under one interface.
+
+The interface is intentionally narrow: `id` + `address`. Account-scoped
+analytics (`ranking`, `collateralBalance`, …) live on `Account`
+directly rather than the interface, because the vault equivalents are
+different metrics (a vault's balance is its on-chain `availableAssets` /
+`deployed`, not a wallet transfer-sum). If a genuinely shared
+address-scoped field emerges, promote it here then.
 """
 interface AddressEntity implements Node {
   id: ID!
@@ -214,6 +219,66 @@ type Vault implements Node & AddressEntity {
   Chain the vault is deployed on.
   """
   chainId: Int!
+
+  """
+  Latest economic snapshot for this vault (balance, deployed/undeployed
+  collateral, realized PnL, flows). `null` until the stats writer has
+  recorded a first snapshot for the vault.
+  """
+  stats: VaultStat
+
+  """
+  Time-series of this vault's economic snapshots, newest first. Backs the
+  vault dashboard's TVL / PnL charts. Defaults to `TIMESTAMP DESC`.
+  """
+  statsHistory(
+    first: Int = 30
+    after: String
+    filter: VaultStatFilter
+  ): VaultStatConnection!
+}
+
+"""
+One economic snapshot of a vault, taken by the stats writer. Amounts are
+wUSDe wei. Field names drop the leaked `vault*` Prisma column prefixes
+(redundant under `Vault`) and use the schema's collateral vocabulary.
+"""
+type VaultStat {
+  timestamp: UnixSeconds!
+  """
+  Raw wUSDe held by the vault contract (`balanceOf`), excludes deployed
+  funds.
+  """
+  balance: BigInt!
+  """Collateral deployed into escrow (backing open positions)."""
+  deployedCollateral: BigInt!
+  """Liquid collateral not yet deployed to escrow. `balance + deployed` is AUM."""
+  undeployedCollateral: BigInt!
+  """Settlement PnL: gross payouts to the vault minus its primary-creation collateral."""
+  realizedPnl: BigInt!
+  deposits: BigInt!
+  withdrawals: BigInt!
+  positionsWon: Int!
+  positionsLost: Int!
+  collateralWon: BigInt!
+  collateralLost: BigInt!
+}
+
+type VaultStatEdge {
+  cursor: String!
+  node: VaultStat!
+}
+
+type VaultStatConnection {
+  edges: [VaultStatEdge!]!
+  nodes: [VaultStat!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+input VaultStatFilter {
+  """Snapshot timestamp window in epoch seconds (inclusive)."""
+  timestamp: IntRangeFilter
 }
 
 type VaultEdge {
@@ -1249,12 +1314,21 @@ type Protocol {
   re-key when granularity becomes configurable.
   """
   openInterestByTimeToResolution: [TimeToResolutionBucket!]!
+
+  """
+  Total value locked across the protocol, wei. Escrow collateral (which
+  includes settled-but-unclaimed winnings) plus undeployed available
+  assets summed across **every** configured vault — not just the default
+  one. Computed server-side from the latest per-vault stats snapshots.
+  """
+  tvl: BigInt!
 }
 
 """
 Protocol-wide snapshot of cumulative + period metrics. v2 drops the
-vault-scoped fields v1 carried (`vault*`, `periodPnL`) — vault-specific
-stats live on `Vault.stats` in the same shape.
+vault-scoped fields v1 carried (`vault*`, `periodPnL`); protocol-level
+TVL is exposed directly as `Protocol.tvl`, and per-vault stat breakdowns
+live on `Vault.stats` / `Vault.statsHistory`.
 """
 type ProtocolStat {
   timestamp: UnixSeconds!

--- a/packages/sdk/types/graphql.v2.ts
+++ b/packages/sdk/types/graphql.v2.ts
@@ -930,14 +930,20 @@ export type Protocol = {
    * re-key when granularity becomes configurable.
    */
   openInterestByTimeToResolution: Array<TimeToResolutionBucket>;
-  stats: ProtocolStatConnection;
   /**
-   * Total value locked across the protocol, wei. Escrow collateral (which
-   * includes settled-but-unclaimed winnings) plus undeployed available
-   * assets summed across **every** configured vault — not just the default
-   * one. Computed server-side from the latest per-vault stats snapshots.
+   * Live, current protocol-wide stats — a single `ProtocolStat` with
+   * `timestamp = now`. Volume / trade-count / open-interest reflect the
+   * in-progress period and `totalValueLocked` is read across every configured
+   * vault at query time. Use `statsHistory` for the recorded daily series.
    */
-  tvl: Scalars['BigInt']['output'];
+  stats: ProtocolStat;
+  /**
+   * Recorded protocol-wide snapshots, oldest first — backs the analytics
+   * volume / TVL / open-interest time-series charts. (Previously named
+   * `stats`; renamed to `statsHistory` so `stats` can be the live singular,
+   * matching the `Vault` access pattern.)
+   */
+  statsHistory: ProtocolStatConnection;
 };
 
 /**
@@ -945,7 +951,7 @@ export type Protocol = {
  * breakdowns the dashboard renders. Lookup is via `protocol { … }`; no
  * arguments needed.
  */
-export type ProtocolStatsArgs = {
+export type ProtocolStatsHistoryArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   filter?: InputMaybe<ProtocolStatFilter>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -953,9 +959,10 @@ export type ProtocolStatsArgs = {
 
 /**
  * Protocol-wide snapshot of cumulative + period metrics. v2 drops the
- * vault-scoped fields v1 carried (`vault*`, `periodPnL`); protocol-level
- * TVL is exposed directly as `Protocol.tvl`, and per-vault stat breakdowns
- * live on `Vault.stats` / `Vault.statsHistory`.
+ * vault-scoped fields v1 carried (`vault*`, `periodPnL`); per-vault stat
+ * breakdowns live on `Vault.stats` / `Vault.statsHistory`. Protocol-level
+ * TVL is carried here as `totalValueLocked` (read live on `Protocol.stats`,
+ * aggregated per snapshot on `Protocol.statsHistory`).
  */
 export type ProtocolStat = {
   __typename?: 'ProtocolStat';
@@ -966,6 +973,14 @@ export type ProtocolStat = {
   periodTradeCount: Scalars['Int']['output'];
   periodVolume: Scalars['BigInt']['output'];
   timestamp: Scalars['UnixSeconds']['output'];
+  /**
+   * Total value locked across the protocol, wei: escrow collateral (which
+   * includes settled-but-unclaimed winnings) plus undeployed available assets
+   * summed across **every** configured vault family — not just the default
+   * one (the v1 series under-counted by scoping to a single family). Computed
+   * by read-time aggregation, so history and the live `Protocol.stats` agree.
+   */
+  totalValueLocked: Scalars['BigInt']['output'];
 };
 
 export type ProtocolStatConnection = {
@@ -1632,26 +1647,34 @@ export type TradeOrderField = 'BLOCK_NUMBER' | 'EXECUTED_AT';
  * exists primarily for enumeration; per-vault refetch goes through
  * `vault(address:)`.
  */
-export type Vault = AddressEntity &
-  Node & {
-    __typename?: 'Vault';
-    /** Canonical lowercase vault contract address (current primary). */
-    address: Scalars['Address']['output'];
-    /** Chain the vault is deployed on. */
-    chainId: Scalars['Int']['output'];
-    id: Scalars['ID']['output'];
-    /**
-     * Latest economic snapshot for this vault (balance, deployed/undeployed
-     * collateral, realized PnL, flows). `null` until the stats writer has
-     * recorded a first snapshot for the vault.
-     */
-    stats?: Maybe<VaultStat>;
-    /**
-     * Time-series of this vault's economic snapshots, newest first. Backs the
-     * vault dashboard's TVL / PnL charts. Defaults to `TIMESTAMP DESC`.
-     */
-    statsHistory: VaultStatConnection;
-  };
+export type Vault = Node & {
+  __typename?: 'Vault';
+  /**
+   * The vault's on-chain identity as an account: address, chainId, live wallet
+   * balance, ranking, and balance history. A vault *is* an account (by
+   * composition); its address and chain live here rather than being duplicated
+   * onto `Vault`.
+   */
+  account: Account;
+  id: Scalars['ID']['output'];
+  /**
+   * Latest economic snapshot for this vault (balance, deployed/undeployed
+   * collateral, realized PnL, flows). `null` until the stats writer has
+   * recorded a first snapshot for the vault.
+   *
+   * DEFERRED — not built yet: this is currently the latest *recorded*
+   * snapshot. The target is a live, non-null chain read computed at query time
+   * (reusing v1's live-candle helpers in `sdl/resolvers/queries/analytics.ts`)
+   * so `/vaults` can drop its own `usePassiveLiquidityVault` RPC reads. Big
+   * lift: needs per-request chain reads, not just a snapshot lookup.
+   */
+  stats?: Maybe<VaultStat>;
+  /**
+   * Time-series of this vault's economic snapshots, newest first. Backs the
+   * vault dashboard's TVL / PnL charts. Defaults to `TIMESTAMP DESC`.
+   */
+  statsHistory: VaultStatConnection;
+};
 
 /**
  * A statically configured protocol vault. Vaults are address-keyed like
@@ -1719,6 +1742,17 @@ export type VaultStat = {
   balance: Scalars['BigInt']['output'];
   collateralLost: Scalars['BigInt']['output'];
   collateralWon: Scalars['BigInt']['output'];
+  /**
+   * Cumulative trading PnL the vault dashboard plots: settlement PnL, plus
+   * wUSDe earmarked from resolved-but-unredeemed wins, plus net secondary-
+   * market flow (`realizedPnl + unredeemedClaim + secondarySold −
+   * secondaryBought`). This is the *same* numerator the account behind the
+   * vault carries; the vault presents it as a return on total assets
+   * (`balance + deployedCollateral`), where the account measures it against
+   * deployed capital. The unredeemed term cancels the transient phantom loss
+   * between a position resolving and its redeem being indexed.
+   */
+  cumulativePnl: Scalars['BigInt']['output'];
   /** Collateral deployed into escrow (backing open positions). */
   deployedCollateral: Scalars['BigInt']['output'];
   deposits: Scalars['BigInt']['output'];

--- a/packages/sdk/types/graphql.v2.ts
+++ b/packages/sdk/types/graphql.v2.ts
@@ -190,9 +190,14 @@ export type ActivityType = 'PREDICTION' | 'TRADE';
 /**
  * Anything addressable on-chain. Both wallet-keyed accounts and
  * contract-controlled vaults expose an `address` and a Node identity, so
- * v2 unifies them under one interface. Address-scoped fields shared by
- * both kinds (`stats`, `collateralBalance`, `rank`, …) attach here in the
- * phases that introduce them; this stub starts the interface narrow.
+ * v2 unifies them under one interface.
+ *
+ * The interface is intentionally narrow: `id` + `address`. Account-scoped
+ * analytics (`ranking`, `collateralBalance`, …) live on `Account`
+ * directly rather than the interface, because the vault equivalents are
+ * different metrics (a vault's balance is its on-chain `availableAssets` /
+ * `deployed`, not a wallet transfer-sum). If a genuinely shared
+ * address-scoped field emerges, promote it here then.
  */
 export type AddressEntity = {
   address: Scalars['Address']['output'];
@@ -926,6 +931,13 @@ export type Protocol = {
    */
   openInterestByTimeToResolution: Array<TimeToResolutionBucket>;
   stats: ProtocolStatConnection;
+  /**
+   * Total value locked across the protocol, wei. Escrow collateral (which
+   * includes settled-but-unclaimed winnings) plus undeployed available
+   * assets summed across **every** configured vault — not just the default
+   * one. Computed server-side from the latest per-vault stats snapshots.
+   */
+  tvl: Scalars['BigInt']['output'];
 };
 
 /**
@@ -941,8 +953,9 @@ export type ProtocolStatsArgs = {
 
 /**
  * Protocol-wide snapshot of cumulative + period metrics. v2 drops the
- * vault-scoped fields v1 carried (`vault*`, `periodPnL`) — vault-specific
- * stats live on `Vault.stats` in the same shape.
+ * vault-scoped fields v1 carried (`vault*`, `periodPnL`); protocol-level
+ * TVL is exposed directly as `Protocol.tvl`, and per-vault stat breakdowns
+ * live on `Vault.stats` / `Vault.statsHistory`.
  */
 export type ProtocolStat = {
   __typename?: 'ProtocolStat';
@@ -1627,7 +1640,31 @@ export type Vault = AddressEntity &
     /** Chain the vault is deployed on. */
     chainId: Scalars['Int']['output'];
     id: Scalars['ID']['output'];
+    /**
+     * Latest economic snapshot for this vault (balance, deployed/undeployed
+     * collateral, realized PnL, flows). `null` until the stats writer has
+     * recorded a first snapshot for the vault.
+     */
+    stats?: Maybe<VaultStat>;
+    /**
+     * Time-series of this vault's economic snapshots, newest first. Backs the
+     * vault dashboard's TVL / PnL charts. Defaults to `TIMESTAMP DESC`.
+     */
+    statsHistory: VaultStatConnection;
   };
+
+/**
+ * A statically configured protocol vault. Vaults are address-keyed like
+ * accounts but contract-controlled, with their own deployment kind and
+ * historical legacy aliases. The small total count means the connection
+ * exists primarily for enumeration; per-vault refetch goes through
+ * `vault(address:)`.
+ */
+export type VaultStatsHistoryArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<VaultStatFilter>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+};
 
 export type VaultConnection = {
   __typename?: 'VaultConnection';
@@ -1667,6 +1704,52 @@ export type VaultOrder = {
  * for future sort columns.
  */
 export type VaultOrderField = 'ADDRESS';
+
+/**
+ * One economic snapshot of a vault, taken by the stats writer. Amounts are
+ * wUSDe wei. Field names drop the leaked `vault*` Prisma column prefixes
+ * (redundant under `Vault`) and use the schema's collateral vocabulary.
+ */
+export type VaultStat = {
+  __typename?: 'VaultStat';
+  /**
+   * Raw wUSDe held by the vault contract (`balanceOf`), excludes deployed
+   * funds.
+   */
+  balance: Scalars['BigInt']['output'];
+  collateralLost: Scalars['BigInt']['output'];
+  collateralWon: Scalars['BigInt']['output'];
+  /** Collateral deployed into escrow (backing open positions). */
+  deployedCollateral: Scalars['BigInt']['output'];
+  deposits: Scalars['BigInt']['output'];
+  positionsLost: Scalars['Int']['output'];
+  positionsWon: Scalars['Int']['output'];
+  /** Settlement PnL: gross payouts to the vault minus its primary-creation collateral. */
+  realizedPnl: Scalars['BigInt']['output'];
+  timestamp: Scalars['UnixSeconds']['output'];
+  /** Liquid collateral not yet deployed to escrow. `balance + deployed` is AUM. */
+  undeployedCollateral: Scalars['BigInt']['output'];
+  withdrawals: Scalars['BigInt']['output'];
+};
+
+export type VaultStatConnection = {
+  __typename?: 'VaultStatConnection';
+  edges: Array<VaultStatEdge>;
+  nodes: Array<VaultStat>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type VaultStatEdge = {
+  __typename?: 'VaultStatEdge';
+  cursor: Scalars['String']['output'];
+  node: VaultStat;
+};
+
+export type VaultStatFilter = {
+  /** Snapshot timestamp window in epoch seconds (inclusive). */
+  timestamp?: InputMaybe<IntRangeFilter>;
+};
 
 /**
  * Which similar-market-volume window the filter / sort looks at.


### PR DESCRIPTION
## Summary

Stacked on `feat/v2-graphql-endpoint` to review **Option A** for the vault-economics surface (findings #16/#23) before deciding between this and the lighter Option B.

- **`Vault.stats: VaultStat`** — latest economic snapshot per vault (balance, deployed/undeployed collateral, realized PnL, deposits/withdrawals, wins/losses). Null until the stats writer records a first snapshot.
- **`Vault.statsHistory(first, after, filter): VaultStatConnection!`** — newest-first time series, backing the vault dashboard's TVL/PnL charts.
- **`Protocol.tvl: BigInt!`** — escrow collateral + undeployed collateral summed across **all** configured vaults (protocol / pyth / single-leg / strategy-b). Fixes a v1 undercount (v1 only counted the default vault) and replaces the FE's hand-rolled `escrowBalance + vaultAvailableAssets`.
- New types: `VaultStat`, `VaultStatEdge`, `VaultStatConnection`, `VaultStatFilter`. Field names drop the leaked `vault*` Prisma prefixes and use the schema's collateral vocabulary.
- Docstring fixes: `ProtocolStat` no longer promises a nonexistent `Vault.stats`; `AddressEntity` documents why account-scoped analytics stay on `Account` (#23).

## Option A vs B

- **A (this PR):** richer per-vault surface (`Vault.stats` / `statsHistory`), time-series capable, FE-migration-ready for the `/vault` dashboard. Costs a `VaultStat` type + connection + filter.
- **B (alternative):** just `Vault.deployedCollateral` / `Vault.undeployedCollateral` bare fields + `Protocol.tvl`. Smaller, but no time series and no path off the `/vault` page's on-chain `getTotalLiquidValue()` read.

## Notes

- Backed by `protocol_stats_snapshot` `(chainId, vaultAddress, timestamp)`.
- Cumulative PnL for the PnL chart is a follow-up — `VaultStat` exposes per-period `realizedPnl` today.

## Test plan

- [x] `pnpm --filter @sapience/api run test` — 590 passing
- [x] type-check clean (v1 + v2 codegen)
- [ ] decide A vs B; if A, fold into the v2 branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)