### PR TITLE
Staging -> Main: fix admin referral codes pagination 400

### DIFF
--- a/packages/app/src/hooks/referrals/__tests__/useAdminReferralCodes.test.ts
+++ b/packages/app/src/hooks/referrals/__tests__/useAdminReferralCodes.test.ts
@@ -51,6 +51,29 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+const makeClaimant = (n: number) => ({
+  address: `0x${n.toString(16).padStart(40, '0')}`,
+  tradingVolume: '0',
+  positionCount: 0,
+});
+
+const analyticsPage = (
+  claimants: ReturnType<typeof makeClaimant>[],
+  nextCursor: number | null
+) => ({
+  referralCodes: {
+    items: [
+      {
+        id: 1,
+        claimCount: 3,
+        totalVolume: '123',
+        totalPositions: 7,
+        claimants: { items: claimants, nextCursor },
+      },
+    ],
+  },
+});
+
 describe('useAdminReferralCodes — pagination', () => {
   it('returns the single page when nextCursor is null', async () => {
     mockGraphqlRequest.mockResolvedValueOnce(
@@ -67,7 +90,7 @@ describe('useAdminReferralCodes — pagination', () => {
     });
     expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
     expect(mockGraphqlRequest).toHaveBeenCalledWith(expect.any(String), {
-      limit: 500,
+      limit: 100,
       cursor: null,
     });
   });
@@ -88,15 +111,15 @@ describe('useAdminReferralCodes — pagination', () => {
     });
     expect(mockGraphqlRequest).toHaveBeenCalledTimes(3);
     expect(mockGraphqlRequest).toHaveBeenNthCalledWith(1, expect.any(String), {
-      limit: 500,
+      limit: 100,
       cursor: null,
     });
     expect(mockGraphqlRequest).toHaveBeenNthCalledWith(2, expect.any(String), {
-      limit: 500,
+      limit: 100,
       cursor: 9,
     });
     expect(mockGraphqlRequest).toHaveBeenNthCalledWith(3, expect.any(String), {
-      limit: 500,
+      limit: 100,
       cursor: 7,
     });
   });
@@ -116,6 +139,87 @@ describe('useAdminReferralCodes — pagination', () => {
     });
     // 50 pages × 1 row each
     expect(result.current.data?.length).toBe(50);
+    expect(mockGraphqlRequest).toHaveBeenCalledTimes(50);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('MAX_PAGES'));
+    warn.mockRestore();
+  });
+});
+
+describe('useAdminReferralCodeAnalytics — claimants pagination', () => {
+  it('returns a single page of claimants when nextCursor is null', async () => {
+    mockGraphqlRequest.mockResolvedValueOnce(
+      analyticsPage([makeClaimant(1), makeClaimant(2)], null)
+    );
+
+    const { useAdminReferralCodeAnalytics } = await import(
+      '../useAdminReferralCodes'
+    );
+    const { result } = renderHook(() => useAdminReferralCodeAnalytics(1), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toBeDefined();
+    });
+    expect(result.current.data?.claimants.length).toBe(2);
+    expect(result.current.data?.totalVolume).toBe('123');
+    expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(expect.any(String), {
+      id: 1,
+      claimantsLimit: 100,
+      claimantsCursor: null,
+    });
+  });
+
+  it('follows nextCursor across claimant pages and concatenates results', async () => {
+    mockGraphqlRequest
+      .mockResolvedValueOnce(
+        analyticsPage([makeClaimant(1), makeClaimant(2)], 2)
+      )
+      .mockResolvedValueOnce(analyticsPage([makeClaimant(3)], null));
+
+    const { useAdminReferralCodeAnalytics } = await import(
+      '../useAdminReferralCodes'
+    );
+    const { result } = renderHook(() => useAdminReferralCodeAnalytics(1), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.claimants.length).toBe(3);
+    });
+    expect(result.current.data?.claimants.map((c) => c.address)).toEqual([
+      makeClaimant(1).address,
+      makeClaimant(2).address,
+      makeClaimant(3).address,
+    ]);
+    expect(mockGraphqlRequest).toHaveBeenNthCalledWith(1, expect.any(String), {
+      id: 1,
+      claimantsLimit: 100,
+      claimantsCursor: null,
+    });
+    expect(mockGraphqlRequest).toHaveBeenNthCalledWith(2, expect.any(String), {
+      id: 1,
+      claimantsLimit: 100,
+      claimantsCursor: 2,
+    });
+  });
+
+  it('caps at MAX_PAGES so a non-progressing claimants cursor cannot loop forever', async () => {
+    mockGraphqlRequest.mockResolvedValue(analyticsPage([makeClaimant(1)], 1));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { useAdminReferralCodeAnalytics } = await import(
+      '../useAdminReferralCodes'
+    );
+    const { result } = renderHook(() => useAdminReferralCodeAnalytics(1), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toBeDefined();
+    });
+    expect(result.current.data?.claimants.length).toBe(50);
     expect(mockGraphqlRequest).toHaveBeenCalledTimes(50);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('MAX_PAGES'));
     warn.mockRestore();

--- a/packages/app/src/hooks/referrals/useAdminReferralCodes.ts
+++ b/packages/app/src/hooks/referrals/useAdminReferralCodes.ts
@@ -115,10 +115,10 @@ const REFERRAL_CODES_QUERY = `
   }
 `;
 
-// Server caps `limit` at 500 per page. We auto-paginate so the admin UI
-// doesn't silently truncate at 500 codes; MAX_PAGES is a safety net against
-// a buggy server returning a non-progressing cursor.
-const PAGE_SIZE = 500;
+// The API rejects any `limit` above GRAPHQL_MAX_LIST_SIZE (100) with a 400.
+// We auto-paginate so the admin UI doesn't silently truncate; MAX_PAGES is a
+// safety net against a buggy server returning a non-progressing cursor.
+const PAGE_SIZE = 100;
 const MAX_PAGES = 50;
 
 type ReferralCodesPageResponse = {
@@ -128,15 +128,34 @@ type ReferralCodesPageResponse = {
   };
 };
 
+type ReferralCodeAnalyticsResponse = {
+  referralCodes: {
+    items: Array<{
+      id: number;
+      claimCount: number;
+      totalVolume: string;
+      totalPositions: number;
+      claimants: {
+        items: Array<{
+          address: string;
+          tradingVolume: string;
+          positionCount: number;
+        }>;
+        nextCursor: number | null;
+      };
+    }>;
+  };
+};
+
 const REFERRAL_CODE_ANALYTICS_QUERY = `
-  query AdminReferralCodeAnalytics($id: Int!, $claimantsLimit: Int!) {
+  query AdminReferralCodeAnalytics($id: Int!, $claimantsLimit: Int!, $claimantsCursor: Int) {
     referralCodes(id: $id, limit: 1) {
       items {
         id
         claimCount
         totalVolume
         totalPositions
-        claimants(limit: $claimantsLimit) {
+        claimants(limit: $claimantsLimit, cursor: $claimantsCursor) {
           items {
             address
             tradingVolume
@@ -181,24 +200,34 @@ export function useAdminReferralCodeAnalytics(
   return useQuery<AdminReferralAnalytics>({
     queryKey: ['admin', 'referralCodeAnalytics', id],
     queryFn: async () => {
-      const data = await graphqlRequest<{
-        referralCodes: {
-          items: Array<{
-            id: number;
-            claimCount: number;
-            totalVolume: string;
-            totalPositions: number;
-            claimants: {
-              items: Array<{
-                address: string;
-                tradingVolume: string;
-                positionCount: number;
-              }>;
-            };
-          }>;
-        };
-      }>(REFERRAL_CODE_ANALYTICS_QUERY, { id, claimantsLimit: 500 });
-      const code = data.referralCodes.items[0];
+      const claimants: AdminReferralAnalytics['claimants'] = [];
+      let code: {
+        id: number;
+        claimCount: number;
+        totalVolume: string;
+        totalPositions: number;
+      } | null = null;
+      let cursor: number | null = null;
+      for (let page = 0; page < MAX_PAGES; page += 1) {
+        const data: ReferralCodeAnalyticsResponse =
+          await graphqlRequest<ReferralCodeAnalyticsResponse>(
+            REFERRAL_CODE_ANALYTICS_QUERY,
+            { id, claimantsLimit: PAGE_SIZE, claimantsCursor: cursor }
+          );
+        const item = data.referralCodes.items[0];
+        if (!item) {
+          throw new Error('Referral code not found');
+        }
+        code ??= item;
+        claimants.push(...item.claimants.items);
+        cursor = item.claimants.nextCursor;
+        if (cursor == null) break;
+        if (page === MAX_PAGES - 1) {
+          console.warn(
+            `useAdminReferralCodeAnalytics: stopped at MAX_PAGES (${MAX_PAGES}); claimants may be truncated`
+          );
+        }
+      }
       if (!code) {
         throw new Error('Referral code not found');
       }
@@ -207,7 +236,7 @@ export function useAdminReferralCodeAnalytics(
         claimCount: code.claimCount,
         totalVolume: code.totalVolume,
         totalPositions: code.totalPositions,
-        claimants: code.claimants.items,
+        claimants,
       };
     },
     enabled: typeof id === 'number',


### PR DESCRIPTION
## Summary
- The `/admin` referral codes page failed with a GraphQL 400 (`PAGINATION_LIMIT_EXCEEDED`): the frontend requested `limit: 500`, but the API rejects any `limit`/`take`/`first` argument above `GRAPHQL_MAX_LIST_SIZE` (default 100).
- Drop the codes-list `PAGE_SIZE` to 100 — the hook already auto-paginates via `nextCursor`, so no data is lost.
- `useAdminReferralCodeAnalytics` previously fetched claimants in a single `limit: 500` request; it now cursor-paginates claimants at 100 per page with the same `MAX_PAGES` safety net.

## Test plan
- [x] New/updated vitest coverage in `useAdminReferralCodes.test.ts`: codes-list pagination now asserts `limit: 100`; added claimants pagination tests (single page, multi-page concatenation, MAX_PAGES cap) — 6/6 passing
- [x] `tsc --noEmit` clean in `@sapience/app`
- [ ] Verify `/admin` loads referral codes against a deployed API

🤖 Generated with [Claude Code](https://claude.com/claude-code)