### PR TITLE
feat(api): questionType filter on questions query

### DIFF
--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -1611,9 +1611,9 @@ type Query {
   protocolVolume(from: DateTimeISO, interval: TimeInterval!, to: DateTimeISO): [VolumeDataPoint!]! @deprecated
 
   """
-  Sorted, paginated list of questions — groups and ungrouped conditions interleaved by the chosen sort field
+  Sorted, paginated list of questions — groups and ungrouped conditions interleaved by the chosen sort field. `questionType` filters by rendered item type: `condition` returns items that resolve to a standalone condition (ungrouped conditions plus single-condition groups, which are unwrapped), `group` returns multi-condition groups only.
   """
-  questions(categorySlugs: [String!], chainId: Int, maxEstimatedPrice: Float, maxSimilarMarketVolume: Float, minEndTime: Int, minEstimatedPrice: Float, minSimilarMarketVolume: Float, resolutionStatus: ResolutionStatus, search: String, similarMarketVolumeWindow: VolumeWindow, skip: Int! = 0, sortDirection: SortOrder! = desc, sortField: QuestionSortField, tag: String, take: Int! = 50): [Question!]!
+  questions(categorySlugs: [String!], chainId: Int, maxEstimatedPrice: Float, maxSimilarMarketVolume: Float, minEndTime: Int, minEstimatedPrice: Float, minSimilarMarketVolume: Float, questionType: QuestionItemType, resolutionStatus: ResolutionStatus, search: String, similarMarketVolumeWindow: VolumeWindow, skip: Int! = 0, sortDirection: SortOrder! = desc, sortField: QuestionSortField, tag: String, take: Int! = 50): [Question!]!
 
   """
   Public referral analytics. Referral codes are attribution hints, not

--- a/packages/api/src/graphql/sdl/resolvers/queries/questions.test.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/questions.test.ts
@@ -1,12 +1,23 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { queryRawMock, conditionGroupFindManyMock, conditionFindManyMock } =
+  vi.hoisted(() => ({
+    queryRawMock: vi.fn(),
+    conditionGroupFindManyMock: vi.fn(),
+    conditionFindManyMock: vi.fn(),
+  }));
 
 vi.mock('../../../../core/db', () => ({
   default: {
-    $queryRaw: vi.fn(),
+    $queryRaw: queryRawMock,
+    conditionGroup: { findMany: conditionGroupFindManyMock },
+    condition: { findMany: conditionFindManyMock },
   },
 }));
 
-const { resolveVolumeKey } = await import('./questions');
+const { resolveVolumeKey, questions } = await import('./questions');
+const { Prisma } = await import('../../../../../generated/prisma');
+const { QuestionItemType } = await import('../../__generated__/resolvers');
 
 describe('resolveVolumeKey', () => {
   it('maps GraphQL VolumeWindow enum values to internal volume keys', () => {
@@ -30,5 +41,144 @@ describe('resolveVolumeKey', () => {
   it('falls back to volume24h for unrecognized window values', () => {
     expect(resolveVolumeKey('1hFiltered')).toBe('volume24h');
     expect(resolveVolumeKey('bogus')).toBe('volume24h');
+  });
+});
+
+/**
+ * Reconstruct the flattened SQL text of the (single) $queryRaw call —
+ * the resolver invokes it as a tagged template, so the captured args
+ * are [TemplateStringsArray, ...values] and Prisma.sql flattens any
+ * nested Sql fragments for us.
+ */
+const capturedSql = (): string => {
+  expect(queryRawMock).toHaveBeenCalledTimes(1);
+  const [strings, ...values] = queryRawMock.mock.calls[0] as [
+    TemplateStringsArray,
+    ...unknown[],
+  ];
+  return Prisma.sql(strings, ...values).sql.replace(/\s+/g, ' ');
+};
+
+const baseArgs = {
+  take: 50,
+  skip: 0,
+  sortDirection: 'desc',
+} as const;
+
+const callQuestions = (extra: Record<string, unknown> = {}) =>
+  (
+    questions as unknown as (
+      parent: unknown,
+      args: Record<string, unknown>
+    ) => Promise<unknown[]>
+  )({}, { ...baseArgs, ...extra });
+
+describe('questions questionType filter', () => {
+  beforeEach(() => {
+    queryRawMock.mockReset().mockResolvedValue([]);
+    conditionGroupFindManyMock.mockReset().mockResolvedValue([]);
+    conditionFindManyMock.mockReset().mockResolvedValue([]);
+  });
+
+  it('includes both UNION parts and all active groups when questionType is omitted', async () => {
+    await callQuestions();
+    const sql = capturedSql();
+    expect(sql).toContain('UNION ALL');
+    expect(sql).toContain('"conditionGroupId" IS NULL');
+    expect(sql).not.toContain('"publicConditionCount" = 1');
+    expect(sql).not.toContain('"publicConditionCount" >= 2');
+  });
+
+  it('questionType=condition keeps ungrouped conditions and restricts groups to single-condition groups', async () => {
+    await callQuestions({ questionType: QuestionItemType.Condition });
+    const sql = capturedSql();
+    expect(sql).toContain('"conditionGroupId" IS NULL');
+    expect(sql).toContain('"publicConditionCount" = 1');
+  });
+
+  it('questionType=group omits ungrouped conditions and restricts to multi-condition groups', async () => {
+    await callQuestions({ questionType: QuestionItemType.Group });
+    const sql = capturedSql();
+    expect(sql).not.toContain('UNION ALL');
+    expect(sql).not.toContain('"conditionGroupId" IS NULL');
+    expect(sql).toContain('"publicConditionCount" >= 2');
+  });
+
+  it('questionType=condition with per-condition filters restricts via HAVING COUNT', async () => {
+    await callQuestions({
+      questionType: QuestionItemType.Condition,
+      chainId: 8453,
+    });
+    const sql = capturedSql();
+    expect(sql).toContain('HAVING COUNT(c.id) = 1');
+  });
+
+  it('questionType=group with per-condition filters restricts via HAVING COUNT', async () => {
+    await callQuestions({
+      questionType: QuestionItemType.Group,
+      chainId: 8453,
+    });
+    const sql = capturedSql();
+    expect(sql).toContain('HAVING COUNT(c.id) >= 2');
+  });
+
+  it('questionType=condition unwraps a single-condition group into a condition item', async () => {
+    queryRawMock.mockResolvedValue([
+      {
+        item_type: 'group',
+        group_id: 1,
+        condition_id: null,
+        prediction_count: 3n,
+      },
+    ]);
+    conditionGroupFindManyMock.mockResolvedValue([
+      { id: 1, condition: [{ id: '0xabc' }] },
+    ]);
+
+    const result = (await callQuestions({
+      questionType: QuestionItemType.Condition,
+    })) as Array<{ questionType: string; condition: { id: string } | null }>;
+
+    expect(result).toHaveLength(1);
+    expect(result[0].questionType).toBe(QuestionItemType.Condition);
+    expect(result[0].condition?.id).toBe('0xabc');
+  });
+
+  it('questionType=condition drops a group that hydrates with multiple conditions', async () => {
+    queryRawMock.mockResolvedValue([
+      {
+        item_type: 'group',
+        group_id: 1,
+        condition_id: null,
+        prediction_count: 5n,
+      },
+    ]);
+    conditionGroupFindManyMock.mockResolvedValue([
+      { id: 1, condition: [{ id: '0xabc' }, { id: '0xdef' }] },
+    ]);
+
+    const result = await callQuestions({
+      questionType: QuestionItemType.Condition,
+    });
+    expect(result).toHaveLength(0);
+  });
+
+  it('questionType=group drops a group that hydrates down to a single condition', async () => {
+    queryRawMock.mockResolvedValue([
+      {
+        item_type: 'group',
+        group_id: 1,
+        condition_id: null,
+        prediction_count: 2n,
+      },
+    ]);
+    conditionGroupFindManyMock.mockResolvedValue([
+      { id: 1, condition: [{ id: '0xabc' }] },
+    ]);
+
+    const result = await callQuestions({
+      questionType: QuestionItemType.Group,
+    });
+    expect(result).toHaveLength(0);
   });
 });

--- a/packages/api/src/graphql/sdl/resolvers/queries/questions.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/questions.ts
@@ -141,6 +141,7 @@ export const questions: NonNullable<QueryResolvers['questions']> = async (
     maxSimilarMarketVolume,
     tag,
     similarMarketVolumeWindow,
+    questionType,
   }
 ) => {
   const sanitizedSortField = sortField ?? 'endTime';
@@ -271,9 +272,33 @@ export const questions: NonNullable<QueryResolvers['questions']> = async (
     ? Prisma.sql`COALESCE(MAX(c."endTime"), 0)`
     : Prisma.sql`cg."maxEndTime"`;
 
+  // `questionType` filters by *rendered* item type: single-condition
+  // groups unwrap into standalone condition items at hydration, so
+  // `condition` admits ungrouped conditions plus groups with exactly
+  // one matching condition; `group` admits only groups with 2+.
+  const groupCountHaving =
+    questionType === 'condition'
+      ? Prisma.sql`HAVING COUNT(c.id) = 1`
+      : questionType === 'group'
+        ? Prisma.sql`HAVING COUNT(c.id) >= 2`
+        : Prisma.sql`HAVING COUNT(c.id) > 0`;
+
   const groupByClause = requiresConditionJoin
-    ? Prisma.sql`GROUP BY cg.id HAVING COUNT(c.id) > 0`
+    ? Prisma.sql`GROUP BY cg.id ${groupCountHaving}`
     : Prisma.empty;
+
+  // Without the condition join, the denormalized public count stands in
+  // for COUNT(c.id) — consistent with the hydration-time unwrap, whose
+  // `conditionWhere` is just `public: true` when no filters are active.
+  const groupPublicCountFilter = requiresConditionJoin
+    ? Prisma.empty
+    : questionType === 'condition'
+      ? Prisma.sql`AND cg."publicConditionCount" = 1`
+      : questionType === 'group'
+        ? Prisma.sql`AND cg."publicConditionCount" >= 2`
+        : Prisma.empty;
+
+  const includeUngroupedConditions = questionType !== 'group';
 
   const condSortValue =
     sanitizedSortField === 'openInterest'
@@ -301,6 +326,7 @@ export const questions: NonNullable<QueryResolvers['questions']> = async (
       FROM condition_group cg
       ${groupConditionJoin}
       WHERE cg."publicConditionCount" > 0
+        ${groupPublicCountFilter}
         ${
           boundedSearch
             ? Prisma.sql`AND (
@@ -335,6 +361,9 @@ export const questions: NonNullable<QueryResolvers['questions']> = async (
         }
       ${groupByClause}
 
+      ${
+        includeUngroupedConditions
+          ? Prisma.sql`
       UNION ALL
 
       -- Part B: Ungrouped conditions
@@ -363,7 +392,9 @@ export const questions: NonNullable<QueryResolvers['questions']> = async (
           boundedTag
             ? Prisma.sql`AND ${boundedTag} = ANY(c.tags)`
             : Prisma.empty
-        }
+        }`
+          : Prisma.empty
+      }
     )
     SELECT item_type, group_id, condition_id, prediction_count
     FROM combined
@@ -501,6 +532,18 @@ export const questions: NonNullable<QueryResolvers['questions']> = async (
         predictionCount: Number(item.prediction_count),
       });
     }
+  }
+
+  // The SQL count restriction and the hydration unwrap can disagree
+  // when aggregates drift (trigger lag), so enforce the requested
+  // rendered type after unwrapping too.
+  if (questionType != null) {
+    // Items are pushed as plain objects above; the ResolverTypeWrapper
+    // union just obscures that from the type checker.
+    return result.filter(
+      (q) =>
+        (q as { questionType: QuestionItemType }).questionType === questionType
+    );
   }
 
   return result;

--- a/packages/api/src/graphql/sdl/schema/schema.graphql
+++ b/packages/api/src/graphql/sdl/schema/schema.graphql
@@ -1622,9 +1622,9 @@ type Query {
   protocolVolume(from: DateTimeISO, interval: TimeInterval!, to: DateTimeISO): [VolumeDataPoint!]! @deprecated
 
   """
-  Sorted, paginated list of questions — groups and ungrouped conditions interleaved by the chosen sort field
+  Sorted, paginated list of questions — groups and ungrouped conditions interleaved by the chosen sort field. `questionType` filters by rendered item type: `condition` returns items that resolve to a standalone condition (ungrouped conditions plus single-condition groups, which are unwrapped), `group` returns multi-condition groups only.
   """
-  questions(categorySlugs: [String!], chainId: Int, maxEstimatedPrice: Float, maxSimilarMarketVolume: Float, minEndTime: Int, minEstimatedPrice: Float, minSimilarMarketVolume: Float, resolutionStatus: ResolutionStatus, search: String, similarMarketVolumeWindow: VolumeWindow, skip: Int! = 0, sortDirection: SortOrder! = desc, sortField: QuestionSortField, tag: String, take: Int! = 50): [Question!]!
+  questions(categorySlugs: [String!], chainId: Int, maxEstimatedPrice: Float, maxSimilarMarketVolume: Float, minEndTime: Int, minEstimatedPrice: Float, minSimilarMarketVolume: Float, questionType: QuestionItemType, resolutionStatus: ResolutionStatus, search: String, similarMarketVolumeWindow: VolumeWindow, skip: Int! = 0, sortDirection: SortOrder! = desc, sortField: QuestionSortField, tag: String, take: Int! = 50): [Question!]!
 
   """
   Public referral analytics. Referral codes are attribution hints, not

--- a/packages/sdk/types/graphql.ts
+++ b/packages/sdk/types/graphql.ts
@@ -1687,7 +1687,7 @@ export type Query = {
    * @deprecated Field no longer supported
    */
   protocolVolume: Array<VolumeDataPoint>;
-  /** Sorted, paginated list of questions — groups and ungrouped conditions interleaved by the chosen sort field */
+  /** Sorted, paginated list of questions — groups and ungrouped conditions interleaved by the chosen sort field. `questionType` filters by rendered item type: `condition` returns items that resolve to a standalone condition (ungrouped conditions plus single-condition groups, which are unwrapped), `group` returns multi-condition groups only. */
   questions: Array<Question>;
   /**
    * Public referral analytics. Referral codes are attribution hints, not
@@ -1984,6 +1984,7 @@ export type QueryQuestionsArgs = {
   minEndTime?: InputMaybe<Scalars['Int']['input']>;
   minEstimatedPrice?: InputMaybe<Scalars['Float']['input']>;
   minSimilarMarketVolume?: InputMaybe<Scalars['Float']['input']>;
+  questionType?: InputMaybe<QuestionItemType>;
   resolutionStatus?: InputMaybe<ResolutionStatus>;
   search?: InputMaybe<Scalars['String']['input']>;
   similarMarketVolumeWindow?: InputMaybe<VolumeWindow>;


### PR DESCRIPTION
## Summary

Adds an optional `questionType` argument (reusing the existing `QuestionItemType` enum) to `Query.questions`, so clients can request only single conditions or only groups — e.g. for a featured "Top 5 single conditions" section on the Prediction Home Page without over-fetching and filtering client-side.

## Semantics

The filter follows the **rendered** item type, consistent with the existing single-condition-group unwrap:

- `questionType: condition` — ungrouped conditions **plus** groups with exactly one matching condition (these already unwrap into standalone condition items at hydration). Truly ungrouped conditions are rare, so including unwrapped single-condition groups is what makes this useful.
- `questionType: group` — groups with 2+ matching conditions only; the ungrouped half of the UNION is skipped entirely.
- Omitted — unchanged behavior.

## Implementation

- Group-count restriction uses the denormalized `publicConditionCount` when no per-condition filters are active, and `HAVING COUNT(c.id)` under the condition LEFT JOIN otherwise — mirroring the hydration-time unwrap in both modes.
- A post-hydration guard drops items whose rendered type drifts from the SQL decision (aggregate trigger lag).
- Filtering can only shrink the query (one UNION half is dropped for `group`), never adds cost.

## Testing

- New unit tests cover the SQL shape for both filter values (with and without per-condition filters), the unfiltered default, the single-condition-group unwrap, and the drift guard (red-green TDD).
- Full API suite passes (558 tests), `type-check` and `lint` clean.
- `schema.graphql` / `sdk/types/graphql.ts` regenerated via `generate-types`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)