### PR TITLE
fix(api): restore attestation migration history

### DIFF
--- a/packages/api/prisma/migrations/20260514000000_rename_attestation_prediction_to_forecast/migration.sql
+++ b/packages/api/prisma/migrations/20260514000000_rename_attestation_prediction_to_forecast/migration.sql
@@ -1,0 +1,9 @@
+-- Rename the `prediction` column on `attestation` to `forecast`. The
+-- on-chain EAS schema literally declares this field as `uint256 forecast`,
+-- and the indexer, scoring service, and SDK all refer to it as "forecast"
+-- — the `prediction` column name was a leftover ambiguity with the
+-- escrow-prediction concept (CLAUDE.md reserves "prediction" for user
+-- escrow positions). This rename aligns the column with the on-chain
+-- schema name and the in-tree terminology.
+
+ALTER TABLE "attestation" RENAME COLUMN "prediction" TO "forecast";

--- a/packages/api/prisma/migrations/20260529000000_rename_attestation_forecast_back_to_prediction/migration.sql
+++ b/packages/api/prisma/migrations/20260529000000_rename_attestation_forecast_back_to_prediction/migration.sql
@@ -1,0 +1,23 @@
+-- Reverse the previously-applied staging migration that renamed attestation.prediction
+-- to attestation.forecast. Keep the old migration file in-tree so Prisma can
+-- validate databases that already applied it, then move the live schema back to
+-- the current Prisma model column name.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'attestation'
+      AND column_name = 'forecast'
+  ) AND NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'attestation'
+      AND column_name = 'prediction'
+  ) THEN
+    ALTER TABLE "attestation" RENAME COLUMN "forecast" TO "prediction";
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- restore the deleted `20260514000000_rename_attestation_prediction_to_forecast` migration so Prisma can validate DBs that already applied it
- add a later guarded migration to rename `attestation.forecast` back to `attestation.prediction`
- leave the current Prisma schema unchanged; fresh DBs apply both migrations and end at `prediction`

## Verification
- `git diff --check origin/staging..HEAD`
- confirmed only Prisma migration files changed
- confirmed `packages/api/prisma/schema.prisma` has no diff from `origin/staging`

Note: local worktree does not have repo dependencies installed, so I did not run `prisma validate` here.