### PR TITLE
feat(market-keeper): extend market ingestion window 21 → 90 days

### DIFF
--- a/packages/market-keeper/src/constants.ts
+++ b/packages/market-keeper/src/constants.ts
@@ -31,7 +31,7 @@ export const ALL_POLYMARKET_RESOLVER_ADDRESSES: string[] =
 export const DEFAULT_SAPIENCE_API_URL = 'https://api.sapience.xyz';
 
 // Maximum end date window (in days) for fetching markets
-export const MAX_END_DATE_DAYS = 21;
+export const MAX_END_DATE_DAYS = 90;
 
 // Minimum volume threshold (in USD) for including markets
 export const MIN_VOLUME_THRESHOLD = 1_000;

--- a/packages/market-keeper/src/generate/index.ts
+++ b/packages/market-keeper/src/generate/index.ts
@@ -28,7 +28,7 @@ export function showHelp(): void {
   console.log(`
 Usage: tsx generate-sapience-conditions.ts [options]
 
-Fetches markets ending within 7 days from Polymarket and submits them to the Sapience API.
+Fetches markets ending within 90 days from Polymarket and submits them to the Sapience API.
 
 Options:
   --dry-run      Show what would be submitted without actually submitting
@@ -81,7 +81,7 @@ export async function main() {
   }
 
   try {
-    // Fetch Polymarket markets ending within 7 days
+    // Fetch Polymarket markets ending within 90 days
     const markets = await fetchEndingSoonestMarkets();
 
     const sapienceData = await groupMarkets(markets, apiUrl);

--- a/packages/market-keeper/src/prices-and-1d-7d-volume/index.ts
+++ b/packages/market-keeper/src/prices-and-1d-7d-volume/index.ts
@@ -6,7 +6,7 @@
  * and submits batch price + volume updates.
  *
  * This covers markets outside the generate/relist windows
- * (e.g., markets ending >21 days from now).
+ * (e.g., markets ending >90 days from now).
  */
 
 import 'dotenv/config';


### PR DESCRIPTION
## What

Raise `MAX_END_DATE_DAYS` from **21 → 90** in the market-keeper generate pipeline, so it ingests Polymarket markets ending up to ~3 months out instead of ~3 weeks. No logic change to the filtering pipeline — only the window bound moves. Also fixes stale `"7 days"` / `">21 days"` comments to describe the new window.

Diff (vs `staging`):
- `constants.ts` — `MAX_END_DATE_DAYS = 90`
- `generate/index.ts` — help text + comment now say "90 days"
- `prices-and-1d-7d-volume/index.ts` — out-of-window example now ">90 days"

## Why

Markets currently only get listed once they're within 21 days of resolving. Widening to 90 days surfaces them ~2 months earlier and catches markets that close/resolve before they'd ever reach the 21-day window.

## Impact (estimated against live Polymarket + prod data)

- **~1,900 net-new markets** ingested as a one-time backfill on first run after merge — group-level estimate after the keeper's existing filters (binary, volume ≥ $1k & liquidity ≥ $1k, non-crypto, always-include). That's roughly **+40%** on the current ~4,600 live tradeable conditions.
- Mostly a **timing shift, not extra throughput** — a market ending in 80 days would enter the 21-day window in ~59 days and be listed anyway; this just lists it earlier. Steady-state inflow is ~unchanged.
- **LLM enrichment cost** for the backfill (Perplexity Sonar endTime search batches 1 call per event ≈ ~230 calls, plus gpt-4o-mini enrichment): **~$4–6** on `perplexity/sonar` or **~$8–14** on `perplexity/sonar-pro`.
- **Runtime:** the generate run paginates further through Gamma (~3–4× more pages per run); still well under the Gamma rate limit.

## Testing

- `pnpm --filter @sapience/market-keeper run type-check` ✅
- `pnpm --filter @sapience/market-keeper run lint` ✅
- `pnpm --filter @sapience/market-keeper run test` ✅ (460 tests). No test references the window value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)