### PR TITLE
feat(api/v2): questionType filter on questions connection

### DIFF
--- a/packages/api/schema.v2.graphql
+++ b/packages/api/schema.v2.graphql
@@ -1444,6 +1444,24 @@ input QuestionFilter {
   the group's conditions. Inclusive on both bounds.
   """
   endsAt: IntRangeFilter
+
+  """
+  Restrict to one side of the `QuestionItem` union, by *rendered* kind:
+  `CONDITION` returns items that resolve to a standalone Condition
+  (ungrouped conditions plus single-condition groups, which the feed
+  unwraps); `CONDITION_GROUP` returns multi-condition ConditionGroups
+  only. Both kinds when omitted.
+  """
+  questionType: QuestionItemKind
+}
+
+"""
+Which side of the `QuestionItem` union a feed item resolves to. Values
+mirror the union's member type names.
+"""
+enum QuestionItemKind {
+  CONDITION
+  CONDITION_GROUP
 }
 
 """

--- a/packages/api/src/graphql/sdl/resolvers/queries/questions.test.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/questions.test.ts
@@ -1,12 +1,23 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { queryRawMock, conditionGroupFindManyMock, conditionFindManyMock } =
+  vi.hoisted(() => ({
+    queryRawMock: vi.fn(),
+    conditionGroupFindManyMock: vi.fn(),
+    conditionFindManyMock: vi.fn(),
+  }));
 
 vi.mock('../../../../core/db', () => ({
   default: {
-    $queryRaw: vi.fn(),
+    $queryRaw: queryRawMock,
+    conditionGroup: { findMany: conditionGroupFindManyMock },
+    condition: { findMany: conditionFindManyMock },
   },
 }));
 
-const { resolveVolumeKey } = await import('./questions');
+const { resolveVolumeKey, runQuestionsData } = await import('./questions');
+const { Prisma } = await import('../../../../../generated/prisma');
+const { QuestionItemType } = await import('../../__generated__/resolvers');
 
 describe('resolveVolumeKey', () => {
   it('maps GraphQL VolumeWindow enum values to internal volume keys', () => {
@@ -30,5 +41,148 @@ describe('resolveVolumeKey', () => {
   it('falls back to volume24h for unrecognized window values', () => {
     expect(resolveVolumeKey('1hFiltered')).toBe('volume24h');
     expect(resolveVolumeKey('bogus')).toBe('volume24h');
+  });
+});
+
+/**
+ * Reconstruct the flattened SQL text of the first $queryRaw call — the
+ * runner invokes it as a tagged template, so the captured args are
+ * [TemplateStringsArray, ...values] and Prisma.sql flattens any nested
+ * Sql fragments for us.
+ */
+const capturedSql = (): string => {
+  expect(queryRawMock).toHaveBeenCalled();
+  const [strings, ...values] = queryRawMock.mock.calls[0] as [
+    TemplateStringsArray,
+    ...unknown[],
+  ];
+  return Prisma.sql(strings, ...values).sql.replace(/\s+/g, ' ');
+};
+
+describe('runQuestionsData questionType filter', () => {
+  beforeEach(() => {
+    queryRawMock.mockReset().mockResolvedValue([]);
+    conditionGroupFindManyMock.mockReset().mockResolvedValue([]);
+    conditionFindManyMock.mockReset().mockResolvedValue([]);
+  });
+
+  it('includes both UNION parts and all active groups when questionType is omitted', async () => {
+    await runQuestionsData({ take: 10 });
+    const sql = capturedSql();
+    expect(sql).toContain('UNION ALL');
+    expect(sql).toContain('"conditionGroupId" IS NULL');
+    expect(sql).not.toContain('"publicConditionCount" = 1');
+    expect(sql).not.toContain('"publicConditionCount" >= 2');
+  });
+
+  it('questionType=condition keeps ungrouped conditions and restricts groups to single-condition groups', async () => {
+    await runQuestionsData({
+      take: 10,
+      questionType: QuestionItemType.Condition,
+    });
+    const sql = capturedSql();
+    expect(sql).toContain('"conditionGroupId" IS NULL');
+    expect(sql).toContain('"publicConditionCount" = 1');
+  });
+
+  it('questionType=group omits ungrouped conditions and restricts to multi-condition groups', async () => {
+    await runQuestionsData({ take: 10, questionType: QuestionItemType.Group });
+    const sql = capturedSql();
+    expect(sql).not.toContain('UNION ALL');
+    expect(sql).not.toContain('"conditionGroupId" IS NULL');
+    expect(sql).toContain('"publicConditionCount" >= 2');
+  });
+
+  it('questionType=condition with per-condition filters restricts via HAVING COUNT', async () => {
+    await runQuestionsData({
+      take: 10,
+      questionType: QuestionItemType.Condition,
+      chainId: 8453,
+    });
+    const sql = capturedSql();
+    expect(sql).toContain('HAVING COUNT(c.id) = 1');
+  });
+
+  it('questionType=group with per-condition filters restricts via HAVING COUNT', async () => {
+    await runQuestionsData({
+      take: 10,
+      questionType: QuestionItemType.Group,
+      chainId: 8453,
+    });
+    const sql = capturedSql();
+    expect(sql).toContain('HAVING COUNT(c.id) >= 2');
+  });
+
+  it('questionType=condition unwraps a single-condition group into a condition item', async () => {
+    queryRawMock.mockResolvedValue([
+      {
+        item_type: 'group',
+        group_id: 1,
+        condition_id: null,
+        prediction_count: 3n,
+        sort_value: 100,
+        end_time: 1_900_000_000,
+      },
+    ]);
+    conditionGroupFindManyMock.mockResolvedValue([
+      { id: 1, condition: [{ id: '0xabc' }] },
+    ]);
+
+    const { items } = await runQuestionsData({
+      take: 10,
+      questionType: QuestionItemType.Condition,
+    });
+
+    expect(items).toHaveLength(1);
+    const item = items[0] as unknown as {
+      questionType: string;
+      condition: { id: string } | null;
+    };
+    expect(item.questionType).toBe(QuestionItemType.Condition);
+    expect(item.condition?.id).toBe('0xabc');
+  });
+
+  it('questionType=condition drops a group that hydrates with multiple conditions', async () => {
+    queryRawMock.mockResolvedValue([
+      {
+        item_type: 'group',
+        group_id: 1,
+        condition_id: null,
+        prediction_count: 5n,
+        sort_value: 100,
+        end_time: 1_900_000_000,
+      },
+    ]);
+    conditionGroupFindManyMock.mockResolvedValue([
+      { id: 1, condition: [{ id: '0xabc' }, { id: '0xdef' }] },
+    ]);
+
+    const { items } = await runQuestionsData({
+      take: 10,
+      questionType: QuestionItemType.Condition,
+    });
+    expect(items).toHaveLength(0);
+  });
+
+  it('questionType=group drops a group that hydrates down to a single condition', async () => {
+    queryRawMock.mockResolvedValue([
+      {
+        item_type: 'group',
+        group_id: 1,
+        condition_id: null,
+        prediction_count: 2n,
+        sort_value: 100,
+        end_time: 1_900_000_000,
+      },
+    ]);
+    conditionGroupFindManyMock.mockResolvedValue([
+      { id: 1, condition: [{ id: '0xabc' }] },
+    ]);
+
+    const { items } = await runQuestionsData({
+      take: 10,
+      questionType: QuestionItemType.Group,
+    });
+    expect(items).toHaveLength(0);
   });
 });

--- a/packages/api/src/graphql/sdl/resolvers/queries/questions.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/questions.ts
@@ -181,6 +181,13 @@ export interface RunQuestionsInput {
   sortField?: QuestionSortField | null;
   sortDirection?: SortOrder | null;
   afterCursor?: QuestionCursor | null;
+  /**
+   * Restrict by *rendered* item type. `condition` admits ungrouped
+   * conditions plus single-condition groups (which hydration unwraps
+   * into standalone condition items); `group` admits only groups with
+   * 2+ matching conditions.
+   */
+  questionType?: QuestionItemType | null;
 }
 
 interface NormalizedArgs {
@@ -202,6 +209,7 @@ interface NormalizedArgs {
   sortField: string;
   sortDirectionRaw: 'ASC' | 'DESC';
   afterCursor: QuestionCursor | null;
+  questionType: QuestionItemType | null;
   volumeKey: VolumeKey;
   useWindowedSimilarMarketVolume: boolean;
   /**
@@ -271,6 +279,7 @@ const normalizeArgs = (args: RunQuestionsInput): NormalizedArgs => {
     sortField,
     sortDirectionRaw: args.sortDirection === 'asc' ? 'ASC' : 'DESC',
     afterCursor: args.afterCursor ?? null,
+    questionType: args.questionType ?? null,
     volumeKey,
     useWindowedSimilarMarketVolume,
     requiresConditionJoin:
@@ -460,8 +469,19 @@ const buildSortFragments = (
     ? Prisma.sql`COALESCE(MAX(c."endTime"), 0)`
     : Prisma.sql`cg."maxEndTime"`;
 
+  // `questionType` filters by *rendered* item type: single-condition
+  // groups unwrap into standalone condition items at hydration, so
+  // `condition` admits only groups with exactly one matching condition
+  // and `group` admits only groups with 2+.
+  const groupCountHaving =
+    n.questionType === QuestionItemType.Condition
+      ? Prisma.sql`HAVING COUNT(c.id) = 1`
+      : n.questionType === QuestionItemType.Group
+        ? Prisma.sql`HAVING COUNT(c.id) >= 2`
+        : Prisma.sql`HAVING COUNT(c.id) > 0`;
+
   const groupByClause = n.requiresConditionJoin
-    ? Prisma.sql`GROUP BY cg.id HAVING COUNT(c.id) > 0`
+    ? Prisma.sql`GROUP BY cg.id ${groupCountHaving}`
     : Prisma.empty;
 
   const condSortValue =
@@ -611,24 +631,22 @@ const fetchSortedItems = async (
     ? Prisma.empty
     : Prisma.sql`OFFSET ${n.skip}`;
 
-  return prisma.$queryRaw<SortedItemRow[]>`
-    WITH combined AS (
-      -- Part A: Active groups
-      SELECT
-        'group' as item_type,
-        cg.id as group_id,
-        NULL::text as condition_id,
-        ${sort.groupSortValue} as sort_value,
-        ${sort.groupPredictionCount} as prediction_count,
-        ${sort.groupEndTime} as end_time
-      FROM condition_group cg
-      ${sort.groupConditionJoin}
-      WHERE cg."publicConditionCount" > 0
-        ${search.groupSearch}
-        ${search.groupCategory}
-        ${search.groupTag}
-      ${sort.groupByClause}
+  // Without the condition join, the denormalized public count stands in
+  // for COUNT(c.id) in the questionType restriction — consistent with
+  // the hydration-time unwrap, whose `conditionWhere` is just
+  // `public: true` when no per-condition filters are active.
+  const groupPublicCountFilter = n.requiresConditionJoin
+    ? Prisma.empty
+    : n.questionType === QuestionItemType.Condition
+      ? Prisma.sql`AND cg."publicConditionCount" = 1`
+      : n.questionType === QuestionItemType.Group
+        ? Prisma.sql`AND cg."publicConditionCount" >= 2`
+        : Prisma.empty;
 
+  const ungroupedConditionsPart =
+    n.questionType === QuestionItemType.Group
+      ? Prisma.empty
+      : Prisma.sql`
       UNION ALL
 
       -- Part B: Ungrouped conditions
@@ -645,7 +663,28 @@ const fetchSortedItems = async (
         ${filters.conditionFilters}
         ${search.condSearch}
         ${search.condCategory}
-        ${search.condTag}
+        ${search.condTag}`;
+
+  return prisma.$queryRaw<SortedItemRow[]>`
+    WITH combined AS (
+      -- Part A: Active groups
+      SELECT
+        'group' as item_type,
+        cg.id as group_id,
+        NULL::text as condition_id,
+        ${sort.groupSortValue} as sort_value,
+        ${sort.groupPredictionCount} as prediction_count,
+        ${sort.groupEndTime} as end_time
+      FROM condition_group cg
+      ${sort.groupConditionJoin}
+      WHERE cg."publicConditionCount" > 0
+        ${groupPublicCountFilter}
+        ${search.groupSearch}
+        ${search.groupCategory}
+        ${search.groupTag}
+      ${sort.groupByClause}
+
+      ${ungroupedConditionsPart}
     )
     SELECT item_type, group_id, condition_id, prediction_count, sort_value, end_time
     FROM combined
@@ -859,6 +898,15 @@ export const runQuestionsData = async (
   let skip = n.skip;
   let hasMore = false;
 
+  // The SQL count restriction and the hydration unwrap can disagree
+  // when aggregates drift (trigger lag), so enforce the requested
+  // rendered type after unwrapping too — the refill loop below tops the
+  // page back up after any drops.
+  const matchesRequestedType = (entry: HydratedQuestion) =>
+    n.questionType == null ||
+    (entry.item as { questionType?: QuestionItemType }).questionType ===
+      n.questionType;
+
   while (hydrated.length < n.take) {
     const remaining = n.take - hydrated.length;
     const sortedItems = await fetchSortedItems({
@@ -871,7 +919,11 @@ export const runQuestionsData = async (
     const pageItems = sortedItems.slice(0, remaining);
     if (pageItems.length === 0) break;
 
-    hydrated.push(...(await hydrateItems(pageItems, conditionWhere)));
+    hydrated.push(
+      ...(await hydrateItems(pageItems, conditionWhere)).filter(
+        matchesRequestedType
+      )
+    );
 
     const lastPageItem = pageItems[pageItems.length - 1];
     afterCursor = {

--- a/packages/api/src/graphql/v2/resolvers/Questions.test.ts
+++ b/packages/api/src/graphql/v2/resolvers/Questions.test.ts
@@ -220,6 +220,36 @@ describe('questions (v2)', () => {
     );
   });
 
+  it('maps v2 questionType CONDITION/CONDITION_GROUP to the v1 QuestionItemType', async () => {
+    await callResolver(questions)(
+      null,
+      { first: 10, filter: { questionType: 'CONDITION' } },
+      {},
+      null
+    );
+    expect(mockRunQuestionsData).toHaveBeenCalledWith(
+      expect.objectContaining({ questionType: 'condition' })
+    );
+
+    mockRunQuestionsData.mockClear();
+    await callResolver(questions)(
+      null,
+      { first: 10, filter: { questionType: 'CONDITION_GROUP' } },
+      {},
+      null
+    );
+    expect(mockRunQuestionsData).toHaveBeenCalledWith(
+      expect.objectContaining({ questionType: 'group' })
+    );
+  });
+
+  it('passes questionType: null to the runner when the filter omits it', async () => {
+    await callResolver(questions)(null, { first: 10 }, {}, null);
+    expect(mockRunQuestionsData).toHaveBeenCalledWith(
+      expect.objectContaining({ questionType: null })
+    );
+  });
+
   it('passes resolvers / categorySlugs / search / tag through unchanged', async () => {
     await callResolver(questions)(
       null,

--- a/packages/api/src/graphql/v2/resolvers/queries/questions.ts
+++ b/packages/api/src/graphql/v2/resolvers/queries/questions.ts
@@ -20,6 +20,7 @@ import {
   type RunQuestionsInput,
 } from '../../../sdl/resolvers/queries/questions';
 import {
+  QuestionItemType as V1QuestionItemType,
   QuestionSortField,
   ResolutionStatus as V1ResolutionStatus,
   SortOrder as V1SortOrder,
@@ -28,6 +29,7 @@ import {
 import type {
   QueryResolvers,
   QuestionFilter,
+  QuestionItemKind,
   QuestionItemResolvers,
   ResolutionStatus,
   VolumeWindow,
@@ -46,6 +48,15 @@ const RESOLUTION_STATUS_MAP: Record<ResolutionStatus, V1ResolutionStatus> = {
   RESOLVED_YES: V1ResolutionStatus.ResolvedYes,
   RESOLVED_NO: V1ResolutionStatus.ResolvedNo,
 } as Record<ResolutionStatus, V1ResolutionStatus>;
+
+/**
+ * v2's `QuestionItemKind` values mirror the `QuestionItem` union's
+ * member type names; v1's `QuestionItemType` uses condition/group.
+ */
+const QUESTION_ITEM_KIND_MAP: Record<QuestionItemKind, V1QuestionItemType> = {
+  CONDITION: V1QuestionItemType.Condition,
+  CONDITION_GROUP: V1QuestionItemType.Group,
+} as Record<QuestionItemKind, V1QuestionItemType>;
 
 const VOLUME_WINDOW_MAP: Record<VolumeWindow, V1VolumeWindow> = {
   ONE_HOUR: V1VolumeWindow.OneHour,
@@ -172,6 +183,9 @@ const toRunnerArgs = (
     sortField: order.sortField,
     sortDirection: direction === 'asc' ? V1SortOrder.Asc : V1SortOrder.Desc,
     afterCursor: null,
+    questionType: filter?.questionType
+      ? QUESTION_ITEM_KIND_MAP[filter.questionType]
+      : null,
   };
 };
 

--- a/packages/api/src/graphql/v2/schema/schema.graphql
+++ b/packages/api/src/graphql/v2/schema/schema.graphql
@@ -1594,6 +1594,23 @@ input QuestionFilter {
   the group's conditions. Inclusive on both bounds.
   """
   endsAt: IntRangeFilter
+  """
+  Restrict to one side of the `QuestionItem` union, by *rendered* kind:
+  `CONDITION` returns items that resolve to a standalone Condition
+  (ungrouped conditions plus single-condition groups, which the feed
+  unwraps); `CONDITION_GROUP` returns multi-condition ConditionGroups
+  only. Both kinds when omitted.
+  """
+  questionType: QuestionItemKind
+}
+
+"""
+Which side of the `QuestionItem` union a feed item resolves to. Values
+mirror the union's member type names.
+"""
+enum QuestionItemKind {
+  CONDITION
+  CONDITION_GROUP
 }
 
 """

--- a/packages/sdk/types/graphql.v2.ts
+++ b/packages/sdk/types/graphql.v2.ts
@@ -1358,6 +1358,14 @@ export type QuestionFilter = {
   endsAt?: InputMaybe<IntRangeFilter>;
   /** Range over the Polymarket-derived `estimatedPrice` 0–1 probability. */
   estimatedPrice?: InputMaybe<FloatFilter>;
+  /**
+   * Restrict to one side of the `QuestionItem` union, by *rendered* kind:
+   * `CONDITION` returns items that resolve to a standalone Condition
+   * (ungrouped conditions plus single-condition groups, which the feed
+   * unwraps); `CONDITION_GROUP` returns multi-condition ConditionGroups
+   * only. Both kinds when omitted.
+   */
+  questionType?: InputMaybe<QuestionItemKind>;
   /** Resolution-status filter; defaults to ALL when omitted. */
   resolutionStatus?: InputMaybe<ResolutionStatus>;
   /**
@@ -1387,6 +1395,12 @@ export type QuestionFilter = {
  * type via inline fragments.
  */
 export type QuestionItem = Condition | ConditionGroup;
+
+/**
+ * Which side of the `QuestionItem` union a feed item resolves to. Values
+ * mirror the union's member type names.
+ */
+export type QuestionItemKind = 'CONDITION' | 'CONDITION_GROUP';
 
 export type QuestionOrder = {
   direction: OrderDirection;


### PR DESCRIPTION
## Summary

Adds an optional `questionType` field to the v2 `QuestionFilter` so clients can request only single conditions or only groups from the `questions` connection — e.g. for a featured "Top 5 single conditions" section on the Prediction Home Page.

Counterpart of #1840 (which adds the same capability to the v1 `questions` query on staging). When staging merges into this branch the runner-side changes will conflict trivially — they're the same logic, just applied to the refactored `runQuestionsData` here.

## Schema

New enum, values mirroring the `QuestionItem` union's member type names (`Condition | ConditionGroup`):

```graphql
enum QuestionItemKind {
  CONDITION
  CONDITION_GROUP
}

input QuestionFilter {
  # ...
  questionType: QuestionItemKind
}
```

## Semantics

The filter follows the **rendered** item kind, consistent with the existing single-condition-group unwrap:

- `CONDITION` — ungrouped conditions **plus** groups with exactly one matching condition (these already unwrap into standalone `Condition` union members). Truly ungrouped conditions are rare, so including unwrapped single-condition groups is what makes this useful.
- `CONDITION_GROUP` — groups with 2+ matching conditions only; the ungrouped half of the UNION is skipped entirely.
- Omitted — unchanged behavior.

## Implementation

- v2 resolver maps `QuestionItemKind` → v1 `QuestionItemType` and passes it through `toRunnerArgs`.
- Shared runner (`runQuestionsData`): group-count restriction via the denormalized `publicConditionCount` when no per-condition filters are active, `HAVING COUNT(c.id)` under the condition LEFT JOIN otherwise — mirroring the hydration-time unwrap in both modes.
- Post-hydration guard drops items whose rendered type drifts from the SQL decision (aggregate trigger lag); the runner's existing refill loop tops the page back up, so keyset cursor pagination is unaffected.
- The v1 `questions` resolver on this branch doesn't expose the arg (that's #1840's job); the runner field is optional, so v1 behavior here is unchanged.

## Testing

- Runner tests: SQL shape for both filter values (with/without per-condition filters), unfiltered default, single-condition-group unwrap, and drift guard (red-green TDD).
- v2 resolver tests: `CONDITION`/`CONDITION_GROUP` → v1 enum mapping, `null` passthrough when omitted.
- Full API suite passes (712 tests), `type-check` and `lint` clean.
- `schema.v2.graphql` / `sdk/types/graphql.v2.ts` regenerated via `generate-types`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)