### PR TITLE
feat(api): allow combo-bingo.vercel.app CORS

### DIFF
--- a/packages/api/src/runtime/middleware.test.ts
+++ b/packages/api/src/runtime/middleware.test.ts
@@ -53,6 +53,49 @@ describe('CORS origin allowlist', () => {
     expect(isAllowedCorsOrigin('https://evil.example:5173')).toBe(false);
   });
 
+  it('allows combo-bingo.vercel.app only when staging origins are enabled', async () => {
+    const { isAllowedCorsOrigin } = await import('./middleware');
+
+    expect(
+      isAllowedCorsOrigin('https://combo-bingo.vercel.app', {
+        allowStagingPreviewOrigins: true,
+      })
+    ).toBe(true);
+    expect(isAllowedCorsOrigin('https://combo-bingo.vercel.app')).toBe(false);
+  });
+
+  it('allows combo-bingo preflight on staging API host only', async () => {
+    vi.doMock('../core/config', () => ({
+      config: {
+        isProd: true,
+        NODE_ENV: 'production',
+        RATE_LIMIT_WINDOW_MS: 60000,
+        RATE_LIMIT_MAX_REQUESTS: 100,
+      },
+    }));
+
+    const { createApp } = await import('../core/app');
+    const app = createApp();
+    const origin = 'https://combo-bingo.vercel.app';
+
+    const stagingRes = await request(app)
+      .options('/graphql')
+      .set('Host', 'api.staging.sapience.xyz')
+      .set('Origin', origin)
+      .set('Access-Control-Request-Method', 'POST');
+
+    expect(stagingRes.status).toBe(200);
+    expect(stagingRes.headers['access-control-allow-origin']).toBe(origin);
+
+    const prodRes = await request(app)
+      .options('/graphql')
+      .set('Host', 'api.sapience.xyz')
+      .set('Origin', origin)
+      .set('Access-Control-Request-Method', 'POST');
+
+    expect(prodRes.headers['access-control-allow-origin']).toBeUndefined();
+  });
+
   it('allows LAN dev preflight on staging API host only', async () => {
     vi.doMock('../core/config', () => ({
       config: {

--- a/packages/api/src/runtime/middleware.test.ts
+++ b/packages/api/src/runtime/middleware.test.ts
@@ -53,18 +53,17 @@ describe('CORS origin allowlist', () => {
     expect(isAllowedCorsOrigin('https://evil.example:5173')).toBe(false);
   });
 
-  it('allows combo-bingo.vercel.app only when staging origins are enabled', async () => {
+  it('allows combo-bingo.vercel.app in all environments', async () => {
     const { isAllowedCorsOrigin } = await import('./middleware');
 
-    expect(
-      isAllowedCorsOrigin('https://combo-bingo.vercel.app', {
-        allowStagingPreviewOrigins: true,
-      })
-    ).toBe(true);
-    expect(isAllowedCorsOrigin('https://combo-bingo.vercel.app')).toBe(false);
+    expect(isAllowedCorsOrigin('https://combo-bingo.vercel.app')).toBe(true);
+    expect(isAllowedCorsOrigin('http://combo-bingo.vercel.app')).toBe(true);
+    expect(isAllowedCorsOrigin('https://combo-bingo-evil.vercel.app')).toBe(
+      false
+    );
   });
 
-  it('allows combo-bingo preflight on staging API host only', async () => {
+  it('allows combo-bingo preflight on production API host', async () => {
     vi.doMock('../core/config', () => ({
       config: {
         isProd: true,
@@ -78,22 +77,14 @@ describe('CORS origin allowlist', () => {
     const app = createApp();
     const origin = 'https://combo-bingo.vercel.app';
 
-    const stagingRes = await request(app)
-      .options('/graphql')
-      .set('Host', 'api.staging.sapience.xyz')
-      .set('Origin', origin)
-      .set('Access-Control-Request-Method', 'POST');
-
-    expect(stagingRes.status).toBe(200);
-    expect(stagingRes.headers['access-control-allow-origin']).toBe(origin);
-
     const prodRes = await request(app)
       .options('/graphql')
       .set('Host', 'api.sapience.xyz')
       .set('Origin', origin)
       .set('Access-Control-Request-Method', 'POST');
 
-    expect(prodRes.headers['access-control-allow-origin']).toBeUndefined();
+    expect(prodRes.status).toBe(200);
+    expect(prodRes.headers['access-control-allow-origin']).toBe(origin);
   });
 
   it('allows LAN dev preflight on staging API host only', async () => {

--- a/packages/api/src/runtime/middleware.ts
+++ b/packages/api/src/runtime/middleware.ts
@@ -99,7 +99,6 @@ const PRIVATE_LAN_DEV_PORTS = new Set(['5173']);
 
 type CorsOriginOptions = {
   allowPrivateLanDevOrigins?: boolean;
-  allowStagingPreviewOrigins?: boolean;
 };
 
 function isPrivateIpv4(hostname: string): boolean {
@@ -132,21 +131,13 @@ export function isAllowedCorsOrigin(
     /^https?:\/\/([a-zA-Z0-9-]+\.)*ethereal\.trade$/.test(origin) ||
     /^https?:\/\/([a-zA-Z0-9-]+\.)*etherealtest\.net$/.test(origin) ||
     /^https?:\/\/([a-zA-Z0-9-]+\.)*etherealdev\.net$/.test(origin) ||
-    /^https?:\/\/(app|docs)\.vercel\.app$/.test(origin) ||
+    /^https?:\/\/(app|docs|combo-bingo)\.vercel\.app$/.test(origin) ||
     /^https?:\/\/(app|docs)-[a-z0-9-]+-sapiencexyz\.vercel\.app$/.test(
       origin
     ) ||
     /^https?:\/\/([a-zA-Z0-9-]+-)?meridianxyz\.vercel\.app$/.test(origin) ||
     /^https?:\/\/localhost(:\d+)?$/.test(origin) ||
     /^https?:\/\/127\.0\.0\.1(:\d+)?$/.test(origin)
-  ) {
-    return true;
-  }
-
-  // Staging-only preview origins (e.g. external collaborators' Vercel previews).
-  if (
-    options.allowStagingPreviewOrigins === true &&
-    /^https?:\/\/combo-bingo\.vercel\.app$/.test(origin)
   ) {
     return true;
   }
@@ -198,7 +189,6 @@ function createCorsOptions(request: Request): cors.CorsOptions {
       if (
         isAllowedCorsOrigin(origin, {
           allowPrivateLanDevOrigins: isStagingRequest(request),
-          allowStagingPreviewOrigins: isStagingRequest(request),
         })
       ) {
         callback(null, true);

--- a/packages/api/src/runtime/middleware.ts
+++ b/packages/api/src/runtime/middleware.ts
@@ -99,6 +99,7 @@ const PRIVATE_LAN_DEV_PORTS = new Set(['5173']);
 
 type CorsOriginOptions = {
   allowPrivateLanDevOrigins?: boolean;
+  allowStagingPreviewOrigins?: boolean;
 };
 
 function isPrivateIpv4(hostname: string): boolean {
@@ -138,6 +139,14 @@ export function isAllowedCorsOrigin(
     /^https?:\/\/([a-zA-Z0-9-]+-)?meridianxyz\.vercel\.app$/.test(origin) ||
     /^https?:\/\/localhost(:\d+)?$/.test(origin) ||
     /^https?:\/\/127\.0\.0\.1(:\d+)?$/.test(origin)
+  ) {
+    return true;
+  }
+
+  // Staging-only preview origins (e.g. external collaborators' Vercel previews).
+  if (
+    options.allowStagingPreviewOrigins === true &&
+    /^https?:\/\/combo-bingo\.vercel\.app$/.test(origin)
   ) {
     return true;
   }
@@ -189,6 +198,7 @@ function createCorsOptions(request: Request): cors.CorsOptions {
       if (
         isAllowedCorsOrigin(origin, {
           allowPrivateLanDevOrigins: isStagingRequest(request),
+          allowStagingPreviewOrigins: isStagingRequest(request),
         })
       ) {
         callback(null, true);


### PR DESCRIPTION
## Summary

Allows browser requests from `combo-bingo.vercel.app` through the API CORS allowlist in **all environments** (staging and production), by adding it alongside the existing `app`/`docs` Vercel origins.

- `isAllowedCorsOrigin`: `/^https?:\/\/(app|docs|combo-bingo)\.vercel\.app$/`

## Testing

- `pnpm --filter @sapience/api run test` — 517 passed, including:
  - unit: `combo-bingo.vercel.app` allowed (http + https), `combo-bingo-evil.vercel.app` rejected (anchored regex)
  - preflight integration: succeeds with `Access-Control-Allow-Origin` on the production API host

🤖 Generated with [Claude Code](https://claude.com/claude-code)