### PR TITLE
Staging -> Main: keeper 90-day window, API boot-seeding fix, questionType filter

### DIFF
--- a/packages/api/schema.graphql
+++ b/packages/api/schema.graphql
@@ -1611,9 +1611,9 @@ type Query {
   protocolVolume(from: DateTimeISO, interval: TimeInterval!, to: DateTimeISO): [VolumeDataPoint!]! @deprecated
 
   """
-  Sorted, paginated list of questions — groups and ungrouped conditions interleaved by the chosen sort field
+  Sorted, paginated list of questions — groups and ungrouped conditions interleaved by the chosen sort field. `questionType` filters by rendered item type: `condition` returns items that resolve to a standalone condition (ungrouped conditions plus single-condition groups, which are unwrapped), `group` returns multi-condition groups only.
   """
-  questions(categorySlugs: [String!], chainId: Int, maxEstimatedPrice: Float, maxSimilarMarketVolume: Float, minEndTime: Int, minEstimatedPrice: Float, minSimilarMarketVolume: Float, resolutionStatus: ResolutionStatus, search: String, similarMarketVolumeWindow: VolumeWindow, skip: Int! = 0, sortDirection: SortOrder! = desc, sortField: QuestionSortField, tag: String, take: Int! = 50): [Question!]!
+  questions(categorySlugs: [String!], chainId: Int, maxEstimatedPrice: Float, maxSimilarMarketVolume: Float, minEndTime: Int, minEstimatedPrice: Float, minSimilarMarketVolume: Float, questionType: QuestionItemType, resolutionStatus: ResolutionStatus, search: String, similarMarketVolumeWindow: VolumeWindow, skip: Int! = 0, sortDirection: SortOrder! = desc, sortField: QuestionSortField, tag: String, take: Int! = 50): [Question!]!
 
   """
   Public referral analytics. Referral codes are attribution hints, not

--- a/packages/api/src/core/config.ts
+++ b/packages/api/src/core/config.ts
@@ -39,6 +39,10 @@ const validators = {
     default: 8000,
     desc: 'Maximum time for a Prisma query to complete',
   }),
+  FIXTURE_SEED_TIMEOUT_MS: num({
+    default: 25000,
+    desc: 'Hard ceiling on how long boot-time fixture seeding may delay binding the HTTP port. Exceeding it is non-fatal — the port binds and seeding continues in the background.',
+  }),
   DATABASE_URL: str({
     desc: 'Postgres connection string',
   }),

--- a/packages/api/src/core/db.test.ts
+++ b/packages/api/src/core/db.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+
+// Importing db.ts is side-effect free: `config` is lazily validated on
+// first property access and the PrismaClient is created lazily in
+// getInstance(), so no DB connection or env validation happens at import.
+// We still set a dummy DATABASE_URL so any accidental access is benign.
+process.env.DATABASE_URL ||= 'postgresql://user:pass@localhost:5432/test';
+
+type DbModule = typeof import('./db');
+let db: DbModule;
+
+beforeAll(async () => {
+  db = await import('./db');
+});
+
+const resolveAfter =
+  <T>(ms: number, value: T) =>
+  (): Promise<T> =>
+    new Promise((resolve) => setTimeout(() => resolve(value), ms));
+
+describe('withQueryTimeout', () => {
+  it('rejects with a labelled error when the operation exceeds the timeout', async () => {
+    await expect(
+      db.withQueryTimeout(resolveAfter(80, 'late'), {
+        label: 'Category.findFirst',
+        timeoutMs: 20,
+      })
+    ).rejects.toThrow('Query timeout: Category.findFirst exceeded 20ms');
+  });
+
+  it('resolves when the operation finishes before the timeout', async () => {
+    await expect(
+      db.withQueryTimeout(resolveAfter(5, 'fast'), {
+        label: 'Category.findFirst',
+        timeoutMs: 200,
+      })
+    ).resolves.toBe('fast');
+  });
+
+  it('bypasses the timeout inside runWithoutQueryTimeout (boot/seed queries)', async () => {
+    // The fix for the boot-timeout -> permanent-502 incident: a one-time
+    // seeding query slower than the request-path timeout must NOT be aborted.
+    await expect(
+      db.runWithoutQueryTimeout(() =>
+        db.withQueryTimeout(resolveAfter(80, 'seeded'), {
+          label: 'Category.findFirst',
+          timeoutMs: 20,
+        })
+      )
+    ).resolves.toBe('seeded');
+  });
+});

--- a/packages/api/src/core/db.ts
+++ b/packages/api/src/core/db.ts
@@ -11,6 +11,54 @@ export const requestContext = new AsyncLocalStorage<{
   requestId: string;
 }>();
 
+/**
+ * Async-scoped opt-out of the request-path query timeout.
+ *
+ * One-time boot/seed queries (fixtures) run before steady-state traffic,
+ * and a transient cold-DB slowdown there must NOT abort the operation:
+ * the request-path timeout exists to shed load, which is meaningless for
+ * seeding. Wrapping a seeding call in `runWithoutQueryTimeout` makes every
+ * Prisma query inside it bypass the timeout in `withQueryTimeout` below.
+ *
+ * This is the root-cause fix for the incident where a boot-time
+ * `Category.findFirst` crossed the 8s timeout, aborted startup before the
+ * HTTP port bound, and 502'd every request until a manual redeploy.
+ */
+const queryTimeoutBypass = new AsyncLocalStorage<true>();
+
+export const runWithoutQueryTimeout = <T>(fn: () => Promise<T>): Promise<T> =>
+  queryTimeoutBypass.run(true, fn);
+
+/**
+ * Race an async operation against a timeout, rejecting with a labelled
+ * error if it overruns. Operations run inside `runWithoutQueryTimeout`
+ * bypass the timeout entirely.
+ *
+ * NOTE: the timeout only stops *waiting* — the underlying query keeps
+ * running on its connection until Postgres finishes it.
+ */
+export const withQueryTimeout = async <T>(
+  run: () => Promise<T>,
+  opts: { label: string; timeoutMs: number }
+): Promise<T> => {
+  if (queryTimeoutBypass.getStore()) return run();
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(
+        new Error(`Query timeout: ${opts.label} exceeded ${opts.timeoutMs}ms`)
+      );
+    }, opts.timeoutMs);
+  });
+
+  try {
+    return await Promise.race([run(), timeoutPromise]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+};
+
 let _instance: PrismaClient | undefined;
 let _extendedInstance: PrismaClient | undefined;
 
@@ -47,38 +95,25 @@ function getInstance(): PrismaClient {
         const store = requestContext.getStore();
         if (store) store.count++;
 
-        const timeout = config.PRISMA_QUERY_TIMEOUT_MS;
-        let timer: ReturnType<typeof setTimeout> | undefined;
-        const timeoutPromise = new Promise<never>((_, reject) => {
-          timer = setTimeout(() => {
-            reject(
-              new Error(
-                `Query timeout: ${model ?? 'raw'}.${operation} exceeded ${timeout}ms`
-              )
-            );
-          }, timeout);
-        });
-
         const start = performance.now();
-        try {
-          const result = await Promise.race([query(args), timeoutPromise]);
-          const durationMs = performance.now() - start;
-          // Per-query logs at debug level — one Prisma operation per
-          // resolver field gets noisy fast in production. Filter with
-          // LOG_LEVEL=debug while investigating.
-          log.debug(
-            {
-              model: model ?? 'raw',
-              operation,
-              durationMs: Number(durationMs.toFixed(1)),
-              requestId: store?.requestId || undefined,
-            },
-            'prisma.query'
-          );
-          return result;
-        } finally {
-          if (timer) clearTimeout(timer);
-        }
+        const result = await withQueryTimeout(() => query(args), {
+          label: `${model ?? 'raw'}.${operation}`,
+          timeoutMs: config.PRISMA_QUERY_TIMEOUT_MS,
+        });
+        const durationMs = performance.now() - start;
+        // Per-query logs at debug level — one Prisma operation per
+        // resolver field gets noisy fast in production. Filter with
+        // LOG_LEVEL=debug while investigating.
+        log.debug(
+          {
+            model: model ?? 'raw',
+            operation,
+            durationMs: Number(durationMs.toFixed(1)),
+            requestId: store?.requestId || undefined,
+          },
+          'prisma.query'
+        );
+        return result;
       },
     },
   }) as unknown as PrismaClient;

--- a/packages/api/src/core/seedFixtures.test.ts
+++ b/packages/api/src/core/seedFixtures.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { seedFixturesWithRetry } from './seedFixtures';
+
+const noopSleep = () => Promise.resolve();
+
+describe('seedFixturesWithRetry', () => {
+  it('retries until the seed succeeds and then stops', async () => {
+    const seed = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Query timeout'))
+      .mockRejectedValueOnce(new Error('Query timeout'))
+      .mockResolvedValueOnce(undefined);
+    const sleep = vi.fn(noopSleep);
+
+    await seedFixturesWithRetry(seed, {
+      maxAttempts: 5,
+      baseDelayMs: 1,
+      sleep,
+    });
+
+    expect(seed).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2); // backoff between the 3 attempts
+  });
+
+  it('throws after exhausting retries (definitive failure → caller crashes loudly)', async () => {
+    const err = new Error('relation "Category" does not exist');
+    const seed = vi.fn().mockRejectedValue(err);
+    const sleep = vi.fn(noopSleep);
+
+    await expect(
+      seedFixturesWithRetry(seed, { maxAttempts: 3, baseDelayMs: 1, sleep })
+    ).rejects.toThrow(err);
+
+    expect(seed).toHaveBeenCalledTimes(3);
+    // sleeps only between attempts, not after the final failure
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT throw when the boot budget elapses, even while retries are failing', async () => {
+    // Slowness must stay non-fatal — crashing here would re-create the
+    // boot-timeout -> permanent-502 incident as a crash-loop.
+    let calls = 0;
+    const seed = vi.fn(() => {
+      calls += 1;
+      // Each attempt hangs; the boot budget (not retry exhaustion) ends it.
+      return new Promise<void>(() => {});
+    });
+
+    await expect(
+      seedFixturesWithRetry(seed, {
+        maxAttempts: 3,
+        baseDelayMs: 1,
+        overallTimeoutMs: 20,
+        sleep: vi.fn(noopSleep),
+      })
+    ).resolves.toBeUndefined();
+
+    expect(calls).toBe(1); // first attempt still hanging when the budget hit
+  });
+
+  it('does not sleep when the first attempt succeeds', async () => {
+    const seed = vi.fn().mockResolvedValueOnce(undefined);
+    const sleep = vi.fn(noopSleep);
+
+    await seedFixturesWithRetry(seed, {
+      maxAttempts: 5,
+      baseDelayMs: 1,
+      sleep,
+    });
+
+    expect(seed).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('stops awaiting and returns when the overall boot budget elapses', async () => {
+    // A hung seed must not block startup forever — the boot budget caps how
+    // long seeding may delay binding the port. This is the regression guard
+    // for the boot-timeout -> permanent-502 incident.
+    const seed = vi.fn(() => new Promise<void>(() => {})); // never resolves
+    const sleep = vi.fn(noopSleep);
+
+    await expect(
+      seedFixturesWithRetry(seed, {
+        overallTimeoutMs: 20,
+        baseDelayMs: 1,
+        sleep,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(seed).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/src/core/seedFixtures.ts
+++ b/packages/api/src/core/seedFixtures.ts
@@ -1,0 +1,107 @@
+import { createLogger } from './logger';
+
+const log = createLogger('fixtures');
+
+export interface SeedRetryOptions {
+  /** Total attempts before giving up (logged, never thrown). */
+  maxAttempts?: number;
+  /** Base backoff; the delay before attempt N is baseDelayMs * (N-1). */
+  baseDelayMs?: number;
+  /**
+   * Hard ceiling on how long seeding may delay startup. When exceeded we
+   * stop awaiting and return (non-fatal); any in-flight attempt keeps
+   * running in the background. Omit to wait for the retry loop to finish.
+   */
+  overallTimeoutMs?: number;
+  /** Injectable for tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run a one-time seeding operation with bounded retry. Two terminal modes,
+ * by design — they correspond to genuinely different failure causes:
+ *
+ *   - RESOLVES on success, OR when the overall boot budget elapses while a
+ *     seed is still in flight (slow/hung query). Budget-exceeded is logged
+ *     at error level (→ Sentry) but NON-FATAL: the caller binds the port
+ *     and serves. Crashing on slowness would just re-create the
+ *     boot-timeout → permanent-502 incident as a crash-loop.
+ *   - THROWS when every retry errors out before the budget elapses
+ *     (definitive failure). With the DB already connected (initializeDataSource
+ *     runs first), that means seeding genuinely can't proceed — a real bug or
+ *     bad deploy — so the caller should crash loudly and let the platform
+ *     restart, rather than serve an unseeded API.
+ *
+ * Boot queries bypass the request-path 8s timeout (the caller wraps `seed`
+ * in runWithoutQueryTimeout) so a slow-but-progressing cold-boot query isn't
+ * killed; `overallTimeoutMs` is the only ceiling on how long seeding may
+ * hold up the port.
+ */
+export const seedFixturesWithRetry = async (
+  seed: () => Promise<void>,
+  {
+    maxAttempts = 5,
+    baseDelayMs = 1_000,
+    overallTimeoutMs,
+    sleep = defaultSleep,
+  }: SeedRetryOptions = {}
+): Promise<void> => {
+  let timedOut = false;
+
+  const loop = async (): Promise<void> => {
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      if (timedOut) return;
+      try {
+        await seed();
+        if (attempt > 1) {
+          log.info({ attempt }, 'Fixture seeding succeeded after retry');
+        }
+        return;
+      } catch (err) {
+        // Budget elapsed mid-flight: stop quietly — the caller has already
+        // moved on and binding the port must not be undone by a late throw.
+        if (timedOut) return;
+        if (attempt >= maxAttempts) {
+          log.error(
+            { err, attempt },
+            'Fixture seeding failed after all retries'
+          );
+          throw err;
+        }
+        log.warn({ err, attempt }, 'Fixture seeding attempt failed; retrying');
+        await sleep(baseDelayMs * attempt);
+      }
+    }
+  };
+
+  if (overallTimeoutMs == null) {
+    await loop();
+    return;
+  }
+
+  let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<'timeout'>((resolve) => {
+    deadlineTimer = setTimeout(() => {
+      timedOut = true;
+      resolve('timeout');
+    }, overallTimeoutMs);
+  });
+
+  try {
+    const result = await Promise.race([
+      loop().then(() => 'done' as const),
+      deadline,
+    ]);
+    if (result === 'timeout') {
+      log.error(
+        { overallTimeoutMs },
+        'Fixture seeding exceeded boot budget; binding port anyway (any in-flight seed continues in the background)'
+      );
+    }
+  } finally {
+    if (deadlineTimer) clearTimeout(deadlineTimer);
+  }
+};

--- a/packages/api/src/core/server.ts
+++ b/packages/api/src/core/server.ts
@@ -11,7 +11,8 @@ import { startInflightDump } from '../runtime/inflightDump';
 import Sentry from './instrument';
 import { NextFunction, Request, Response } from 'express';
 import { initializeFixtures } from '../fixtures';
-import prisma from './db';
+import { seedFixturesWithRetry } from './seedFixtures';
+import prisma, { runWithoutQueryTimeout } from './db';
 import { config } from './config';
 import { createLogger } from './logger';
 import { createConcurrencyLimiter } from '../runtime/concurrencyLimiter';
@@ -31,13 +32,25 @@ initSentry();
 const startServer = async () => {
   await initializeDataSource();
 
+  // Seed fixtures from fixtures.json before serving. Boot queries bypass the
+  // request-path 8s timeout (runWithoutQueryTimeout) so a slow cold-boot query
+  // isn't killed. Two outcomes, by design:
+  //   - definitive failure (every retry errors out) -> seedFixturesWithRetry
+  //     throws -> the outer catch process.exit(1)s -> the platform restarts.
+  //     A deploy that genuinely can't seed should fail loudly, not serve.
+  //   - slow/hung seed (exceeds FIXTURE_SEED_TIMEOUT_MS) -> non-fatal: bind
+  //     the port and serve (logged to Sentry). Crashing on slowness would
+  //     just re-create the boot-timeout -> permanent-502 incident as a
+  //     crash-loop.
   if (config.isDev && process.env.DATABASE_URL?.includes('railway')) {
     log.info(
       'Skipping fixtures initialization (dev mode + production database)'
     );
   } else {
-    // Initialize fixtures from fixtures.json
-    await initializeFixtures();
+    await seedFixturesWithRetry(
+      () => runWithoutQueryTimeout(() => initializeFixtures()),
+      { overallTimeoutMs: config.FIXTURE_SEED_TIMEOUT_MS }
+    );
   }
 
   const apolloServer = await initializeApolloServer();
@@ -252,5 +265,10 @@ const startServer = async () => {
 try {
   await startServer();
 } catch (err) {
+  // Exit so the platform restarts the container. Without this the process
+  // lingers (the pg pool keeps the event loop alive) with no HTTP listener
+  // bound, returning 502 for every request indefinitely — a failed boot
+  // must crash-and-restart, not become a portless zombie.
   log.fatal({ err }, 'Unable to start server');
+  process.exit(1);
 }

--- a/packages/api/src/graphql/sdl/resolvers/queries/questions.test.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/questions.test.ts
@@ -1,12 +1,23 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { queryRawMock, conditionGroupFindManyMock, conditionFindManyMock } =
+  vi.hoisted(() => ({
+    queryRawMock: vi.fn(),
+    conditionGroupFindManyMock: vi.fn(),
+    conditionFindManyMock: vi.fn(),
+  }));
 
 vi.mock('../../../../core/db', () => ({
   default: {
-    $queryRaw: vi.fn(),
+    $queryRaw: queryRawMock,
+    conditionGroup: { findMany: conditionGroupFindManyMock },
+    condition: { findMany: conditionFindManyMock },
   },
 }));
 
-const { resolveVolumeKey } = await import('./questions');
+const { resolveVolumeKey, questions } = await import('./questions');
+const { Prisma } = await import('../../../../../generated/prisma');
+const { QuestionItemType } = await import('../../__generated__/resolvers');
 
 describe('resolveVolumeKey', () => {
   it('maps GraphQL VolumeWindow enum values to internal volume keys', () => {
@@ -30,5 +41,144 @@ describe('resolveVolumeKey', () => {
   it('falls back to volume24h for unrecognized window values', () => {
     expect(resolveVolumeKey('1hFiltered')).toBe('volume24h');
     expect(resolveVolumeKey('bogus')).toBe('volume24h');
+  });
+});
+
+/**
+ * Reconstruct the flattened SQL text of the (single) $queryRaw call —
+ * the resolver invokes it as a tagged template, so the captured args
+ * are [TemplateStringsArray, ...values] and Prisma.sql flattens any
+ * nested Sql fragments for us.
+ */
+const capturedSql = (): string => {
+  expect(queryRawMock).toHaveBeenCalledTimes(1);
+  const [strings, ...values] = queryRawMock.mock.calls[0] as [
+    TemplateStringsArray,
+    ...unknown[],
+  ];
+  return Prisma.sql(strings, ...values).sql.replace(/\s+/g, ' ');
+};
+
+const baseArgs = {
+  take: 50,
+  skip: 0,
+  sortDirection: 'desc',
+} as const;
+
+const callQuestions = (extra: Record<string, unknown> = {}) =>
+  (
+    questions as unknown as (
+      parent: unknown,
+      args: Record<string, unknown>
+    ) => Promise<unknown[]>
+  )({}, { ...baseArgs, ...extra });
+
+describe('questions questionType filter', () => {
+  beforeEach(() => {
+    queryRawMock.mockReset().mockResolvedValue([]);
+    conditionGroupFindManyMock.mockReset().mockResolvedValue([]);
+    conditionFindManyMock.mockReset().mockResolvedValue([]);
+  });
+
+  it('includes both UNION parts and all active groups when questionType is omitted', async () => {
+    await callQuestions();
+    const sql = capturedSql();
+    expect(sql).toContain('UNION ALL');
+    expect(sql).toContain('"conditionGroupId" IS NULL');
+    expect(sql).not.toContain('"publicConditionCount" = 1');
+    expect(sql).not.toContain('"publicConditionCount" >= 2');
+  });
+
+  it('questionType=condition keeps ungrouped conditions and restricts groups to single-condition groups', async () => {
+    await callQuestions({ questionType: QuestionItemType.Condition });
+    const sql = capturedSql();
+    expect(sql).toContain('"conditionGroupId" IS NULL');
+    expect(sql).toContain('"publicConditionCount" = 1');
+  });
+
+  it('questionType=group omits ungrouped conditions and restricts to multi-condition groups', async () => {
+    await callQuestions({ questionType: QuestionItemType.Group });
+    const sql = capturedSql();
+    expect(sql).not.toContain('UNION ALL');
+    expect(sql).not.toContain('"conditionGroupId" IS NULL');
+    expect(sql).toContain('"publicConditionCount" >= 2');
+  });
+
+  it('questionType=condition with per-condition filters restricts via HAVING COUNT', async () => {
+    await callQuestions({
+      questionType: QuestionItemType.Condition,
+      chainId: 8453,
+    });
+    const sql = capturedSql();
+    expect(sql).toContain('HAVING COUNT(c.id) = 1');
+  });
+
+  it('questionType=group with per-condition filters restricts via HAVING COUNT', async () => {
+    await callQuestions({
+      questionType: QuestionItemType.Group,
+      chainId: 8453,
+    });
+    const sql = capturedSql();
+    expect(sql).toContain('HAVING COUNT(c.id) >= 2');
+  });
+
+  it('questionType=condition unwraps a single-condition group into a condition item', async () => {
+    queryRawMock.mockResolvedValue([
+      {
+        item_type: 'group',
+        group_id: 1,
+        condition_id: null,
+        prediction_count: 3n,
+      },
+    ]);
+    conditionGroupFindManyMock.mockResolvedValue([
+      { id: 1, condition: [{ id: '0xabc' }] },
+    ]);
+
+    const result = (await callQuestions({
+      questionType: QuestionItemType.Condition,
+    })) as Array<{ questionType: string; condition: { id: string } | null }>;
+
+    expect(result).toHaveLength(1);
+    expect(result[0].questionType).toBe(QuestionItemType.Condition);
+    expect(result[0].condition?.id).toBe('0xabc');
+  });
+
+  it('questionType=condition drops a group that hydrates with multiple conditions', async () => {
+    queryRawMock.mockResolvedValue([
+      {
+        item_type: 'group',
+        group_id: 1,
+        condition_id: null,
+        prediction_count: 5n,
+      },
+    ]);
+    conditionGroupFindManyMock.mockResolvedValue([
+      { id: 1, condition: [{ id: '0xabc' }, { id: '0xdef' }] },
+    ]);
+
+    const result = await callQuestions({
+      questionType: QuestionItemType.Condition,
+    });
+    expect(result).toHaveLength(0);
+  });
+
+  it('questionType=group drops a group that hydrates down to a single condition', async () => {
+    queryRawMock.mockResolvedValue([
+      {
+        item_type: 'group',
+        group_id: 1,
+        condition_id: null,
+        prediction_count: 2n,
+      },
+    ]);
+    conditionGroupFindManyMock.mockResolvedValue([
+      { id: 1, condition: [{ id: '0xabc' }] },
+    ]);
+
+    const result = await callQuestions({
+      questionType: QuestionItemType.Group,
+    });
+    expect(result).toHaveLength(0);
   });
 });

--- a/packages/api/src/graphql/sdl/resolvers/queries/questions.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/questions.ts
@@ -141,6 +141,7 @@ export const questions: NonNullable<QueryResolvers['questions']> = async (
     maxSimilarMarketVolume,
     tag,
     similarMarketVolumeWindow,
+    questionType,
   }
 ) => {
   const sanitizedSortField = sortField ?? 'endTime';
@@ -271,9 +272,33 @@ export const questions: NonNullable<QueryResolvers['questions']> = async (
     ? Prisma.sql`COALESCE(MAX(c."endTime"), 0)`
     : Prisma.sql`cg."maxEndTime"`;
 
+  // `questionType` filters by *rendered* item type: single-condition
+  // groups unwrap into standalone condition items at hydration, so
+  // `condition` admits ungrouped conditions plus groups with exactly
+  // one matching condition; `group` admits only groups with 2+.
+  const groupCountHaving =
+    questionType === 'condition'
+      ? Prisma.sql`HAVING COUNT(c.id) = 1`
+      : questionType === 'group'
+        ? Prisma.sql`HAVING COUNT(c.id) >= 2`
+        : Prisma.sql`HAVING COUNT(c.id) > 0`;
+
   const groupByClause = requiresConditionJoin
-    ? Prisma.sql`GROUP BY cg.id HAVING COUNT(c.id) > 0`
+    ? Prisma.sql`GROUP BY cg.id ${groupCountHaving}`
     : Prisma.empty;
+
+  // Without the condition join, the denormalized public count stands in
+  // for COUNT(c.id) — consistent with the hydration-time unwrap, whose
+  // `conditionWhere` is just `public: true` when no filters are active.
+  const groupPublicCountFilter = requiresConditionJoin
+    ? Prisma.empty
+    : questionType === 'condition'
+      ? Prisma.sql`AND cg."publicConditionCount" = 1`
+      : questionType === 'group'
+        ? Prisma.sql`AND cg."publicConditionCount" >= 2`
+        : Prisma.empty;
+
+  const includeUngroupedConditions = questionType !== 'group';
 
   const condSortValue =
     sanitizedSortField === 'openInterest'
@@ -301,6 +326,7 @@ export const questions: NonNullable<QueryResolvers['questions']> = async (
       FROM condition_group cg
       ${groupConditionJoin}
       WHERE cg."publicConditionCount" > 0
+        ${groupPublicCountFilter}
         ${
           boundedSearch
             ? Prisma.sql`AND (
@@ -335,6 +361,9 @@ export const questions: NonNullable<QueryResolvers['questions']> = async (
         }
       ${groupByClause}
 
+      ${
+        includeUngroupedConditions
+          ? Prisma.sql`
       UNION ALL
 
       -- Part B: Ungrouped conditions
@@ -363,7 +392,9 @@ export const questions: NonNullable<QueryResolvers['questions']> = async (
           boundedTag
             ? Prisma.sql`AND ${boundedTag} = ANY(c.tags)`
             : Prisma.empty
-        }
+        }`
+          : Prisma.empty
+      }
     )
     SELECT item_type, group_id, condition_id, prediction_count
     FROM combined
@@ -501,6 +532,18 @@ export const questions: NonNullable<QueryResolvers['questions']> = async (
         predictionCount: Number(item.prediction_count),
       });
     }
+  }
+
+  // The SQL count restriction and the hydration unwrap can disagree
+  // when aggregates drift (trigger lag), so enforce the requested
+  // rendered type after unwrapping too.
+  if (questionType != null) {
+    // Items are pushed as plain objects above; the ResolverTypeWrapper
+    // union just obscures that from the type checker.
+    return result.filter(
+      (q) =>
+        (q as { questionType: QuestionItemType }).questionType === questionType
+    );
   }
 
   return result;

--- a/packages/api/src/graphql/sdl/schema/schema.graphql
+++ b/packages/api/src/graphql/sdl/schema/schema.graphql
@@ -1622,9 +1622,9 @@ type Query {
   protocolVolume(from: DateTimeISO, interval: TimeInterval!, to: DateTimeISO): [VolumeDataPoint!]! @deprecated
 
   """
-  Sorted, paginated list of questions — groups and ungrouped conditions interleaved by the chosen sort field
+  Sorted, paginated list of questions — groups and ungrouped conditions interleaved by the chosen sort field. `questionType` filters by rendered item type: `condition` returns items that resolve to a standalone condition (ungrouped conditions plus single-condition groups, which are unwrapped), `group` returns multi-condition groups only.
   """
-  questions(categorySlugs: [String!], chainId: Int, maxEstimatedPrice: Float, maxSimilarMarketVolume: Float, minEndTime: Int, minEstimatedPrice: Float, minSimilarMarketVolume: Float, resolutionStatus: ResolutionStatus, search: String, similarMarketVolumeWindow: VolumeWindow, skip: Int! = 0, sortDirection: SortOrder! = desc, sortField: QuestionSortField, tag: String, take: Int! = 50): [Question!]!
+  questions(categorySlugs: [String!], chainId: Int, maxEstimatedPrice: Float, maxSimilarMarketVolume: Float, minEndTime: Int, minEstimatedPrice: Float, minSimilarMarketVolume: Float, questionType: QuestionItemType, resolutionStatus: ResolutionStatus, search: String, similarMarketVolumeWindow: VolumeWindow, skip: Int! = 0, sortDirection: SortOrder! = desc, sortField: QuestionSortField, tag: String, take: Int! = 50): [Question!]!
 
   """
   Public referral analytics. Referral codes are attribution hints, not

--- a/packages/api/test/contract/__snapshots__/introspection.json
+++ b/packages/api/test/contract/__snapshots__/introspection.json
@@ -16697,7 +16697,7 @@
           },
           {
             "name": "questions",
-            "description": "Sorted, paginated list of questions — groups and ungrouped conditions interleaved by the chosen sort field",
+            "description": "Sorted, paginated list of questions — groups and ungrouped conditions interleaved by the chosen sort field. `questionType` filters by rendered item type: `condition` returns items that resolve to a standalone condition (ungrouped conditions plus single-condition groups, which are unwrapped), `group` returns multi-condition groups only.",
             "args": [
               {
                 "name": "categorySlugs",
@@ -16773,6 +16773,16 @@
                 "type": {
                   "kind": "SCALAR",
                   "name": "Float",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "questionType",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "QuestionItemType",
                   "ofType": null
                 },
                 "defaultValue": null

--- a/packages/api/test/contract/__snapshots__/schema.sdl.graphql
+++ b/packages/api/test/contract/__snapshots__/schema.sdl.graphql
@@ -1611,9 +1611,9 @@ type Query {
   protocolVolume(from: DateTimeISO, interval: TimeInterval!, to: DateTimeISO): [VolumeDataPoint!]! @deprecated
 
   """
-  Sorted, paginated list of questions — groups and ungrouped conditions interleaved by the chosen sort field
+  Sorted, paginated list of questions — groups and ungrouped conditions interleaved by the chosen sort field. `questionType` filters by rendered item type: `condition` returns items that resolve to a standalone condition (ungrouped conditions plus single-condition groups, which are unwrapped), `group` returns multi-condition groups only.
   """
-  questions(categorySlugs: [String!], chainId: Int, maxEstimatedPrice: Float, maxSimilarMarketVolume: Float, minEndTime: Int, minEstimatedPrice: Float, minSimilarMarketVolume: Float, resolutionStatus: ResolutionStatus, search: String, similarMarketVolumeWindow: VolumeWindow, skip: Int! = 0, sortDirection: SortOrder! = desc, sortField: QuestionSortField, tag: String, take: Int! = 50): [Question!]!
+  questions(categorySlugs: [String!], chainId: Int, maxEstimatedPrice: Float, maxSimilarMarketVolume: Float, minEndTime: Int, minEstimatedPrice: Float, minSimilarMarketVolume: Float, questionType: QuestionItemType, resolutionStatus: ResolutionStatus, search: String, similarMarketVolumeWindow: VolumeWindow, skip: Int! = 0, sortDirection: SortOrder! = desc, sortField: QuestionSortField, tag: String, take: Int! = 50): [Question!]!
 
   """
   Public referral analytics. Referral codes are attribution hints, not

--- a/packages/app/src/hooks/referrals/__tests__/useAdminReferralCodes.test.ts
+++ b/packages/app/src/hooks/referrals/__tests__/useAdminReferralCodes.test.ts
@@ -51,6 +51,29 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+const makeClaimant = (n: number) => ({
+  address: `0x${n.toString(16).padStart(40, '0')}`,
+  tradingVolume: '0',
+  positionCount: 0,
+});
+
+const analyticsPage = (
+  claimants: ReturnType<typeof makeClaimant>[],
+  nextCursor: number | null
+) => ({
+  referralCodes: {
+    items: [
+      {
+        id: 1,
+        claimCount: 3,
+        totalVolume: '123',
+        totalPositions: 7,
+        claimants: { items: claimants, nextCursor },
+      },
+    ],
+  },
+});
+
 describe('useAdminReferralCodes — pagination', () => {
   it('returns the single page when nextCursor is null', async () => {
     mockGraphqlRequest.mockResolvedValueOnce(
@@ -67,7 +90,7 @@ describe('useAdminReferralCodes — pagination', () => {
     });
     expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
     expect(mockGraphqlRequest).toHaveBeenCalledWith(expect.any(String), {
-      limit: 500,
+      limit: 100,
       cursor: null,
     });
   });
@@ -88,15 +111,15 @@ describe('useAdminReferralCodes — pagination', () => {
     });
     expect(mockGraphqlRequest).toHaveBeenCalledTimes(3);
     expect(mockGraphqlRequest).toHaveBeenNthCalledWith(1, expect.any(String), {
-      limit: 500,
+      limit: 100,
       cursor: null,
     });
     expect(mockGraphqlRequest).toHaveBeenNthCalledWith(2, expect.any(String), {
-      limit: 500,
+      limit: 100,
       cursor: 9,
     });
     expect(mockGraphqlRequest).toHaveBeenNthCalledWith(3, expect.any(String), {
-      limit: 500,
+      limit: 100,
       cursor: 7,
     });
   });
@@ -116,6 +139,87 @@ describe('useAdminReferralCodes — pagination', () => {
     });
     // 50 pages × 1 row each
     expect(result.current.data?.length).toBe(50);
+    expect(mockGraphqlRequest).toHaveBeenCalledTimes(50);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('MAX_PAGES'));
+    warn.mockRestore();
+  });
+});
+
+describe('useAdminReferralCodeAnalytics — claimants pagination', () => {
+  it('returns a single page of claimants when nextCursor is null', async () => {
+    mockGraphqlRequest.mockResolvedValueOnce(
+      analyticsPage([makeClaimant(1), makeClaimant(2)], null)
+    );
+
+    const { useAdminReferralCodeAnalytics } = await import(
+      '../useAdminReferralCodes'
+    );
+    const { result } = renderHook(() => useAdminReferralCodeAnalytics(1), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toBeDefined();
+    });
+    expect(result.current.data?.claimants.length).toBe(2);
+    expect(result.current.data?.totalVolume).toBe('123');
+    expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(expect.any(String), {
+      id: 1,
+      claimantsLimit: 100,
+      claimantsCursor: null,
+    });
+  });
+
+  it('follows nextCursor across claimant pages and concatenates results', async () => {
+    mockGraphqlRequest
+      .mockResolvedValueOnce(
+        analyticsPage([makeClaimant(1), makeClaimant(2)], 2)
+      )
+      .mockResolvedValueOnce(analyticsPage([makeClaimant(3)], null));
+
+    const { useAdminReferralCodeAnalytics } = await import(
+      '../useAdminReferralCodes'
+    );
+    const { result } = renderHook(() => useAdminReferralCodeAnalytics(1), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.claimants.length).toBe(3);
+    });
+    expect(result.current.data?.claimants.map((c) => c.address)).toEqual([
+      makeClaimant(1).address,
+      makeClaimant(2).address,
+      makeClaimant(3).address,
+    ]);
+    expect(mockGraphqlRequest).toHaveBeenNthCalledWith(1, expect.any(String), {
+      id: 1,
+      claimantsLimit: 100,
+      claimantsCursor: null,
+    });
+    expect(mockGraphqlRequest).toHaveBeenNthCalledWith(2, expect.any(String), {
+      id: 1,
+      claimantsLimit: 100,
+      claimantsCursor: 2,
+    });
+  });
+
+  it('caps at MAX_PAGES so a non-progressing claimants cursor cannot loop forever', async () => {
+    mockGraphqlRequest.mockResolvedValue(analyticsPage([makeClaimant(1)], 1));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { useAdminReferralCodeAnalytics } = await import(
+      '../useAdminReferralCodes'
+    );
+    const { result } = renderHook(() => useAdminReferralCodeAnalytics(1), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toBeDefined();
+    });
+    expect(result.current.data?.claimants.length).toBe(50);
     expect(mockGraphqlRequest).toHaveBeenCalledTimes(50);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('MAX_PAGES'));
     warn.mockRestore();

--- a/packages/app/src/hooks/referrals/useAdminReferralCodes.ts
+++ b/packages/app/src/hooks/referrals/useAdminReferralCodes.ts
@@ -115,10 +115,10 @@ const REFERRAL_CODES_QUERY = `
   }
 `;
 
-// Server caps `limit` at 500 per page. We auto-paginate so the admin UI
-// doesn't silently truncate at 500 codes; MAX_PAGES is a safety net against
-// a buggy server returning a non-progressing cursor.
-const PAGE_SIZE = 500;
+// The API rejects any `limit` above GRAPHQL_MAX_LIST_SIZE (100) with a 400.
+// We auto-paginate so the admin UI doesn't silently truncate; MAX_PAGES is a
+// safety net against a buggy server returning a non-progressing cursor.
+const PAGE_SIZE = 100;
 const MAX_PAGES = 50;
 
 type ReferralCodesPageResponse = {
@@ -128,15 +128,34 @@ type ReferralCodesPageResponse = {
   };
 };
 
+type ReferralCodeAnalyticsResponse = {
+  referralCodes: {
+    items: Array<{
+      id: number;
+      claimCount: number;
+      totalVolume: string;
+      totalPositions: number;
+      claimants: {
+        items: Array<{
+          address: string;
+          tradingVolume: string;
+          positionCount: number;
+        }>;
+        nextCursor: number | null;
+      };
+    }>;
+  };
+};
+
 const REFERRAL_CODE_ANALYTICS_QUERY = `
-  query AdminReferralCodeAnalytics($id: Int!, $claimantsLimit: Int!) {
+  query AdminReferralCodeAnalytics($id: Int!, $claimantsLimit: Int!, $claimantsCursor: Int) {
     referralCodes(id: $id, limit: 1) {
       items {
         id
         claimCount
         totalVolume
         totalPositions
-        claimants(limit: $claimantsLimit) {
+        claimants(limit: $claimantsLimit, cursor: $claimantsCursor) {
           items {
             address
             tradingVolume
@@ -181,24 +200,34 @@ export function useAdminReferralCodeAnalytics(
   return useQuery<AdminReferralAnalytics>({
     queryKey: ['admin', 'referralCodeAnalytics', id],
     queryFn: async () => {
-      const data = await graphqlRequest<{
-        referralCodes: {
-          items: Array<{
-            id: number;
-            claimCount: number;
-            totalVolume: string;
-            totalPositions: number;
-            claimants: {
-              items: Array<{
-                address: string;
-                tradingVolume: string;
-                positionCount: number;
-              }>;
-            };
-          }>;
-        };
-      }>(REFERRAL_CODE_ANALYTICS_QUERY, { id, claimantsLimit: 500 });
-      const code = data.referralCodes.items[0];
+      const claimants: AdminReferralAnalytics['claimants'] = [];
+      let code: {
+        id: number;
+        claimCount: number;
+        totalVolume: string;
+        totalPositions: number;
+      } | null = null;
+      let cursor: number | null = null;
+      for (let page = 0; page < MAX_PAGES; page += 1) {
+        const data: ReferralCodeAnalyticsResponse =
+          await graphqlRequest<ReferralCodeAnalyticsResponse>(
+            REFERRAL_CODE_ANALYTICS_QUERY,
+            { id, claimantsLimit: PAGE_SIZE, claimantsCursor: cursor }
+          );
+        const item = data.referralCodes.items[0];
+        if (!item) {
+          throw new Error('Referral code not found');
+        }
+        code ??= item;
+        claimants.push(...item.claimants.items);
+        cursor = item.claimants.nextCursor;
+        if (cursor == null) break;
+        if (page === MAX_PAGES - 1) {
+          console.warn(
+            `useAdminReferralCodeAnalytics: stopped at MAX_PAGES (${MAX_PAGES}); claimants may be truncated`
+          );
+        }
+      }
       if (!code) {
         throw new Error('Referral code not found');
       }
@@ -207,7 +236,7 @@ export function useAdminReferralCodeAnalytics(
         claimCount: code.claimCount,
         totalVolume: code.totalVolume,
         totalPositions: code.totalPositions,
-        claimants: code.claimants.items,
+        claimants,
       };
     },
     enabled: typeof id === 'number',

--- a/packages/market-keeper/docs/add-events-staging-test.md
+++ b/packages/market-keeper/docs/add-events-staging-test.md
@@ -1,0 +1,111 @@
+# add-events: staging test plan
+
+`scripts/add-events.ts` manually ingests specific Polymarket events by slug,
+bypassing the 21-day end-date window the `generate` cron uses. After the parity
+fix it shares the cron's processing: it re-fetches the event's markets through
+the canonical `/markets` endpoint, applies the same active/open + binary
+filters, and only then runs `groupMarkets` → `submitToAPI`.
+
+Use this checklist to validate against **staging** before touching production.
+
+## What the fix changed (and what to look for)
+
+| #   | Gap closed                                                          | Observable signal                                                         |
+| --- | ------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| 1   | active/closed/archived filter                                       | resolved/eliminated basket legs are NOT created                           |
+| 2   | binary `MARKET_FILTERS`                                             | non-binary markets are dropped                                            |
+| 3   | canonical `/markets` shape (`seriesSlug`/`series`, `gameStartTime`) | sports `endTime` comes from game/series, not the Polymarket+1day fallback |
+| 4   | `confirmProductionAccess()`                                         | a y/N prompt fires for `api.sapience.xyz` (not for staging)               |
+| 5   | `sapience-conditions.json` artifact                                 | the file is written on every run, incl. `--dry-run`                       |
+| 6   | dedup by conditionId                                                | passing overlapping slugs creates no duplicates                           |
+
+negRisk was already handled (market-level `negRisk`/`negRiskMarketID` survive)
+and is covered by a regression test; verify it still lands (Phase 3).
+
+## Environment (mirror the staging keeper)
+
+```bash
+export SAPIENCE_API_URL=https://api.staging.sapience.xyz
+export CHAIN_ID=<ethereal-testnet-id>        # the value the staging keeper uses
+export RESOLVER_ADDRESS=0x9938583eA9a6450Cc64502bDcBF76f4EEa2F9560   # ManualConditionResolver (testnet)
+export ADMIN_PRIVATE_KEY=<staging admin key>
+export NODE_ENV=development
+export LLM_ENABLED=false                      # staging keeper runs LLM off → deterministic
+```
+
+`confirmProductionAccess` only prompts when the URL contains the contiguous
+string `api.sapience.xyz`, so `api.staging.sapience.xyz` never prompts — safe to
+run unattended.
+
+## Phase 0 — Local gates
+
+```bash
+pnpm --filter @sapience/sdk run build:lib          # SDK builds first
+pnpm --filter @sapience/market-keeper run type-check
+pnpm --filter @sapience/market-keeper run lint
+pnpm --filter @sapience/market-keeper run test     # incl. from-event-slugs + negRisk tests
+```
+
+## Phase 1 — Dry-run inspection (no writes)
+
+Pick events that each exercise a gap:
+
+- a negRisk basket with dead legs (e.g. `2026-nba-champion`) → gaps 1, 6, negRisk
+- a sports game event with `gameStartTime` → gap 3
+- (best-effort) an event containing a non-binary market → gap 2
+
+```bash
+pnpm --filter @sapience/market-keeper run add-events:dry-run 2026-nba-champion
+```
+
+Inspect the printed output **and** `packages/market-keeper/sapience-conditions.json`:
+
+- only binary, active, open legs present (closed/eliminated legs gone);
+- each basket condition has `negRisk: true` + a shared `negRiskMarketId`, and the group carries `negRiskMarketId`;
+- sports `endTime` derives from gameStartTime/series, not Polymarket end + 1 day;
+- `optionName` (= `groupItemTitle`), `categorySlug`, `externalEventId` populated.
+
+## Phase 1b — Parity proof vs `generate`
+
+Pick an event that ALSO falls inside generate's 21-day window. With
+`LLM_ENABLED=false` (deterministic), run both and diff that event's entries:
+
+```bash
+pnpm --filter @sapience/market-keeper run generate:dry-run        # writes sapience-conditions.json
+cp packages/market-keeper/sapience-conditions.json /tmp/from-generate.json
+pnpm --filter @sapience/market-keeper run add-events:dry-run <that-event-slug>
+# diff the group/conditions for <that-event-slug> across the two JSON files — expect identical
+```
+
+## Phase 2 — Submit to staging
+
+```bash
+pnpm --filter @sapience/market-keeper run add-events <slug>       # no --dry-run; no prod prompt on staging URL
+```
+
+## Phase 3 — Verify in staging
+
+Query the staging API for the created group (by `externalEventId`) and its
+conditions (by `conditionHash`) and assert:
+
+- `group.negRisk == true` for a basket;
+- per-condition `endTime`, `categorySlug`, `chainId == <testnet>`, `resolver`, `optionName` correct;
+- the event renders as a grouped market in the staging UI (if available).
+
+## Phase 4 — Idempotency
+
+Re-run the same command. Expect existing conditions skipped (409 handled), no
+duplicate groups, and no cross-slug duplicates.
+
+## Phase 5 — Edge cases
+
+- Event whose legs are all closed → nothing created.
+- Bogus slug → graceful warning, non-zero exit, no partial writes.
+- Multiple slugs including an overlap → no duplicates.
+
+## Phase 6 — Production
+
+```bash
+SAPIENCE_API_URL=https://api.sapience.xyz pnpm --filter @sapience/market-keeper run add-events:dry-run <slug>   # inspect first
+SAPIENCE_API_URL=https://api.sapience.xyz pnpm --filter @sapience/market-keeper run add-events <slug>           # confirmProductionAccess prompts → y
+```

--- a/packages/market-keeper/package.json
+++ b/packages/market-keeper/package.json
@@ -8,6 +8,8 @@
     "build": "tsc",
     "generate": "tsx scripts/generate.ts",
     "generate:dry-run": "LLM_ENABLED=false tsx scripts/generate.ts --dry-run",
+    "add-events": "tsx scripts/add-events.ts",
+    "add-events:dry-run": "LLM_ENABLED=false tsx scripts/add-events.ts --dry-run",
     "settle-polymarket": "tsx scripts/settle-polymarket.ts",
     "settle-polymarket:dry-run": "tsx scripts/settle-polymarket.ts --dry-run",
     "settle-polymarket:execute": "tsx scripts/settle-polymarket.ts --execute",

--- a/packages/market-keeper/scripts/add-events.ts
+++ b/packages/market-keeper/scripts/add-events.ts
@@ -4,6 +4,13 @@
  * One-off script to add specific Polymarket events by slug.
  * Bypasses the 21-day end date window used by the generate pipeline.
  *
+ * Shares the generate cron's processing exactly: it resolves each slug to its
+ * market conditionIds, re-fetches those markets via the canonical /markets
+ * endpoint (so they carry the same seriesSlug/series/gameStartTime embed the
+ * endTime cascade needs), applies the same active/open + binary filters, then
+ * runs groupMarkets → submitToAPI. The only intentional difference is that the
+ * 21-day end-date window is not applied.
+ *
  * Usage:
  *   tsx scripts/add-events.ts <event-slug-1> [event-slug-2] ...
  *   tsx scripts/add-events.ts --dry-run <event-slug-1> [event-slug-2] ...
@@ -18,61 +25,11 @@
  */
 
 import 'dotenv/config';
-import type { PolymarketMarket } from '../src/types';
 import { DEFAULT_SAPIENCE_API_URL } from '../src/constants';
-import { fetchWithRetry, validatePrivateKey } from '../src/utils';
-import { groupMarkets } from '../src/generate/grouping';
+import { validatePrivateKey, confirmProductionAccess } from '../src/utils';
+import { fetchMarketsForEventSlugs } from '../src/generate/from-event-slugs';
+import { groupMarkets, exportJSON } from '../src/generate/grouping';
 import { printDryRun, submitToAPI } from '../src/generate/api';
-
-async function fetchEventBySlug(slug: string): Promise<PolymarketMarket[]> {
-  const url = `https://gamma-api.polymarket.com/events?slug=${encodeURIComponent(slug)}`;
-  const response = await fetchWithRetry(url, {
-    headers: { Accept: 'application/json' },
-  });
-
-  if (!response.ok) {
-    console.error(`[Polymarket] Failed to fetch event "${slug}": HTTP ${response.status}`);
-    return [];
-  }
-
-  const events: Array<{
-    id?: string;
-    title?: string;
-    slug?: string;
-    description?: string;
-    markets?: PolymarketMarket[];
-  }> = await response.json();
-
-  if (events.length === 0) {
-    console.warn(`[Polymarket] No event found for slug "${slug}"`);
-    return [];
-  }
-
-  const markets: PolymarketMarket[] = [];
-  for (const event of events) {
-    const parentEvent = {
-      id: event.id,
-      title: event.title,
-      slug: event.slug,
-      description: event.description,
-    };
-
-    for (const market of event.markets ?? []) {
-      market.events = [parentEvent];
-      // API requires non-empty description; fall back to event description or question
-      if (!market.description) {
-        market.description = event.description || market.question;
-      }
-      markets.push(market);
-    }
-
-    console.log(
-      `[Polymarket] Event "${event.title}" (${slug}): ${event.markets?.length ?? 0} markets`
-    );
-  }
-
-  return markets;
-}
 
 async function main() {
   const args = process.argv.slice(2);
@@ -80,8 +37,12 @@ async function main() {
   const slugs = args.filter((a) => !a.startsWith('--'));
 
   if (slugs.length === 0) {
-    console.error('Usage: tsx scripts/add-events.ts [--dry-run] <event-slug-1> [event-slug-2] ...');
-    console.error('Example: tsx scripts/add-events.ts maine-senate-election-winner');
+    console.error(
+      'Usage: tsx scripts/add-events.ts [--dry-run] <event-slug-1> [event-slug-2] ...'
+    );
+    console.error(
+      'Example: tsx scripts/add-events.ts maine-senate-election-winner'
+    );
     process.exit(1);
   }
 
@@ -96,13 +57,15 @@ async function main() {
     }
   }
 
-  // Fetch all markets from the given event slugs
-  const allMarkets: PolymarketMarket[] = [];
-  for (const slug of slugs) {
-    const markets = await fetchEventBySlug(slug);
-    allMarkets.push(...markets);
+  // Confirm production access early (before any work), matching generate.
+  if (!dryRun && privateKey) {
+    await confirmProductionAccess(apiUrl);
   }
 
+  // Fetch canonical markets for the requested slugs — same object shape and
+  // active/open + binary filtering as the generate cron, minus the 21-day
+  // window.
+  const allMarkets = await fetchMarketsForEventSlugs(slugs);
   if (allMarkets.length === 0) {
     console.error('No markets found for the given event slugs.');
     process.exit(1);
@@ -110,9 +73,14 @@ async function main() {
 
   console.log(`\nTotal markets fetched: ${allMarkets.length}`);
 
-  // Transform through the same pipeline as generate
+  // Transform through the same pipeline as generate.
   const sapienceData = await groupMarkets(allMarkets, apiUrl);
-  console.log(`Transformed into ${sapienceData.metadata.totalConditions} conditions`);
+  console.log(
+    `Transformed into ${sapienceData.metadata.totalConditions} conditions`
+  );
+
+  // Write the inspection artifact (generate writes this on every run).
+  exportJSON(sapienceData);
 
   if (dryRun) {
     printDryRun(sapienceData);
@@ -120,7 +88,9 @@ async function main() {
   }
 
   if (!privateKey) {
-    console.error('ADMIN_PRIVATE_KEY is required for submission (use --dry-run to preview)');
+    console.error(
+      'ADMIN_PRIVATE_KEY is required for submission (use --dry-run to preview)'
+    );
     process.exit(1);
   }
 

--- a/packages/market-keeper/scripts/update-condition.ts
+++ b/packages/market-keeper/scripts/update-condition.ts
@@ -1,12 +1,22 @@
 #!/usr/bin/env node
 /// <reference types="node" />
 /**
- * One-off script: update the question (full name) and/or endTime for a single
- * Sapience condition. Targets `PUT /admin/conditions/:id`, which accepts a
- * partial update — pass only the fields you want changed.
+ * One-off script: update the question (full name) and/or endTime for Sapience
+ * conditions. Targets `PUT /admin/conditions/:id`, which accepts a partial
+ * update — pass only the fields you want changed.
+ *
+ * Two modes:
+ *   --id <conditionHash>   update a single condition (question and/or endTime)
+ *   --event <pm-slug>      update EVERY Sapience condition whose conditionId
+ *                          matches a market in the given Polymarket event(s).
+ *                          Repeatable. endTime only — the same value is applied
+ *                          to all legs (correct for a basket: every leg of
+ *                          e.g. "World Cup Winner" resolves at the same time).
+ *                          Conditions not present on Sapience (404) are skipped.
  *
  * Usage:
  *   tsx scripts/update-condition.ts --id <conditionHash> [--question "..."] [--end-time <ISO|unix>] [--dry-run]
+ *   tsx scripts/update-condition.ts --event <pm-slug> [--event <pm-slug> ...] --end-time <ISO|unix> [--dry-run]
  *
  * Examples:
  *   tsx scripts/update-condition.ts \
@@ -14,7 +24,7 @@
  *     --question "Will Trump endorse Ken Paxton for TX-Sen by Nov 2 2026 ET?" \
  *     --end-time 2026-11-04T00:00:00Z
  *
- *   tsx scripts/update-condition.ts --id 0x... --end-time 1762214400 --dry-run
+ *   tsx scripts/update-condition.ts --event world-cup-winner --end-time 2026-07-19T22:00:00Z --dry-run
  *
  * Environment Variables (required for API submission):
  *   SAPIENCE_API_URL     API URL (default: https://api.sapience.xyz)
@@ -31,18 +41,25 @@ import {
   logError,
 } from '../src/utils';
 import { getAdminAuthHeaders } from '../src/utils/auth';
+import { fetchConditionIdsForSlugs } from '../src/generate/from-event-slugs';
 
 interface CLIOptions {
   id?: string;
+  events: string[];
   question?: string;
   endTime?: number;
   dryRun: boolean;
   help: boolean;
 }
 
+interface ConditionUpdate {
+  question?: string;
+  endTime?: number;
+}
+
 function parseArgs(): CLIOptions {
   const args = process.argv.slice(2);
-  const opts: CLIOptions = { dryRun: false, help: false };
+  const opts: CLIOptions = { events: [], dryRun: false, help: false };
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -50,6 +67,12 @@ function parseArgs(): CLIOptions {
       case '--id':
         opts.id = args[++i];
         break;
+      case '--event': {
+        const slug = args[++i];
+        if (!slug) throw new Error('--event requires a Polymarket event slug');
+        opts.events.push(slug);
+        break;
+      }
       case '--question':
         opts.question = args[++i];
         break;
@@ -95,16 +118,22 @@ function parseEndTime(raw: string | undefined): number {
 
 function showHelp(): void {
   console.log(`
-Usage: tsx scripts/update-condition.ts --id <conditionHash> [options]
+Usage:
+  tsx scripts/update-condition.ts --id <conditionHash> [--question "..."] [--end-time <value>] [--dry-run]
+  tsx scripts/update-condition.ts --event <pm-slug> [--event <pm-slug> ...] --end-time <value> [--dry-run]
 
-Updates the question and/or endTime for a single Sapience condition via
-PUT /admin/conditions/:id. At least one of --question or --end-time is required.
+--id mode: update a single condition's question and/or endTime.
+--event mode: resolve the Polymarket event(s) to their market conditionIds and
+  apply the SAME endTime to every matching condition on Sapience. Conditions not
+  present on Sapience are skipped (404). --question is not allowed here (it would
+  overwrite every market with identical text).
 
 Options:
-  --id <hash>          Condition hash (0x-prefixed 32-byte hex). Required.
-  --question "..."     New question text (full name)
+  --id <hash>          Condition hash (0x-prefixed 32-byte hex)
+  --event <slug>       Polymarket event slug (repeatable)
+  --question "..."     New question text (full name) — --id mode only
   --end-time <value>   New endTime as ISO 8601 (e.g. 2026-11-04T00:00:00Z) or unix seconds
-  --dry-run            Print the payload without submitting
+  --dry-run            Print what would be sent without submitting
   --help, -h           Show this help message
 
 Notes:
@@ -115,6 +144,156 @@ Environment Variables (required for submission):
   SAPIENCE_API_URL     API URL (default: https://api.sapience.xyz)
   ADMIN_PRIVATE_KEY    64-char hex private key for signing admin requests
 `);
+}
+
+interface PutResult {
+  ok: boolean;
+  status: number;
+  body: string;
+}
+
+/** Apply a partial update to one condition via PUT /admin/conditions/:id. */
+async function putCondition(
+  apiUrl: string,
+  id: string,
+  payload: ConditionUpdate,
+  privateKey: `0x${string}`
+): Promise<PutResult> {
+  // Sign per request — a long --event loop can outlive a single signature's
+  // timestamp window.
+  const authHeaders = await getAdminAuthHeaders(privateKey);
+  const response = await fetchWithRetry(`${apiUrl}/admin/conditions/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', ...authHeaders },
+    body: JSON.stringify(payload),
+  });
+  const body = response.ok ? '' : await response.text().catch(() => '');
+  return { ok: response.ok, status: response.status, body };
+}
+
+function requirePrivateKey(): `0x${string}` {
+  let privateKey: `0x${string}` | undefined;
+  try {
+    privateKey = validatePrivateKey(process.env.ADMIN_PRIVATE_KEY);
+  } catch (error) {
+    logError(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+  if (!privateKey) {
+    logError(
+      'ADMIN_PRIVATE_KEY is required for submission (use --dry-run to preview)'
+    );
+    process.exit(1);
+  }
+  return privateKey;
+}
+
+/** --id mode: update a single condition. */
+async function runSingle(apiUrl: string, options: CLIOptions): Promise<void> {
+  const id = options.id!;
+  if (!/^0x[0-9a-fA-F]{64}$/.test(id)) {
+    logError(`Invalid --id format: ${id} (expected 0x-prefixed 32-byte hex)`);
+    process.exit(1);
+  }
+  if (options.question === undefined && options.endTime === undefined) {
+    logError('At least one of --question or --end-time is required');
+    showHelp();
+    process.exit(1);
+  }
+
+  const payload: ConditionUpdate = {};
+  if (options.question !== undefined) payload.question = options.question;
+  if (options.endTime !== undefined) payload.endTime = options.endTime;
+
+  log(`[UpdateCondition] Target: ${apiUrl}/admin/conditions/${id}`);
+  log(`[UpdateCondition] Payload: ${JSON.stringify(payload, null, 2)}`);
+  if (options.endTime !== undefined) {
+    log(
+      `[UpdateCondition]   endTime ${options.endTime} = ${new Date(options.endTime * 1000).toISOString()}`
+    );
+  }
+
+  if (options.dryRun) {
+    log('[UpdateCondition] Dry run — not submitting');
+    return;
+  }
+
+  const privateKey = requirePrivateKey();
+  await confirmProductionAccess(apiUrl);
+
+  const result = await putCondition(apiUrl, id, payload, privateKey);
+  if (!result.ok) {
+    logError(
+      `[UpdateCondition] Failed: HTTP ${result.status} — ${result.body.slice(0, 500)}`
+    );
+    process.exit(1);
+  }
+  log(`[UpdateCondition] Updated condition ${id}`);
+}
+
+/** --event mode: update every Sapience condition under the given PM event(s). */
+async function runEvent(apiUrl: string, options: CLIOptions): Promise<void> {
+  if (options.endTime === undefined) {
+    logError('--event requires --end-time');
+    showHelp();
+    process.exit(1);
+  }
+  if (options.question !== undefined) {
+    logError(
+      '--question cannot be combined with --event (it would overwrite every market with identical text)'
+    );
+    process.exit(1);
+  }
+
+  log(
+    `[UpdateCondition] Resolving Polymarket event(s): ${options.events.join(', ')}`
+  );
+  const conditionIds = await fetchConditionIdsForSlugs(options.events);
+  if (conditionIds.length === 0) {
+    logError('No markets found for the given event slug(s).');
+    process.exit(1);
+  }
+
+  const payload: ConditionUpdate = { endTime: options.endTime };
+  log(
+    `[UpdateCondition] ${conditionIds.length} market conditionId(s) resolved; ` +
+      `endTime ${options.endTime} = ${new Date(options.endTime * 1000).toISOString()}`
+  );
+
+  if (options.dryRun) {
+    log('[UpdateCondition] Dry run — would PUT the above endTime to each of:');
+    for (const id of conditionIds) log(`  ${id}`);
+    return;
+  }
+
+  const privateKey = requirePrivateKey();
+  log(`[UpdateCondition] Target: ${apiUrl}/admin/conditions/:id`);
+  await confirmProductionAccess(apiUrl);
+
+  let updated = 0;
+  let notOnSapience = 0;
+  let failed = 0;
+  for (const id of conditionIds) {
+    const result = await putCondition(apiUrl, id, payload, privateKey);
+    if (result.ok) {
+      updated++;
+      log(`  ✓ ${id} updated`);
+    } else if (result.status === 404) {
+      notOnSapience++;
+      log(`  – ${id} not on Sapience (404), skipped`);
+    } else {
+      failed++;
+      logError(
+        `  ✗ ${id} HTTP ${result.status} — ${result.body.slice(0, 200)}`
+      );
+    }
+  }
+
+  log(
+    `[UpdateCondition] Done: ${updated} updated, ${notOnSapience} not on Sapience, ` +
+      `${failed} failed (of ${conditionIds.length})`
+  );
+  if (failed > 0) process.exit(1);
 }
 
 async function main(): Promise<void> {
@@ -132,73 +311,25 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (!options.id) {
-    logError('--id is required');
-    showHelp();
+  const useEvent = options.events.length > 0;
+  const useId = options.id !== undefined;
+  if (useEvent && useId) {
+    logError('Use --id OR --event, not both');
     process.exit(1);
   }
-  if (!/^0x[0-9a-fA-F]{64}$/.test(options.id)) {
-    logError(`Invalid --id format: ${options.id} (expected 0x-prefixed 32-byte hex)`);
-    process.exit(1);
-  }
-  if (options.question === undefined && options.endTime === undefined) {
-    logError('At least one of --question or --end-time is required');
+  if (!useEvent && !useId) {
+    logError('One of --id or --event is required');
     showHelp();
     process.exit(1);
   }
 
   const apiUrl = process.env.SAPIENCE_API_URL || DEFAULT_SAPIENCE_API_URL;
 
-  const payload: { question?: string; endTime?: number } = {};
-  if (options.question !== undefined) payload.question = options.question;
-  if (options.endTime !== undefined) payload.endTime = options.endTime;
-
-  log(`[UpdateCondition] Target: ${apiUrl}/admin/conditions/${options.id}`);
-  log(`[UpdateCondition] Payload: ${JSON.stringify(payload, null, 2)}`);
-  if (options.endTime !== undefined) {
-    log(
-      `[UpdateCondition]   endTime ${options.endTime} = ${new Date(options.endTime * 1000).toISOString()}`
-    );
+  if (useEvent) {
+    await runEvent(apiUrl, options);
+  } else {
+    await runSingle(apiUrl, options);
   }
-
-  if (options.dryRun) {
-    log('[UpdateCondition] Dry run — not submitting');
-    return;
-  }
-
-  let privateKey: `0x${string}` | undefined;
-  try {
-    privateKey = validatePrivateKey(process.env.ADMIN_PRIVATE_KEY);
-  } catch (error) {
-    logError(error instanceof Error ? error.message : String(error));
-    process.exit(1);
-  }
-  if (!privateKey) {
-    logError('ADMIN_PRIVATE_KEY is required for submission (use --dry-run to preview)');
-    process.exit(1);
-  }
-
-  await confirmProductionAccess(apiUrl);
-
-  const authHeaders = await getAdminAuthHeaders(privateKey);
-  const response = await fetchWithRetry(
-    `${apiUrl}/admin/conditions/${options.id}`,
-    {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json', ...authHeaders },
-      body: JSON.stringify(payload),
-    }
-  );
-
-  if (!response.ok) {
-    const body = await response.text().catch(() => '');
-    logError(
-      `[UpdateCondition] Failed: HTTP ${response.status} — ${body.slice(0, 500)}`
-    );
-    process.exit(1);
-  }
-
-  log(`[UpdateCondition] Updated condition ${options.id}`);
 }
 
 main().catch((error) => {

--- a/packages/market-keeper/src/__tests__/from-event-slugs.test.ts
+++ b/packages/market-keeper/src/__tests__/from-event-slugs.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PolymarketMarket } from '../types';
+
+// Keep LLM/constants test-safe; from-event-slugs pulls these transitively via
+// pipeline → filters and refresh-metadata/fetch → tags.
+vi.mock('../constants', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    CHAIN_ID: 5064014,
+    LLM_ENRICHMENT_ENABLED: false,
+    LLM_ENDTIME_SEARCH_ENABLED: false,
+    OPENROUTER_API_KEY: '',
+    LLM_MODEL: '',
+    LLM_ENDTIME_MODEL: '',
+    DEFAULT_SAPIENCE_API_URL: 'https://test-api.example.com',
+  };
+});
+
+// Mock fetchWithRetry at the source — both from-event-slugs (/events) and
+// refresh-metadata/fetch (/markets) read it from utils. A recorded call array
+// plus a queue of canned responses lets each test wire exactly the traffic it
+// cares about.
+type FetchCall = { url: string; init?: RequestInit };
+const fetchCalls: FetchCall[] = [];
+const fetchQueue: Array<() => Response> = [];
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+vi.mock('../utils/fetch', () => ({
+  fetchWithRetry: vi.fn(async (url: string, init?: RequestInit) => {
+    fetchCalls.push({ url, init });
+    const next = fetchQueue.shift();
+    if (!next) throw new Error(`No queued response for ${url}`);
+    return next();
+  }),
+}));
+
+import {
+  isTradeableMarket,
+  fetchConditionIdsForSlugs,
+  fetchMarketsForEventSlugs,
+} from '../generate/from-event-slugs';
+
+beforeEach(() => {
+  fetchCalls.length = 0;
+  fetchQueue.length = 0;
+  vi.clearAllMocks();
+});
+
+function makeMarket(
+  overrides: Partial<PolymarketMarket> = {}
+): PolymarketMarket {
+  return {
+    id: 'test',
+    question: 'Q?',
+    conditionId: '0x123',
+    outcomes: ['Yes', 'No'],
+    volume: '1000',
+    liquidity: '1000',
+    endDate: '2030-01-01T00:00:00Z',
+    description: 'desc',
+    slug: 'm',
+    active: true,
+    closed: false,
+    ...overrides,
+  };
+}
+
+function eventResponse(slug: string, conditionIds: string[]): Response {
+  return jsonResponse([
+    {
+      id: `evt-${slug}`,
+      title: `Event ${slug}`,
+      slug,
+      description: 'event desc',
+      markets: conditionIds.map((conditionId) => ({ conditionId })),
+    },
+  ]);
+}
+
+describe('isTradeableMarket', () => {
+  it('keeps active, open, non-archived markets', () => {
+    expect(isTradeableMarket(makeMarket())).toBe(true);
+    expect(isTradeableMarket(makeMarket({ archived: undefined }))).toBe(true);
+  });
+
+  it('drops closed, archived, or inactive markets (matches generate gate)', () => {
+    expect(isTradeableMarket(makeMarket({ closed: true }))).toBe(false);
+    expect(isTradeableMarket(makeMarket({ archived: true }))).toBe(false);
+    expect(isTradeableMarket(makeMarket({ active: false }))).toBe(false);
+  });
+});
+
+describe('fetchConditionIdsForSlugs', () => {
+  it('collects market conditionIds across slugs and dedups overlap', async () => {
+    fetchQueue.push(() => eventResponse('a', ['0x1', '0x2']));
+    fetchQueue.push(() => eventResponse('b', ['0x2', '0x3']));
+
+    const ids = await fetchConditionIdsForSlugs(['a', 'b']);
+
+    expect([...ids].sort()).toEqual(['0x1', '0x2', '0x3']);
+    expect(fetchCalls).toHaveLength(2);
+    expect(fetchCalls[0].url).toContain(
+      'gamma-api.polymarket.com/events?slug=a'
+    );
+  });
+
+  it('skips a slug that errors and continues with the rest', async () => {
+    fetchQueue.push(
+      () => new Response('nope', { status: 500, statusText: 'err' })
+    );
+    fetchQueue.push(() => eventResponse('b', ['0x9']));
+
+    const ids = await fetchConditionIdsForSlugs(['a', 'b']);
+
+    expect([...ids]).toEqual(['0x9']);
+  });
+
+  it('handles a slug with no matching event', async () => {
+    fetchQueue.push(() => jsonResponse([]));
+    const ids = await fetchConditionIdsForSlugs(['missing']);
+    expect([...ids]).toEqual([]);
+  });
+});
+
+describe('fetchMarketsForEventSlugs', () => {
+  it('re-fetches via /markets, drops closed + non-binary, preserves negRisk', async () => {
+    // /events resolves the slug to three conditionIds.
+    fetchQueue.push(() => eventResponse('nba', ['0x1', '0x2', '0x3']));
+    // /markets closed=false side: an active binary negRisk leg + an active
+    // NON-binary market.
+    fetchQueue.push(() =>
+      jsonResponse([
+        makeMarket({
+          conditionId: '0x1',
+          outcomes: ['Yes', 'No'],
+          negRisk: true,
+          negRiskMarketID: '0xBASKET',
+        }),
+        makeMarket({ conditionId: '0x2', outcomes: ['A', 'B', 'C'] }),
+      ])
+    );
+    // /markets closed=true side: a resolved (closed) leg.
+    fetchQueue.push(() =>
+      jsonResponse([makeMarket({ conditionId: '0x3', closed: true })])
+    );
+
+    const markets = await fetchMarketsForEventSlugs(['nba']);
+
+    // 0x2 dropped by the binary filter, 0x3 dropped by the active/open gate.
+    expect(markets.map((m) => m.conditionId)).toEqual(['0x1']);
+    // negRisk fields survive the round-trip so groupMarkets stamps the basket.
+    expect(markets[0].negRisk).toBe(true);
+    expect(markets[0].negRiskMarketID).toBe('0xBASKET');
+  });
+
+  it('returns [] without fetching markets when no event resolves', async () => {
+    fetchQueue.push(() => jsonResponse([]));
+    const markets = await fetchMarketsForEventSlugs(['missing']);
+    expect(markets).toEqual([]);
+    // only the /events call happened, no /markets round-trip
+    expect(fetchCalls).toHaveLength(1);
+  });
+});

--- a/packages/market-keeper/src/constants.ts
+++ b/packages/market-keeper/src/constants.ts
@@ -31,7 +31,7 @@ export const ALL_POLYMARKET_RESOLVER_ADDRESSES: string[] =
 export const DEFAULT_SAPIENCE_API_URL = 'https://api.sapience.xyz';
 
 // Maximum end date window (in days) for fetching markets
-export const MAX_END_DATE_DAYS = 21;
+export const MAX_END_DATE_DAYS = 90;
 
 // Minimum volume threshold (in USD) for including markets
 export const MIN_VOLUME_THRESHOLD = 1_000;

--- a/packages/market-keeper/src/generate/from-event-slugs.ts
+++ b/packages/market-keeper/src/generate/from-event-slugs.ts
@@ -1,0 +1,118 @@
+/**
+ * Resolve specific Polymarket event slugs into the SAME canonical market
+ * objects the `generate` cron consumes, so the manual add-events path and the
+ * cron stay in lockstep.
+ *
+ * Why two hops (/events then /markets): the /events?slug= endpoint embeds its
+ * markets but omits the event-level `seriesSlug`/`series` and per-market
+ * `gameStartTime` that the endTime cascade (leagueForMarket → gameEndTime)
+ * relies on — and its markets carry no `events[]` embed at all. The /markets
+ * endpoint returns the full embed. So we hit /events only to discover the
+ * event's market conditionIds, then re-fetch those exact markets via
+ * `fetchMarketsByConditionIds` to get generate's representation verbatim.
+ *
+ * After re-fetching we mirror `fetchEndingSoonestMarkets`' post-fetch
+ * processing: drop closed/archived/inactive markets (the cron filters these at
+ * the /markets query level) and run the binary `MARKET_FILTERS`. We do NOT
+ * apply the 21-day window — bypassing it is the entire point of add-events.
+ */
+
+import type { PolymarketMarket } from '../types';
+import { fetchWithRetry } from '../utils';
+import { fetchMarketsByConditionIds } from '../refresh-metadata/fetch';
+import { runPipeline, printPipelineStats, MARKET_FILTERS } from './pipeline';
+
+interface PolymarketEventLite {
+  id?: string;
+  title?: string;
+  slug?: string;
+  description?: string;
+  markets?: Array<{ conditionId?: string }>;
+}
+
+/**
+ * Keep only markets the generate cron would: active, not closed, not archived.
+ * The cron enforces this via `active=true&closed=false` on the /markets query;
+ * add-events fetches by conditionId (which returns resolved legs too), so the
+ * gate is applied here instead.
+ */
+export function isTradeableMarket(market: PolymarketMarket): boolean {
+  return (
+    market.active === true && market.closed !== true && market.archived !== true
+  );
+}
+
+/**
+ * Resolve event slugs to the conditionIds of their markets, deduped across
+ * slugs (passing overlapping slugs must not create duplicates). A slug that
+ * fails to fetch or matches no event is logged and skipped — the rest proceed.
+ */
+export async function fetchConditionIdsForSlugs(
+  slugs: string[]
+): Promise<string[]> {
+  const ids = new Set<string>();
+
+  for (const slug of slugs) {
+    const url = `https://gamma-api.polymarket.com/events?slug=${encodeURIComponent(slug)}`;
+    const response = await fetchWithRetry(url, {
+      headers: { Accept: 'application/json' },
+    });
+
+    if (!response.ok) {
+      console.error(
+        `[Polymarket] Failed to fetch event "${slug}": HTTP ${response.status}`
+      );
+      continue;
+    }
+
+    const events: PolymarketEventLite[] = await response.json();
+    if (events.length === 0) {
+      console.warn(`[Polymarket] No event found for slug "${slug}"`);
+      continue;
+    }
+
+    let count = 0;
+    for (const event of events) {
+      for (const market of event.markets ?? []) {
+        if (market.conditionId) {
+          ids.add(market.conditionId);
+          count++;
+        }
+      }
+    }
+    console.log(
+      `[Polymarket] Event slug "${slug}": ${count} markets (${ids.size} unique so far)`
+    );
+  }
+
+  return [...ids];
+}
+
+/**
+ * Fetch the canonical, generate-equivalent markets for a set of event slugs.
+ * Returns markets ready to hand to `groupMarkets` exactly as the cron does.
+ */
+export async function fetchMarketsForEventSlugs(
+  slugs: string[]
+): Promise<PolymarketMarket[]> {
+  const conditionIds = await fetchConditionIdsForSlugs(slugs);
+  if (conditionIds.length === 0) return [];
+
+  // Re-fetch via /markets to get the full embed (seriesSlug/series,
+  // gameStartTime) and dedup by conditionId for free (Map-keyed).
+  const marketMap = await fetchMarketsByConditionIds(conditionIds);
+  const tradeable = [...marketMap.values()].filter(isTradeableMarket);
+
+  console.log(
+    `[Polymarket] Re-fetched ${marketMap.size}/${conditionIds.length} markets; ` +
+      `${tradeable.length} active after closed/archived gate`
+  );
+
+  // Same binary filter the cron applies in fetchEndingSoonestMarkets.
+  const { output, stats } = runPipeline(tradeable, MARKET_FILTERS, {
+    verbose: false,
+  });
+  printPipelineStats(stats, 'Market Pipeline');
+
+  return output;
+}

--- a/packages/market-keeper/src/generate/index.ts
+++ b/packages/market-keeper/src/generate/index.ts
@@ -28,7 +28,7 @@ export function showHelp(): void {
   console.log(`
 Usage: tsx generate-sapience-conditions.ts [options]
 
-Fetches markets ending within 7 days from Polymarket and submits them to the Sapience API.
+Fetches markets ending within 90 days from Polymarket and submits them to the Sapience API.
 
 Options:
   --dry-run      Show what would be submitted without actually submitting
@@ -81,7 +81,7 @@ export async function main() {
   }
 
   try {
-    // Fetch Polymarket markets ending within 7 days
+    // Fetch Polymarket markets ending within 90 days
     const markets = await fetchEndingSoonestMarkets();
 
     const sapienceData = await groupMarkets(markets, apiUrl);

--- a/packages/market-keeper/src/prices-and-1d-7d-volume/index.ts
+++ b/packages/market-keeper/src/prices-and-1d-7d-volume/index.ts
@@ -6,7 +6,7 @@
  * and submits batch price + volume updates.
  *
  * This covers markets outside the generate/relist windows
- * (e.g., markets ending >21 days from now).
+ * (e.g., markets ending >90 days from now).
  */
 
 import 'dotenv/config';

--- a/packages/sdk/types/graphql.ts
+++ b/packages/sdk/types/graphql.ts
@@ -1687,7 +1687,7 @@ export type Query = {
    * @deprecated Field no longer supported
    */
   protocolVolume: Array<VolumeDataPoint>;
-  /** Sorted, paginated list of questions — groups and ungrouped conditions interleaved by the chosen sort field */
+  /** Sorted, paginated list of questions — groups and ungrouped conditions interleaved by the chosen sort field. `questionType` filters by rendered item type: `condition` returns items that resolve to a standalone condition (ungrouped conditions plus single-condition groups, which are unwrapped), `group` returns multi-condition groups only. */
   questions: Array<Question>;
   /**
    * Public referral analytics. Referral codes are attribution hints, not
@@ -1984,6 +1984,7 @@ export type QueryQuestionsArgs = {
   minEndTime?: InputMaybe<Scalars['Int']['input']>;
   minEstimatedPrice?: InputMaybe<Scalars['Float']['input']>;
   minSimilarMarketVolume?: InputMaybe<Scalars['Float']['input']>;
+  questionType?: InputMaybe<QuestionItemType>;
   resolutionStatus?: InputMaybe<ResolutionStatus>;
   search?: InputMaybe<Scalars['String']['input']>;
   similarMarketVolumeWindow?: InputMaybe<VolumeWindow>;


### PR DESCRIPTION
Promotes `staging` to `main`. Three merged PRs in this diff:

### Included
- **#1840 — feat(api): questionType filter on questions query**
  Adds a `questionType` filter to the `questions` GraphQL query (resolver + schema + SDK types).
- **#1839 — fix(api): bound boot-time fixture seeding + market-keeper event tooling**
  Bounds boot-time fixture seeding so a slow query can't wedge API startup; adds market-keeper manual event tooling (`add-events` / `update-condition` reusing the generate-cron path) with tests + docs.
- **#1842 — feat(market-keeper): extend market ingestion window 21 → 90 days**
  Raises `MAX_END_DATE_DAYS` 21 → 90 so the keeper lists markets ending up to ~3 months out.

### Operational note (from #1842)
Once this hits production, the next keeper `generate` run does a **one-time backfill of ~1,900 net-new markets** (~+40% on the current ~4,600 live set) and incurs **~$8–14 of LLM enrichment** (Perplexity `sonar-pro` default; ~$4–6 if switched to `sonar`). Mostly a timing shift, not extra steady-state throughput. The model is still `sonar-pro` — no env change to `sonar` is included here.

### Verification
Each PR was tested and reviewed on its own before merge to staging (type-check / lint / test green per package). No additional changes introduced by this promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)