### PR TITLE
test(api): update contract snapshots for questions.questionType filter

### DIFF
--- a/packages/api/test/contract/__snapshots__/introspection.json
+++ b/packages/api/test/contract/__snapshots__/introspection.json
@@ -16697,7 +16697,7 @@
           },
           {
             "name": "questions",
-            "description": "Sorted, paginated list of questions — groups and ungrouped conditions interleaved by the chosen sort field",
+            "description": "Sorted, paginated list of questions — groups and ungrouped conditions interleaved by the chosen sort field. `questionType` filters by rendered item type: `condition` returns items that resolve to a standalone condition (ungrouped conditions plus single-condition groups, which are unwrapped), `group` returns multi-condition groups only.",
             "args": [
               {
                 "name": "categorySlugs",
@@ -16773,6 +16773,16 @@
                 "type": {
                   "kind": "SCALAR",
                   "name": "Float",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "questionType",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "QuestionItemType",
                   "ofType": null
                 },
                 "defaultValue": null

--- a/packages/api/test/contract/__snapshots__/schema.sdl.graphql
+++ b/packages/api/test/contract/__snapshots__/schema.sdl.graphql
@@ -1611,9 +1611,9 @@ type Query {
   protocolVolume(from: DateTimeISO, interval: TimeInterval!, to: DateTimeISO): [VolumeDataPoint!]! @deprecated
 
   """
-  Sorted, paginated list of questions — groups and ungrouped conditions interleaved by the chosen sort field
+  Sorted, paginated list of questions — groups and ungrouped conditions interleaved by the chosen sort field. `questionType` filters by rendered item type: `condition` returns items that resolve to a standalone condition (ungrouped conditions plus single-condition groups, which are unwrapped), `group` returns multi-condition groups only.
   """
-  questions(categorySlugs: [String!], chainId: Int, maxEstimatedPrice: Float, maxSimilarMarketVolume: Float, minEndTime: Int, minEstimatedPrice: Float, minSimilarMarketVolume: Float, resolutionStatus: ResolutionStatus, search: String, similarMarketVolumeWindow: VolumeWindow, skip: Int! = 0, sortDirection: SortOrder! = desc, sortField: QuestionSortField, tag: String, take: Int! = 50): [Question!]!
+  questions(categorySlugs: [String!], chainId: Int, maxEstimatedPrice: Float, maxSimilarMarketVolume: Float, minEndTime: Int, minEstimatedPrice: Float, minSimilarMarketVolume: Float, questionType: QuestionItemType, resolutionStatus: ResolutionStatus, search: String, similarMarketVolumeWindow: VolumeWindow, skip: Int! = 0, sortDirection: SortOrder! = desc, sortField: QuestionSortField, tag: String, take: Int! = 50): [Question!]!
 
   """
   Public referral analytics. Referral codes are attribution hints, not


### PR DESCRIPTION
## What

Regenerate the two API contract snapshots so they match the schema after **#1840** (questionType filter on the `questions` query):
- `test/contract/__snapshots__/schema.sdl.graphql`
- `test/contract/__snapshots__/introspection.json`

## Why

`#1840` added the `questionType: QuestionItemType` argument and an expanded description to the `questions` query, but didn't regenerate the contract snapshots. As a result `test-api` fails on `staging` (and on the staging→main promotion #1843):

```
× schema snapshot > committed schema.graphql matches the recorded contract
× introspection snapshot > live server introspection matches the recorded contract
```

## Change scope

The only diff in both snapshots is the `questions` field's new `questionType` arg (ENUM `QuestionItemType`) and its updated description — no other schema surface moves. UTF-8 (em-dash) preserved.

## Testing

Regenerated via `vitest -u` on the two files only, then verified green without the update flag (DB-independent via `CONTRACT_SKIP_SERVER=1`, since these are schema/introspection tests):

```
✓ test/contract/introspection.test.ts
✓ test/contract/schema.snapshot.test.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)