### PR TITLE
fix(app): port main-only UI hotfixes back to staging

### DIFF
--- a/packages/app/src/components/markets/ExampleCombos.tsx
+++ b/packages/app/src/components/markets/ExampleCombos.tsx
@@ -76,7 +76,7 @@ const ExampleCombos: React.FC<ExampleCombosProps> = ({ className }) => {
 
   return (
     <div className={'w-full ' + (className ?? '')}>
-      <div className="flex items-center mb-1 px-1">
+      <div className="flex items-center mb-2 px-1 pt-1">
         <h2 className="sc-heading text-foreground">
           Example combo
           <AnimatePresence mode="wait">

--- a/packages/app/src/components/vaults/vaultAnchors.ts
+++ b/packages/app/src/components/vaults/vaultAnchors.ts
@@ -1,5 +1,8 @@
 import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
-import { predictionMarketVault } from '@sapience/sdk/contracts';
+import {
+  predictionMarketVault,
+  predictionMarketVaultStrategyB,
+} from '@sapience/sdk/contracts';
 
 // Per-vault "start of visible history" for the Vault PnL chart. A vault may
 // have had TVL (and near-zero PnL accrual) for some time before the team
@@ -7,14 +10,21 @@ import { predictionMarketVault } from '@sapience/sdk/contracts';
 // date hides that pre-activity tail so the %/APY read off the real curve.
 // Requested by fifa for the Core Vault (Discord, 2026-04-24).
 const CORE_VAULT_ADDRESS = predictionMarketVault[DEFAULT_CHAIN_ID]?.address;
+const EDGE_VAULT_ADDRESS =
+  predictionMarketVaultStrategyB[DEFAULT_CHAIN_ID]?.address;
 
-export const VAULT_PNL_ANCHORS_SEC: Record<string, number> = CORE_VAULT_ADDRESS
-  ? {
-      [CORE_VAULT_ADDRESS.toLowerCase()]: Math.floor(
-        Date.UTC(2026, 3, 17) / 1000
-      ),
-    }
-  : {};
+export const VAULT_PNL_ANCHORS_SEC: Record<string, number> = {
+  ...(CORE_VAULT_ADDRESS && {
+    [CORE_VAULT_ADDRESS.toLowerCase()]: Math.floor(
+      Date.UTC(2026, 3, 17) / 1000
+    ),
+  }),
+  ...(EDGE_VAULT_ADDRESS && {
+    [EDGE_VAULT_ADDRESS.toLowerCase()]: Math.floor(
+      Date.UTC(2026, 4, 13) / 1000
+    ),
+  }),
+};
 
 export function getVaultPnlAnchorSec(address?: string): number | undefined {
   if (!address) return undefined;


### PR DESCRIPTION
## Summary

Two UI hotfixes landed directly on `main`, bypassing staging. This PR ports them back so the branches don't drift.

Cherry-picked (in order):

- **#1825** `ui(app): set Edge Vault PnL chart start to May 14, 2026` — adds a per-vault hard-start anchor for the Edge Vault, separate from the Core Vault's April 17 anchor.
- **#1826** `ui(app): align Example Combos header baseline and add spacing` — `pt-1` + `mb-2` tweaks on the Example Combos header.

## Verification

`git diff staging..HEAD` contains only these two changes (2 files, app package):

- `packages/app/src/components/vaults/vaultAnchors.ts`
- `packages/app/src/components/markets/ExampleCombos.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)