### PR TITLE
fix(staging): restore GraphQL client compatibility

### DIFF
--- a/packages/app/src/components/shared/CommandMenu.tsx
+++ b/packages/app/src/components/shared/CommandMenu.tsx
@@ -54,8 +54,8 @@ const SEARCH_QUESTIONS = /* GraphQL */ `
       take: $take
       skip: 0
       chainId: $chainId
-      sortField: "endTime"
-      sortDirection: "asc"
+      sortField: endTime
+      sortDirection: asc
       search: $search
     ) {
       questionType

--- a/packages/market-keeper/src/generate/pipeline/filters/exclude-existing.ts
+++ b/packages/market-keeper/src/generate/pipeline/filters/exclude-existing.ts
@@ -43,25 +43,23 @@ export async function checkExistingConditions(
     const graphqlUrl = apiUrl.replace(/\/+$/, '') + '/graphql';
 
     const query = `
-      query CheckConditions($filters: ConditionFilter!) {
-        conditionsConnection(filter: $filters, first: 100) {
-          nodes {
-            id: conditionId
-            endTime
-            question
-            shortName
-            optionName
-            description
+      query CheckConditions($where: ConditionWhereInput!, $take: Int!) {
+        conditions(where: $where, take: $take) {
+          id
+          endTime
+          question
+          shortName
+          optionName
+          description
+          similarMarkets
+          tags
+          similarMarketVolume
+          similarMarketImage
+          conditionGroup {
+            id
+            name
             similarMarkets
-            tags
-            similarMarketVolume
-            similarMarketImage
-            conditionGroup {
-              id
-              name
-              similarMarkets
-              negRisk
-            }
+            negRisk
           }
         }
       }
@@ -79,9 +77,9 @@ export async function checkExistingConditions(
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           query,
-          // visibility: ALL — we want to detect any pre-existing row (public
-          // or private) so the pipeline doesn't try to recreate it.
-          variables: { filters: { ids: chunk, visibility: 'ALL' } },
+          // Query by primary id only — public and private rows both count as
+          // pre-existing, so the pipeline doesn't try to recreate them.
+          variables: { where: { id: { in: chunk } }, take: PAGE_SIZE },
         }),
       });
 
@@ -91,7 +89,7 @@ export async function checkExistingConditions(
       }
 
       const result = await response.json();
-      for (const condition of result.data?.conditionsConnection?.nodes ?? []) {
+      for (const condition of result.data?.conditions ?? []) {
         existing.set(condition.id, {
           endTime: condition.endTime,
           question: condition.question ?? undefined,

--- a/packages/market-keeper/src/refresh-metadata/fetch.ts
+++ b/packages/market-keeper/src/refresh-metadata/fetch.ts
@@ -43,41 +43,33 @@ export async function fetchAllExistingConditions(
 ): Promise<Map<string, ExistingCondition>> {
   const graphqlUrl = apiUrl.replace(/\/+$/, '') + '/graphql';
 
-  // Uses the Relay-shaped `conditionsConnection` (the legacy bare
-  // `conditions(where:)` resolver is deprecated per the redesign).
-  // Cursor-paginated via `first` / `after`; reads `pageInfo.endCursor`
-  // and `pageInfo.hasNextPage` to drive the loop.
+  // Uses the staging-supported `conditions(where:)` resolver. Offset pagination
+  // is deterministic because we order by stable `id` ascending.
   const query = `
-    query RefreshMetadataConditions($filter: ConditionFilter!, $first: Int!, $after: String) {
-      conditionsConnection(filter: $filter, first: $first, after: $after, orderBy: { field: CREATED_AT, direction: ASC }) {
-        nodes {
-          id: conditionId
-          endTime
-          question
-          shortName
-          optionName
-          description
+    query RefreshMetadataConditions($where: ConditionWhereInput!, $take: Int!, $skip: Int!, $orderBy: [ConditionOrderByWithRelationInput!]) {
+      conditions(where: $where, take: $take, skip: $skip, orderBy: $orderBy) {
+        id
+        endTime
+        question
+        shortName
+        optionName
+        description
+        similarMarkets
+        tags
+        similarMarketVolume
+        similarMarketImage
+        conditionGroup {
+          id
+          name
           similarMarkets
-          tags
-          similarMarketVolume
-          similarMarketImage
-          conditionGroup {
-            id
-            name
-            similarMarkets
-            negRisk
-          }
-        }
-        pageInfo {
-          hasNextPage
-          endCursor
+          negRisk
         }
       }
     }
   `;
 
   const existing = new Map<string, ExistingCondition>();
-  let after: string | null = null;
+  let skip = 0;
   let pageCount = 0;
 
   while (true) {
@@ -89,13 +81,14 @@ export async function fetchAllExistingConditions(
       body: JSON.stringify({
         query,
         variables: {
-          filter: {
-            visibility: 'PUBLIC',
-            settled: false,
-            hasSimilarMarkets: true,
+          where: {
+            public: { equals: true },
+            settled: { equals: false },
+            similarMarkets: { isEmpty: false },
           },
-          first: SAPIENCE_PAGE_SIZE,
-          after,
+          take: SAPIENCE_PAGE_SIZE,
+          skip,
+          orderBy: [{ id: 'asc' }],
         },
       }),
     });
@@ -108,36 +101,29 @@ export async function fetchAllExistingConditions(
 
     const result = (await response.json()) as {
       data?: {
-        conditionsConnection?: {
-          nodes?: Array<{
-            id: string;
-            endTime: number;
-            question?: string | null;
-            shortName?: string | null;
-            optionName?: string | null;
-            description?: string | null;
+        conditions?: Array<{
+          id: string;
+          endTime: number;
+          question?: string | null;
+          shortName?: string | null;
+          optionName?: string | null;
+          description?: string | null;
+          similarMarkets?: string[] | null;
+          tags?: string[] | null;
+          similarMarketVolume?: number | null;
+          similarMarketImage?: string | null;
+          conditionGroup?: {
+            id?: number | null;
+            name?: string | null;
             similarMarkets?: string[] | null;
-            tags?: string[] | null;
-            similarMarketVolume?: number | null;
-            similarMarketImage?: string | null;
-            conditionGroup?: {
-              id?: number | null;
-              name?: string | null;
-              similarMarkets?: string[] | null;
-              negRisk?: boolean | null;
-            } | null;
-          }>;
-          pageInfo?: {
-            hasNextPage?: boolean | null;
-            endCursor?: string | null;
+            negRisk?: boolean | null;
           } | null;
-        };
+        }>;
       };
     };
 
-    const conditions = result.data?.conditionsConnection?.nodes ?? [];
-    const pageInfo = result.data?.conditionsConnection?.pageInfo;
-    const hasMore = pageInfo?.hasNextPage ?? false;
+    const conditions = result.data?.conditions ?? [];
+    const hasMore = conditions.length === SAPIENCE_PAGE_SIZE;
 
     for (const c of conditions) {
       existing.set(c.id, {
@@ -163,8 +149,7 @@ export async function fetchAllExistingConditions(
     );
 
     if (!hasMore) break;
-    after = pageInfo?.endCursor ?? null;
-    if (!after) break;
+    skip += SAPIENCE_PAGE_SIZE;
   }
 
   return existing;

--- a/packages/sdk/queries/__tests__/categories.test.ts
+++ b/packages/sdk/queries/__tests__/categories.test.ts
@@ -11,20 +11,21 @@ beforeEach(() => {
 });
 
 describe('fetchCategories', () => {
-  test('uses categoriesConnection instead of the deleted categoriesPage field', async () => {
-    expect(GET_CATEGORIES).toContain('categoriesConnection(first: 100)');
+  test('uses the staging-supported categories field', async () => {
+    expect(GET_CATEGORIES).toContain('categories {');
+    expect(GET_CATEGORIES).not.toContain('categoriesConnection');
     expect(GET_CATEGORIES).not.toContain('categoriesPage');
   });
 
-  test('returns category nodes from valid response', async () => {
-    const nodes = [
-      { id: 'Q2F0ZWdvcnk6MQ==', name: 'Crypto', slug: 'crypto' },
-      { id: 'Q2F0ZWdvcnk6Mg==', name: 'Politics', slug: 'politics' },
+  test('returns categories from valid response', async () => {
+    const categories = [
+      { id: 1, name: 'Crypto', slug: 'crypto' },
+      { id: 2, name: 'Politics', slug: 'politics' },
     ];
-    mockGraphqlRequest.mockResolvedValue({ categoriesConnection: { nodes } });
+    mockGraphqlRequest.mockResolvedValue({ categories });
 
     const result = await fetchCategories();
-    expect(result).toEqual(nodes);
+    expect(result).toEqual(categories);
   });
 
   test('throws on null response', async () => {
@@ -34,26 +35,22 @@ describe('fetchCategories', () => {
     );
   });
 
-  test('throws when categoriesConnection.nodes is not an array', async () => {
-    mockGraphqlRequest.mockResolvedValue({
-      categoriesConnection: { nodes: 'not-an-array' },
-    });
+  test('throws when categories is not an array', async () => {
+    mockGraphqlRequest.mockResolvedValue({ categories: 'not-an-array' });
     await expect(fetchCategories()).rejects.toThrow(
       'Failed to fetch categories: Invalid response structure'
     );
   });
 
-  test('throws when categoriesConnection field is missing', async () => {
+  test('throws when categories field is missing', async () => {
     mockGraphqlRequest.mockResolvedValue({});
     await expect(fetchCategories()).rejects.toThrow(
       'Failed to fetch categories: Invalid response structure'
     );
   });
 
-  test('returns empty array when categoriesConnection has no nodes', async () => {
-    mockGraphqlRequest.mockResolvedValue({
-      categoriesConnection: { nodes: [] },
-    });
+  test('returns empty array when response has empty categories', async () => {
+    mockGraphqlRequest.mockResolvedValue({ categories: [] });
     const result = await fetchCategories();
     expect(result).toEqual([]);
   });

--- a/packages/sdk/queries/categories.ts
+++ b/packages/sdk/queries/categories.ts
@@ -1,33 +1,31 @@
 import { graphqlRequest } from './client/graphqlClient';
 
 export type CategoryQueryResult = {
-  id: string;
+  id: number;
   name: string;
   slug: string;
 };
 
 export const GET_CATEGORIES = /* GraphQL */ `
   query Categories {
-    categoriesConnection(first: 100) {
-      nodes {
-        id
-        name
-        slug
-      }
+    categories {
+      id
+      name
+      slug
     }
   }
 `;
 
 export async function fetchCategories(): Promise<CategoryQueryResult[]> {
   type CategoriesResponse = {
-    categoriesConnection: { nodes: CategoryQueryResult[] };
+    categories: CategoryQueryResult[];
   };
 
   const data = await graphqlRequest<CategoriesResponse>(GET_CATEGORIES);
 
-  if (!data || !Array.isArray(data.categoriesConnection?.nodes)) {
+  if (!data || !Array.isArray(data.categories)) {
     throw new Error('Failed to fetch categories: Invalid response structure');
   }
 
-  return data.categoriesConnection.nodes;
+  return data.categories;
 }


### PR DESCRIPTION
## Summary
- restore SDK categories query to the staging-supported `categories` field
- fix CommandMenu GraphQL enum literals
- move market-keeper condition lookups off stale `conditionsConnection` / `ConditionFilter` and back to staging-supported `conditions(where:)`

## Verification
- embedded GraphQL validation against `packages/api/schema.graphql`: 52 docs, 0 failures
- `pnpm --filter @sapience/sdk exec vitest run queries/__tests__/categories.test.ts`
- `pnpm --filter @sapience/market-keeper exec vitest run src/__tests__/refresh-metadata.test.ts src/__tests__/metadata-updates.test.ts src/__tests__/api-submit-negrisk.test.ts`
- `pnpm --filter @sapience/market-keeper run type-check`
- `pnpm --filter @sapience/app run type-check`
- `pnpm --filter @sapience/app run build`