### PR TITLE
Recover stale session policy errors

### DIFF
--- a/packages/app/src/hooks/blockchain/useSapienceWriteContract.ts
+++ b/packages/app/src/hooks/blockchain/useSapienceWriteContract.ts
@@ -515,9 +515,12 @@ export function useSapienceWriteContract({
       const { chainId: _chainId, retry } = ctx;
       // Only auto-recover for a genuine stale-session policy error, and only
       // once per user action (guards against a retry that fails the same way).
+      // Skip if a session creation is already in flight — don't tear down a
+      // session out from under a concurrent startSession.
       if (
         !isSessionPolicyError(error) ||
         sessionRecoveryInFlightRef.current ||
+        isStartingSession ||
         _chainId == null ||
         retry == null
       ) {
@@ -525,36 +528,56 @@ export function useSapienceWriteContract({
         return;
       }
 
+      // Set before any side effects so the finally always clears it, even if
+      // endSession()/toast() throw synchronously.
       sessionRecoveryInFlightRef.current = true;
-      console.warn(
-        `[${label}] Session key policy mismatch — refreshing session and retrying`,
-        error
-      );
-      Sentry.captureException(error, {
-        tags: { component: 'session', executionPath: ctx.executionPath },
-        extra: {
-          function: label,
-          chainId: _chainId,
-          isSessionPolicyError: true,
-        },
-      });
-      endSession();
-      toast({
-        title: 'Session Needs Refresh',
-        description:
-          'Approve the new session request in your wallet — we’ll retry your transaction automatically.',
-        duration: 12000,
-      });
-
       try {
+        console.warn(
+          `[${label}] Session key policy mismatch — refreshing session and retrying`,
+          error
+        );
+        Sentry.captureException(error, {
+          tags: { component: 'session', executionPath: ctx.executionPath },
+          extra: {
+            function: label,
+            chainId: _chainId,
+            isSessionPolicyError: true,
+          },
+        });
+        endSession();
+        toast({
+          title: 'Session Needs Refresh',
+          description:
+            'Approve the new session request in your wallet — we’ll retry your transaction automatically.',
+          duration: 12000,
+        });
+
         const replacement = await startReplacementSession(_chainId);
         if (!replacement) {
           // Session creation failed; startReplacementSession already toasted.
           onError?.(error as Error);
           return;
         }
+
+        // A fresh session is created eagerly only for the Ethereal/default
+        // chain; Arbitrum sessions are created lazily on first use, so the
+        // replacement has no ready client for them. Without a concrete fresh
+        // client we can't safely auto-retry (the dead client is still closed
+        // over), so fall back to a manual retry — the user's next attempt takes
+        // the lazy-creation path once React state has settled.
+        if (!replacement.sessionClient) {
+          toast({
+            title: 'Session Refreshed',
+            description:
+              'Your session is ready again. Please try the transaction once more.',
+            duration: 8000,
+          });
+          onError?.(error as Error);
+          return;
+        }
+
         // Retry once with the fresh session. Any failure here is surfaced
-        // normally (and the guard below blocks a second recovery attempt).
+        // normally (and the guard above blocks a second recovery attempt).
         await retry(replacement);
       } catch (retryError) {
         reportTransactionFailure(retryError, `${label} (retry)`, ctx);
@@ -568,6 +591,7 @@ export function useSapienceWriteContract({
       startReplacementSession,
       reportTransactionFailure,
       onError,
+      isStartingSession,
     ]
   );
 

--- a/packages/app/src/hooks/blockchain/useSapienceWriteContract.ts
+++ b/packages/app/src/hooks/blockchain/useSapienceWriteContract.ts
@@ -26,6 +26,7 @@ import {
   type TransactionCall,
   type WriteContractParams,
   type SessionClient,
+  type ExecutionDeps,
 } from './transactionExecutor';
 import {
   handleViemError,
@@ -259,6 +260,10 @@ export function useSapienceWriteContract({
   // Capture the address that submitted the transaction to avoid race conditions
   // if user toggles account mode while transaction is in-flight
   const transactionAddressRef = useRef<`0x${string}` | null>(null);
+  // Guards stale-session auto-recovery to ONE attempt per user action. Once a
+  // recovery (refresh + retry) is in flight, a second session-policy error
+  // surfaces normally instead of looping into another refresh/retry.
+  const sessionRecoveryInFlightRef = useRef(false);
   // Get position form context - may be undefined if not within provider
   const createPositionContext = useContext(CreatePositionContext);
 
@@ -416,86 +421,154 @@ export function useSapienceWriteContract({
     }
   }, [createArbitrumSessionIfNeeded]);
 
-  const startReplacementSession = useCallback(async () => {
-    if (isStartingSession) return;
+  // Create a fresh session to replace a stale one. Returns the session
+  // client/config for `chainId` so the caller can retry the failed transaction
+  // immediately, or null if a new session could not be created.
+  const startReplacementSession = useCallback(
+    async (
+      _chainId: number
+    ): Promise<Pick<
+      ExecutionDeps,
+      'sessionClient' | 'sessionConfig'
+    > | null> => {
+      if (isStartingSession) return null;
 
-    try {
-      await startSession({
-        durationHours:
-          connectionDurationHours ?? DEFAULT_CONNECTION_DURATION_HOURS,
-      });
-      toast({
-        title: 'Session Created',
-        description:
-          'Your new session is ready. Please try the transaction again.',
-        duration: 5000,
-      });
-    } catch (error) {
-      console.error(
-        '[Session] Failed to refresh session after policy error:',
-        error
-      );
-      Sentry.captureException(error, {
-        tags: { component: 'session' },
-        extra: { function: 'startReplacementSession' },
-      });
-      toast({
-        title: 'Failed to Start Session',
-        description: handleViemError(
-          error,
-          'Please create a new session from the connection menu.'
-        ),
-        duration: 8000,
-        variant: 'destructive',
-      });
-    }
-  }, [connectionDurationHours, isStartingSession, startSession, toast]);
+      try {
+        const result = await startSession({
+          durationHours:
+            connectionDurationHours ?? DEFAULT_CONNECTION_DURATION_HOURS,
+        });
+        const sessionClient =
+          _chainId === arbitrum.id
+            ? result.arbitrumClient
+            : result.etherealClient;
+        return { sessionClient, sessionConfig: result.config };
+      } catch (error) {
+        console.error(
+          '[Session] Failed to refresh session after policy error:',
+          error
+        );
+        Sentry.captureException(error, {
+          tags: { component: 'session' },
+          extra: { function: 'startReplacementSession' },
+        });
+        toast({
+          title: 'Failed to Start Session',
+          description: handleViemError(
+            error,
+            'Please create a new session from the connection menu.'
+          ),
+          duration: 8000,
+          variant: 'destructive',
+        });
+        return null;
+      }
+    },
+    [connectionDurationHours, isStartingSession, startSession, toast]
+  );
 
-  /** Handle catch errors from writeContract / sendCalls — detects stale session keys */
-  const handleCatchError = useCallback(
+  // Surface a plain transaction failure: toast, report, notify caller.
+  const reportTransactionFailure = useCallback(
     (
       error: unknown,
       label: string,
-      ctx: { chainId?: number; executionPath?: string } = {}
+      ctx: { chainId?: number; executionPath?: string }
     ) => {
-      setIsSubmitting(false);
-      const isStaleSession = isSessionPolicyError(error);
-      if (isStaleSession) {
-        console.warn(
-          `[${label}] Session key policy mismatch — clearing stale session`,
-          error
-        );
-        endSession();
-        toast({
-          title: 'Session Needs Refresh',
-          description:
-            'This transaction uses a contract your current session was not authorized for. Please approve the new session request in your wallet, then try again.',
-          duration: 12000,
-          variant: 'destructive',
-        });
-        void startReplacementSession();
-      } else {
-        toast({
-          title: 'Transaction Failed',
-          description: handleViemError(error, fallbackErrorMessage),
-          duration: 5000,
-          variant: 'destructive',
-        });
-      }
+      toast({
+        title: 'Transaction Failed',
+        description: handleViemError(error, fallbackErrorMessage),
+        duration: 5000,
+        variant: 'destructive',
+      });
       Sentry.captureException(error, {
-        tags: {
-          component: isStaleSession ? 'session' : 'rpc',
-          executionPath: ctx.executionPath,
-        },
-        extra: {
-          function: label,
-          chainId: ctx.chainId,
-          isSessionPolicyError: isStaleSession,
-        },
+        tags: { component: 'rpc', executionPath: ctx.executionPath },
+        extra: { function: label, chainId: ctx.chainId },
       });
       onError?.(error as Error);
     },
-    [endSession, toast, fallbackErrorMessage, onError, startReplacementSession]
+    [toast, fallbackErrorMessage, onError]
+  );
+
+  /**
+   * Handle catch errors from writeContract / sendCalls.
+   *
+   * On a stale-session policy error we automatically tear down the dead session,
+   * create a fresh one, and retry the original transaction ONCE. The retry runs
+   * with the freshly-created session client (passed explicitly, since React
+   * state won't have propagated yet). `sessionRecoveryInFlightRef` caps this to a
+   * single recovery+retry per user action so a persistent failure can't loop.
+   */
+  const handleCatchError = useCallback(
+    async (
+      error: unknown,
+      label: string,
+      ctx: {
+        chainId?: number;
+        executionPath?: string;
+        retry?: (
+          override: Pick<ExecutionDeps, 'sessionClient' | 'sessionConfig'>
+        ) => Promise<void>;
+      } = {}
+    ) => {
+      setIsSubmitting(false);
+
+      const { chainId: _chainId, retry } = ctx;
+      // Only auto-recover for a genuine stale-session policy error, and only
+      // once per user action (guards against a retry that fails the same way).
+      if (
+        !isSessionPolicyError(error) ||
+        sessionRecoveryInFlightRef.current ||
+        _chainId == null ||
+        retry == null
+      ) {
+        reportTransactionFailure(error, label, ctx);
+        return;
+      }
+
+      sessionRecoveryInFlightRef.current = true;
+      console.warn(
+        `[${label}] Session key policy mismatch — refreshing session and retrying`,
+        error
+      );
+      Sentry.captureException(error, {
+        tags: { component: 'session', executionPath: ctx.executionPath },
+        extra: {
+          function: label,
+          chainId: _chainId,
+          isSessionPolicyError: true,
+        },
+      });
+      endSession();
+      toast({
+        title: 'Session Needs Refresh',
+        description:
+          'Approve the new session request in your wallet — we’ll retry your transaction automatically.',
+        duration: 12000,
+      });
+
+      try {
+        const replacement = await startReplacementSession(_chainId);
+        if (!replacement) {
+          // Session creation failed; startReplacementSession already toasted.
+          onError?.(error as Error);
+          return;
+        }
+        // Retry once with the fresh session. Any failure here is surfaced
+        // normally (and the guard below blocks a second recovery attempt).
+        await retry(replacement);
+      } catch (retryError) {
+        reportTransactionFailure(retryError, `${label} (retry)`, ctx);
+      } finally {
+        sessionRecoveryInFlightRef.current = false;
+      }
+    },
+    [
+      endSession,
+      toast,
+      startReplacementSession,
+      reportTransactionFailure,
+      onError,
+    ]
   );
 
   // Custom write contract function that handles chain validation
@@ -511,6 +584,37 @@ export function useSapienceWriteContract({
       // Lifted out of the try so it's available in catch for Sentry context.
       const executionPath = getExecutionPathForChain(_chainId);
 
+      const params = args[0] as WriteContractParams;
+      const calls = [encodeWriteContractToCall(params)];
+
+      // Re-runnable so a stale-session recovery can retry with a fresh session
+      // client (passed via `override`) instead of the dead one.
+      const runWrite = async (
+        override?: Pick<ExecutionDeps, 'sessionClient' | 'sessionConfig'>
+      ) => {
+        if (executionPath !== 'eoa') setIsSubmitting(true);
+        const result = await executeTransaction(
+          calls,
+          _chainId,
+          executionPath,
+          {
+            sessionClient:
+              override?.sessionClient ?? getSessionClient(_chainId),
+            sessionConfig: override?.sessionConfig ?? sessionConfig,
+            needsArbitrumSession: needsArbitrumSession(_chainId),
+            createArbitrumSessionIfNeeded: wrapArbitrumSessionCreation,
+            executeViaSessionKey,
+            executeViaOwnerSigning,
+            writeContractAsync,
+            sendCallsAsync,
+            validateAndSwitchChain,
+          },
+          'writeContract',
+          args[0]
+        );
+        completeTransaction(result.hash);
+      };
+
       try {
         // Reset state
         setTxHash(undefined);
@@ -525,35 +629,12 @@ export function useSapienceWriteContract({
             ? (wagmiAddress ?? null)
             : (smartAccountAddress ?? wagmiAddress ?? null);
 
-        if (executionPath !== 'eoa') setIsSubmitting(true);
-
-        const params = args[0] as WriteContractParams;
-        const calls = [encodeWriteContractToCall(params)];
-
-        const result = await executeTransaction(
-          calls,
-          _chainId,
-          executionPath,
-          {
-            sessionClient: getSessionClient(_chainId),
-            sessionConfig,
-            needsArbitrumSession: needsArbitrumSession(_chainId),
-            createArbitrumSessionIfNeeded: wrapArbitrumSessionCreation,
-            executeViaSessionKey,
-            executeViaOwnerSigning,
-            writeContractAsync,
-            sendCallsAsync,
-            validateAndSwitchChain,
-          },
-          'writeContract',
-          args[0]
-        );
-
-        completeTransaction(result.hash);
+        await runWrite();
       } catch (error) {
-        handleCatchError(error, 'WriteContract', {
+        await handleCatchError(error, 'WriteContract', {
           chainId: _chainId,
           executionPath,
+          retry: runWrite,
         });
       }
     },
@@ -590,43 +671,32 @@ export function useSapienceWriteContract({
       // Lifted out of the try so it's available in catch for Sentry context.
       const executionPath = getExecutionPathForChain(_chainId);
 
-      try {
-        // Reset state
-        setTxHash(undefined);
-        resetCalls();
-        didRedirectRef.current = false;
-        didShowSuccessToastRef.current = false;
+      // Convert SendCall[] to TransactionCall[]
+      const body = (args[0] ?? {}) as SendCallsParams;
+      const rawCalls: SendCall[] = Array.isArray(body?.calls) ? body.calls : [];
+      const calls: TransactionCall[] = rawCalls.map((call: SendCall) => ({
+        to: call.to,
+        data: call.data ?? ('0x' as Hex),
+        value: call.value ? BigInt(call.value) : 0n,
+      }));
 
-        // Capture the address at transaction submission time to avoid race conditions
-        // if user toggles account mode while transaction is in-flight
-        transactionAddressRef.current =
-          executionPath === 'eoa'
-            ? (wagmiAddress ?? null)
-            : (smartAccountAddress ?? wagmiAddress ?? null);
-
-        if (executionPath !== 'eoa') setIsSubmitting(true);
-
-        // Convert SendCall[] to TransactionCall[]
-        const body = (args[0] ?? {}) as SendCallsParams;
-        const rawCalls: SendCall[] = Array.isArray(body?.calls)
-          ? body.calls
-          : [];
+      // Re-runnable so a stale-session recovery can retry with a fresh session
+      // client (passed via `override`) instead of the dead one.
+      const runSendCalls = async (
+        override?: Pick<ExecutionDeps, 'sessionClient' | 'sessionConfig'>
+      ) => {
         if (rawCalls.length === 0) {
           throw new Error('No calls to execute');
         }
-        const calls: TransactionCall[] = rawCalls.map((call: SendCall) => ({
-          to: call.to,
-          data: call.data ?? ('0x' as Hex),
-          value: call.value ? BigInt(call.value) : 0n,
-        }));
-
+        if (executionPath !== 'eoa') setIsSubmitting(true);
         const result = await executeTransaction(
           calls,
           _chainId,
           executionPath,
           {
-            sessionClient: getSessionClient(_chainId),
-            sessionConfig,
+            sessionClient:
+              override?.sessionClient ?? getSessionClient(_chainId),
+            sessionConfig: override?.sessionConfig ?? sessionConfig,
             needsArbitrumSession: needsArbitrumSession(_chainId),
             createArbitrumSessionIfNeeded: wrapArbitrumSessionCreation,
             executeViaSessionKey,
@@ -646,10 +716,28 @@ export function useSapienceWriteContract({
             | undefined;
         }
         completeTransaction(finalHash);
+      };
+
+      try {
+        // Reset state
+        setTxHash(undefined);
+        resetCalls();
+        didRedirectRef.current = false;
+        didShowSuccessToastRef.current = false;
+
+        // Capture the address at transaction submission time to avoid race conditions
+        // if user toggles account mode while transaction is in-flight
+        transactionAddressRef.current =
+          executionPath === 'eoa'
+            ? (wagmiAddress ?? null)
+            : (smartAccountAddress ?? wagmiAddress ?? null);
+
+        await runSendCalls();
       } catch (error) {
-        handleCatchError(error, 'SendCalls', {
+        await handleCatchError(error, 'SendCalls', {
           chainId: _chainId,
           executionPath,
+          retry: runSendCalls,
         });
       }
     },

--- a/packages/app/src/hooks/blockchain/useSapienceWriteContract.ts
+++ b/packages/app/src/hooks/blockchain/useSapienceWriteContract.ts
@@ -1,13 +1,6 @@
 'use client';
 import * as Sentry from '@sentry/nextjs';
-import {
-  createElement,
-  useCallback,
-  useMemo,
-  useRef,
-  useState,
-  useContext,
-} from 'react';
+import { useCallback, useMemo, useRef, useState, useContext } from 'react';
 import type { useTransactionReceipt } from 'wagmi';
 import {
   useWriteContract,
@@ -19,10 +12,6 @@ import type { EIP1193Provider, Hash, Hex } from 'viem';
 import { useRouter } from 'next/navigation';
 
 import { useToast } from '@sapience/ui/hooks/use-toast';
-import {
-  ToastAction,
-  type ToastActionElement,
-} from '@sapience/ui/components/ui/toast';
 
 import { arbitrum } from 'viem/chains';
 import { useSwitchChain } from 'wagmi';
@@ -480,20 +469,11 @@ export function useSapienceWriteContract({
         toast({
           title: 'Session Needs Refresh',
           description:
-            'This transaction uses a contract your current session was not authorized for. Create a new session, then try again.',
+            'This transaction uses a contract your current session was not authorized for. Please approve the new session request in your wallet, then try again.',
           duration: 12000,
           variant: 'destructive',
-          action: createElement(
-            ToastAction,
-            {
-              altText: 'Create new session',
-              onClick: () => {
-                void startReplacementSession();
-              },
-            },
-            isStartingSession ? 'Creating...' : 'Create session'
-          ) as unknown as ToastActionElement,
         });
+        void startReplacementSession();
       } else {
         toast({
           title: 'Transaction Failed',
@@ -515,14 +495,7 @@ export function useSapienceWriteContract({
       });
       onError?.(error as Error);
     },
-    [
-      endSession,
-      toast,
-      fallbackErrorMessage,
-      onError,
-      startReplacementSession,
-      isStartingSession,
-    ]
+    [endSession, toast, fallbackErrorMessage, onError, startReplacementSession]
   );
 
   // Custom write contract function that handles chain validation

--- a/packages/app/src/hooks/blockchain/useSapienceWriteContract.ts
+++ b/packages/app/src/hooks/blockchain/useSapienceWriteContract.ts
@@ -1,6 +1,13 @@
 'use client';
 import * as Sentry from '@sentry/nextjs';
-import { useCallback, useMemo, useRef, useState, useContext } from 'react';
+import {
+  createElement,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  useContext,
+} from 'react';
 import type { useTransactionReceipt } from 'wagmi';
 import {
   useWriteContract,
@@ -12,6 +19,10 @@ import type { EIP1193Provider, Hash, Hex } from 'viem';
 import { useRouter } from 'next/navigation';
 
 import { useToast } from '@sapience/ui/hooks/use-toast';
+import {
+  ToastAction,
+  type ToastActionElement,
+} from '@sapience/ui/components/ui/toast';
 
 import { arbitrum } from 'viem/chains';
 import { useSwitchChain } from 'wagmi';
@@ -35,6 +46,10 @@ import { useChainValidation } from '~/hooks/blockchain/useChainValidation';
 import { useMonitorTxStatus } from '~/hooks/blockchain/useMonitorTxStatus';
 import { CreatePositionContext } from '~/lib/context/CreatePositionContext';
 import { useSession } from '~/lib/context/SessionContext';
+import {
+  DEFAULT_CONNECTION_DURATION_HOURS,
+  useSettings,
+} from '~/lib/context/SettingsContext';
 import {
   ethereal,
   executeSudoTransaction,
@@ -137,7 +152,10 @@ export function useSapienceWriteContract({
     hasArbitrumSession,
     createArbitrumSessionIfNeeded,
     endSession,
+    startSession,
+    isStartingSession,
   } = useSession();
+  const { connectionDurationHours } = useSettings();
 
   // Check if session can handle a specific chain
   // Returns true ONLY if user is in smart-account mode AND session is active
@@ -409,6 +427,41 @@ export function useSapienceWriteContract({
     }
   }, [createArbitrumSessionIfNeeded]);
 
+  const startReplacementSession = useCallback(async () => {
+    if (isStartingSession) return;
+
+    try {
+      await startSession({
+        durationHours:
+          connectionDurationHours ?? DEFAULT_CONNECTION_DURATION_HOURS,
+      });
+      toast({
+        title: 'Session Created',
+        description:
+          'Your new session is ready. Please try the transaction again.',
+        duration: 5000,
+      });
+    } catch (error) {
+      console.error(
+        '[Session] Failed to refresh session after policy error:',
+        error
+      );
+      Sentry.captureException(error, {
+        tags: { component: 'session' },
+        extra: { function: 'startReplacementSession' },
+      });
+      toast({
+        title: 'Failed to Start Session',
+        description: handleViemError(
+          error,
+          'Please create a new session from the connection menu.'
+        ),
+        duration: 8000,
+        variant: 'destructive',
+      });
+    }
+  }, [connectionDurationHours, isStartingSession, startSession, toast]);
+
   /** Handle catch errors from writeContract / sendCalls — detects stale session keys */
   const handleCatchError = useCallback(
     (
@@ -425,10 +478,21 @@ export function useSapienceWriteContract({
         );
         endSession();
         toast({
-          title: 'Session Expired',
-          description: 'Please start a new session.',
-          duration: 8000,
+          title: 'Session Needs Refresh',
+          description:
+            'This transaction uses a contract your current session was not authorized for. Create a new session, then try again.',
+          duration: 12000,
           variant: 'destructive',
+          action: createElement(
+            ToastAction,
+            {
+              altText: 'Create new session',
+              onClick: () => {
+                void startReplacementSession();
+              },
+            },
+            isStartingSession ? 'Creating...' : 'Create session'
+          ) as unknown as ToastActionElement,
         });
       } else {
         toast({
@@ -451,7 +515,14 @@ export function useSapienceWriteContract({
       });
       onError?.(error as Error);
     },
-    [endSession, toast, fallbackErrorMessage, onError]
+    [
+      endSession,
+      toast,
+      fallbackErrorMessage,
+      onError,
+      startReplacementSession,
+      isStartingSession,
+    ]
   );
 
   // Custom write contract function that handles chain validation

--- a/packages/app/src/lib/context/SessionContext.tsx
+++ b/packages/app/src/lib/context/SessionContext.tsx
@@ -119,6 +119,18 @@ interface ChainClients {
   arbitrum: KernelAccountClient | null;
 }
 
+/**
+ * Result returned by {@link SessionContextValue.startSession}. Returning the
+ * freshly-created clients/config lets callers retry a transaction immediately
+ * with the new session, without waiting for React state (chainClients /
+ * sessionConfig) to propagate through a re-render.
+ */
+export interface StartSessionResult {
+  config: SessionConfig;
+  etherealClient: KernelAccountClient | null;
+  arbitrumClient: KernelAccountClient | null;
+}
+
 // Type for signTypedData parameters
 interface SignTypedDataParams {
   domain: {
@@ -161,7 +173,7 @@ interface SessionContextValue {
   startSession: (params: {
     durationHours: number;
     etherealChainId?: number;
-  }) => Promise<void>;
+  }) => Promise<StartSessionResult>;
   endSession: () => void;
 
   // Status
@@ -654,6 +666,14 @@ export function SessionProvider({ children }: SessionProviderProps) {
           '[SessionContext] Session active, smart account:',
           result.config.smartAccountAddress
         );
+
+        // Return the fresh clients/config so callers can retry immediately with
+        // the new session (state updates above won't be visible until re-render).
+        return {
+          config: result.config,
+          etherealClient: result.etherealClient,
+          arbitrumClient: result.arbitrumClient,
+        };
       } catch (error) {
         console.error('Failed to start session:', error);
         Sentry.captureException(error, {

--- a/packages/app/src/lib/utils/handleViemError.test.ts
+++ b/packages/app/src/lib/utils/handleViemError.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { isSessionPolicyError } from './handleViemError';
+
+describe('isSessionPolicyError', () => {
+  it('detects the existing AA23 + param-rule session policy failure', () => {
+    expect(
+      isSessionPolicyError(
+        new Error(
+          'UserOperation reverted during simulation with reason: AA23 reverted: CallViolatesParamRule(0x59d52e40)'
+        )
+      )
+    ).toBe(true);
+  });
+
+  it('detects account-validation failures for unauthorized target contracts', () => {
+    expect(
+      isSessionPolicyError(
+        new Error(
+          'account validation reverted: target contract not authorized by current session'
+        )
+      )
+    ).toBe(true);
+  });
+
+  it('does not classify broad account-validation errors as session policy errors', () => {
+    expect(
+      isSessionPolicyError(new Error('AA23 reverted: invalid signature'))
+    ).toBe(false);
+  });
+
+  it('does not classify policy-looking messages outside user-op validation', () => {
+    expect(
+      isSessionPolicyError(new Error('target contract not authorized'))
+    ).toBe(false);
+  });
+});

--- a/packages/app/src/lib/utils/handleViemError.test.ts
+++ b/packages/app/src/lib/utils/handleViemError.test.ts
@@ -34,4 +34,35 @@ describe('isSessionPolicyError', () => {
       isSessionPolicyError(new Error('target contract not authorized'))
     ).toBe(false);
   });
+
+  it("does not treat a target contract's own authorization revert as a session policy error", () => {
+    // A called contract's own access control reverts during simulation with the
+    // same "not authorized" wording. Without a session-specific marker this must
+    // NOT tear down the session.
+    expect(
+      isSessionPolicyError(
+        new Error(
+          'UserOperation reverted during simulation with reason: execution reverted: Ownable: caller is not authorized'
+        )
+      )
+    ).toBe(false);
+  });
+
+  it('does not classify generic ERC20-style authorization reverts as session policy errors', () => {
+    expect(
+      isSessionPolicyError(
+        new Error('AA23 reverted: ERC20: transfer amount not authorized')
+      )
+    ).toBe(false);
+  });
+
+  it('still detects generic authorization failures that reference the session', () => {
+    expect(
+      isSessionPolicyError(
+        new Error(
+          'AA23 reverted: call not authorized by the current session policy'
+        )
+      )
+    ).toBe(true);
+  });
 });

--- a/packages/app/src/lib/utils/handleViemError.ts
+++ b/packages/app/src/lib/utils/handleViemError.ts
@@ -29,23 +29,47 @@ export function handleViemError(
  * Session key policy errors from ZeroDev smart accounts.
  *
  * These occur when the session key's permission policy doesn't match the
- * current contract addresses (e.g. after an escrow redeploy). The session
- * must be re-created to pick up the new addresses.
+ * current contract addresses (e.g. after an escrow redeploy, or when a flow
+ * starts calling a contract that the existing session was never authorized to
+ * call). The session must be re-created to pick up the new addresses/policies.
  *
  * We require both conditions:
- * - AA23 (account validation reverted) — the bundler rejection code
- * - CallViolatesParamRule / 0x59d52e40 — the specific revert reason
+ * - a user-op/account-validation failure marker from the bundler/paymaster path
+ * - a call-policy / not-authorized marker from the session policy validation
  *
- * AA23 alone is too broad (any validation failure), and the revert selector
- * alone could appear in non-bundler contexts. Together they're precise.
+ * AA23 alone is too broad (any validation failure), and the policy markers alone
+ * could appear in non-session contexts. Together they're precise enough to
+ * clear the stale session and offer recovery.
  */
-const REVERT_PATTERNS = ['CallViolatesParamRule', '0x59d52e40'] as const;
+const USER_OP_VALIDATION_PATTERNS = [
+  'AA23',
+  'account validation reverted',
+  'UserOperation reverted during simulation',
+  'user operation reverted during simulation',
+] as const;
+
+const SESSION_POLICY_PATTERNS = [
+  'CallViolatesParamRule',
+  'CallViolatesTarget',
+  'CallViolatesTargetAddress',
+  'CallNotAllowed',
+  'TargetNotAllowed',
+  'not authorized',
+  'not authorised',
+  '0x59d52e40',
+] as const;
 
 /** Returns true if the error indicates a stale session key policy. */
 export function isSessionPolicyError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error ?? '');
-  return (
-    message.includes('AA23') &&
-    REVERT_PATTERNS.some((pattern) => message.includes(pattern))
+  const lowerMessage = message.toLowerCase();
+
+  const hasUserOpValidationFailure = USER_OP_VALIDATION_PATTERNS.some(
+    (pattern) => lowerMessage.includes(pattern.toLowerCase())
   );
+  const hasSessionPolicyFailure = SESSION_POLICY_PATTERNS.some((pattern) =>
+    lowerMessage.includes(pattern.toLowerCase())
+  );
+
+  return hasUserOpValidationFailure && hasSessionPolicyFailure;
 }

--- a/packages/app/src/lib/utils/handleViemError.ts
+++ b/packages/app/src/lib/utils/handleViemError.ts
@@ -33,13 +33,20 @@ export function handleViemError(
  * starts calling a contract that the existing session was never authorized to
  * call). The session must be re-created to pick up the new addresses/policies.
  *
- * We require both conditions:
+ * We require two conditions:
  * - a user-op/account-validation failure marker from the bundler/paymaster path
- * - a call-policy / not-authorized marker from the session policy validation
+ * - a session-policy marker (see below)
  *
- * AA23 alone is too broad (any validation failure), and the policy markers alone
- * could appear in non-session contexts. Together they're precise enough to
- * clear the stale session and offer recovery.
+ * The user-op marker alone is too broad (any validation failure). For the
+ * policy half we deliberately split the markers by confidence:
+ *
+ * - {@link SESSION_POLICY_NAMED_PATTERNS} are ZeroDev permission-validator revert
+ *   names / selectors. Each is an unambiguous session-policy failure on its own.
+ * - Generic authorization wording ("not authorized") is NOT trusted on its own:
+ *   a called contract's own access control reverts with the exact same words.
+ *   We only treat it as a session-policy failure when the message ALSO references
+ *   the session itself. Otherwise a stale-session recovery (which tears down the
+ *   session and re-prompts the wallet) would fire on unrelated contract reverts.
  */
 const USER_OP_VALIDATION_PATTERNS = [
   'AA23',
@@ -48,28 +55,39 @@ const USER_OP_VALIDATION_PATTERNS = [
   'user operation reverted during simulation',
 ] as const;
 
-const SESSION_POLICY_PATTERNS = [
+const SESSION_POLICY_NAMED_PATTERNS = [
   'CallViolatesParamRule',
   'CallViolatesTarget',
   'CallViolatesTargetAddress',
   'CallNotAllowed',
   'TargetNotAllowed',
-  'not authorized',
-  'not authorised',
   '0x59d52e40',
 ] as const;
+
+const AUTHORIZATION_FAILURE_PATTERNS = [
+  'not authorized',
+  'not authorised',
+] as const;
+
+const SESSION_CONTEXT_PATTERNS = ['session'] as const;
 
 /** Returns true if the error indicates a stale session key policy. */
 export function isSessionPolicyError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error ?? '');
   const lowerMessage = message.toLowerCase();
+  const includes = (pattern: string) =>
+    lowerMessage.includes(pattern.toLowerCase());
 
-  const hasUserOpValidationFailure = USER_OP_VALIDATION_PATTERNS.some(
-    (pattern) => lowerMessage.includes(pattern.toLowerCase())
-  );
-  const hasSessionPolicyFailure = SESSION_POLICY_PATTERNS.some((pattern) =>
-    lowerMessage.includes(pattern.toLowerCase())
-  );
+  const hasUserOpValidationFailure = USER_OP_VALIDATION_PATTERNS.some(includes);
+  if (!hasUserOpValidationFailure) return false;
 
-  return hasUserOpValidationFailure && hasSessionPolicyFailure;
+  const hasNamedPolicyFailure = SESSION_POLICY_NAMED_PATTERNS.some(includes);
+
+  // Generic authorization wording only counts when the message is clearly about
+  // the session — not a target contract's own "not authorized" revert.
+  const hasSessionScopedAuthFailure =
+    AUTHORIZATION_FAILURE_PATTERNS.some(includes) &&
+    SESSION_CONTEXT_PATTERNS.some(includes);
+
+  return hasNamedPolicyFailure || hasSessionScopedAuthFailure;
 }


### PR DESCRIPTION
## Summary
- broaden session-policy error detection for paymaster/bundler failures caused by unauthorized target contracts
- when this happens, clear the stale session and show a destructive toast with a "Create session" action
- reuse the configured connection duration when creating the replacement session
- add unit coverage for policy-error detection and false positives

## Verification
- `npm exec --yes pnpm@10.33.4 -- --filter @sapience/app test src/lib/utils/handleViemError.test.ts`
- `npm exec --yes pnpm@10.33.4 -- --filter @sapience/app lint`
- `npm exec --yes pnpm@10.33.4 -- --filter @sapience/app type-check`
