### PR TITLE
fix(api): decrement accountBalance claimable when a position is redeemed

### DIFF
--- a/packages/api/src/services/timeSeriesQueries.balance.integration.test.ts
+++ b/packages/api/src/services/timeSeriesQueries.balance.integration.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Integration test for queryAccountBalance's claimable-collateral accounting.
+ *
+ * Unlike a mocked unit test (which can only assert on the SQL string), this
+ * seeds a real Postgres schema and runs the actual production query, so it
+ * proves the *numbers* — specifically that a settled position's claimable
+ * collateral stops counting once the holder redeems that side, and that a
+ * redemption of the OTHER side does not drop it (side is matched through the
+ * pick configuration's predictor/counterparty token, the same way the PnL
+ * query resolves it).
+ *
+ * The pre-fix query joined Claim.pickConfigId to Prediction.predictionId —
+ * different identifier spaces — so the NOT EXISTS matched zero rows and
+ * claimable was never decremented after a redeem.
+ *
+ * Requires a reachable Postgres (TEST_DATABASE_URL or a local server on :5432).
+ * Skips cleanly when none is available so it never breaks CI without a DB.
+ */
+import { describe, it, expect, afterAll } from 'vitest';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from '../../generated/prisma';
+import { queryAccountBalance } from './timeSeriesQueries';
+import { TimeInterval } from './timeSeriesTypes';
+
+const BASE_URL =
+  process.env.TEST_DATABASE_URL ??
+  process.env.PNL_TEST_DATABASE_URL ??
+  'postgresql://postgres@localhost:5432/postgres';
+
+const SCHEMA = `bal_it_${process.pid}_${Date.now()}`;
+
+// Predictor who redeems their own (winning) side.
+const HOLDER_REDEEMS = '0xaaaa000000000000000000000000000000000001';
+// Predictor whose only claim is on the OTHER side — claimable must persist.
+const HOLDER_OTHER_SIDE = '0xbbbb000000000000000000000000000000000002';
+
+// Minimal slices of the tables queryAccountBalance touches. `position` (the V1
+// legacy table) exists only so the all_deployed UNION branch resolves; it stays
+// empty. Prediction carries both predictionId and pickConfigId so the DDL is
+// valid against the pre-fix query too (proving the test fails before the fix).
+const DDL = `
+  CREATE TABLE "Picks" (id text PRIMARY KEY, "predictorToken" text, "counterpartyToken" text);
+  CREATE TABLE "Prediction" (
+    "predictionId" text, "pickConfigId" text, predictor text, counterparty text,
+    "predictorCollateral" text, "counterpartyCollateral" text,
+    "predictorClaimable" text, "counterpartyClaimable" text,
+    "onChainCreatedAt" integer, "settledAt" integer
+  );
+  CREATE TABLE "Claim" (holder text, "pickConfigId" text, "positionToken" text, "redeemedAt" integer);
+  CREATE TABLE "position" (
+    predictor text, counterparty text, "predictorCollateral" text,
+    "counterpartyCollateral" text, "mintedAt" integer, "settledAt" integer
+  );
+`;
+
+const day = (d: number) => Math.floor(Date.UTC(2026, 0, d, 12, 0, 0) / 1000);
+
+// ── Setup runs at top-level await so `dbAvailable` is known before `describe`
+//    is evaluated (vitest resolves describe.skipIf at collection time). ──
+let client: PrismaClient | undefined;
+let dbAvailable = false;
+
+{
+  const probe = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: BASE_URL }),
+  });
+  try {
+    await probe.$executeRawUnsafe(`CREATE SCHEMA IF NOT EXISTS "${SCHEMA}"`);
+    dbAvailable = true;
+  } catch {
+    dbAvailable = false;
+  } finally {
+    await probe.$disconnect();
+  }
+
+  if (dbAvailable) {
+    client = new PrismaClient({
+      adapter: new PrismaPg({
+        connectionString: BASE_URL,
+        options: `-c search_path=${SCHEMA}`,
+      }),
+    });
+
+    for (const stmt of DDL.split(';')
+      .map((s) => s.trim())
+      .filter(Boolean)) {
+      await client.$executeRawUnsafe(stmt);
+    }
+
+    await client.$executeRawUnsafe(
+      `INSERT INTO "Picks" (id, "predictorToken", "counterpartyToken") VALUES
+         ('pcA', 'ptokA', 'ctokA'),
+         ('pcB', 'ptokB', 'ctokB')`
+    );
+
+    // Scenario A — predictor with 100 claimable on a position settled day(2),
+    // redeems their predictor token on day(4). Claimable must read 100 on
+    // day(2)/day(3) and 0 from day(4).
+    await client.$executeRawUnsafe(
+      `INSERT INTO "Prediction"
+         ("predictionId", "pickConfigId", predictor, counterparty,
+          "predictorCollateral", "counterpartyCollateral",
+          "predictorClaimable", "counterpartyClaimable",
+          "onChainCreatedAt", "settledAt")
+       VALUES
+         ('pred-A', 'pcA', '${HOLDER_REDEEMS}', '0xother',
+          '100', '0', '100', '0', ${day(1)}, ${day(1)})`
+    );
+    await client.$executeRawUnsafe(
+      `INSERT INTO "Claim" (holder, "pickConfigId", "positionToken", "redeemedAt")
+       VALUES ('${HOLDER_REDEEMS}', 'pcA', 'ptokA', ${day(4)})`
+    );
+
+    // Scenario B — predictor with 50 claimable on a position settled day(2),
+    // but the only claim is on the COUNTERPARTY token. Side mismatch → the
+    // predictor's claimable must NOT be dropped.
+    await client.$executeRawUnsafe(
+      `INSERT INTO "Prediction"
+         ("predictionId", "pickConfigId", predictor, counterparty,
+          "predictorCollateral", "counterpartyCollateral",
+          "predictorClaimable", "counterpartyClaimable",
+          "onChainCreatedAt", "settledAt")
+       VALUES
+         ('pred-B', 'pcB', '${HOLDER_OTHER_SIDE}', '0xother',
+          '50', '0', '50', '0', ${day(1)}, ${day(1)})`
+    );
+    await client.$executeRawUnsafe(
+      `INSERT INTO "Claim" (holder, "pickConfigId", "positionToken", "redeemedAt")
+       VALUES ('${HOLDER_OTHER_SIDE}', 'pcB', 'ctokB', ${day(4)})`
+    );
+  }
+}
+
+afterAll(async () => {
+  if (!client) return;
+  await client.$executeRawUnsafe(`DROP SCHEMA IF EXISTS "${SCHEMA}" CASCADE`);
+  await client.$disconnect();
+});
+
+describe.skipIf(!dbAvailable)(
+  'queryAccountBalance (integration: real SQL)',
+  () => {
+    const from = new Date('2026-01-01T00:00:00Z');
+    const to = new Date('2026-01-08T00:00:00Z');
+
+    const claimableByDay = async (holder: string) => {
+      const points = await queryAccountBalance(
+        holder,
+        TimeInterval.DAY,
+        from,
+        to,
+        client
+      );
+      return new Map(
+        points.map((p) => [
+          new Date(p.timestamp * 1000).getUTCDate(),
+          Number(p.claimableCollateral),
+        ])
+      );
+    };
+
+    it('decrements claimable collateral once the holder redeems that side', async () => {
+      const byDay = await claimableByDay(HOLDER_REDEEMS);
+
+      // Settled day(1): claimable is counted from the next bucket on.
+      expect(byDay.get(2)).toBe(100);
+      expect(byDay.get(3)).toBe(100);
+      // Redeemed day(4) noon → drops from the day(5) bucket (the bug left it at
+      // 100 forever because the join never matched).
+      expect(byDay.get(5)).toBe(0);
+      expect(byDay.get(6)).toBe(0);
+    });
+
+    it('does not decrement when only the other side was redeemed', async () => {
+      const byDay = await claimableByDay(HOLDER_OTHER_SIDE);
+
+      // A counterparty-token redemption must not clear a predictor-side claimable.
+      expect(byDay.get(2)).toBe(50);
+      expect(byDay.get(5)).toBe(50);
+      expect(byDay.get(7)).toBe(50);
+    });
+  }
+);

--- a/packages/api/src/services/timeSeriesQueries.ts
+++ b/packages/api/src/services/timeSeriesQueries.ts
@@ -321,7 +321,8 @@ export async function queryAccountBalance(
   address: string,
   interval: TimeInterval,
   from?: Date,
-  to?: Date
+  to?: Date,
+  db: RawQueryClient = prisma
 ): Promise<BalanceDataPoint[]> {
   const { fromEpoch, toEpoch, pgTrunc, pgStep } = resolveDefaults(
     interval,
@@ -330,7 +331,7 @@ export async function queryAccountBalance(
   );
   const addr = address.toLowerCase();
 
-  const rows = await prisma.$queryRaw<BalanceRow[]>`
+  const rows = await db.$queryRaw<BalanceRow[]>`
     WITH buckets AS (
       SELECT
         EXTRACT(EPOCH FROM gs)::BIGINT AS bucket_epoch
@@ -367,15 +368,27 @@ export async function queryAccountBalance(
              WHEN p.counterparty = ${addr}
              THEN CAST(COALESCE(p."counterpartyClaimable", '0') AS DECIMAL)
              ELSE 0 END AS claimable,
-        p."predictionId"
+        p."pickConfigId" AS pick_config_id,
+        CASE WHEN p.predictor = ${addr} THEN 'predictor'
+             WHEN p.counterparty = ${addr} THEN 'counterparty'
+        END AS side
       FROM "Prediction" p
       WHERE (p.predictor = ${addr} OR p.counterparty = ${addr})
         AND p."settledAt" IS NOT NULL
     ),
+    -- A redeem burns the holder's whole position token for one (pickConfig,
+    -- side). Claim.pickConfigId gives the config; the side is identified by
+    -- matching the burned positionToken to the pick configuration's
+    -- predictor/counterparty token, the same way the accountPnl query does.
     account_claims AS (
-      SELECT "pickConfigId", "redeemedAt"
-      FROM "Claim"
-      WHERE holder = ${addr}
+      SELECT cl."pickConfigId" AS pick_config_id,
+             CASE WHEN cl."positionToken" = pk."predictorToken" THEN 'predictor'
+                  WHEN cl."positionToken" = pk."counterpartyToken" THEN 'counterparty'
+             END AS side,
+             cl."redeemedAt"
+      FROM "Claim" cl
+      LEFT JOIN "Picks" pk ON cl."pickConfigId" = pk.id
+      WHERE cl.holder = ${addr}
     )
     SELECT
       b.bucket_epoch AS timestamp,
@@ -390,13 +403,11 @@ export async function queryAccountBalance(
         FROM all_claimable ac
         WHERE ac.settled_ts <= b.bucket_epoch
           AND NOT EXISTS (
-            -- FIXME (pre-existing, behavior preserved by the rename): this
-            -- compares Claim.pickConfigId to Prediction.predictionId, which are
-            -- different identifier spaces, so it matches zero rows — claimable
-            -- collateral is never decremented when a position is redeemed. Same
-            -- root cause as the accountPnl bug; resolve through pickConfigId.
+            -- Stop counting this position's claimable once the holder has
+            -- redeemed that (pickConfig, side) at or before the bucket.
             SELECT 1 FROM account_claims c
-            WHERE c."pickConfigId" = ac."predictionId"
+            WHERE c.pick_config_id = ac.pick_config_id
+              AND c.side = ac.side
               AND c."redeemedAt" <= b.bucket_epoch
           )
       ), 0)::TEXT AS claimable_collateral


### PR DESCRIPTION
## What

`queryAccountBalance` never decremented a settled position's **claimable collateral** after the holder redeemed it. The `NOT EXISTS` that was supposed to drop redeemed claimable joined `Claim.pickConfigId` to `Prediction.predictionId` — different identifier spaces — so it matched **zero rows**. Every account that has redeemed reported an overstated `claimableCollateral`. Same root cause as the `accountPnl` Claims bug fixed in the base branch.

## Fix

Resolve the claim↔position match through the pick configuration, mirroring `queryAccountPnl`:
- A claim's `(pickConfig, side)` is identified by `Claim.pickConfigId` + the burned `positionToken` matching `Picks.predictor/counterpartyToken`.
- The prediction's side is whether the account is `predictor` or `counterparty`.
- `NOT EXISTS` now matches on `(pickConfigId, side, redeemedAt)`.

## Tests

`queryAccountBalance` had **zero** coverage. Added a real-SQL integration test (same harness as the PnL one) proving the numbers:
- claimable reads `100` while settled-and-unredeemed, drops to `0` after the predictor token is redeemed;
- claimable is **not** dropped when only the *counterparty* token was redeemed (side discrimination).

Skips cleanly when no Postgres is reachable. `queryAccountBalance` gained an optional Prisma-client arg (defaults to the singleton) so the test can run against an isolated schema — same pattern as `queryAccountPnl`.

## Note

Stacked on `fix/account-pnl-claims-pickconfig-join` (the `Claim.pickConfigId` rename), which this depends on — review/merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)