### PR TITLE
Add event identity columns to condition_group

### DIFF
--- a/packages/api/prisma/migrations/20260526232237_add_condition_group_event_identity/migration.sql
+++ b/packages/api/prisma/migrations/20260526232237_add_condition_group_event_identity/migration.sql
@@ -1,0 +1,24 @@
+-- Future-proof condition_group identity: add a (source, externalEventId)
+-- shape so we can later switch the keeper from name-keyed lookups (which
+-- silently collapse weekly Polymarket events into a single group — see the
+-- backfill investigation in scripts/investigateEventGrouping.ts) to
+-- event-keyed lookups.
+--
+-- Backwards-compatible by design: the existing UNIQUE("name") constraint
+-- stays in place, and `source`/`externalEventId` are populated by a
+-- separate backfill script. Application code keeps treating
+-- `source = 'polymarket'` as implicit until a follow-up PR switches the
+-- keeper to read the new identity. See
+-- scripts/backfillConditionGroupEvent.ts for the data fill.
+
+ALTER TABLE "condition_group"
+  ADD COLUMN "source" VARCHAR NOT NULL DEFAULT 'polymarket',
+  ADD COLUMN "externalEventId" VARCHAR;
+
+-- Partial uniqueness — the canonical identity for platform-sourced groups.
+-- NULL externalEventId is allowed for legacy / Sapience-native / curated
+-- groups and intentionally falls outside this index (Postgres treats NULL
+-- as distinct, so multiple NULL rows coexist without colliding here).
+CREATE UNIQUE INDEX "uq_condition_group_source_event"
+  ON "condition_group" ("source", "externalEventId")
+  WHERE "externalEventId" IS NOT NULL;

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -240,6 +240,19 @@ model ConditionGroup {
   /// field is derived from this being non-null; the boolean itself is not
   /// stored as a column.
   negRiskMarketId String?    @db.VarChar
+  /// Origin of the group's identity. Future-proofs for multi-platform support
+  /// without threading `(source, externalEventId)` through every resolver
+  /// today — application code still treats this column as implicitly
+  /// `'polymarket'`. Add new sources only when a non-Polymarket integration
+  /// actually lands.
+  source         String      @default("polymarket") @db.VarChar
+  /// Stable platform-level identifier for the group. For
+  /// `source = 'polymarket'` this is the Polymarket event id
+  /// (`events[0].id` on the Gamma /markets response). Null for legacy /
+  /// Sapience-native / curated groups that don't originate from a platform
+  /// event. Uniqueness is enforced together with `source` by a partial
+  /// unique index — see migration.
+  externalEventId String?    @db.VarChar
   condition      Condition[]
 
   // Denormalized aggregates maintained by trigger on condition table
@@ -269,6 +282,10 @@ model ConditionGroup {
   // - IDX_cg_total_prediction_count: "totalPredictionCount" DESC WHERE "publicConditionCount" > 0
   // - IDX_cg_max_created_at_epoch: "maxCreatedAtEpoch" DESC WHERE "publicConditionCount" > 0
   // - IDX_cg_total_volume_*: volume DESC WHERE "publicConditionCount" > 0
+  // - uq_condition_group_source_event: partial UNIQUE("source","externalEventId")
+  //   WHERE "externalEventId" IS NOT NULL — the canonical identity for
+  //   platform-sourced groups. Cannot be represented as a Prisma @@unique
+  //   because Prisma 6 doesn't support partial unique indexes natively.
   // Trigger: trg_condition_group_aggregates maintains aggregates on condition INSERT/UPDATE/DELETE
   @@map("condition_group")
 }


### PR DESCRIPTION
## Summary

- Adds two additive columns to `condition_group`: `source` (default `'polymarket'`) and `externalEventId` (nullable, Polymarket event id when set)
- Adds a **partial** unique index `uq_condition_group_source_event` on `(source, externalEventId) WHERE externalEventId IS NOT NULL`
- **No drops, no data changes, no behavioural changes to existing code paths** — `UNIQUE(name)` is intentionally retained for now

## Why

We're staging an architectural shift: condition_group identity will move from name-keyed to event-keyed. Today the keeper folds same-named Polymarket markets across weeks/seasons into a single group (e.g. "Top US Netflix Movie This Week" silently merges 11 weeks of distinct Polymarket events into one Sapience group), causing the basket-invariant conflicts we've been triaging.

A separate investigation against the affected data confirmed a perfect 1:1 bijection between Polymarket events and negRisk baskets — see `scripts/investigateEventGrouping.ts` in a follow-up PR. That's what makes `externalEventId` a sound identity choice.

This PR only adds the **storage shape**. The application code that *reads* the new identity (keeper / admin route changes) and the data backfill that *populates* it are sequenced as follow-up PRs:

1. ✅ (this PR) Schema migration — additive, low-risk
2. Backfill script — populates `externalEventId` (and opportunistically `negRiskMarketId` where NULL) from Polymarket Gamma. Handles the existing 82 name-collapsed groups via a `--resolve-conflicts` "latest event wins" heuristic.
3. Switch keeper/admin-route lookups to `(source, externalEventId)`, drop `UNIQUE(name)`

## Design notes

- **Why `source` now, when only Polymarket is integrated?** Adding the column at the storage layer is essentially free (one fixed string × ~30k rows ≈ 300 KB), and retrofitting polymorphic identity later means migrating every consumer simultaneously. Application code stays Polymarket-implicit until a second platform actually lands.
- **Why partial unique on (source, externalEventId)?** NULL `externalEventId` must be allowed for legacy / Sapience-native / curated groups. Postgres treats NULL as distinct so multiple NULL rows coexist without colliding.
- **Why keep `UNIQUE(name)`?** The keeper and admin routes still look up groups by name. Dropping the constraint belongs with the lookup-change PR, not this one.

## Test plan

- [ ] CI: lint + tsc green
- [ ] Migration applies cleanly on staging (`prisma migrate deploy`)
- [ ] Verify columns exist on `condition_group`: `\d condition_group`
- [ ] Verify partial unique index exists: `\d uq_condition_group_source_event`
- [ ] Spot-check that existing queries still work (no behavioural regression — the migration is additive)
- [ ] Confirm `source = 'polymarket'` on all existing rows after migration (the default fires on backfill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)