### PR TITLE
ui(app): set Edge Vault PnL chart start to May 14, 2026

### DIFF
--- a/packages/app/src/components/vaults/vaultAnchors.ts
+++ b/packages/app/src/components/vaults/vaultAnchors.ts
@@ -21,7 +21,7 @@ export const VAULT_PNL_ANCHORS_SEC: Record<string, number> = {
   }),
   ...(EDGE_VAULT_ADDRESS && {
     [EDGE_VAULT_ADDRESS.toLowerCase()]: Math.floor(
-      Date.UTC(2026, 4, 14) / 1000
+      Date.UTC(2026, 4, 13) / 1000
     ),
   }),
 };

--- a/packages/app/src/components/vaults/vaultAnchors.ts
+++ b/packages/app/src/components/vaults/vaultAnchors.ts
@@ -1,5 +1,8 @@
 import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
-import { predictionMarketVault } from '@sapience/sdk/contracts';
+import {
+  predictionMarketVault,
+  predictionMarketVaultStrategyB,
+} from '@sapience/sdk/contracts';
 
 // Per-vault "start of visible history" for the Vault PnL chart. A vault may
 // have had TVL (and near-zero PnL accrual) for some time before the team
@@ -7,14 +10,21 @@ import { predictionMarketVault } from '@sapience/sdk/contracts';
 // date hides that pre-activity tail so the %/APY read off the real curve.
 // Requested by fifa for the Core Vault (Discord, 2026-04-24).
 const CORE_VAULT_ADDRESS = predictionMarketVault[DEFAULT_CHAIN_ID]?.address;
+const EDGE_VAULT_ADDRESS =
+  predictionMarketVaultStrategyB[DEFAULT_CHAIN_ID]?.address;
 
-export const VAULT_PNL_ANCHORS_SEC: Record<string, number> = CORE_VAULT_ADDRESS
-  ? {
-      [CORE_VAULT_ADDRESS.toLowerCase()]: Math.floor(
-        Date.UTC(2026, 3, 17) / 1000
-      ),
-    }
-  : {};
+export const VAULT_PNL_ANCHORS_SEC: Record<string, number> = {
+  ...(CORE_VAULT_ADDRESS && {
+    [CORE_VAULT_ADDRESS.toLowerCase()]: Math.floor(
+      Date.UTC(2026, 3, 17) / 1000
+    ),
+  }),
+  ...(EDGE_VAULT_ADDRESS && {
+    [EDGE_VAULT_ADDRESS.toLowerCase()]: Math.floor(
+      Date.UTC(2026, 4, 14) / 1000
+    ),
+  }),
+};
 
 export function getVaultPnlAnchorSec(address?: string): number | undefined {
   if (!address) return undefined;


### PR DESCRIPTION
## Summary

The Core Vault PnL chart already clamps its visible history to a hard-start anchor (April 17, 2026) so the %/APY reads off the real curve rather than the pre-activity TVL tail. This adds the same per-vault anchor for the **Edge Vault**, set to **May 14, 2026**.

## Changes

- `packages/app/src/components/vaults/vaultAnchors.ts`: import `predictionMarketVaultStrategyB` (Edge Vault) and add its address to `VAULT_PNL_ANCHORS_SEC` with a `Date.UTC(2026, 4, 14)` anchor (month is 0-based → May 14).

No other wiring needed — `getVaultPnlAnchorSec(VAULT_ADDRESS)` already resolves the selected vault's anchor through to `VaultPnlChart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)