### PR TITLE
fix(api, market-keeper): close negRisk basket gaps and prod prompt-log leak

### DIFF
--- a/packages/api/src/routes/conditionGroups.test.ts
+++ b/packages/api/src/routes/conditionGroups.test.ts
@@ -178,7 +178,7 @@ describe('conditionGroups routes', () => {
   });
 
   describe('PUT /admin/conditionGroups/:id/conditions', () => {
-    it('assigns conditions to a group without inspecting per-condition basket fields', async () => {
+    it('assigns conditions when every candidate already shares the target basket', async () => {
       mockPrisma.conditionGroup.findUnique
         .mockResolvedValueOnce({
           id: 42,
@@ -187,8 +187,8 @@ describe('conditionGroups routes', () => {
         })
         .mockResolvedValueOnce({ id: 42, condition: [] });
       mockPrisma.condition.findMany.mockResolvedValue([
-        { id: HASH_A },
-        { id: HASH_B },
+        { id: HASH_A, conditionGroup: { negRiskMarketId: 'basket-a' } },
+        { id: HASH_B, conditionGroup: { negRiskMarketId: 'basket-a' } },
       ]);
       mockPrisma.condition.updateMany.mockResolvedValue({ count: 0 });
       mockPrisma.condition.update.mockResolvedValue({});
@@ -198,9 +198,70 @@ describe('conditionGroups routes', () => {
         .send({ conditionIds: [HASH_A, HASH_B] });
 
       expect(res.status).toBe(200);
-      expect(mockPrisma.condition.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({ select: { id: true } })
-      );
+      expect(mockPrisma.condition.update).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects attaching a non-basket condition to a basket group', async () => {
+      mockPrisma.conditionGroup.findUnique.mockResolvedValue({
+        id: 42,
+        name: 'NBA winner',
+        negRiskMarketId: 'basket-a',
+      });
+      mockPrisma.condition.findMany.mockResolvedValue([
+        { id: HASH_A, conditionGroup: null },
+        { id: HASH_B, conditionGroup: { negRiskMarketId: 'basket-a' } },
+      ]);
+
+      const res = await request(app)
+        .put('/admin/conditionGroups/42/conditions')
+        .send({ conditionIds: [HASH_A, HASH_B] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/Cannot attach conditions/);
+      expect(res.body.message).toContain(HASH_A);
+      expect(mockPrisma.condition.update).not.toHaveBeenCalled();
+      expect(mockPrisma.condition.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('rejects attaching a cross-basket condition to a basket group', async () => {
+      mockPrisma.conditionGroup.findUnique.mockResolvedValue({
+        id: 42,
+        name: 'NBA winner',
+        negRiskMarketId: 'basket-a',
+      });
+      mockPrisma.condition.findMany.mockResolvedValue([
+        { id: HASH_A, conditionGroup: { negRiskMarketId: 'basket-b' } },
+      ]);
+
+      const res = await request(app)
+        .put('/admin/conditionGroups/42/conditions')
+        .send({ conditionIds: [HASH_A] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/Cannot attach conditions/);
+      expect(mockPrisma.condition.update).not.toHaveBeenCalled();
+    });
+
+    it('allows attaching unaffiliated conditions to a non-basket group', async () => {
+      mockPrisma.conditionGroup.findUnique
+        .mockResolvedValueOnce({
+          id: 50,
+          name: 'Misc',
+          negRiskMarketId: null,
+        })
+        .mockResolvedValueOnce({ id: 50, condition: [] });
+      mockPrisma.condition.findMany.mockResolvedValue([
+        { id: HASH_A, conditionGroup: null },
+        { id: HASH_B, conditionGroup: null },
+      ]);
+      mockPrisma.condition.updateMany.mockResolvedValue({ count: 0 });
+      mockPrisma.condition.update.mockResolvedValue({});
+
+      const res = await request(app)
+        .put('/admin/conditionGroups/50/conditions')
+        .send({ conditionIds: [HASH_A, HASH_B] });
+
+      expect(res.status).toBe(200);
       expect(mockPrisma.condition.update).toHaveBeenCalledTimes(2);
     });
 
@@ -210,7 +271,9 @@ describe('conditionGroups routes', () => {
         name: 'NBA winner',
         negRiskMarketId: 'basket-a',
       });
-      mockPrisma.condition.findMany.mockResolvedValue([{ id: HASH_A }]);
+      mockPrisma.condition.findMany.mockResolvedValue([
+        { id: HASH_A, conditionGroup: null },
+      ]);
 
       const res = await request(app)
         .put('/admin/conditionGroups/42/conditions')

--- a/packages/api/src/routes/conditionGroups.ts
+++ b/packages/api/src/routes/conditionGroups.ts
@@ -231,16 +231,46 @@ router.put('/:id/conditions', async (req: Request, res: Response) => {
       return res.status(404).json({ message: 'Condition group not found' });
     }
 
-    // Validate all condition IDs exist
+    // Validate all condition IDs exist and load their current basket
+    // affiliation. A condition's effective basket is the negRiskMarketId
+    // of its current group (or null when unattached). Reuse this on the
+    // basket check below so we don't round-trip twice.
     const validConditions = await prisma.condition.findMany({
       where: { id: { in: conditionIds } },
-      select: { id: true },
+      select: {
+        id: true,
+        conditionGroup: { select: { negRiskMarketId: true } },
+      },
     });
     const validIds = new Set(validConditions.map((c) => c.id));
     const invalidIds = conditionIds.filter((cid) => !validIds.has(cid));
     if (invalidIds.length > 0) {
       return res.status(400).json({
         message: `Invalid condition IDs: ${invalidIds.join(', ')}`,
+      });
+    }
+
+    // Basket invariant: attaching a condition to a group is only legal
+    // when the condition's current basket matches the target group's
+    // basket exactly (null included). Without this, an unrelated market
+    // can drift into a mutually-exclusive negRisk basket and corrupt
+    // settlement. Conditions already in the target group trivially
+    // agree (the current group IS the target group).
+    const targetBasket = existing.negRiskMarketId;
+    const mismatched = validConditions.filter((c) => {
+      const currentBasket = c.conditionGroup?.negRiskMarketId ?? null;
+      return currentBasket !== targetBasket;
+    });
+    if (mismatched.length > 0) {
+      return res.status(400).json({
+        message:
+          `Cannot attach conditions to group ${groupId} ` +
+          `(expected negRiskMarketId ${targetBasket ?? 'null'}): ` +
+          mismatched
+            .map(
+              (c) => `${c.id}=${c.conditionGroup?.negRiskMarketId ?? 'null'}`
+            )
+            .join(', '),
       });
     }
 

--- a/packages/api/src/routes/conditions.test.ts
+++ b/packages/api/src/routes/conditions.test.ts
@@ -663,6 +663,86 @@ describe('conditions routes', () => {
       expect(mockPrisma.condition.create).not.toHaveBeenCalled();
     });
 
+    it('rejects batch items with an endTime in the past', async () => {
+      // The single-create path enforces endTime > now; batch-create now
+      // mirrors that. Without this guard, the keeper's LLM endtime parser
+      // (which intentionally surfaces past dates) could let an already-
+      // settled-on-arrival condition land in the DB via batch submission.
+      const res = await request(app)
+        .post('/admin/conditions/batch-create')
+        .send({
+          conditions: [
+            {
+              conditionHash: '0x' + '33'.repeat(32),
+              question: 'Past?',
+              endTime: PAST_END_TIME,
+              description: 'test',
+              resolver: VALID_RESOLVER,
+            },
+          ],
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/future Unix timestamp/i);
+      expect(mockPrisma.condition.create).not.toHaveBeenCalled();
+    });
+
+    it('seeds new auto-created groups with similarMarkets from the first item', async () => {
+      // Auto-created groups previously landed without similarMarkets,
+      // making negRisk baskets show up empty on the discovery surface
+      // until a later refresh. Carry the first item's payload forward.
+      mockPrisma.condition.create.mockResolvedValue({});
+      mockPrisma.category.findFirst.mockResolvedValue(null);
+      mockPrisma.conditionGroup.findMany.mockResolvedValue([]);
+      mockPrisma.conditionGroup.create.mockResolvedValue({
+        id: 77,
+        name: 'Auto group',
+        negRiskMarketId: 'basket-a',
+      });
+
+      const res = await request(app)
+        .post('/admin/conditions/batch-create')
+        .send({
+          conditions: [
+            {
+              conditionHash: '0x' + '44'.repeat(32),
+              question: 'Q1?',
+              endTime: FUTURE_END_TIME,
+              description: 'test',
+              resolver: VALID_RESOLVER,
+              groupName: 'Auto group',
+              negRisk: true,
+              negRiskMarketId: 'basket-a',
+              similarMarkets: [
+                'https://polymarket.com/event/foo',
+                'https://polymarket.com/event/bar',
+              ],
+            },
+            {
+              conditionHash: '0x' + '55'.repeat(32),
+              question: 'Q2?',
+              endTime: FUTURE_END_TIME,
+              description: 'test',
+              resolver: VALID_RESOLVER,
+              groupName: 'Auto group',
+              negRisk: true,
+              negRiskMarketId: 'basket-a',
+              similarMarkets: [
+                'https://polymarket.com/event/foo',
+                'https://polymarket.com/event/bar',
+              ],
+            },
+          ],
+        });
+
+      expect(res.status).toBe(201);
+      const createCall = mockPrisma.conditionGroup.create.mock.calls[0][0];
+      expect(createCall.data.similarMarkets).toEqual([
+        'https://polymarket.com/event/foo',
+        'https://polymarket.com/event/bar',
+      ]);
+    });
+
     it('persists optionName for every item in the batch', async () => {
       mockPrisma.condition.create.mockResolvedValue({});
       mockPrisma.category.findFirst.mockResolvedValue(null);
@@ -1160,6 +1240,31 @@ describe('conditions routes', () => {
       const updateCall = mockPrisma.condition.update.mock.calls[0][0];
       expect(updateCall.data.question).toBe('Edited question');
     });
+
+    it('grandfathers a current basket-group member when groupName is restated without the basket id', async () => {
+      // The keeper's refresh flow restates groupName per condition but
+      // doesn't always restate the basket id. Without grandfathering,
+      // every routine edit on an existing basket-group member would 400.
+      mockPrisma.condition.findUnique.mockResolvedValue(
+        existingCondition({ conditionGroupId: 9 })
+      );
+      mockPrisma.conditionGroup.findFirst.mockResolvedValue({
+        id: 9,
+        name: 'NBA champion',
+        negRiskMarketId: 'basket-a',
+      });
+      mockPrisma.condition.update.mockResolvedValue({ id: VALID_ID });
+
+      const res = await request(app)
+        .put(`/admin/conditions/${VALID_ID}`)
+        // groupName restated, no negRiskMarketId — should be accepted
+        // because the condition is already in this exact group.
+        .send({ groupName: 'NBA champion', description: 'fresh copy' });
+
+      expect(res.status).toBe(200);
+      const updateCall = mockPrisma.condition.update.mock.calls[0][0];
+      expect(updateCall.data.description).toBe('fresh copy');
+    });
   });
 
   // ---------- PUT /admin/conditions/batch-metadata ----------
@@ -1307,6 +1412,79 @@ describe('conditions routes', () => {
       expect(updateCall.data).not.toHaveProperty('negRisk');
       expect(updateCall.data).not.toHaveProperty('negRiskMarketId');
     });
+
+    it('grandfathers an existing basket-group member when the batch item omits the basket id', async () => {
+      // The keeper's refresh pass restates groupName per condition but
+      // not the basket id. Without grandfathering, a metadata-only
+      // refresh on an existing basket-group member would always 400.
+      mockPrisma.conditionGroup.findMany.mockResolvedValue([
+        {
+          id: 42,
+          name: 'NBA champion',
+          negRiskMarketId: 'basket-a',
+        },
+      ]);
+      mockPrisma.condition.findMany.mockResolvedValue([
+        {
+          id: VALID_ID,
+          endTime: FUTURE_END_TIME,
+          settled: false,
+          conditionGroupId: 42,
+        },
+      ]);
+      mockPrisma.condition.update.mockResolvedValue({});
+
+      const res = await request(app)
+        .put('/admin/conditions/batch-metadata')
+        .send({
+          updates: [
+            {
+              id: VALID_ID,
+              fields: { groupName: 'NBA champion', description: 'refreshed' },
+            },
+          ],
+        });
+
+      expect(res.status).toBe(200);
+      const updateCall = mockPrisma.condition.update.mock.calls[0][0];
+      expect(updateCall.data.description).toBe('refreshed');
+    });
+
+    it('re-validates the basket when the new-group create races and loses', async () => {
+      // Leader-takes-all says the first update's basket id stamps the
+      // new group. When prisma.create races and loses, the now-existing
+      // group's basket may not match what our leader stamped — every
+      // incoming update must be re-checked, not silently admitted.
+      mockPrisma.conditionGroup.findMany.mockResolvedValue([]);
+      mockPrisma.conditionGroup.create.mockRejectedValue(
+        new Error('Unique constraint failed on conditionGroup.name')
+      );
+      mockPrisma.conditionGroup.findFirst.mockResolvedValue({
+        id: 99,
+        name: 'Race target',
+        negRiskMarketId: 'basket-b', // race winner stamped basket-b
+      });
+
+      const res = await request(app)
+        .put('/admin/conditions/batch-metadata')
+        .send({
+          updates: [
+            {
+              id: VALID_ID,
+              fields: {
+                groupName: 'Race target',
+                negRisk: true,
+                negRiskMarketId: 'basket-a', // we wanted basket-a
+              },
+            },
+          ],
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/non-matching condition/i);
+      expect(mockPrisma.condition.update).not.toHaveBeenCalled();
+    });
+
     describe('endTime field (Part C backfill support)', () => {
       it('updates endTime on unsettled rows', async () => {
         mockPrisma.condition.findMany.mockResolvedValue([

--- a/packages/api/src/routes/conditions.test.ts
+++ b/packages/api/src/routes/conditions.test.ts
@@ -663,11 +663,14 @@ describe('conditions routes', () => {
       expect(mockPrisma.condition.create).not.toHaveBeenCalled();
     });
 
-    it('rejects batch items with an endTime in the past', async () => {
-      // The single-create path enforces endTime > now; batch-create now
-      // mirrors that. Without this guard, the keeper's LLM endtime parser
-      // (which intentionally surfaces past dates) could let an already-
-      // settled-on-arrival condition land in the DB via batch submission.
+    it('accepts batch items with an endTime in the past (backfill path)', async () => {
+      // batch-create intentionally allows past endTimes for historical
+      // backfills (PR #1581). The keeper warns loudly when it submits
+      // one so they're auditable; the API itself stays permissive.
+      mockPrisma.condition.create.mockResolvedValue({});
+      mockPrisma.category.findFirst.mockResolvedValue(null);
+      mockPrisma.conditionGroup.findMany.mockResolvedValue([]);
+
       const res = await request(app)
         .post('/admin/conditions/batch-create')
         .send({
@@ -682,9 +685,8 @@ describe('conditions routes', () => {
           ],
         });
 
-      expect(res.status).toBe(400);
-      expect(res.body.message).toMatch(/future Unix timestamp/i);
-      expect(mockPrisma.condition.create).not.toHaveBeenCalled();
+      expect(res.status).toBe(201);
+      expect(mockPrisma.condition.create).toHaveBeenCalledTimes(1);
     });
 
     it('seeds new auto-created groups with similarMarkets from the first item', async () => {

--- a/packages/api/src/routes/conditions.ts
+++ b/packages/api/src/routes/conditions.ts
@@ -210,17 +210,9 @@ router.post('/batch-create', async (req: Request, res: Response) => {
           message: `endTime must be a valid Unix timestamp for ${item.conditionHash}`,
         });
       }
-      // Mirror the single-create future-only guard. The keeper's LLM
-      // endtime parser intentionally surfaces past dates as a signal
-      // for manual review, but they must not slip into batch-create —
-      // an already-elapsed endTime ships a condition that's settle-
-      // ready the moment it's listed.
-      const nowSeconds = Math.floor(Date.now() / 1000);
-      if (endTimeInt <= nowSeconds) {
-        return res.status(400).json({
-          message: `endTime must be a future Unix timestamp (seconds) for ${item.conditionHash}, endTime: ${endTimeInt}, nowSeconds: ${nowSeconds}`,
-        });
-      }
+      // batch-create intentionally accepts past endTimes — historical
+      // backfills (PR #1581) rely on it. The keeper escalates a WARN
+      // log per past-dated submission so they're auditable post-hoc.
     }
 
     // Resolve category slugs (batch lookup)

--- a/packages/api/src/routes/conditions.ts
+++ b/packages/api/src/routes/conditions.ts
@@ -210,6 +210,17 @@ router.post('/batch-create', async (req: Request, res: Response) => {
           message: `endTime must be a valid Unix timestamp for ${item.conditionHash}`,
         });
       }
+      // Mirror the single-create future-only guard. The keeper's LLM
+      // endtime parser intentionally surfaces past dates as a signal
+      // for manual review, but they must not slip into batch-create —
+      // an already-elapsed endTime ships a condition that's settle-
+      // ready the moment it's listed.
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      if (endTimeInt <= nowSeconds) {
+        return res.status(400).json({
+          message: `endTime must be a future Unix timestamp (seconds) for ${item.conditionHash}, endTime: ${endTimeInt}, nowSeconds: ${nowSeconds}`,
+        });
+      }
     }
 
     // Resolve category slugs (batch lookup)
@@ -339,12 +350,27 @@ router.post('/batch-create', async (req: Request, res: Response) => {
       const categoryId = firstItem?.categorySlug
         ? (categoryBySlug.get(firstItem.categorySlug) ?? null)
         : null;
+      // Seed the group's similarMarkets from the first item's payload so
+      // auto-created groups don't ship empty for the discovery surface.
+      // For event-keyed Polymarket groups every sibling carries the same
+      // list, so picking the first is safe; admins can curate later via
+      // PUT /admin/conditionGroups/:id.
+      const seedSimilarMarkets =
+        Array.isArray(firstItem?.similarMarkets) &&
+        firstItem!.similarMarkets!.every(
+          (s) => typeof s === 'string' && isHttpUrl(s)
+        )
+          ? firstItem!.similarMarkets
+          : undefined;
       try {
         const group = await prisma.conditionGroup.create({
           data: {
             name,
             categoryId,
             negRiskMarketId: leaderBasket,
+            ...(seedSimilarMarkets
+              ? { similarMarkets: seedSimilarMarkets }
+              : {}),
           },
         });
         groupIdByName.set(name, group.id);
@@ -578,12 +604,22 @@ router.post('/', async (req: Request, res: Response) => {
       });
       if (!group) {
         // Create with inherited category (smart default). When the payload
-        // claims a basket id, the brand-new group adopts it.
+        // claims a basket id, the brand-new group adopts it. Seed
+        // similarMarkets from the payload so auto-created groups don't
+        // ship empty for the discovery surface (admins can curate later).
+        const seedSimilarMarkets =
+          Array.isArray(similarMarkets) &&
+          similarMarkets.every((s) => typeof s === 'string' && isHttpUrl(s))
+            ? similarMarkets
+            : undefined;
         group = await prisma.conditionGroup.create({
           data: {
             name: groupName.trim(),
             categoryId: resolvedCategoryId ?? undefined,
             negRiskMarketId: normalizedNegRiskMarketId,
+            ...(seedSimilarMarkets
+              ? { similarMarkets: seedSimilarMarkets }
+              : {}),
           },
         });
       }
@@ -927,24 +963,43 @@ router.put('/batch-metadata', async (req: Request, res: Response) => {
       }
     }
 
-    // Pre-fetch existing rows ONLY when at least one update touches endTime.
-    // Mirrors the per-condition PUT /admin/conditions/:id guard at
-    // L832-L836: settled rows reject endTime changes; their other fields
-    // are still updatable. Skipping the query when no endTime is in scope
-    // keeps the common metadata-only flow on one round-trip per row.
+    // Pre-fetch existing rows when at least one update touches endTime
+    // OR groupName. endTime needs `settled` for the settled-row guard
+    // (mirrors per-condition PUT /admin/conditions/:id at L832-L836).
+    // groupName needs `conditionGroupId` so the basket invariant can
+    // grandfather conditions that are already in the target group —
+    // a routine metadata edit must not re-trip basket admission on a
+    // condition that's been a member all along.
     const touchesEndTime = updates.some(
       (u) => typeof u.fields.endTime === 'number'
     );
-    const existingById = touchesEndTime
-      ? new Map(
-          (
-            await prisma.condition.findMany({
-              where: { id: { in: [...new Set(updates.map((u) => u.id))] } },
-              select: { id: true, endTime: true, settled: true },
-            })
-          ).map((r) => [r.id, r])
-        )
-      : new Map<string, { id: string; endTime: number; settled: boolean }>();
+    const touchesGroup = updates.some((u) =>
+      Boolean(u.fields.groupName?.trim())
+    );
+    const existingById =
+      touchesEndTime || touchesGroup
+        ? new Map(
+            (
+              await prisma.condition.findMany({
+                where: { id: { in: [...new Set(updates.map((u) => u.id))] } },
+                select: {
+                  id: true,
+                  endTime: true,
+                  settled: true,
+                  conditionGroupId: true,
+                },
+              })
+            ).map((r) => [r.id, r])
+          )
+        : new Map<
+            string,
+            {
+              id: string;
+              endTime: number;
+              settled: boolean;
+              conditionGroupId: number | null;
+            }
+          >();
 
     // Resolve referenced groups: load existing ones by name and decide which
     // basket id (if any) to stamp onto groups we still need to create.
@@ -975,12 +1030,16 @@ router.put('/batch-metadata', async (req: Request, res: Response) => {
 
     // Validate basket invariants against any *already-persisted* groups
     // before creating new ones, otherwise a mid-batch reject would orphan
-    // empty rows.
+    // empty rows. Conditions already linked to the target group are
+    // grandfathered — admission is what the invariant guards, not
+    // continuing membership.
     for (const u of updates) {
       const groupName = u.fields.groupName?.trim();
       if (!groupName) continue;
       const group = existingGroupsByName.get(groupName);
       if (!group) continue;
+      const existingRow = existingById.get(u.id);
+      if (existingRow && existingRow.conditionGroupId === group.id) continue;
       const payloadBasket = normalizeNegRiskMarketId(u.fields.negRiskMarketId);
       if (!basketsAgree(group.negRiskMarketId, payloadBasket)) {
         return res.status(400).json({
@@ -1065,6 +1124,42 @@ router.put('/batch-metadata', async (req: Request, res: Response) => {
               where: { name },
             });
             if (found) {
+              // Re-check incoming updates against the now-existing group's
+              // basket. Without this, a race where our leader-stamp lost
+              // would silently admit every update into whatever basket the
+              // winner stamped. Mirrors the batch-create race path.
+              const raceMismatched = incomingForGroup.filter((u) => {
+                const existingRow = existingById.get(u.id);
+                if (existingRow && existingRow.conditionGroupId === found.id) {
+                  return false;
+                }
+                return !basketsAgree(
+                  found.negRiskMarketId,
+                  normalizeNegRiskMarketId(u.fields.negRiskMarketId)
+                );
+              });
+              if (raceMismatched.length > 0) {
+                return res.status(400).json({
+                  ...negRiskMismatchPayload(
+                    `Cannot add non-matching condition${raceMismatched.length > 1 ? 's' : ''} to negRisk group ${name}. ` +
+                      `Expected negRiskMarketId ${found.negRiskMarketId ?? 'null'}; ` +
+                      `mismatched: ${raceMismatched.map((u) => u.id).join(', ')}`,
+                    [
+                      {
+                        type: 'EXISTING_GROUP_MISMATCH',
+                        groupName: name,
+                        expectedNegRiskMarketId: found.negRiskMarketId,
+                        mismatched: raceMismatched.map((u) => ({
+                          conditionHash: u.id,
+                          actualNegRiskMarketId: normalizeNegRiskMarketId(
+                            u.fields.negRiskMarketId
+                          ),
+                        })),
+                      },
+                    ]
+                  ),
+                });
+              }
               groupByName.set(name, {
                 id: found.id,
                 negRiskMarketId: found.negRiskMarketId,
@@ -1326,13 +1421,23 @@ router.put('/:id', async (req: Request, res: Response) => {
         where: { name: groupName.trim() },
       });
       if (!group) {
-        // Create with inherited category (smart default: use resolved or existing category)
+        // Create with inherited category (smart default: use resolved or
+        // existing category). Seed similarMarkets from the payload so
+        // auto-created groups don't ship empty for the discovery surface.
         const categoryForGroup = resolvedCategoryId ?? existing.categoryId;
+        const seedSimilarMarkets =
+          Array.isArray(similarMarkets) &&
+          similarMarkets.every((s) => typeof s === 'string' && isHttpUrl(s))
+            ? similarMarkets
+            : undefined;
         group = await prisma.conditionGroup.create({
           data: {
             name: groupName.trim(),
             categoryId: categoryForGroup ?? undefined,
             negRiskMarketId: normalizedNegRiskMarketId,
+            ...(seedSimilarMarkets
+              ? { similarMarkets: seedSimilarMarkets }
+              : {}),
           },
         });
       }
@@ -1362,7 +1467,15 @@ router.put('/:id', async (req: Request, res: Response) => {
           .json({ message: 'tags must be an array of strings' });
       }
 
+      // Only validate the basket on *admission* — a condition already in
+      // the target group is grandfathered, matching the comment above.
+      // Routine metadata edits (description, tags, etc.) restate
+      // groupName without negRiskMarketId, so without this short-circuit
+      // every such edit on a negRisk group member would 400.
+      const isAdmission =
+        targetGroup && existing.conditionGroupId !== targetGroup.id;
       if (
+        isAdmission &&
         targetGroup &&
         !basketsAgree(targetGroup.negRiskMarketId, normalizedNegRiskMarketId)
       ) {

--- a/packages/market-keeper/src/generate/api.ts
+++ b/packages/market-keeper/src/generate/api.ts
@@ -91,6 +91,8 @@ function logEndTimeDecision(
   const llmTs = c.llmEndTime?.ts ?? null;
   const pmTs = c.endDate ? toUnixTimestamp(c.endDate) : null;
   const drift = llmTs !== null && pmTs !== null ? llmTs - pmTs : null;
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const isPast = decision.ts <= nowSeconds;
   const payload = {
     event: 'endtime_decided',
     conditionHash: c.conditionHash,
@@ -103,8 +105,22 @@ function logEndTimeDecision(
     isTemplated: c.isTemplated ?? false,
     driftSeconds: drift,
     finalTs: decision.ts,
+    isPast,
+    secondsPast: isPast ? nowSeconds - decision.ts : null,
   };
-  console.log(JSON.stringify(payload));
+  // Past-dated submissions are legal (backfills rely on it) but rare
+  // enough that operators should see them in log scans. Anything else
+  // stays on console.log so the daily generate doesn't shout.
+  if (isPast) {
+    console.warn(
+      `[endtime_decided] PAST endTime submitted for ${c.conditionHash}: ` +
+        `finalTs=${decision.ts} (${nowSeconds - decision.ts}s ago), ` +
+        `source=${decision.source}`
+    );
+    console.warn(JSON.stringify(payload));
+  } else {
+    console.log(JSON.stringify(payload));
+  }
 }
 
 /**

--- a/packages/market-keeper/src/llm/openrouter.ts
+++ b/packages/market-keeper/src/llm/openrouter.ts
@@ -78,12 +78,17 @@ function logLLMResponse(
   response: string,
   opts: LLMLogOptions
 ): void {
-  // NOTE: NODE_ENV=production gate intentionally removed for now so the
-  // backfill (and the daily generate) write full prompt + raw response +
-  // citations + per-market parsed status to `llm-markets.log`. Re-add the
-  // gate once we're done iterating on the Sonar prompt — this file grows
-  // ~10KB per Sonar call, fine for a one-shot backfill but unwanted noise
-  // for a long-running daemon.
+  // Gate the verbose prompt+response log behind non-production. The file
+  // grows ~10KB per Sonar call — fine for a one-shot backfill / dev
+  // iteration on the prompt, but unwanted disk growth and unnecessary
+  // data retention on a long-running daemon. Set
+  // LLM_LOG_FULL_RESPONSES=1 to force-enable in prod when iterating.
+  if (
+    process.env.NODE_ENV === 'production' &&
+    process.env.LLM_LOG_FULL_RESPONSES !== '1'
+  ) {
+    return;
+  }
 
   const timestamp = new Date().toISOString();
 

--- a/packages/market-keeper/src/refresh-metadata/index.ts
+++ b/packages/market-keeper/src/refresh-metadata/index.ts
@@ -142,12 +142,20 @@ export async function main() {
   const apiUrl = process.env.SAPIENCE_API_URL || DEFAULT_SAPIENCE_API_URL;
   const rawPrivateKey = process.env.ADMIN_PRIVATE_KEY;
 
+  // The key only signs *submitted* admin requests. --dry-run never
+  // submits, so don't make a missing key block a safe local preview.
   let privateKey: `0x${string}` | undefined;
   try {
     privateKey = validatePrivateKey(rawPrivateKey);
   } catch (error) {
-    logError(error instanceof Error ? error.message : String(error));
-    process.exit(1);
+    if (options.dryRun) {
+      log(
+        '[RefreshMetadata] No ADMIN_PRIVATE_KEY available; continuing in dry-run mode only.'
+      );
+    } else {
+      logError(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
   }
 
   const hasAPICredentials = apiUrl && privateKey;


### PR DESCRIPTION
## Summary

Closes seven findings flagged on the `#1814` release diff. All sit on admin / keeper paths the negRisk work introduced or expanded. Targets `staging` so the fixes ride into `main` with the release rather than landing as a follow-up patch.

### High

- **#1 `PUT /admin/conditionGroups/:id/conditions` basket-bypass.** Previously validated only that condition ids existed. Now loads each candidate's current group basket and rejects any attachment whose basket disagrees with the target group's. Same-basket members stay legal; admins can no longer attach arbitrary conditions to a negRisk group through this endpoint.
- **#2 Batch-create accepted past `endTime`.** Decision after discussion: leave batch-create permissive (historical backfills via #1581 rely on it) but make the keeper *loud* about every past-dated submission. `logEndTimeDecision` now emits `isPast` + `secondsPast` on the structured payload and routes the line through `console.warn` so operators see it in log scans.
- **#3 Metadata edits falsely rejected existing basket-group members.** `basketsAgree` now runs only on *admission* — both in `PUT /admin/conditions/:id` and in `batch-metadata`, conditions already in the target group are grandfathered. Routine keeper refreshes that restate `groupName` without restating the basket id no longer 400 on every existing member.

### Medium

- **#4 Batch-metadata race let the loser bypass the basket check.** When the leader-take-all `create` races and loses, the catch block now re-validates incoming updates against the now-existing group's basket (mirroring batch-create) instead of silently admitting them.
- **#5 Auto-created groups landed without `similarMarkets`.** Batch-create, single-create, and single-PUT now seed `similarMarkets` from the first item's payload when auto-creating a group. Context: this gap originated in #1548 (April 14) when `submitToAPI` swapped to `batch-create`, leaving the dead `submitConditionGroup` helper behind. `refresh-metadata` (#1677, May 5) already backfills `similarMarkets` on the next cron sweep, so this fix only narrows the window from "≤ one cron cycle" to "0."
- **#6 `refresh-metadata --dry-run` required `ADMIN_PRIVATE_KEY`.** The key only signs *submitted* admin requests; a dry-run never submits. Missing key now falls through with a one-line notice in dry-run mode and still exits in submit mode.

### Low

- **#7 Production LLM prompt + raw-response log re-gated.** The `NODE_ENV=production` short-circuit was intentionally removed during prompt iteration. Restored as the default; set `LLM_LOG_FULL_RESPONSES=1` to force-enable in prod when iterating. Removes the steady disk-growth + data-retention bleed on the long-running daemon.

## Known follow-ups (not in this PR)

- **TOCTOU on basket validation.** The basket check reads `group.negRiskMarketId` at one moment; the condition write happens later in a separate query. A concurrent `PUT /admin/conditionGroups/:id` mutating the basket between check and write would slip past. Closing this requires `SELECT … FOR UPDATE` on the group row inside a `prisma.$transaction` per affected group — cross-cutting refactor, not security-release-blocking.
- **`PUT /admin/conditionGroups/:id` accepts arbitrary `negRiskMarketId` changes** without checking whether existing members are consistent with the new value. Intentional for now (it's the explicit admin-control surface), but the verb pairs poorly with #1's tightening — worth a follow-up that at minimum logs the mutation loudly.
- **Dead-code cleanup.** `submitConditionGroup` and `submitCondition` in market-keeper, plus `PUT /admin/conditionGroups/:id/conditions` itself (no in-tree callers), are stale since #1548. Separate PR.

## Tests

- New: PUT `/:id/conditions` basket bypass / cross-basket / unaffiliated cases (`conditionGroups.test.ts`).
- New: batch-create past-`endTime` *acceptance* (with keeper-side warn), batch-create `similarMarkets` seeding, single-PUT and batch-metadata grandfathering, batch-metadata race re-validation (`conditions.test.ts`).
- Full `@sapience/api` suite: **523 / 523** green.
- Full `@sapience/market-keeper` suite: **408 / 408** green (+ 4 skipped, unchanged).
- `tsc --noEmit` clean on both packages.

## Test plan

- [ ] CI green
- [ ] Smoke `PUT /admin/conditionGroups/:id/conditions` against staging with a basket group + an unrelated condition — expect 400
- [ ] Confirm a past-dated condition submitted via `batch-create` lands in the DB **and** produces a `[endtime_decided] PAST endTime submitted ...` `console.warn` line in keeper logs
- [ ] Run keeper `refresh-metadata --dry-run` *without* `ADMIN_PRIVATE_KEY` in env — expect the dry-run summary, not exit(1)
- [ ] Confirm `llm-markets.log` is no longer written on the prod keeper (or is written only when `LLM_LOG_FULL_RESPONSES=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)