### PR TITLE
Add event-id backfill tool for condition_group

### DIFF
--- a/packages/api/.gitignore
+++ b/packages/api/.gitignore
@@ -11,6 +11,9 @@ data
 
 tsconfig.tsbuildinfo
 
+# One-shot backfill / verification script run logs
+scripts/logs/
+
 # Test NFT storage
 test-nft-ids.json
 test-assertion-data.json

--- a/packages/api/eslint.config.js
+++ b/packages/api/eslint.config.js
@@ -31,11 +31,12 @@ export default [
   },
   {
     // instrument.ts runs Sentry init before the logger module loads, so it
-    // can't use `logger`. One-off scripts (src/scripts/*) and prisma/seed.ts
-    // are CLI tools where console output is the intentional UX.
+    // can't use `logger`. One-off scripts (src/scripts/*, scripts/*) and
+    // prisma/seed.ts are CLI tools where console output is the intentional UX.
     files: [
       'src/core/instrument.ts',
       'src/scripts/**',
+      'scripts/**',
       'prisma/seed.ts',
     ],
     rules: {

--- a/packages/api/scripts/backfillConditionGroupEvent.ts
+++ b/packages/api/scripts/backfillConditionGroupEvent.ts
@@ -1,0 +1,573 @@
+/**
+ * Backfill `condition_group.externalEventId` (and opportunistically
+ * `negRiskMarketId`) from Polymarket Gamma.
+ *
+ * Companion to migration 20260526232237_add_condition_group_event_identity.
+ * `externalEventId` is the platform-level identity that will replace
+ * name-keyed grouping in a follow-up PR. See
+ * scripts/investigateEventGrouping.ts — that analysis confirmed a perfect
+ * 1:1 bijection between Polymarket events and negRisk baskets in the
+ * affected data, which is what makes the conflict-resolution heuristic
+ * below structurally sound.
+ *
+ * Per-group decision tree:
+ *
+ *   - already has externalEventId set         → skip (idempotent re-run)
+ *   - no members are known to Polymarket      → leave NULL (legacy /
+ *                                                Sapience-native /
+ *                                                fully-delisted)
+ *   - all members agree on one event_id       → UPDATE externalEventId,
+ *                                                and (if currently NULL)
+ *                                                also negRiskMarketId
+ *   - members span >1 events AND default      → log + skip (operator picks)
+ *   - members span >1 events AND
+ *     --resolve-conflicts                     → pick the bucket with the
+ *                                                most-recent endTime; write
+ *                                                its (event_id, basket_id)
+ *                                                pair. Older-event members
+ *                                                stay in the group as
+ *                                                historical pollution but
+ *                                                will never accept new
+ *                                                conditions for other
+ *                                                events (the keeper will
+ *                                                create fresh groups for
+ *                                                those, post-refactor).
+ *
+ * Existing non-null `negRiskMarketId` is never overwritten — the basket
+ * backfill is authoritative for the groups it already populated.
+ *
+ * Defaults to dry-run. Pass `--apply` to write. Run on staging first.
+ *
+ * Usage:
+ *   # 1. Dry-run, see what would be written
+ *   pnpm --filter @sapience/api exec tsx scripts/backfillConditionGroupEvent.ts
+ *
+ *   # 2. Apply unambiguous backfills only (conflicts still skipped)
+ *   pnpm --filter @sapience/api exec tsx scripts/backfillConditionGroupEvent.ts --apply
+ *
+ *   # 3. Resolve conflicts with "latest event wins"
+ *   pnpm --filter @sapience/api exec tsx scripts/backfillConditionGroupEvent.ts --apply --resolve-conflicts
+ *
+ * If the initial Prisma query times out:
+ *   PRISMA_QUERY_TIMEOUT_MS=60000 pnpm --filter @sapience/api exec tsx scripts/backfillConditionGroupEvent.ts
+ */
+import { createWriteStream, mkdirSync, type WriteStream } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import prisma from '../src/core/db';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const APPLY = process.argv.includes('--apply');
+// When set, polluted groups (members span multiple Polymarket events) get
+// the most-recent member's (event_id, basket_id) pair written, instead of
+// being skipped. Investigation showed a perfect 1:1 bijection between
+// events and baskets in the dataset, so this is informationally equivalent
+// to a basket-based partition for those groups. Groups remain "polluted"
+// in that they still contain older-event members, but they become coherent
+// for the basket invariant and for future event-keyed lookups, and any
+// brand-new weekly events will create their own fresh groups.
+const RESOLVE_CONFLICTS = process.argv.includes('--resolve-conflicts');
+// Same throttling profile as backfillConditionGroupBaskets.ts — tuned
+// against Polymarket's documented 300 req/10s limit on /markets.
+const POLYMARKET_BATCH = 75;
+const FETCH_CONCURRENCY = 2;
+const MIN_REQUEST_INTERVAL_MS = 50;
+const UPDATE_CONCURRENCY = 10;
+const GAMMA_URL = 'https://gamma-api.polymarket.com/markets';
+
+interface PolymarketEvent {
+  id?: string | number;
+  title?: string;
+  slug?: string;
+}
+
+interface PolymarketMarket {
+  conditionId: string;
+  negRiskMarketId?: string | number;
+  negRiskMarketID?: string | number;
+  neg_risk_market_id?: string | number;
+  events?: PolymarketEvent[];
+}
+
+interface MarketInfo {
+  eventIds: string[];
+  eventTitle?: string;
+  negRiskMarketId: string | null;
+}
+
+function normalizeBasketId(market: PolymarketMarket): string | null {
+  const raw =
+    market.negRiskMarketId ??
+    market.negRiskMarketID ??
+    market.neg_risk_market_id;
+  if (raw === undefined || raw === null) return null;
+  const s = String(raw).trim();
+  return s.length > 0 ? s : null;
+}
+
+function extractMarketInfo(market: PolymarketMarket): MarketInfo {
+  const eventIds: string[] = [];
+  let eventTitle: string | undefined;
+  for (const e of market.events ?? []) {
+    if (e.id === undefined || e.id === null) continue;
+    const id = String(e.id).trim();
+    if (id.length === 0) continue;
+    if (!eventIds.includes(id)) {
+      eventIds.push(id);
+      if (eventTitle === undefined) {
+        eventTitle = e.title ?? e.slug;
+      }
+    }
+  }
+  return {
+    eventIds,
+    eventTitle,
+    negRiskMarketId: normalizeBasketId(market),
+  };
+}
+
+/** Fixed-concurrency worker pool. Preserves input order in results. */
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  worker: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+  const runnerCount = Math.max(1, Math.min(limit, items.length));
+  const runners = Array.from({ length: runnerCount }, async () => {
+    while (true) {
+      const idx = cursor++;
+      if (idx >= items.length) return;
+      results[idx] = await worker(items[idx], idx);
+    }
+  });
+  await Promise.all(runners);
+  return results;
+}
+
+let nextGammaSlot = 0;
+async function awaitGammaSlot(): Promise<void> {
+  const now = Date.now();
+  const wait = Math.max(0, nextGammaSlot - now);
+  nextGammaSlot = Math.max(now, nextGammaSlot) + MIN_REQUEST_INTERVAL_MS;
+  if (wait > 0) await new Promise((r) => setTimeout(r, wait));
+}
+function postponeGammaSlot(delayMs: number): void {
+  nextGammaSlot = Math.max(nextGammaSlot, Date.now() + delayMs);
+}
+
+async function fetchBatch(chunk: string[]): Promise<Map<string, MarketInfo>> {
+  const out = new Map<string, MarketInfo>();
+  if (chunk.length === 0) return out;
+
+  // Same open+closed merging strategy as the basket backfill: Gamma defaults
+  // to closed=false, so closed-state markets would otherwise drop out.
+  const fetchOne = async (closed: boolean): Promise<PolymarketMarket[]> => {
+    const params = chunk
+      .map((id) => `condition_ids=${encodeURIComponent(id)}`)
+      .join('&');
+    const url = `${GAMMA_URL}?${params}&closed=${closed}&limit=${chunk.length}`;
+    const MAX_ATTEMPTS = 6;
+    const PER_REQUEST_TIMEOUT_MS = 15_000;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      await awaitGammaSlot();
+      try {
+        const res = await fetch(url, {
+          headers: { Accept: 'application/json' },
+          signal: AbortSignal.timeout(PER_REQUEST_TIMEOUT_MS),
+        });
+        if (res.status === 429 || (res.status >= 500 && res.status < 600)) {
+          if (attempt === MAX_ATTEMPTS) {
+            console.warn(
+              `[backfill]   gamma fetch (closed=${closed}) gave up after ${MAX_ATTEMPTS} attempts: HTTP ${res.status}`
+            );
+            return [];
+          }
+          const retryAfterHeader = res.headers.get('Retry-After');
+          const retryAfterSec = retryAfterHeader
+            ? Number(retryAfterHeader)
+            : NaN;
+          const baseBackoffMs =
+            Number.isFinite(retryAfterSec) && retryAfterSec > 0
+              ? retryAfterSec * 1000
+              : 1000 * 2 ** (attempt - 1);
+          const backoffMs = baseBackoffMs + Math.floor(Math.random() * 500);
+          postponeGammaSlot(backoffMs);
+          console.warn(
+            `[backfill]   gamma fetch (closed=${closed}) HTTP ${res.status} attempt ${attempt}/${MAX_ATTEMPTS}; retrying in ${backoffMs}ms`
+          );
+          await new Promise((r) => setTimeout(r, backoffMs));
+          continue;
+        }
+        if (!res.ok) {
+          console.warn(
+            `[backfill]   gamma fetch (closed=${closed}) failed: HTTP ${res.status}`
+          );
+          return [];
+        }
+        return (await res.json()) as PolymarketMarket[];
+      } catch (err) {
+        const reason =
+          err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+        if (attempt === MAX_ATTEMPTS) {
+          console.warn(
+            `[backfill]   gamma fetch (closed=${closed}) network error after ${MAX_ATTEMPTS} attempts: ${reason}`
+          );
+          return [];
+        }
+        const backoffMs =
+          500 * 2 ** (attempt - 1) + Math.floor(Math.random() * 250);
+        postponeGammaSlot(backoffMs);
+        console.warn(
+          `[backfill]   gamma fetch (closed=${closed}) attempt ${attempt}/${MAX_ATTEMPTS} failed (${reason}); retrying in ${backoffMs}ms`
+        );
+        await new Promise((r) => setTimeout(r, backoffMs));
+      }
+    }
+    return [];
+  };
+
+  const [open, closedMarkets] = await Promise.all([
+    fetchOne(false),
+    fetchOne(true),
+  ]);
+  const seen = new Set<string>();
+  for (const m of [...open, ...closedMarkets]) {
+    if (!m.conditionId || seen.has(m.conditionId)) continue;
+    seen.add(m.conditionId);
+    out.set(m.conditionId, extractMarketInfo(m));
+  }
+  return out;
+}
+
+function setupFileLogger(): { logPath: string; close: () => Promise<void> } {
+  const runId = new Date()
+    .toISOString()
+    .replace(/[:.]/g, '-')
+    .replace('Z', '');
+  const logsDir = resolve(__dirname, 'logs');
+  mkdirSync(logsDir, { recursive: true });
+  const logPath = resolve(
+    logsDir,
+    `backfill-events-${APPLY ? 'apply' : 'dryrun'}-${runId}.log`
+  );
+  const stream: WriteStream = createWriteStream(logPath, { flags: 'a' });
+  const originals = {
+    log: console.log.bind(console),
+    warn: console.warn.bind(console),
+    error: console.error.bind(console),
+  };
+  const tee =
+    (orig: (...args: unknown[]) => void, level: string) =>
+    (...args: unknown[]) => {
+      const line = args
+        .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
+        .join(' ');
+      stream.write(`[${new Date().toISOString()}] ${level} ${line}\n`);
+      orig(...args);
+    };
+  console.log = tee(originals.log, 'INFO ');
+  console.warn = tee(originals.warn, 'WARN ');
+  console.error = tee(originals.error, 'ERROR');
+  return {
+    logPath,
+    close: () =>
+      new Promise<void>((res) => {
+        console.log = originals.log;
+        console.warn = originals.warn;
+        console.error = originals.error;
+        stream.end(res);
+      }),
+  };
+}
+
+interface Counters {
+  groupsScanned: number;
+  groupsAlreadySet: number;
+  groupsNoMembers: number;
+  groupsAllUnknown: number;
+  groupsBackfilled: number;
+  groupsEventConflictResolved: number;
+  groupsEventConflictSkipped: number;
+  groupsNoEventOnPolymarket: number;
+  basketAlsoBackfilled: number;
+}
+
+async function main(): Promise<void> {
+  console.log(
+    `[backfill] ${APPLY ? 'APPLY mode — UPDATEs will be written' : 'dry-run — pass --apply to write'}` +
+      (RESOLVE_CONFLICTS
+        ? ' | --resolve-conflicts: polluted groups get the most-recent member\'s (event,basket) pair'
+        : '')
+  );
+
+  const groups = await prisma.conditionGroup.findMany({
+    where: { condition: { some: {} } },
+    include: { condition: { select: { id: true, endTime: true } } },
+    orderBy: { id: 'asc' },
+  });
+
+  const counters: Counters = {
+    groupsScanned: 0,
+    groupsAlreadySet: 0,
+    groupsNoMembers: 0,
+    groupsAllUnknown: 0,
+    groupsBackfilled: 0,
+    groupsEventConflictResolved: 0,
+    groupsEventConflictSkipped: 0,
+    groupsNoEventOnPolymarket: 0,
+    basketAlsoBackfilled: 0,
+  };
+
+  console.log(`[backfill] scanning ${groups.length} condition_groups…`);
+
+  type EligibleGroup = (typeof groups)[number];
+  const eligibleGroups: EligibleGroup[] = [];
+  const allMemberIds = new Set<string>();
+  for (const g of groups) {
+    counters.groupsScanned++;
+    if (g.externalEventId) {
+      counters.groupsAlreadySet++;
+      continue;
+    }
+    if (g.condition.length === 0) {
+      counters.groupsNoMembers++;
+      continue;
+    }
+    eligibleGroups.push(g);
+    for (const c of g.condition) allMemberIds.add(c.id);
+  }
+
+  const memberIdArray = Array.from(allMemberIds);
+  const chunks: string[][] = [];
+  for (let i = 0; i < memberIdArray.length; i += POLYMARKET_BATCH) {
+    chunks.push(memberIdArray.slice(i, i + POLYMARKET_BATCH));
+  }
+  console.log(
+    `[backfill] fetching ${memberIdArray.length} unique conditions across ${eligibleGroups.length} eligible groups in ${chunks.length} batches (concurrency=${FETCH_CONCURRENCY})…`
+  );
+  const fetchStart = Date.now();
+  const PROGRESS_EVERY = Math.max(1, Math.floor(chunks.length / 40));
+  let completed = 0;
+  const batchResults = await mapWithConcurrency(
+    chunks,
+    FETCH_CONCURRENCY,
+    async (chunk) => {
+      const r = await fetchBatch(chunk);
+      completed += 1;
+      if (completed % PROGRESS_EVERY === 0 || completed === chunks.length) {
+        const elapsedSec = (Date.now() - fetchStart) / 1000;
+        const reqPerSec = (completed * 2) / Math.max(elapsedSec, 0.001);
+        const etaSec =
+          ((chunks.length - completed) * elapsedSec) / Math.max(completed, 1);
+        console.log(
+          `[backfill]   progress ${completed}/${chunks.length} batches ` +
+            `(${((completed / chunks.length) * 100).toFixed(1)}%) — ` +
+            `${reqPerSec.toFixed(1)} req/s avg, ` +
+            `elapsed ${elapsedSec.toFixed(0)}s, ETA ${etaSec.toFixed(0)}s`
+        );
+      }
+      return r;
+    }
+  );
+  const eventsByCondition = new Map<string, MarketInfo>();
+  for (const m of batchResults) {
+    for (const [k, v] of m) eventsByCondition.set(k, v);
+  }
+  console.log(
+    `[backfill] gamma fetch complete in ${((Date.now() - fetchStart) / 1000).toFixed(1)}s ` +
+      `(${eventsByCondition.size}/${memberIdArray.length} conditions found on Polymarket)`
+  );
+
+  // An update may set externalEventId, negRiskMarketId, or both, depending
+  // on the group's current state. We never overwrite a non-null
+  // negRiskMarketId — the basket backfill ran first and is authoritative
+  // for groups it already populated.
+  interface GroupUpdate {
+    id: EligibleGroup['id'];
+    eventId: string;
+    basketId: string | null;
+    writeBasket: boolean;
+  }
+  const updates: GroupUpdate[] = [];
+  for (const g of eligibleGroups) {
+    const memberIds = g.condition.map((c) => c.id);
+    let unknownCount = 0;
+    let noEventCount = 0;
+    // event_id -> { title, basketId (any one), latestEndTime, memberCount }
+    interface EventBucket {
+      title: string;
+      basketId: string | null;
+      latestEndTime: number;
+    }
+    const observed = new Map<string, EventBucket>();
+    for (const m of g.condition) {
+      const info = eventsByCondition.get(m.id);
+      if (!info) {
+        unknownCount++;
+        continue;
+      }
+      if (info.eventIds.length === 0) {
+        noEventCount++;
+        continue;
+      }
+      // We confirmed every market belongs to exactly one event in the
+      // investigation; defensively treat events[0] as canonical.
+      const eid = info.eventIds[0];
+      const existing = observed.get(eid);
+      if (!existing) {
+        observed.set(eid, {
+          title: info.eventTitle ?? '',
+          basketId: info.negRiskMarketId,
+          latestEndTime: m.endTime,
+        });
+      } else if (m.endTime > existing.latestEndTime) {
+        existing.latestEndTime = m.endTime;
+        // Bijection guaranteed by the investigation; refresh basket too.
+        existing.basketId = info.negRiskMarketId;
+      }
+    }
+
+    if (observed.size === 0) {
+      if (unknownCount === memberIds.length) {
+        counters.groupsAllUnknown++;
+        console.log(
+          `  · group ${g.id} "${g.name}" — all ${memberIds.length} members unknown to Polymarket; skip`
+        );
+      } else {
+        counters.groupsNoEventOnPolymarket++;
+        console.log(
+          `  · group ${g.id} "${g.name}" — Polymarket returned no event for any member (${noEventCount}/${memberIds.length} known but eventless); skip`
+        );
+      }
+      continue;
+    }
+
+    // For >1 events: pick the bucket with the latest endTime and use its
+    // (event, basket) pair. For singletons this collapses to the obvious
+    // single bucket.
+    const conflicted = observed.size > 1;
+    if (conflicted && !RESOLVE_CONFLICTS) {
+      counters.groupsEventConflictSkipped++;
+      console.error(
+        `  ✗ group ${g.id} "${g.name}" CONFLICT — members span distinct events: ` +
+          [...observed]
+            .map(
+              ([id, bucket]) =>
+                `${id}${bucket.title ? ' (' + bucket.title + ')' : ''}`
+            )
+            .join(', ') +
+          ` (${unknownCount} unknown / ${noEventCount} eventless) — ` +
+          `re-run with --resolve-conflicts to assign latest`
+      );
+      continue;
+    }
+
+    let chosenEventId: string;
+    let chosenBucket: EventBucket;
+    if (conflicted) {
+      const latest = [...observed].reduce((a, b) =>
+        b[1].latestEndTime > a[1].latestEndTime ? b : a
+      );
+      chosenEventId = latest[0];
+      chosenBucket = latest[1];
+    } else {
+      const [[only, bucket]] = observed;
+      chosenEventId = only;
+      chosenBucket = bucket;
+    }
+
+    const writeBasket = g.negRiskMarketId === null && chosenBucket.basketId !== null;
+    if (conflicted) {
+      counters.groupsEventConflictResolved++;
+      console.log(
+        `  ◇ group ${g.id} "${g.name}" CONFLICT-RESOLVED → event ${chosenEventId}` +
+          (chosenBucket.title ? ` (${chosenBucket.title})` : '') +
+          ` [latest of ${observed.size} events; older-event members remain in group]` +
+          (writeBasket ? ` + basket ${chosenBucket.basketId?.slice(0, 14)}…` : '')
+      );
+    } else {
+      counters.groupsBackfilled++;
+      console.log(
+        `  ✓ group ${g.id} "${g.name}" → event ${chosenEventId}` +
+          (chosenBucket.title ? ` (${chosenBucket.title})` : '') +
+          (writeBasket ? ` + basket ${chosenBucket.basketId?.slice(0, 14)}…` : '') +
+          (unknownCount
+            ? ` (${unknownCount}/${memberIds.length} unknown)`
+            : '') +
+          (noEventCount
+            ? ` (${noEventCount}/${memberIds.length} eventless)`
+            : '')
+      );
+    }
+    if (writeBasket) counters.basketAlsoBackfilled++;
+    updates.push({
+      id: g.id,
+      eventId: chosenEventId,
+      basketId: chosenBucket.basketId,
+      writeBasket,
+    });
+  }
+
+  if (APPLY && updates.length > 0) {
+    console.log(
+      `[backfill] writing ${updates.length} UPDATEs (concurrency=${UPDATE_CONCURRENCY})…`
+    );
+    await mapWithConcurrency(updates, UPDATE_CONCURRENCY, async (u) => {
+      await prisma.conditionGroup.update({
+        where: { id: u.id },
+        data: {
+          externalEventId: u.eventId,
+          ...(u.writeBasket ? { negRiskMarketId: u.basketId } : {}),
+        },
+      });
+    });
+  }
+
+  console.log(`\n[backfill] done${APPLY ? '' : ' (dry-run)'}`);
+  console.log(`  scanned                         : ${counters.groupsScanned}`);
+  console.log(`  already had externalEventId     : ${counters.groupsAlreadySet}`);
+  console.log(`  groups with no members          : ${counters.groupsNoMembers}`);
+  console.log(`  members unknown to Polymarket   : ${counters.groupsAllUnknown}`);
+  console.log(
+    `  members eventless on Polymarket : ${counters.groupsNoEventOnPolymarket}`
+  );
+  console.log(
+    `  event conflicts (skipped)       : ${counters.groupsEventConflictSkipped}` +
+      (counters.groupsEventConflictSkipped > 0
+        ? '  ← re-run with --resolve-conflicts to assign latest'
+        : '')
+  );
+  console.log(
+    `  event conflicts (resolved)      : ${counters.groupsEventConflictResolved}` +
+      (counters.groupsEventConflictResolved > 0
+        ? '  ← group keeps latest event\'s (event, basket); older members stay'
+        : '')
+  );
+  console.log(
+    `  backfilled (unambiguous)        : ${counters.groupsBackfilled}` +
+      (APPLY ? '' : '  (would write in --apply mode)')
+  );
+  console.log(
+    `  basket also populated           : ${counters.basketAlsoBackfilled}  (groups with null negRiskMarketId that got filled)`
+  );
+}
+
+const logger = setupFileLogger();
+console.log(`[backfill] log file: ${logger.logPath}`);
+
+let exitCode = 0;
+main()
+  .catch((err) => {
+    console.error(err);
+    exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect().catch(() => {});
+    console.log(`[backfill] log saved: ${logger.logPath}`);
+    await logger.close();
+    process.exit(exitCode);
+  });


### PR DESCRIPTION
## Summary

Companion data-fix tool for #1809. The migration added `externalEventId` + `source` columns to `condition_group`, but no script in the repo populates them; this PR ships the operator-runnable backfill so the staging and prod fills run from a tagged checkout rather than a developer's working tree.

**Strictly tooling — no production behavior change.** The script only executes when an operator runs it manually.

## What it does

Decision tree per `condition_group`:

| State | Behavior |
|---|---|
| Already has `externalEventId` | Skip (idempotent re-run) |
| No members | Skip |
| All members unknown to Polymarket | Skip + log |
| Members agree on one event_id | Write `externalEventId`; also `negRiskMarketId` if currently NULL |
| Members disagree (conflict), default | Skip + log |
| Members disagree, `--resolve-conflicts` | Pick bucket with latest endTime, write its `(event_id, basket)` pair |

Existing non-null `negRiskMarketId` is **never** overwritten. Older-event members in conflict-resolved groups remain as historical pollution but the group becomes coherent for the keeper's basket invariant.

## Why "latest event wins" is sound

The companion investigation (PR #1809 description) confirmed a **perfect 1:1 bijection** between Polymarket events and negRisk baskets across the 1,007 members of the 82 basket-conflict groups: 240 distinct events ↔ 240 distinct baskets, zero events containing >1 basket, zero baskets spanning >1 event. So picking any one event_id for a polluted group is informationally identical to a basket-based partition.

Live-group blast radius is much smaller than the raw conflict count suggests: of the ~906 event-conflict groups, only ~55 have any public+unsettled member; the rest are settled or private.

## Run modes

```bash
# 1. Dry-run, see the summary counters
PRISMA_QUERY_TIMEOUT_MS=60000 pnpm --filter @sapience/api exec tsx \\
  scripts/backfillConditionGroupEvent.ts

# 2. Apply, skipping conflicts (safer first pass)
PRISMA_QUERY_TIMEOUT_MS=60000 pnpm --filter @sapience/api exec tsx \\
  scripts/backfillConditionGroupEvent.ts --apply

# 3. Apply, including conflict resolution
PRISMA_QUERY_TIMEOUT_MS=60000 pnpm --filter @sapience/api exec tsx \\
  scripts/backfillConditionGroupEvent.ts --apply --resolve-conflicts
```

Expected staging dry-run output (based on the 2026-05-28 run):

\`\`\`
scanned                           : ~29,181
unambiguous (event_id agrees)     : ~28,271
conflicts (skipped without flag)  :    ~906
unknown to Polymarket             :        4
basket also populated (subset)    :  ~9,519
\`\`\`

## Implementation notes

- Same rate-limited Gamma fetcher pattern as the existing `backfillConditionGroupBaskets.ts`: process-global token bucket tuned to Polymarket's documented 300 req/10s ceiling for `/markets`, 429/5xx retry with `Retry-After` + jitter, file-logging tee.
- Intentionally duplicated rather than extracted into a shared module — both scripts are one-shot operator tools and a shared module would need its own PR/tests/review. Deferred to a future cleanup ticket once a third script needs the same machinery.
- ESLint `no-console` override extended to cover `scripts/**` (mirrors the existing `src/scripts/**` entry) since the script uses `console.*` deliberately for operator-facing output.
- `scripts/logs/` added to `.gitignore` so run artifacts don't get committed.

## What this PR does NOT do

- Apply the backfill to any environment (that's a separate operator action after merge)
- Touch the keeper or admin routes (those are PRs A + B in the broader roadmap)
- Drop `UNIQUE(name)` (PR C, after PR B has soaked through a weekly Polymarket cycle)
- Ship the one-off analysis scripts (`investigateEventGrouping.ts`, `analyzeConflictBlastRadius.ts`) — they served their purpose during planning; staying out of the repo

## Test plan

- [ ] CI: lint + tsc green
- [ ] Reviewer confirms the ESLint override change matches the pattern of the pre-existing `'src/scripts/**'` entry
- [ ] **Post-merge, operator-driven**: run dry-run on staging, eyeball counters, then \`--apply --resolve-conflicts\` and spot-check
- [ ] Sanity-check write via SQL after \`--apply\`:
  \`\`\`sql
  -- Should be near-zero (only the 4 unknowns + any new groups since the dry-run)
  SELECT COUNT(*) FROM condition_group cg
  WHERE cg."externalEventId" IS NULL
    AND EXISTS (SELECT 1 FROM condition c WHERE c."conditionGroupId" = cg.id);
  \`\`\`
- [ ] GraphQL spot-check: query \`negRisk\` for one of the ~9,519 newly-unblocked groups, confirm \`true\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)