### PR TITLE
fix: refresh-metadata mixed-basket bug + wire gql operation names

### DIFF
--- a/packages/api/src/graphql/plugins/operationTimingPlugin.ts
+++ b/packages/api/src/graphql/plugins/operationTimingPlugin.ts
@@ -1,6 +1,7 @@
 import type { ApolloServerPlugin } from '@apollo/server';
 import type { ApolloContext } from '../startApolloServer';
 import { createLogger } from '../../core/logger';
+import { inflightRegistry } from '../../runtime/inflightRegistry';
 
 /**
  * Apollo plugin that emits one structured log line per GraphQL request.
@@ -49,12 +50,42 @@ const truncate = (s: string | undefined, max = 120): string | undefined => {
   return s.length > max ? `${s.slice(0, max)}…` : s;
 };
 
+type GetHeader = { get(name: string): string | null | undefined };
+
+function resolveRequestId(
+  contextValue: ApolloContext,
+  headers: GetHeader | undefined
+): string | undefined {
+  // pino-http types req.id as ReqId (string | number | object); coerce
+  // to string for stable log output. Falls back to upstream header so
+  // requests outside the Express stack (tests, scripts) still log a
+  // correlation id when available.
+  const reqIdRaw = contextValue.req?.id;
+  if (reqIdRaw != null) return String(reqIdRaw);
+  return headers?.get('x-request-id') ?? undefined;
+}
+
 export function operationTimingPlugin(): ApolloServerPlugin<ApolloContext> {
   return {
     async requestDidStart() {
       const startedAt = performance.now();
 
       return {
+        // didResolveOperation is the earliest hook that has the parsed
+        // operation name. Push it onto the inflight registry so a
+        // concurrency-limit dump shows "GetUserPositions" instead of
+        // the parsing/unknown placeholder. requestDidStart is too early
+        // (no operation yet); willSendResponse is too late (the slot is
+        // about to be removed anyway).
+        async didResolveOperation({ request, contextValue, operation }) {
+          const headers = request.http?.headers;
+          const requestId = resolveRequestId(contextValue, headers);
+          if (!requestId) return;
+          const operationName =
+            operation?.name?.value ?? request.operationName ?? 'anonymous';
+          inflightRegistry.setOperation(requestId, operationName);
+        },
+
         async willSendResponse({ request, response, contextValue, operation }) {
           const durationMs = Math.round(performance.now() - startedAt);
 
@@ -67,15 +98,7 @@ export function operationTimingPlugin(): ApolloServerPlugin<ApolloContext> {
           const headers = request.http?.headers;
           const clientName = headers?.get('apollographql-client-name');
           const userAgent = headers?.get('user-agent');
-          // pino-http types req.id as ReqId (string | number | object); coerce
-          // to string for stable log output. Falls back to upstream header so
-          // requests outside the Express stack (tests, scripts) still log a
-          // correlation id when available.
-          const reqIdRaw = contextValue.req?.id;
-          const requestId =
-            reqIdRaw != null
-              ? String(reqIdRaw)
-              : (headers?.get('x-request-id') ?? undefined);
+          const requestId = resolveRequestId(contextValue, headers);
 
           const fields = {
             event: 'gql_request',

--- a/packages/market-keeper/src/__tests__/metadata-updates.test.ts
+++ b/packages/market-keeper/src/__tests__/metadata-updates.test.ts
@@ -529,6 +529,67 @@ describe('computeGroupMetadataUpdates', () => {
     expect(groupMetadataUpdates[0].old.negRiskMarketId).toBeNull();
   });
 
+  it('does not promote a Sapience group to negRisk when its siblings disagree on basket id', () => {
+    // refresh-metadata feeds one-market synthetic groups in. Without
+    // aggregating by the Sapience conditionGroupId first, the FIRST
+    // synthetic group's basket would stamp the whole group — even
+    // when another sibling has a different (or no) basket. Reject
+    // mixed sets the same way generate's grouping does.
+    const childA = makeMarket({
+      conditionId: '0xchildA',
+      slug: 'foo-a',
+      events: [
+        {
+          title: 'Mixed group',
+          slug: 'mixed-group',
+          negRisk: true,
+          negRiskMarketId: 'basket-x',
+        },
+      ],
+    });
+    const childB = makeMarket({
+      conditionId: '0xchildB',
+      slug: 'foo-b',
+      events: [
+        {
+          title: 'Mixed group',
+          slug: 'mixed-group',
+          negRisk: true,
+          negRiskMarketId: 'basket-y',
+        },
+      ],
+    });
+
+    const existing = new Map([
+      [
+        '0xchildA',
+        existingFromMarket(childA, {
+          conditionGroupId: 11,
+          conditionGroupNegRisk: false,
+          conditionGroupSimilarMarkets: [
+            'https://polymarket.com/event/mixed-group#foo-a',
+          ],
+        }),
+      ],
+      [
+        '0xchildB',
+        existingFromMarket(childB, {
+          conditionGroupId: 11,
+          conditionGroupNegRisk: false,
+          conditionGroupSimilarMarkets: [
+            'https://polymarket.com/event/mixed-group#foo-a',
+          ],
+        }),
+      ],
+    ]);
+
+    const { groupMetadataUpdates } = runDiff([childA, childB], existing);
+
+    // No negRiskMarketId set, because the siblings disagree. No
+    // similarMarkets update either (the stored URL is already current).
+    expect(groupMetadataUpdates).toHaveLength(0);
+  });
+
   it('refuses to demote ConditionGroup.negRisk from true to false; logs an error instead', () => {
     const errors: string[] = [];
     const errSpy = vi

--- a/packages/market-keeper/src/generate/grouping.ts
+++ b/packages/market-keeper/src/generate/grouping.ts
@@ -502,10 +502,14 @@ export function computeMetadataUpdates(
 /**
  * Compare stored ConditionGroup.similarMarkets against what we'd generate
  * fresh from Polymarket and emit an update for any group whose URL has
- * drifted (event slug rename, earlier broken format, etc.). Each filtered
- * group is processed once; we key by the existing conditionGroupId looked
- * up via the group's first market, so we can't double-emit even if future
- * changes allow multi-market groups.
+ * drifted (event slug rename, earlier broken format, etc.).
+ *
+ * Fresh markets are first aggregated by the existing Sapience
+ * `conditionGroupId` they map to, so `sharedNegRiskMarketId` evaluates the
+ * **full sibling set** instead of one market in isolation. Without this,
+ * refresh-metadata's one-market-per-synthetic-group input would let any
+ * single sibling unilaterally stamp the whole group's basket id, even
+ * when other siblings disagree.
  */
 export function computeGroupMetadataUpdates(
   groups: Array<{
@@ -515,26 +519,54 @@ export function computeGroupMetadataUpdates(
   }>,
   existingIds: Map<string, ExistingCondition>
 ): GroupMetadataUpdate[] {
-  const updates: GroupMetadataUpdate[] = [];
-  const seenGroupIds = new Set<number>();
+  // Aggregate fresh markets by the Sapience conditionGroupId they belong
+  // to. A single synthetic input group has at most one market, so we
+  // collapse across synthetic groups here.
+  type AggregatedGroup = {
+    sapienceGroupId: number;
+    sapienceGroupNegRisk: boolean;
+    sapienceGroupSimilarMarkets: string[] | undefined;
+    title: string;
+    markets: PolymarketMarket[];
+  };
+  const aggregated = new Map<number, AggregatedGroup>();
   for (const group of groups) {
-    const market = group.markets[0];
-    if (!market) continue;
+    for (const market of group.markets) {
+      const existing = existingIds.get(market.conditionId);
+      if (!existing?.conditionGroupId) continue;
+      const bucket = aggregated.get(existing.conditionGroupId);
+      if (bucket) {
+        bucket.markets.push(market);
+      } else {
+        aggregated.set(existing.conditionGroupId, {
+          sapienceGroupId: existing.conditionGroupId,
+          sapienceGroupNegRisk: existing.conditionGroupNegRisk ?? false,
+          sapienceGroupSimilarMarkets: existing.conditionGroupSimilarMarkets,
+          title: group.title,
+          markets: [market],
+        });
+      }
+    }
+  }
 
-    const existing = existingIds.get(market.conditionId);
-    if (!existing?.conditionGroupId) continue;
-    if (seenGroupIds.has(existing.conditionGroupId)) continue;
-    seenGroupIds.add(existing.conditionGroupId);
+  const updates: GroupMetadataUpdate[] = [];
+  for (const bucket of aggregated.values()) {
+    // Use the first market only to derive the URL — every Polymarket
+    // sibling under the same event resolves to the same canonical
+    // event URL, so picking one is fine and matches the prior behaviour.
+    const firstMarket = bucket.markets[0];
+    if (!firstMarket) continue;
 
     // If we can't build a correct fresh URL (market lacks an event slug),
     // skip rather than clear the existing value — matches the backfill's
     // "never overwrite with worse data" stance.
-    const freshUrl = getPolymarketUrl(market);
+    const freshUrl = getPolymarketUrl(firstMarket);
     if (!freshUrl) continue;
 
     const freshSimilarMarkets = [freshUrl];
-    const oldSimilarMarkets = existing.conditionGroupSimilarMarkets;
-    const freshNegRiskMarketId = sharedNegRiskMarketId(group.markets);
+    const oldSimilarMarkets = bucket.sapienceGroupSimilarMarkets;
+    // Now evaluated across the *full* sibling set, not a single market.
+    const freshNegRiskMarketId = sharedNegRiskMarketId(bucket.markets);
 
     const fields: GroupSyncableFields = {};
     const old: GroupSyncableFields = {};
@@ -552,20 +584,20 @@ export function computeGroupMetadataUpdates(
     // `negRiskMarketId` directly via PUT /admin/conditionGroups/:id and the
     // API computes the boolean from it being non-null.
     if (
-      existing.conditionGroupNegRisk === false &&
+      bucket.sapienceGroupNegRisk === false &&
       freshNegRiskMarketId !== undefined
     ) {
       fields.negRiskMarketId = freshNegRiskMarketId;
       old.negRiskMarketId = null;
     } else if (
-      existing.conditionGroupNegRisk === true &&
+      bucket.sapienceGroupNegRisk === true &&
       freshNegRiskMarketId === undefined
     ) {
       console.error(
-        `[Metadata] refused to demote group ${existing.conditionGroupId} ` +
-          `("${group.title}") from negRisk: fresh Polymarket markets disagree on ` +
+        `[Metadata] refused to demote group ${bucket.sapienceGroupId} ` +
+          `("${bucket.title}") from negRisk: fresh Polymarket markets disagree on ` +
           `basket id (or are missing it). Conditions: ` +
-          group.markets
+          bucket.markets
             .map((m) => `${m.conditionId}=${getNegRiskMarketId(m) ?? 'none'}`)
             .join(', ')
       );
@@ -573,7 +605,7 @@ export function computeGroupMetadataUpdates(
 
     if (Object.keys(fields).length > 0) {
       updates.push({
-        groupId: existing.conditionGroupId,
+        groupId: bucket.sapienceGroupId,
         fields,
         old,
       });


### PR DESCRIPTION
## Summary

Two findings from a follow-up review on top of #1817. Both are real but smaller in scope than the #1817 set — separate PR to keep the audit trail clean. Targets \`staging\`.

### High — refresh-metadata could stamp a mixed Sapience group as negRisk

\`refresh-metadata\` synthesizes **one-market** Polymarket groups (each market becomes its own synthetic group). \`computeGroupMetadataUpdates\` iterated those one-market groups and deduped by \`existing.conditionGroupId\` after the *first* one hit, so \`sharedNegRiskMarketId(group.markets)\` was always called with a single-market array. Result: any single child of a Sapience group could unilaterally stamp a basket id onto the whole group — even when other siblings declared a different (or no) basket. The exact invariant violation the function's comment block warns against.

The fix aggregates fresh markets into buckets keyed by \`existing.conditionGroupId\` before evaluating \`sharedNegRiskMarketId\`, so the check sees the full sibling set. Mixed buckets fall through; the existing \"refused to demote\" error log still fires when an already-negRisk group's siblings disagree.

Regression test: two children of the same Sapience group, each declaring a different Polymarket basket id, must NOT promote the group to negRisk.

### Med/Low — GraphQL operation names missing from inflight diagnostics

\`InflightRegistry.setOperation\` existed but had no callers, so concurrency-limit dumps showed every slot as \`parsing/unknown\` instead of the actual operation name. Wired into \`operationTimingPlugin\`'s \`didResolveOperation\` hook (earliest point the parsed operation is available). Extracted \`resolveRequestId\` into a helper so the new hook and the existing \`willSendResponse\` stay in lockstep.

## Tests

- New: \`computeGroupMetadataUpdates > does not promote a Sapience group to negRisk when its siblings disagree on basket id\` (\`metadata-updates.test.ts\`).
- Full \`@sapience/api\` suite: **515 / 515** green.
- Full \`@sapience/market-keeper\` suite: **409 / 413** green (+4 pre-existing skips).
- \`tsc --noEmit\` clean on both packages.

## Not in this PR

- The other reviewer-flagged item — event-keyed identity (\`source\` / \`externalEventId\`) not yet threaded through the write paths — is already being addressed on the \`activate-event-keyed-condition-group-identity\` branch (4 commits ahead of staging). Land that separately when ready.
- Pre-existing format failures on a few keeper scripts and \`schema.graphql\` are not from this PR; tackle in a dedicated format-sweep PR.

## Test plan

- [ ] CI green
- [ ] After deploy, dump the inflight registry while load is in flight (concurrency-limit shed log) and confirm \`operationName\` shows real names instead of \`parsing/unknown\`
- [ ] Run a refresh-metadata dry-run against a known mixed-basket Sapience group (if one exists) and confirm no \`negRiskMarketId\` write is proposed

🤖 Generated with [Claude Code](https://claude.com/claude-code)