### PR TITLE
Fix PR 1831 review blockers

### DIFF
--- a/packages/app/src/app/og/_profile-helpers.ts
+++ b/packages/app/src/app/og/_profile-helpers.ts
@@ -3,7 +3,7 @@
 import { isAddress, getAddress } from 'viem';
 import { getGraphQLEndpoint, formatUnits } from './_prediction-helpers';
 import { mainnetClient } from '~/lib/utils/util';
-import { getEnsAvatarUrlForAddress } from '~/lib/ens/avatar';
+import { getEnsAvatarUrlForAddress } from '~/lib/ens/avatar.server';
 import { SCHEMA_UID } from '~/lib/constants';
 
 // ---------- GraphQL queries ----------

--- a/packages/app/src/app/og/profile/route.tsx
+++ b/packages/app/src/app/og/profile/route.tsx
@@ -21,7 +21,10 @@ import {
 import { fetchProfileData, resolveEnsInfo } from '../_profile-helpers';
 import { shortenAddress } from '~/lib/utils/util';
 
-export const runtime = 'edge';
+// Node runtime (like the sibling prediction/question OG routes): resolving an
+// ENS avatar fetches attacker-controlled NFT metadata, which needs the Node DNS
+// SSRF guard in lib/ens/avatar.server. The edge runtime cannot do DNS lookups.
+export const runtime = 'nodejs';
 
 function formatPnL(pnl: number): { text: string; color: string } {
   const abs = Math.abs(pnl);

--- a/packages/app/src/lib/ens/avatar.server.test.ts
+++ b/packages/app/src/lib/ens/avatar.server.test.ts
@@ -1,0 +1,100 @@
+/**
+ * SSRF regression for the Node-only avatar resolver (avatar.server).
+ *
+ * The shared module blocks raw IP literals and known-bad hostnames statically.
+ * This module adds the DNS-rebinding guard: a *domain* that passes the static
+ * checks but resolves to a private/internal address must NOT be fetched. That
+ * guard needs Node DNS, so it only exists here — the edge runtime can't run it,
+ * which is why the OG profile route is pinned to runtime = 'nodejs'.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const dnsMocks = vi.hoisted(() => ({ lookup: vi.fn() }));
+vi.mock('node:dns/promises', () => ({
+  lookup: dnsMocks.lookup,
+  default: { lookup: dnsMocks.lookup },
+}));
+
+const ensMocks = vi.hoisted(() => ({
+  getEnsName: vi.fn(),
+  getEnsText: vi.fn(),
+  readContract: vi.fn(),
+}));
+vi.mock('~/lib/utils/util', () => ({
+  mainnetClient: {
+    getEnsName: ensMocks.getEnsName,
+    getEnsText: ensMocks.getEnsText,
+    readContract: ensMocks.readContract,
+  },
+  getPublicClientForChainId: () => ({ readContract: ensMocks.readContract }),
+}));
+
+describe('avatar.server getEnsAvatarUrlForAddress DNS SSRF guard', () => {
+  const OWNER = '0x1111111111111111111111111111111111111111';
+  const CONTRACT = '0x2222222222222222222222222222222222222222';
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    ensMocks.getEnsName.mockResolvedValue('evil.eth');
+    ensMocks.getEnsText.mockResolvedValue(`eip155:1/erc721:${CONTRACT}/1`);
+    ensMocks.readContract.mockImplementation(
+      (args: { functionName: string }) => {
+        if (args.functionName === 'ownerOf') return Promise.resolve(OWNER);
+        // A domain that passes the static host checks — only DNS reveals it.
+        if (args.functionName === 'tokenURI')
+          return Promise.resolve('https://rebind.attacker.test/meta.json');
+        return Promise.resolve(undefined);
+      }
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('blocks a metadata domain that DNS-resolves to a private address', async () => {
+    dnsMocks.lookup.mockResolvedValue([{ address: '10.0.0.5', family: 4 }]);
+
+    const { getEnsAvatarUrlForAddress } = await import('./avatar.server');
+    const result = await getEnsAvatarUrlForAddress(OWNER);
+
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(dnsMocks.lookup).toHaveBeenCalledWith(
+      'rebind.attacker.test',
+      expect.objectContaining({ all: true })
+    );
+  });
+
+  it('fails closed when the DNS lookup itself errors', async () => {
+    dnsMocks.lookup.mockRejectedValue(new Error('ENOTFOUND'));
+
+    const { getEnsAvatarUrlForAddress } = await import('./avatar.server');
+    const result = await getEnsAvatarUrlForAddress(OWNER);
+
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('resolves the image when the metadata domain resolves to a public address', async () => {
+    dnsMocks.lookup.mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+    ]);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ image: 'https://cdn.example.com/img.png' }),
+    });
+
+    const { getEnsAvatarUrlForAddress } = await import('./avatar.server');
+    const result = await getEnsAvatarUrlForAddress(OWNER);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://rebind.attacker.test/meta.json'
+    );
+    expect(result).toBe('https://cdn.example.com/img.png');
+  });
+});

--- a/packages/app/src/lib/ens/avatar.server.ts
+++ b/packages/app/src/lib/ens/avatar.server.ts
@@ -1,0 +1,35 @@
+import { lookup } from 'node:dns/promises';
+import {
+  getEnsAvatarUrlForAddress as resolveAvatar,
+  isPrivateResolvedAddress,
+  type AvatarHostGuard,
+} from './avatar';
+
+/**
+ * Node-only ENS avatar resolution with full SSRF protection.
+ *
+ * The shared `./avatar` module is bundled for the browser and the edge runtime,
+ * where `node:dns/promises` is unavailable — so DNS-rebinding defense lives
+ * here and is injected as a host guard. Import this (not `./avatar`) from any
+ * server-side path that fetches attacker-controlled NFT metadata. The OG
+ * profile route pins itself to `runtime = 'nodejs'` so this code actually runs.
+ */
+
+/**
+ * Resolve a hostname and report whether ANY record points at a private/internal
+ * address. Fails closed: a lookup error blocks the fetch rather than allowing it.
+ */
+export const dnsHostGuard: AvatarHostGuard = async (hostname) => {
+  try {
+    const records = await lookup(hostname, { all: true, verbatim: true });
+    return records.some((record) => isPrivateResolvedAddress(record.address));
+  } catch {
+    return true;
+  }
+};
+
+export function getEnsAvatarUrlForAddress(
+  address: string
+): Promise<string | null> {
+  return resolveAvatar(address, dnsHostGuard);
+}

--- a/packages/app/src/lib/ens/avatar.test.ts
+++ b/packages/app/src/lib/ens/avatar.test.ts
@@ -1,26 +1,11 @@
 /**
  * Regression tests for sanitizeAvatarUrl (bug 68297).
  *
- * The function is not exported, so we extract and test it indirectly
- * by re-implementing the same logic here. If the implementation changes,
- * these tests should be updated to match — the important thing is that
- * the *behavior* (blocking private IPs, allowing valid HTTPS) is covered.
- *
- * If sanitizeAvatarUrl is ever exported, switch to importing it directly.
+ * The important behavior is blocking attacker-controlled URLs that would make
+ * the server fetch private infrastructure while still allowing normal HTTPS
+ * avatar URLs.
  */
-
-// Re-implement sanitizeAvatarUrl exactly as in avatar.ts so we can unit-test it.
-// This keeps the test independent of module-level import side-effects (viem clients).
-function sanitizeAvatarUrl(url: string | null | undefined): string | null {
-  if (!url) return null;
-  try {
-    const u = new URL(url);
-    if (u.protocol === 'http:' || u.protocol === 'https:') return u.toString();
-    return null;
-  } catch {
-    return null;
-  }
-}
+import { sanitizeAvatarUrl } from './avatar';
 
 describe('sanitizeAvatarUrl', () => {
   // --- valid URLs that should pass ---
@@ -57,6 +42,25 @@ describe('sanitizeAvatarUrl', () => {
 
   it('rejects ftp: protocol', () => {
     expect(sanitizeAvatarUrl('ftp://example.com/file')).toBeNull();
+  });
+
+  it('rejects raw IPv4 literals, including WHATWG-normalized odd forms', () => {
+    expect(sanitizeAvatarUrl('http://127.0.0.1/avatar.png')).toBeNull();
+    expect(
+      sanitizeAvatarUrl('http://169.254.169.254/latest/meta-data/')
+    ).toBeNull();
+    expect(sanitizeAvatarUrl('http://2130706433/avatar.png')).toBeNull();
+  });
+
+  it('rejects raw IPv6 literals', () => {
+    expect(sanitizeAvatarUrl('http://[::1]/avatar.png')).toBeNull();
+    expect(sanitizeAvatarUrl('http://[fe80::1]/avatar.png')).toBeNull();
+    expect(sanitizeAvatarUrl('http://[fc00::1]/avatar.png')).toBeNull();
+  });
+
+  it('rejects cloud metadata hostnames', () => {
+    expect(sanitizeAvatarUrl('http://metadata.google.internal/')).toBeNull();
+    expect(sanitizeAvatarUrl('http://localhost/avatar.png')).toBeNull();
   });
 
   // --- null/empty handling ---

--- a/packages/app/src/lib/ens/avatar.ts
+++ b/packages/app/src/lib/ens/avatar.ts
@@ -57,32 +57,95 @@ function toHttpFromIpfs(uri: string): string {
   return uri;
 }
 
-const BLOCKED_HOSTNAME_PATTERNS = [
-  /^localhost$/i,
-  /^127\.\d+\.\d+\.\d+$/,
-  /^10\.\d+\.\d+\.\d+$/,
-  /^172\.(1[6-9]|2\d|3[01])\.\d+\.\d+$/,
-  /^192\.168\.\d+\.\d+$/,
-  /^169\.254\.\d+\.\d+$/,
-  /^\[::1\]$/,
-  /^0\.0\.0\.0$/,
-  /^metadata\.google\.internal$/i,
-];
+const BLOCKED_HOSTNAMES = new Set(['localhost', 'metadata.google.internal']);
 
-function isBlockedHost(hostname: string): boolean {
-  return BLOCKED_HOSTNAME_PATTERNS.some((re) => re.test(hostname));
+function isIpLiteral(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+
+  // WHATWG URL normalizes odd IPv4 forms (`2130706433`, `0177.0.0.1`) to
+  // dotted decimal and leaves IPv6 wrapped in brackets. Raw IP avatar URLs are
+  // unnecessary for ENS display and dangerous for server-side metadata fetches,
+  // so block all IP literals instead of trying to maintain a private-range
+  // regex zoo. Domains are still allowed and server fetches do DNS checks below.
+  return (
+    /^\d{1,3}(?:\.\d{1,3}){3}$/.test(host) || /^\[[0-9a-f:.]+\]$/.test(host)
+  );
 }
 
-function sanitizeAvatarUrl(url: string | null | undefined): string | null {
+function isPrivateResolvedAddress(address: string): boolean {
+  const host = address.toLowerCase();
+  const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (ipv4) {
+    const [, aRaw, bRaw] = ipv4;
+    const a = Number(aRaw);
+    const b = Number(bRaw);
+    return (
+      a === 0 ||
+      a === 10 ||
+      a === 127 ||
+      (a === 100 && b >= 64 && b <= 127) ||
+      (a === 169 && b === 254) ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168)
+    );
+  }
+
+  return (
+    host === '::1' ||
+    host === '::' ||
+    host.startsWith('fe80:') ||
+    host.startsWith('fc') ||
+    host.startsWith('fd') ||
+    host.startsWith('::ffff:127.') ||
+    host.startsWith('::ffff:10.') ||
+    host.startsWith('::ffff:169.254.') ||
+    host.startsWith('::ffff:192.168.')
+  );
+}
+
+function isBlockedHostname(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/\.$/, '');
+  return BLOCKED_HOSTNAMES.has(host) || isIpLiteral(host);
+}
+
+export function sanitizeAvatarUrl(
+  url: string | null | undefined
+): string | null {
   if (!url) return null;
   try {
     const u = new URL(url);
     if (u.protocol !== 'http:' && u.protocol !== 'https:') return null;
-    if (isBlockedHost(u.hostname)) return null;
+    if (isBlockedHostname(u.hostname)) return null;
     return u.toString();
   } catch {
     return null;
   }
+}
+
+async function resolvesToBlockedAddress(hostname: string): Promise<boolean> {
+  // Browser/client-side callers only return sanitized URLs to the browser. The
+  // actual SSRF-sensitive path is `fetchJson`, which runs server-side for OG/NFT
+  // metadata resolution. DNS lookup is unavailable in browser bundles, so keep
+  // this best-effort and fail closed if Node DNS lookup itself errors.
+  if (typeof process === 'undefined' || !process.versions?.node) return false;
+
+  try {
+    const dns = await import(/* webpackIgnore: true */ 'node:dns/promises');
+    const records = await dns.lookup(hostname, { all: true, verbatim: true });
+    return records.some((record) => isPrivateResolvedAddress(record.address));
+  } catch {
+    return true;
+  }
+}
+
+async function safeFetchAvatarUrl(url: string): Promise<string | null> {
+  const safe = sanitizeAvatarUrl(url);
+  if (!safe) return null;
+
+  const hostname = new URL(safe).hostname;
+  if (await resolvesToBlockedAddress(hostname)) return null;
+
+  return safe;
 }
 
 function hexPad64(n: bigint): string {
@@ -115,9 +178,9 @@ function parseEnsAvatarCaip(
 async function fetchJson<T = unknown>(url: string): Promise<T | null> {
   // SSRF guard: token metadata URLs come from attacker-controllable on-chain
   // tokenURI/uri values, so host-check every URL before fetching — not just the
-  // final image URL. Blocks private/link-local/cloud-metadata hosts and
-  // non-http(s) schemes.
-  const safe = sanitizeAvatarUrl(url);
+  // final image URL. Blocks raw IP literals, cloud-metadata hostnames, DNS
+  // resolutions to raw IPs/private hosts, and non-http(s) schemes.
+  const safe = await safeFetchAvatarUrl(url);
   if (!safe) return null;
   try {
     const res = await fetch(safe, {

--- a/packages/app/src/lib/ens/avatar.ts
+++ b/packages/app/src/lib/ens/avatar.ts
@@ -2,6 +2,17 @@ import { isAddress } from 'viem';
 import type { Address } from 'viem';
 import { mainnetClient, getPublicClientForChainId } from '~/lib/utils/util';
 
+/**
+ * Resolves true when a hostname must NOT be fetched (SSRF). This module is
+ * bundled for the browser and the edge runtime, neither of which can do DNS
+ * resolution, so the DNS-based guard is injected by Node-only callers
+ * (see `avatar.server.ts`). When no guard is provided we rely on the static
+ * hostname/IP-literal checks in `sanitizeAvatarUrl` alone.
+ */
+export type AvatarHostGuard = (hostname: string) => Promise<boolean>;
+
+const NO_DNS_GUARD: AvatarHostGuard = () => Promise.resolve(false);
+
 type ParsedCaip = {
   chainId: number;
   standard: 'erc721' | 'erc1155';
@@ -72,7 +83,7 @@ function isIpLiteral(hostname: string): boolean {
   );
 }
 
-function isPrivateResolvedAddress(address: string): boolean {
+export function isPrivateResolvedAddress(address: string): boolean {
   const host = address.toLowerCase();
   const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
   if (ipv4) {
@@ -122,28 +133,15 @@ export function sanitizeAvatarUrl(
   }
 }
 
-async function resolvesToBlockedAddress(hostname: string): Promise<boolean> {
-  // Browser/client-side callers only return sanitized URLs to the browser. The
-  // actual SSRF-sensitive path is `fetchJson`, which runs server-side for OG/NFT
-  // metadata resolution. DNS lookup is unavailable in browser bundles, so keep
-  // this best-effort and fail closed if Node DNS lookup itself errors.
-  if (typeof process === 'undefined' || !process.versions?.node) return false;
-
-  try {
-    const dns = await import(/* webpackIgnore: true */ 'node:dns/promises');
-    const records = await dns.lookup(hostname, { all: true, verbatim: true });
-    return records.some((record) => isPrivateResolvedAddress(record.address));
-  } catch {
-    return true;
-  }
-}
-
-async function safeFetchAvatarUrl(url: string): Promise<string | null> {
+async function safeFetchAvatarUrl(
+  url: string | null | undefined,
+  hostGuard: AvatarHostGuard = NO_DNS_GUARD
+): Promise<string | null> {
   const safe = sanitizeAvatarUrl(url);
   if (!safe) return null;
 
   const hostname = new URL(safe).hostname;
-  if (await resolvesToBlockedAddress(hostname)) return null;
+  if (await hostGuard(hostname)) return null;
 
   return safe;
 }
@@ -175,12 +173,16 @@ function parseEnsAvatarCaip(
   return { chainId, standard, contract, tokenId };
 }
 
-async function fetchJson<T = unknown>(url: string): Promise<T | null> {
+async function fetchJson<T = unknown>(
+  url: string,
+  hostGuard: AvatarHostGuard = NO_DNS_GUARD
+): Promise<T | null> {
   // SSRF guard: token metadata URLs come from attacker-controllable on-chain
   // tokenURI/uri values, so host-check every URL before fetching — not just the
   // final image URL. Blocks raw IP literals, cloud-metadata hostnames, DNS
-  // resolutions to raw IPs/private hosts, and non-http(s) schemes.
-  const safe = await safeFetchAvatarUrl(url);
+  // resolutions to raw IPs/private hosts (when a Node DNS guard is injected),
+  // and non-http(s) schemes.
+  const safe = await safeFetchAvatarUrl(url, hostGuard);
   if (!safe) return null;
   try {
     const res = await fetch(safe, {
@@ -197,7 +199,8 @@ async function fetchJson<T = unknown>(url: string): Promise<T | null> {
 
 async function resolveNftImageUrl(
   caip: ParsedCaip,
-  ownerAddress: Address
+  ownerAddress: Address,
+  hostGuard: AvatarHostGuard = NO_DNS_GUARD
 ): Promise<string | null> {
   const client =
     caip.chainId === 1
@@ -222,7 +225,7 @@ async function resolveNftImageUrl(
       args: [caip.tokenId],
     });
     const resolved = toHttpFromIpfs(tokenUri);
-    const metadata = await fetchJson<{ image?: string }>(resolved);
+    const metadata = await fetchJson<{ image?: string }>(resolved, hostGuard);
     const image = toHttpFromIpfs(String(metadata?.image || ''));
     return image || null;
   }
@@ -243,13 +246,14 @@ async function resolveNftImageUrl(
   });
   uri = replaceIdTemplate(uri, caip.tokenId);
   const resolved = toHttpFromIpfs(uri);
-  const metadata = await fetchJson<{ image?: string }>(resolved);
+  const metadata = await fetchJson<{ image?: string }>(resolved, hostGuard);
   const image = toHttpFromIpfs(String(metadata?.image || ''));
   return image || null;
 }
 
 export async function getEnsAvatarUrlForAddress(
-  address: string
+  address: string,
+  hostGuard: AvatarHostGuard = NO_DNS_GUARD
 ): Promise<string | null> {
   try {
     if (!address || !isAddress(address)) return null;
@@ -262,15 +266,18 @@ export async function getEnsAvatarUrlForAddress(
     });
     if (!avatarText) return null;
 
-    // If direct URL/IPFS CID
+    // If direct URL/IPFS CID. Run the final URL through the host guard too —
+    // not just sanitize — so callers can fetch the returned URL (e.g. the OG
+    // route's HEAD probe) without re-checking for DNS-rebinding SSRF.
     if (avatarText.startsWith('ipfs://') || avatarText.startsWith('http')) {
-      return sanitizeAvatarUrl(toHttpFromIpfs(avatarText));
+      return safeFetchAvatarUrl(toHttpFromIpfs(avatarText), hostGuard);
     }
 
     // If NFT CAIP string
     const parsed = parseEnsAvatarCaip(avatarText);
     if (parsed) {
-      return sanitizeAvatarUrl(await resolveNftImageUrl(parsed, addr));
+      const image = await resolveNftImageUrl(parsed, addr, hostGuard);
+      return safeFetchAvatarUrl(image, hostGuard);
     }
     return null;
   } catch {

--- a/packages/market-keeper/src/__tests__/cascade-gate.test.ts
+++ b/packages/market-keeper/src/__tests__/cascade-gate.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 
-import { categoryEndTimeForMarket } from '../generate/grouping';
+import {
+  categoryEndTimeForMarket,
+  gameEndTimeForMarket,
+  leagueForMarket,
+} from '../generate/grouping';
 import type { PolymarketMarket } from '../types';
 
 /**
@@ -29,6 +33,22 @@ function makeMarket(
 }
 
 describe('categoryEndTimeForMarket (Sonar gate predicate)', () => {
+  it('resolves a sports gameStartTime market -> would skip Sonar before category', () => {
+    const m = makeMarket({
+      question: 'Lakers vs Celtics: Moneyline',
+      slug: 'nba-lal-bos-2099-04-01',
+      gameStartTime: '2099-04-01 00:00:00+00',
+      events: [
+        {
+          title: 'Lakers vs Celtics',
+          tags: [{ slug: 'nba', label: 'NBA' }],
+        },
+      ],
+    });
+    expect(leagueForMarket(m)).toBe('nba');
+    expect(gameEndTimeForMarket(m)).toBe(Date.UTC(2099, 3, 1, 3, 29, 0) / 1000);
+  });
+
   it('resolves a mention market -> would skip Sonar', () => {
     const m = makeMarket({
       question: 'Will Trump say "Coward" this week?',
@@ -70,8 +90,18 @@ describe('categoryEndTimeForMarket (Sonar gate predicate)', () => {
         conditionId: '0x2',
         description: 'Generic market, no window.',
       }),
+      makeMarket({
+        conditionId: '0x3',
+        question: 'Yankees vs Mets: Moneyline',
+        slug: 'mlb-yankees-mets-2099-04-01',
+        gameStartTime: '2099-04-01 00:00:00+00',
+        events: [{ title: 'Yankees vs Mets', tags: [{ slug: 'mlb' }] }],
+      }),
     ];
-    const toSonar = markets.filter((m) => categoryEndTimeForMarket(m) == null);
+    const toSonar = markets.filter(
+      (m) =>
+        gameEndTimeForMarket(m) == null && categoryEndTimeForMarket(m) == null
+    );
     expect(toSonar.map((m) => m.conditionId)).toEqual(['0x2']);
   });
 });

--- a/packages/market-keeper/src/__tests__/decide-endtime.test.ts
+++ b/packages/market-keeper/src/__tests__/decide-endtime.test.ts
@@ -30,6 +30,26 @@ describe('decideEndTime', () => {
   });
 
   describe('priority table', () => {
+    it('gameStartTime wins over category, LLM, regex, and PM endDate', () => {
+      const gameStartTime = '2099-04-01 00:00:00+00';
+      const expected = toUnixTimestamp('2099-04-01T03:29:00Z'); // NBA +209m
+      const c = makeCondition({
+        gameStartTime,
+        league: 'nba',
+        categoryEndTime: toUnixTimestamp('2099-04-01T03:59:00Z'),
+        llmEndTime: {
+          ts: toUnixTimestamp('2099-04-05T16:00:00Z'),
+          confidence: 'high',
+        },
+        endDate: '2099-04-01T20:00:00Z',
+        endTimeOverride: toUnixTimestamp('2099-04-02T23:59:00Z'),
+        isTemplated: true,
+      });
+      const { ts, source } = decideEndTime(c);
+      expect(ts).toBe(expected);
+      expect(source).toBe('game');
+    });
+
     it('categoryEndTime wins over LLM, regex, and PM endDate', () => {
       const catTs = toUnixTimestamp('2099-04-01T03:59:00Z');
       const c = makeCondition({

--- a/packages/market-keeper/src/__tests__/transform-to-sapience-condition.test.ts
+++ b/packages/market-keeper/src/__tests__/transform-to-sapience-condition.test.ts
@@ -71,4 +71,21 @@ describe('transformToSapienceCondition', () => {
     expect(c.shortName).toBe('Something weird with no regex match');
     expect(c.optionName).toBe('Opt A');
   });
+
+  it('carries gameStartTime and inferred league for the production endTime cascade', () => {
+    const market = makeMarket({
+      question: 'Lakers vs Celtics: Moneyline',
+      slug: 'nba-lakers-celtics-2099-04-01',
+      gameStartTime: '2099-04-01 00:00:00+00',
+      events: [
+        {
+          title: 'Lakers vs Celtics',
+          tags: [{ slug: 'nba', label: 'NBA' }],
+        },
+      ],
+    });
+    const c = transformToSapienceCondition(market, 'group', enrichment);
+    expect(c.gameStartTime).toBe('2099-04-01 00:00:00+00');
+    expect(c.league).toBe('nba');
+  });
 });

--- a/packages/market-keeper/src/generate/api.ts
+++ b/packages/market-keeper/src/generate/api.ts
@@ -18,6 +18,7 @@ import {
   API_CONDITION_FILTERS,
   // matchesAlwaysIncludePatterns,
 } from './pipeline';
+import { gameEndTime } from './extractors/sports/game';
 
 /**
  * Delay between API submissions to avoid rate limiting
@@ -44,21 +45,23 @@ const PM_FALLBACK_PAD_SECONDS = 86_400;
  * Pick the endTime for a condition payload, with logging for prod observability.
  *
  * Deterministic-first cascade (each rung fits-or-declines; first hit wins):
- *   1. Category specialist (categoryEndTime) — high-precision regex for the
+ *   1. Game start time (gameStartTime + league duration) — the same sports
+ *      rung used by the scoring cascade. Exact, free, and outranks everything.
+ *   2. Category specialist (categoryEndTime) — high-precision regex for the
  *      templated families (weather/crypto/sports/social/snapshot). Read
  *      directly from the description, so it outranks the LLM. Markets it
  *      resolves also skip Sonar entirely (gated upstream in grouping).
- *   2. LLM (Sonar) — the smart generalist for everything the specialists
+ *   3. LLM (Sonar) — the smart generalist for everything the specialists
  *      decline. Any confidence wins; confidence is logged, not gated (the
  *      hallucination-guard knob is re-introducing a `confidence === 'high'`
  *      check here).
- *   3. Regex extraction (endTimeOverride) — the BROAD general regex, trusted
+ *   4. Regex extraction (endTimeOverride) — the BROAD general regex, trusted
  *      only for templated markets (sports/series/group) where the format is
  *      deterministic. Sits BELOW the LLM so a confident-wrong regex date
  *      can't out-rank Sonar (the ETH/USDT $1,800 bug was a Tier 4e false
  *      positive). Non-templated general-regex is never trusted.
- *   4. Polymarket endDate + 1 day — universal floor for PM-sourced markets.
- *   5. Throw — non-templated, non-PM market with no source. Fail loud rather
+ *   5. Polymarket endDate + 1 day — universal floor for PM-sourced markets.
+ *   6. Throw — non-templated, non-PM market with no source. Fail loud rather
  *      than publish a confidently-wrong endTime.
  *
  * No UMA buffer is added; settlement scripts don't gate on `endTime + UMA`.
@@ -66,6 +69,7 @@ const PM_FALLBACK_PAD_SECONDS = 86_400;
 export function decideEndTime(c: SapienceCondition): {
   ts: number;
   source:
+    | 'game'
     | 'category'
     | 'llm-high'
     | 'llm-low'
@@ -73,6 +77,10 @@ export function decideEndTime(c: SapienceCondition): {
     | 'regex-templated'
     | 'pm-fallback';
 } {
+  const game = gameEndTime(c.gameStartTime, c.league);
+  if (game != null) {
+    return { ts: game, source: 'game' };
+  }
   if (c.categoryEndTime != null) {
     return { ts: c.categoryEndTime, source: 'category' };
   }
@@ -114,6 +122,9 @@ function logEndTimeDecision(
     llmTs,
     pmTs,
     categoryTs: c.categoryEndTime ?? null,
+    gameTs: gameEndTime(c.gameStartTime, c.league),
+    gameStartTime: c.gameStartTime ?? null,
+    league: c.league ?? null,
     regexTs: c.endTimeOverride ?? null,
     llmConfidence: c.llmEndTime?.confidence ?? null,
     isTemplated: c.isTemplated ?? false,

--- a/packages/market-keeper/src/generate/grouping.ts
+++ b/packages/market-keeper/src/generate/grouping.ts
@@ -38,6 +38,7 @@ import {
 } from '../llm';
 import { fetchEventTags } from './tags';
 import { parseYesPrice } from '../utils/price';
+import { gameEndTime, SPORT_LEAGUES } from './extractors/sports/game';
 import {
   runPipeline,
   printPipelineStats,
@@ -137,6 +138,49 @@ export function categoryEndTimeForMarket(
   );
 }
 
+function normalizeLeagueCandidate(value: string | undefined | null): string {
+  return (value ?? '')
+    .toLowerCase()
+    .replace(/&/g, 'and')
+    .replace(/[^a-z0-9]+/g, '-');
+}
+
+export function leagueForMarket(market: PolymarketMarket): string | undefined {
+  const rawCandidates = [
+    market.events?.[0]?.seriesSlug,
+    market.events?.[0]?.series?.[0]?.slug,
+    market.events?.[0]?.series?.[0]?.title,
+    ...(market.events?.[0]?.tags ?? []).flatMap((tag) => [tag.slug, tag.label]),
+    market.slug,
+    market.events?.[0]?.slug,
+    market.events?.[0]?.title,
+    market.question,
+  ];
+
+  const haystack = rawCandidates
+    .map(normalizeLeagueCandidate)
+    .filter(Boolean)
+    .join(' ');
+  if (!haystack) return undefined;
+
+  return SPORT_LEAGUES.find((league) => {
+    const normalizedLeague = normalizeLeagueCandidate(league);
+    return new RegExp(`(^|[^a-z0-9])${normalizedLeague}([^a-z0-9]|$)`).test(
+      haystack
+    );
+  });
+}
+
+export function gameEndTimeForMarket(market: PolymarketMarket): number | null {
+  return gameEndTime(market.gameStartTime, leagueForMarket(market));
+}
+
+function deterministicEndTimeForMarket(
+  market: PolymarketMarket
+): number | null {
+  return gameEndTimeForMarket(market) ?? categoryEndTimeForMarket(market);
+}
+
 export function transformToSapienceCondition(
   market: PolymarketMarket,
   groupTitle?: string,
@@ -159,13 +203,15 @@ export function transformToSapienceCondition(
   // Sonar returns UNKNOWN. Always compute it; the combiner decides whether to use it.
   const regexEndTime = extractEndTime(question, market.description ?? '');
 
-  // High-precision category specialist — top of decideEndTime's cascade, and
-  // the signal that gated this market out of the Sonar call upstream.
+  // High-precision category specialist — second rung of decideEndTime's
+  // cascade, after gameStartTime, and one signal that gates this market out of
+  // the Sonar call upstream.
   const categoryEndTime = extractCategoryEndTime(
     question,
     market.description ?? '',
     inferSapienceCategorySlug(market)
   );
+  const league = leagueForMarket(market);
 
   return {
     conditionHash: market.conditionId, // Use Polymarket's conditionId directly
@@ -186,6 +232,8 @@ export function transformToSapienceCondition(
     endTimeOverride: regexEndTime ?? undefined,
     categoryEndTime: categoryEndTime ?? undefined,
     llmEndTime,
+    gameStartTime: market.gameStartTime ?? undefined,
+    league,
     isTemplated: isTemplatedMarket(market),
     negRisk: negRiskMarketId !== undefined,
     negRiskMarketId,
@@ -265,19 +313,19 @@ export async function groupMarkets(
   );
   printPipelineStats(llmFilterStats, 'LLM Pre-Filter');
 
-  // Cascade gate: markets a deterministic category specialist
-  // (weather/crypto/sports/social/snapshot) can resolve skip the Sonar endTime
-  // call entirely — that's where the LLM cost is saved. Sonar still runs for
-  // every market the specialists decline. (category/shortName enrichment is
-  // unaffected and runs on all new markets.)
+  // Cascade gate: markets a deterministic rung (gameStartTime or category
+  // specialist: weather/crypto/sports/social/snapshot) can resolve skip the
+  // Sonar endTime call entirely — that's where the LLM cost is saved. Sonar
+  // still runs for every market the deterministic rungs decline.
+  // (category/shortName enrichment is unaffected and runs on all new markets.)
   const sonarEndTimeMarkets = newMarkets.filter(
-    (m) => categoryEndTimeForMarket(m) == null
+    (m) => deterministicEndTimeForMarket(m) == null
   );
   const gatedCount = newMarkets.length - sonarEndTimeMarkets.length;
   if (gatedCount > 0) {
     console.log(
       `[LLM:endTime] cascade gate: ${gatedCount}/${newMarkets.length} markets ` +
-        `resolved by category specialists — skipping Sonar for those`
+        `resolved by deterministic rungs — skipping Sonar for those`
     );
   }
 

--- a/packages/market-keeper/src/types/polymarket.ts
+++ b/packages/market-keeper/src/types/polymarket.ts
@@ -17,6 +17,7 @@ export interface PolymarketMarket {
   category?: string;
   questionID?: string;
   sportsMarketType?: string;
+  gameStartTime?: string | null;
   events?: Array<{
     id?: string;
     title?: string;

--- a/packages/market-keeper/src/types/sapience.ts
+++ b/packages/market-keeper/src/types/sapience.ts
@@ -46,6 +46,8 @@ export interface SapienceCondition {
   endTimeOverride?: number; // Regex-extracted endTime fallback (unix seconds), only trusted for templated markets
   categoryEndTime?: number; // High-precision category specialist (weather/crypto/sports/social/snapshot) endTime (unix seconds). Top of the cascade; when set, the market also skips Sonar.
   llmEndTime?: LlmEndTimeResult; // Perplexity Sonar result; runs only when categoryEndTime is null
+  gameStartTime?: string; // Polymarket sports game start time; top of the production/scoring endTime cascade
+  league?: string; // Normalized sports league slug used with gameStartTime duration offsets
   isTemplated?: boolean; // True for sports/series/group templates; gates regex-fallback in decideEndTime
   negRisk?: boolean; // True when this condition belongs to a Polymarket negative-risk basket
   negRiskMarketId?: string; // Polymarket negative-risk basket identifier

--- a/packages/relayer/src/__tests__/secondaryMarket.test.ts
+++ b/packages/relayer/src/__tests__/secondaryMarket.test.ts
@@ -23,6 +23,7 @@ import {
   handleSecondaryListingsRequest,
   type SecondaryHandlerContext,
 } from '../secondaryMarketHandlers';
+import { config } from '../config';
 
 // ============================================================================
 // Fixtures
@@ -729,6 +730,54 @@ describe('SecondaryMarketHandlers', () => {
       );
       expect(error).toBeDefined();
       expect(error!.payload.error).toContain('INVALID_SIGNATURE');
+    });
+
+    it('rejects over-cap bids before SDK signature validation', async () => {
+      const { validateSecondaryBid } = await import(
+        '@sapience/sdk/auction/secondaryValidation'
+      );
+      (validateSecondaryBid as ReturnType<typeof vi.fn>).mockClear();
+
+      const sellerClient = createMockClient();
+      const subs = createMockSubs();
+      const ctx = createMockCtx(sellerClient);
+      await handleSecondaryAuctionStart(
+        sellerClient,
+        createListing(),
+        subs,
+        ctx
+      );
+      const ack = findMsg(
+        sellerClient._messages,
+        (m) => m.type === 'secondary.auction.ack' && !!m.payload.auctionId
+      );
+      const auctionId = ack!.payload.auctionId as string;
+
+      const buyerClient = createMockClient();
+      buyerClient.bidCounts = new Map([
+        [`secondary:${auctionId}`, config.MAX_BIDS_PER_CONNECTION_PER_AUCTION],
+      ]);
+
+      const failed = await handleSecondaryBidSubmit(
+        buyerClient,
+        {
+          auctionId,
+          buyer: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          price: '600000000000000000',
+          buyerNonce: 1,
+          buyerDeadline: futureDeadline,
+          buyerSignature: '0x' + 'cd'.repeat(65),
+        },
+        subs
+      );
+
+      expect(failed).toBe(false);
+      expect(validateSecondaryBid).not.toHaveBeenCalled();
+      const error = findMsg(
+        buyerClient._messages,
+        (m) => m.type === 'secondary.bid.ack' && !!m.payload.error
+      );
+      expect(error!.payload.error).toBe('bid_rejected');
     });
 
     it('does not call verifyBuyerSignature separately (SDK validation covers it)', async () => {

--- a/packages/relayer/src/secondaryMarketHandlers.ts
+++ b/packages/relayer/src/secondaryMarketHandlers.ts
@@ -230,7 +230,24 @@ export async function handleSecondaryBidSubmit(
     return true;
   }
 
-  // Tier 1 validation — field presence, deadline, price, signature
+  // Per-connection cap — one connection cannot monopolize a listing's bid
+  // slots. Offline validation passes legitimate smart-account (session-key)
+  // bids through as 'unverified' alongside forged ones, so without this cap a
+  // single connection could fill the listing's bid cap and lock out real
+  // buyers.
+  const bidCountKey = `secondary:${payload.auctionId}`;
+  const priorBidsFromConnection = client.bidCounts?.get(bidCountKey) ?? 0;
+  if (priorBidsFromConnection >= config.MAX_BIDS_PER_CONNECTION_PER_AUCTION) {
+    secondaryBidsSubmitted.inc({ status: 'rejected' });
+    client.send({
+      type: 'secondary.bid.ack',
+      payload: { error: 'bid_rejected' },
+    });
+    return false; // capacity limit, not a validation failure
+  }
+
+  // Tier 1 validation — field presence, deadline, price, signature. Keep this
+  // after the cheap connection cap so over-cap spam cannot force EIP-712 work.
   const validation = await validateSecondaryBid(payload, listing.auction, {
     verifyingContract: listing.auction.escrowContract as Address,
     chainId: listing.auction.chainId,
@@ -250,22 +267,6 @@ export async function handleSecondaryBidSubmit(
       payload: { error: `${validation.code}: ${validation.reason}` },
     });
     return true;
-  }
-
-  // Per-connection cap — one connection cannot monopolize a listing's bid
-  // slots. Offline validation passes legitimate smart-account (session-key)
-  // bids through as 'unverified' alongside forged ones, so without this cap a
-  // single connection could fill the listing's bid cap and lock out real
-  // buyers.
-  const bidCountKey = `secondary:${payload.auctionId}`;
-  const priorBidsFromConnection = client.bidCounts?.get(bidCountKey) ?? 0;
-  if (priorBidsFromConnection >= config.MAX_BIDS_PER_CONNECTION_PER_AUCTION) {
-    secondaryBidsSubmitted.inc({ status: 'rejected' });
-    client.send({
-      type: 'secondary.bid.ack',
-      payload: { error: 'bid_rejected' },
-    });
-    return false; // capacity limit, not a validation failure
   }
 
   const validated: SecondaryValidatedBid = {

--- a/packages/sdk/types/graphql.ts
+++ b/packages/sdk/types/graphql.ts
@@ -392,6 +392,11 @@ export type Claim = {
   id: Scalars['Int']['output'];
   marketAddress: Scalars['String']['output'];
   positionToken: Scalars['String']['output'];
+  /**
+   * Misnomer: this is the redeemed position's pickConfigId, NOT a Prediction.predictionId.
+   * Backed by the Claim.pickConfigId column; the GraphQL field name is kept only for
+   * backward compatibility on this deprecated query.
+   */
   predictionId: Scalars['String']['output'];
   redeemedAt: Scalars['Int']['output'];
   refCode?: Maybe<Scalars['String']['output']>;
@@ -1629,8 +1634,10 @@ export type Query = {
   attestations: Array<Attestation>;
   categories: Array<Category>;
   /**
-   * Paginated list of prediction claim (redemption) records, filterable by holder, prediction, and chain
-   * @deprecated Field no longer supported
+   * Paginated list of prediction claim (redemption) records, filterable by holder, pickConfig, and chain.
+   * NOTE: the `predictionId` filter and the `Claim.predictionId` field are misnamed — both are actually
+   * a pickConfigId (the redeemed position's pick configuration), never a Prediction.predictionId.
+   * @deprecated `predictionId` is a misnomer — it filters on pickConfigId, not Prediction.predictionId.
    */
   claims: Array<Claim>;
   /**


### PR DESCRIPTION
## Summary
- regenerate SDK GraphQL types from the current API schema so `test-api` stops failing on stale generated output
- harden ENS avatar metadata/image fetching against SSRF bypasses: raw IPv4/IPv6 literals, metadata hosts, and DNS results resolving to private/internal ranges, while keeping the Node DNS import out of Next edge/browser bundles
- reject secondary-market over-cap bids before SDK signature validation so spam cannot force expensive validation work
- align production market-keeper `endTime` selection with the scoring cascade: `gameStartTime` + inferred league now wins first, deterministic sports markets skip Sonar, and the payload carries the sports metadata needed by `decideEndTime`

## Validation
- `pnpm --filter @sapience/api run generate-types`
- `pnpm --filter @sapience/api run type-check`
- `pnpm --filter @sapience/api run lint`
- `pnpm --filter @sapience/api run test` — 541 passed, 5 skipped
- `pnpm --filter @sapience/app build`
- `pnpm --filter @sapience/app test -- --run src/lib/ens/avatar.test.ts` — 630 passed
- `pnpm --filter @sapience/app type-check`
- `pnpm --filter @sapience/app lint`
- `pnpm --filter @sapience/relayer test -- --run src/__tests__/secondaryMarket.test.ts`
- `pnpm --filter @sapience/relayer type-check`
- `pnpm --filter @sapience/relayer lint`
- `pnpm --filter @sapience/market-keeper lint`
- `pnpm --filter @sapience/market-keeper type-check`
- `pnpm --filter @sapience/market-keeper test -- --run src/__tests__/decide-endtime.test.ts src/__tests__/cascade-gate.test.ts src/__tests__/transform-to-sapience-condition.test.ts` — 451 passed, 4 skipped
- `git diff --check`
