### PR TITLE
fix(market-keeper): skip Sonar endTime call for crypto-dropped markets

### DIFF
--- a/packages/market-keeper/src/__tests__/cascade-gate.test.ts
+++ b/packages/market-keeper/src/__tests__/cascade-gate.test.ts
@@ -4,8 +4,10 @@ import {
   categoryEndTimeForMarket,
   gameEndTimeForMarket,
   leagueForMarket,
+  marketsNeedingSonar,
 } from '../generate/grouping';
-import type { PolymarketMarket } from '../types';
+import type { PolymarketMarket, SapienceCategorySlug } from '../types';
+import type { MarketEnrichmentOutput } from '../llm';
 
 /**
  * The Sonar gate: markets a deterministic category specialist can resolve are
@@ -103,5 +105,77 @@ describe('categoryEndTimeForMarket (Sonar gate predicate)', () => {
         gameEndTimeForMarket(m) == null && categoryEndTimeForMarket(m) == null
     );
     expect(toSonar.map((m) => m.conditionId)).toEqual(['0x2']);
+  });
+});
+
+/**
+ * The crypto-aware extension of the Sonar gate: a market the category-enrichment
+ * step labels `crypto` gets dropped by the crypto filter before submission, so
+ * spending an (expensive) Sonar endTime call on it is pure waste — and re-incurred
+ * every run, since dropped markets are never persisted and re-enter as "new".
+ * marketsNeedingSonar() runs AFTER category enrichment and skips those markets.
+ */
+describe('marketsNeedingSonar (crypto-aware Sonar gate)', () => {
+  const enrichMap = (
+    entries: Array<[string, SapienceCategorySlug]>
+  ): Map<string, MarketEnrichmentOutput> => {
+    const m = new Map<string, MarketEnrichmentOutput>();
+    for (const [conditionId, category] of entries) {
+      m.set(conditionId, { conditionId, category, shortName: 'short' });
+    }
+    return m;
+  };
+
+  it('skips Sonar for a market the LLM labels crypto (e.g. a HYPE token market)', () => {
+    const m = makeMarket({
+      conditionId: '0xhype',
+      question: 'Will HYPE flip DOGE by 2027?',
+      description: 'Generic crypto market, no resolvable window.',
+    });
+    const out = marketsNeedingSonar([m], enrichMap([['0xhype', 'crypto']]));
+    expect(out).toEqual([]);
+  });
+
+  it('still calls Sonar for a non-crypto market with no deterministic endTime', () => {
+    const m = makeMarket({
+      conditionId: '0xgeo',
+      question: 'Will there be a ceasefire in Country X this year?',
+      description: 'Resolves YES if a formal ceasefire is signed.',
+    });
+    const out = marketsNeedingSonar([m], enrichMap([['0xgeo', 'geopolitics']]));
+    expect(out.map((x) => x.conditionId)).toEqual(['0xgeo']);
+  });
+
+  it('still calls Sonar for an always-include market even when labeled crypto (it survives the filter and needs an endTime)', () => {
+    // Always-include (\bspx\b) with no deterministic window, artificially
+    // labeled crypto: exercises that always-include overrides the crypto skip.
+    const m = makeMarket({
+      conditionId: '0xspx',
+      question: 'Will SPX close green more often than red this year?',
+      description: 'No fixed resolution window.',
+    });
+    const out = marketsNeedingSonar([m], enrichMap([['0xspx', 'crypto']]));
+    expect(out.map((x) => x.conditionId)).toEqual(['0xspx']);
+  });
+
+  it('skips Sonar when a deterministic rung resolves it, regardless of category', () => {
+    const m = makeMarket({
+      conditionId: '0xmention',
+      question: 'Will Trump say "Coward" this week?',
+      description:
+        'This market will resolve to “Yes” if Donald Trump mentions the listed term between May 25, 2026, 12:00 AM ET and May 31, 2026, 11:59 PM ET. Otherwise, this market will resolve to “No”.',
+    });
+    const out = marketsNeedingSonar([m], enrichMap([['0xmention', 'culture']]));
+    expect(out).toEqual([]);
+  });
+
+  it('keeps a market with no enrichment entry (unknown category is not treated as crypto)', () => {
+    const m = makeMarket({
+      conditionId: '0xunknown',
+      question: 'Will there be a ceasefire in Country X this year?',
+      description: 'Resolves YES if a formal ceasefire is signed.',
+    });
+    const out = marketsNeedingSonar([m], new Map());
+    expect(out.map((x) => x.conditionId)).toEqual(['0xunknown']);
   });
 });

--- a/packages/market-keeper/src/generate/grouping.ts
+++ b/packages/market-keeper/src/generate/grouping.ts
@@ -46,6 +46,7 @@ import {
   UNGROUPED_MARKET_FILTERS,
   createLlmPreFilter,
   checkExistingConditions,
+  matchesAlwaysIncludePatterns,
   type MarketGroup,
   type ExistingCondition,
 } from './pipeline';
@@ -181,6 +182,35 @@ function deterministicEndTimeForMarket(
   return gameEndTimeForMarket(market) ?? categoryEndTimeForMarket(market);
 }
 
+/**
+ * Decide which NEW markets still need the (expensive) Perplexity Sonar endTime
+ * call, given the category-enrichment verdict. A market is gated OUT when EITHER:
+ *
+ *   1. a deterministic rung already resolves its endTime (gameStartTime or a
+ *      category specialist) — the existing cascade gate, OR
+ *   2. the LLM labeled it `crypto` and it isn't an always-include market — those
+ *      are dropped by the crypto filter (NonCryptoConditionFilter) before
+ *      submission, so a Sonar call on them is pure waste. Because dropped markets
+ *      are never persisted, they re-enter the pipeline as "new" every run, so the
+ *      waste repeats forever until this gate skips them.
+ *
+ * This mirrors the post-LLM crypto filter's keep-rule (categorySlug !== 'crypto'
+ * OR always-include), so we only skip Sonar for markets we won't submit anyway.
+ * A market with no enrichment entry (unknown category) is conservatively kept.
+ */
+export function marketsNeedingSonar(
+  markets: PolymarketMarket[],
+  enrichments: Map<string, MarketEnrichmentOutput>
+): PolymarketMarket[] {
+  return markets.filter((m) => {
+    if (deterministicEndTimeForMarket(m) != null) return false;
+    const category = enrichments.get(m.conditionId)?.category;
+    const droppedByCryptoFilter =
+      category === 'crypto' && !matchesAlwaysIncludePatterns(m.question);
+    return !droppedByCryptoFilter;
+  });
+}
+
 export function transformToSapienceCondition(
   market: PolymarketMarket,
   groupTitle?: string,
@@ -313,35 +343,34 @@ export async function groupMarkets(
   );
   printPipelineStats(llmFilterStats, 'LLM Pre-Filter');
 
-  // Cascade gate: markets a deterministic rung (gameStartTime or category
-  // specialist: weather/crypto/sports/social/snapshot) can resolve skip the
-  // Sonar endTime call entirely — that's where the LLM cost is saved. Sonar
-  // still runs for every market the deterministic rungs decline.
-  // (category/shortName enrichment is unaffected and runs on all new markets.)
-  const sonarEndTimeMarkets = newMarkets.filter(
-    (m) => deterministicEndTimeForMarket(m) == null
-  );
+  // Category/shortName enrichment runs FIRST (cheap GPT call): its verdict feeds
+  // the Sonar gate below. Markets the LLM labels crypto are dropped by the crypto
+  // filter before submission, so we must know the category before deciding
+  // whether the expensive Sonar endTime call is worth making. This sequences what
+  // used to be a parallel Promise.all — a small latency cost on a cron job in
+  // exchange for not paying Sonar on markets we'll throw away.
+  const enrichments = await enrichMarketsWithLLM(newMarkets, {
+    enabled: LLM_ENRICHMENT_ENABLED,
+    apiKey: OPENROUTER_API_KEY,
+    model: LLM_MODEL,
+  });
+
+  // Sonar gate: skip markets a deterministic rung resolves (existing behavior)
+  // AND markets the crypto filter will drop (new). See marketsNeedingSonar.
+  const sonarEndTimeMarkets = marketsNeedingSonar(newMarkets, enrichments);
   const gatedCount = newMarkets.length - sonarEndTimeMarkets.length;
   if (gatedCount > 0) {
     console.log(
       `[LLM:endTime] cascade gate: ${gatedCount}/${newMarkets.length} markets ` +
-        `resolved by deterministic rungs — skipping Sonar for those`
+        `skip Sonar (deterministic rung or crypto-filtered)`
     );
   }
 
-  // Enrich NEW markets with LLM — category/shortName and endTime run in parallel
-  const [enrichments, endTimeMap] = await Promise.all([
-    enrichMarketsWithLLM(newMarkets, {
-      enabled: LLM_ENRICHMENT_ENABLED,
-      apiKey: OPENROUTER_API_KEY,
-      model: LLM_MODEL,
-    }),
-    enrichEndTimesWithLLM(sonarEndTimeMarkets, {
-      enabled: LLM_ENDTIME_SEARCH_ENABLED,
-      apiKey: OPENROUTER_API_KEY,
-      model: LLM_ENDTIME_MODEL,
-    }),
-  ]);
+  const endTimeMap = await enrichEndTimesWithLLM(sonarEndTimeMarkets, {
+    enabled: LLM_ENDTIME_SEARCH_ENABLED,
+    apiKey: OPENROUTER_API_KEY,
+    model: LLM_ENDTIME_MODEL,
+  });
 
   // Filter out existing markets from groups and ungrouped (no need to submit them)
   const newGroups = filteredGroups.filter(


### PR DESCRIPTION
## Problem

For each new market the keeper makes two LLM calls — a cheap `gpt-4o-mini` category/shortName pass and an expensive Perplexity **Sonar** web-search for the endTime — and they run **in parallel** (`Promise.all`). Markets the LLM classifies as `crypto` (and that aren't always-include, e.g. BTC/ETH price markets) are dropped by the crypto filter (`NonCryptoConditionFilter`) before submission. Because the calls run in parallel, Sonar fires for those markets anyway and the result is thrown away.

Worse, dropped markets are never persisted, so they re-enter the pipeline as "new" on every cron cycle — the wasted Sonar call repeats forever. A crypto token the regex category heuristic misses but the LLM catches (e.g. **HYPE**, whose ticker collides with the English word "hype") loops indefinitely, paying for a discarded Sonar search every run.

## Change

- Sequence the two calls: run category enrichment **first**, then gate the Sonar call on its verdict.
- New `marketsNeedingSonar()` skips a market when **either** a deterministic rung already resolves its endTime (existing cascade-gate behavior) **or** the LLM labeled it `crypto` and it isn't always-include (new). This mirrors the post-LLM crypto filter's keep-rule, so Sonar only runs for markets we'd actually submit. Unknown/absent category is conservatively kept.
- **Tradeoff:** the two LLM calls are now sequential rather than parallel — a small added latency on a cron job in exchange for not paying for discarded Sonar searches.

## Scope / not included

This **caps the cost** but does not stop the loop on its own: the cheap category call still runs each cycle on a heuristic-missed crypto market (that's how we learn it's crypto). Fully eliminating the loop — extending the regex heuristic for named tokens, or a negative cache of rejected `conditionId`s — is intentionally left for follow-up.

## Tests

- New `marketsNeedingSonar` cases in `cascade-gate.test.ts`: crypto market skipped; non-crypto and always-include-but-crypto still call Sonar; deterministic rung wins regardless of category; unknown category kept.
- Full `market-keeper` suite: **461 passing**; `type-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)