### PR TITLE
fix(relayer): gate auction.started feed by connection role

### DIFF
--- a/packages/app/src/lib/auction/useAuctionRelayerFeed.ts
+++ b/packages/app/src/lib/auction/useAuctionRelayerFeed.ts
@@ -16,6 +16,14 @@ export type AuctionFeedMessage = {
 // 30-minute staleness threshold for subscription pruning
 const SUBSCRIPTION_TTL_MS = 30 * 60 * 1000;
 
+// Stable per-page-load id so the relayer can distinguish app sessions in its
+// identify logs. Best-effort: falls back to a random suffix if crypto.randomUUID
+// is unavailable (e.g. during SSR evaluation).
+const appInstanceId =
+  typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? `app-${crypto.randomUUID()}`
+    : `app-${Math.floor(Math.random() * 1e9).toString(36)}`;
+
 export function useAuctionRelayerFeed(options?: {
   observeVaultQuotes?: boolean;
 }) {
@@ -39,10 +47,24 @@ export function useAuctionRelayerFeed(options?: {
   useEffect(() => {
     if (!wsUrl) return;
     const client = getSharedAuctionWsClient(wsUrl);
+    // Declare the connection role as `both`: a terminal/AutoBid session both
+    // starts auctions (predictor side) AND watches the global auction.started
+    // feed (counterparty side). Without this the relayer treats the socket as
+    // a plain `predictor` and — once role gating is on — won't deliver the
+    // feed. Sent immediately (queued until open) here and re-sent on every
+    // (re)open below so it survives reconnects.
+    const identify = () =>
+      client.send({
+        type: 'identify',
+        payload: { service: 'app', instanceId: appInstanceId, role: 'both' },
+      });
+    identify();
     // Observe vault quotes (queued until open)
     if (observeVaultQuotes) client.send({ type: 'vault_quote.observe' });
 
     const offOpen = client.addOpenListener(() => {
+      // Re-announce role on reconnect (the relayer resets identity per socket).
+      identify();
       // Resubscribe to all auctions on reconnect
       for (const id of Array.from(subscribedAuctionsRef.current.keys())) {
         client.send({ type: 'auction.subscribe', payload: { auctionId: id } });

--- a/packages/relayer/src/__tests__/handlers.test.ts
+++ b/packages/relayer/src/__tests__/handlers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { OutcomeSide } from '@sapience/sdk/types';
 import type { ClientConnection, SubscriptionManager } from '../transport/types';
 
@@ -47,6 +47,15 @@ vi.mock('../utils/getProviderForChain', () => ({
     readContract: vi.fn().mockResolvedValue('0xManagerAddress'),
   })),
 }));
+
+// ── Mock config ────────────────────────────────────────────────────────────
+// envalid (v8) returns a Proxy that THROWS on mutation, so tests can't toggle
+// `AUCTION_FEED_ROLE_GATING` on the real object. Replace it with a plain
+// mutable copy that preserves every real value.
+vi.mock('../config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../config')>();
+  return { ...actual, config: { ...actual.config } };
+});
 
 import {
   handleAuctionStart,
@@ -101,6 +110,7 @@ function mockClient(id = crypto.randomUUID()): ClientConnection {
   return {
     id,
     service: 'anonymous',
+    role: 'predictor',
     variant: 'default',
     send: vi.fn().mockReturnValue(true),
     close: vi.fn(),
@@ -290,6 +300,87 @@ describe('Escrow Handlers', () => {
       expect(bot2.send).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'auction.started' })
       );
+    });
+
+    describe('role gating (AUCTION_FEED_ROLE_GATING)', () => {
+      // envalid types config as readonly; cast to mutate it for the test
+      // (the runtime object is a plain, non-frozen object).
+      const cfg = config as unknown as { AUCTION_FEED_ROLE_GATING: boolean };
+      const original = cfg.AUCTION_FEED_ROLE_GATING;
+      afterEach(() => {
+        cfg.AUCTION_FEED_ROLE_GATING = original;
+      });
+
+      it('with gating OFF, broadcasts to every role (incl. predictors)', async () => {
+        cfg.AUCTION_FEED_ROLE_GATING = false;
+        vi.mocked(validateAuctionRFQ).mockResolvedValue({ status: 'valid' });
+        vi.mocked(getEscrowAuctionDetails).mockReturnValue({
+          auctionId: 'auction-123',
+          picks: [],
+        } as never);
+
+        const predictor = mockClient('11111111-0000-0000-0000-000000000000');
+        predictor.role = 'predictor';
+        const counterparty = mockClient('22222222-0000-0000-0000-000000000000');
+        counterparty.role = 'counterparty';
+        const ctx2 = { allClients: () => [predictor, counterparty] };
+
+        await handleAuctionStart(
+          mockClient(),
+          baseAuctionPayload as never,
+          mockSubs(),
+          ctx2
+        );
+
+        expect(predictor.send).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'auction.started' })
+        );
+        expect(counterparty.send).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'auction.started' })
+        );
+      });
+
+      it('with gating ON, sends only to counterparty/both and skips predictor/anonymous', async () => {
+        cfg.AUCTION_FEED_ROLE_GATING = true;
+        vi.mocked(validateAuctionRFQ).mockResolvedValue({ status: 'valid' });
+        vi.mocked(getEscrowAuctionDetails).mockReturnValue({
+          auctionId: 'auction-123',
+          picks: [],
+        } as never);
+
+        const predictor = mockClient('11111111-0000-0000-0000-000000000000');
+        predictor.role = 'predictor';
+        const counterparty = mockClient('22222222-0000-0000-0000-000000000000');
+        counterparty.role = 'counterparty';
+        const both = mockClient('33333333-0000-0000-0000-000000000000');
+        both.role = 'both';
+        // Default role from the transport is 'predictor' — stands in for an
+        // anonymous client that never identified.
+        const anon = mockClient('44444444-0000-0000-0000-000000000000');
+        const ctx2 = {
+          allClients: () => [predictor, counterparty, both, anon],
+        };
+
+        await handleAuctionStart(
+          mockClient(),
+          baseAuctionPayload as never,
+          mockSubs(),
+          ctx2
+        );
+
+        expect(counterparty.send).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'auction.started' })
+        );
+        expect(both.send).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'auction.started' })
+        );
+        expect(predictor.send).not.toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'auction.started' })
+        );
+        expect(anon.send).not.toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'auction.started' })
+        );
+      });
     });
 
     it('records broadcast recipients only when send succeeded', async () => {
@@ -1147,6 +1238,52 @@ describe('handleIdentify', () => {
     expect(client.service).toBe('anonymous');
     expect(client.variant).toBe('default');
     expect(clientsIdentified.inc).not.toHaveBeenCalled();
+  });
+
+  it('stores counterparty / both roles verbatim', () => {
+    const cp = mockClient();
+    handleIdentify(cp, {
+      service: 'auction-bidder',
+      instanceId: 'inst-1',
+      role: 'counterparty',
+    });
+    expect(cp.role).toBe('counterparty');
+
+    const both = mockClient();
+    handleIdentify(both, {
+      service: 'app',
+      instanceId: 'inst-2',
+      role: 'both',
+    });
+    expect(both.role).toBe('both');
+  });
+
+  it('falls back to predictor for missing or unrecognized role', () => {
+    const missing = mockClient();
+    missing.role = 'both'; // ensure it actually gets reset
+    handleIdentify(missing, { service: 'app', instanceId: 'inst-1' });
+    expect(missing.role).toBe('predictor');
+
+    const bogus = mockClient();
+    bogus.role = 'counterparty';
+    handleIdentify(bogus, {
+      service: 'app',
+      instanceId: 'inst-2',
+      role: 'admin' as never,
+    });
+    expect(bogus.role).toBe('predictor');
+  });
+
+  it('upgrades role in place on re-identify (predictor → both)', () => {
+    const client = mockClient();
+    handleIdentify(client, { service: 'app', instanceId: 'inst-1' });
+    expect(client.role).toBe('predictor');
+    handleIdentify(client, {
+      service: 'app',
+      instanceId: 'inst-1',
+      role: 'both',
+    });
+    expect(client.role).toBe('both');
   });
 });
 

--- a/packages/relayer/src/__tests__/transport.test.ts
+++ b/packages/relayer/src/__tests__/transport.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { WebSocket } from 'ws';
 import { InMemorySubscriptionManager } from '../transport/subscriptions';
+import { createWsClientConnection } from '../transport/wsTransport';
 import type { ClientConnection } from '../transport/types';
 
 function mockClient(
@@ -9,6 +11,7 @@ function mockClient(
   return {
     id,
     service: 'anonymous',
+    role: 'predictor',
     variant: 'default',
     send: vi.fn().mockReturnValue(true),
     close: vi.fn(),
@@ -17,6 +20,21 @@ function mockClient(
     },
   };
 }
+
+describe('createWsClientConnection', () => {
+  it('defaults role to predictor at connect time (before identify)', () => {
+    // A client we don't control may connect and never send `identify` — it
+    // must default to `predictor` so it stays OUT of the auction.started feed
+    // when role gating is on. Opting in requires declaring counterparty/both.
+    const fakeWs = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn(),
+      close: vi.fn(),
+    };
+    const conn = createWsClientConnection(fakeWs as unknown as WebSocket);
+    expect(conn.role).toBe('predictor');
+  });
+});
 
 describe('InMemorySubscriptionManager', () => {
   let subs: InMemorySubscriptionManager;

--- a/packages/relayer/src/config.ts
+++ b/packages/relayer/src/config.ts
@@ -30,6 +30,12 @@ export const config = cleanEnv(process.env, {
   WS_MAX_CONNECTIONS_PER_IP: num({ default: 50 }), // Max connections from a single IP
   WS_MAX_VALIDATION_FAILURES: num({ default: 10 }), // Disconnect after N signature validation failures
   WS_MAX_INVALID_MESSAGES: num({ default: 20 }), // Disconnect after N invalid/malformed messages
+  // When true, `auction.started` is delivered only to clients whose identify
+  // role is `counterparty` or `both` (predictors/anonymous are skipped). Kept
+  // false until vault-bot + app deploy with their declared role; flipping it
+  // then cuts the per-auction broadcast fan-out from "every connection" to
+  // "actual counterparties only". See AuctionRole in @sapience/sdk/types.
+  AUCTION_FEED_ROLE_GATING: bool({ default: false }),
   MAX_BIDS_PER_ESCROW_AUCTION: num({ default: 50 }), // Max bids per escrow auction (matches secondary market)
   MAX_BIDS_PER_CONNECTION_PER_AUCTION: num({ default: 5 }), // Per-connection cap so one connection can't monopolize an auction's bid slots with unverifiable bids
 

--- a/packages/relayer/src/handlers/escrow.ts
+++ b/packages/relayer/src/handlers/escrow.ts
@@ -13,6 +13,7 @@ import type {
   ServerToClientMessage,
 } from '../escrowTypes';
 import type {
+  AuctionRole,
   IdentifyPayload,
   AuctionReceivedPayload,
 } from '@sapience/sdk/types';
@@ -46,6 +47,13 @@ import { getProviderForChain } from '../utils/getProviderForChain';
 // Identity helpers — keep clientId/instanceId short in logs.
 const short = (s: string | undefined): string =>
   s ? s.slice(0, 8) : 'unknown';
+
+// A client receives the global `auction.started` feed only if it declared a
+// counterparty-side role. Predictors (the default) and anonymous clients are
+// excluded — they still get bids on their own auctions via the per-auction
+// subscription. See AuctionRole in @sapience/sdk/types.
+const receivesAuctionFeed = (c: ClientConnection): boolean =>
+  c.role === 'counterparty' || c.role === 'both';
 
 // Strip non-printable ASCII so a client can't inject newlines/control chars
 // into our log lines via the `service` field.
@@ -171,13 +179,22 @@ export async function handleAuctionStart(
   if (details) {
     const broadcastMsg = { type: 'auction.started', payload: details };
     const auctionShort = short(auctionId);
+    // When role gating is on, the feed reaches only counterparty/both clients.
+    // Kept behind a flag so clients can deploy their declared role before the
+    // relayer narrows the fan-out (see config.AUCTION_FEED_ROLE_GATING).
+    const roleGating = config.AUCTION_FEED_ROLE_GATING;
     let attempted = 0;
     let sent = 0;
     let failed = 0;
     let skippedClosed = 0;
+    let skippedRole = 0;
     for (const c of ctx.allClients()) {
       if (!c.isOpen) {
         skippedClosed++;
+        continue;
+      }
+      if (roleGating && !receivesAuctionFeed(c)) {
+        skippedRole++;
         continue;
       }
       attempted++;
@@ -210,13 +227,14 @@ export async function handleAuctionStart(
       }
     }
     console.log(
-      `[Relayer] auction.broadcast.done auctionId=${auctionShort} attempted=${attempted} sent=${sent} failed=${failed} skippedClosed=${skippedClosed}`
+      `[Relayer] auction.broadcast.done auctionId=${auctionShort} attempted=${attempted} sent=${sent} failed=${failed} skippedClosed=${skippedClosed} skippedRole=${skippedRole} roleGating=${roleGating}`
     );
     logTiming(auctionId, 'broadcast', startTime, {
       attempted,
       sent,
       failed,
       skippedClosed,
+      skippedRole,
     });
   }
 
@@ -424,18 +442,27 @@ export function handleIdentify(
     typeof payload.chainId === 'number' && Number.isFinite(payload.chainId)
       ? payload.chainId
       : undefined;
+  // Role gates the global auction.started feed. Unknown/missing values fall
+  // back to 'predictor' (no feed) so a malformed identify can't silently
+  // subscribe a client to the broadcast. Re-identify upgrades in place
+  // (e.g. an app session promoting 'predictor' → 'both' on terminal open).
+  const role: AuctionRole =
+    payload.role === 'counterparty' || payload.role === 'both'
+      ? payload.role
+      : 'predictor';
 
   client.service = rawService;
   client.variant = rawVariant;
   client.instanceId = instanceId;
   client.chainId = chainId;
+  client.role = role;
 
   clientsIdentified.inc({
     service: serviceLabel(rawService),
     variant: variantLabel(rawVariant),
   });
   console.log(
-    `[Relayer] client.identified clientId=${short(client.id)} service=${rawService} variant=${rawVariant} instance=${short(
+    `[Relayer] client.identified clientId=${short(client.id)} service=${rawService} variant=${rawVariant} role=${role} instance=${short(
       instanceId
     )} chainId=${chainId ?? 'none'} serviceInstance=${
       typeof payload.serviceInstance === 'string'

--- a/packages/relayer/src/transport/types.ts
+++ b/packages/relayer/src/transport/types.ts
@@ -6,6 +6,8 @@
  * `ClientConnection` + `SubscriptionManager` — never raw WebSocket objects.
  */
 
+import type { AuctionRole } from '@sapience/sdk/types';
+
 /** Opaque handle to a connected client — transport-agnostic. */
 export interface ClientConnection {
   readonly id: string;
@@ -15,6 +17,12 @@ export interface ClientConnection {
    * `service: 'anonymous'` so log lines always have a value.
    */
   service: string;
+  /**
+   * Connection role gating delivery of the global `auction.started` feed.
+   * Defaults to `'predictor'` (no feed) until the client declares otherwise
+   * via `identify`. See `AuctionRole` in `@sapience/sdk/types`.
+   */
+  role: AuctionRole;
   /**
    * Strategy/vault flavor a bot serves (e.g. `'default'`, `'pyth'`).
    * Used in tandem with `service` to break out metrics — see

--- a/packages/relayer/src/transport/wsTransport.ts
+++ b/packages/relayer/src/transport/wsTransport.ts
@@ -14,6 +14,13 @@ export function createWsClientConnection(
   const conn: ClientConnection = {
     id,
     service: 'anonymous',
+    // Default role at connect time, before any `identify`. We default to
+    // `predictor` (does NOT receive the global auction.started feed) on
+    // purpose: there are clients we don't control that connect without ever
+    // identifying, and the safe default is to keep them OUT of the broadcast
+    // fan-out. A client opts INTO the feed by declaring `counterparty`/`both`
+    // via identify. See AuctionRole in @sapience/sdk/types.
+    role: 'predictor',
     variant: 'default',
     instanceId: undefined,
     chainId: undefined,

--- a/packages/sdk/types/escrow.ts
+++ b/packages/sdk/types/escrow.ts
@@ -320,6 +320,24 @@ export interface BidPayload {
 // ----- Client to Server Messages -----
 
 /**
+ * Connection role — decides who receives the global `auction.started` feed.
+ *
+ *   - `predictor`    — only starts auctions (sends `auction.start`). Does NOT
+ *                      receive the global feed; still gets bids on its own
+ *                      auctions via the per-auction subscription. This is the
+ *                      default for clients that never declare a role.
+ *   - `counterparty` — receives every `auction.started` to bid against them
+ *                      (e.g. vault-bot / auction-bidder).
+ *   - `both`         — starts auctions AND receives the global feed (e.g. an
+ *                      app session that opens the terminal / AutoBid).
+ *
+ * The role is declared via `identify` and can be upgraded in place by sending
+ * `identify` again (e.g. a `predictor` app session promoting to `both` when the
+ * user opens the terminal) — no reconnect required.
+ */
+export type AuctionRole = 'predictor' | 'counterparty' | 'both';
+
+/**
  * Client identity announced after WS connect. Backwards-compatible:
  * relayer treats clients without identify as anonymous.
  *
@@ -351,6 +369,12 @@ export interface IdentifyPayload {
    * to `'unknown'`.
    */
   variant?: string;
+  /**
+   * Connection role gating delivery of the global `auction.started` feed.
+   * Omitted / unrecognized values are treated as `'predictor'` (no feed).
+   * See {@link AuctionRole}.
+   */
+  role?: AuctionRole;
 }
 
 /** Optional ack a client sends on receiving auction.started — proves end-to-end delivery. */


### PR DESCRIPTION
## Problema

`handleAuctionStart` reenvía cada `auction.started` a **todos** los clientes conectados (`ctx.allClients()`), sin filtrar por suscripción ni rol. Con `WS_MAX_CONNECTIONS=1000`, un solo `auction.start` se amplifica hasta 1000 envíos + un `console.log` por cliente — vector de amplificación tipo DDoS bajo el rate-limit por conexión.

## Fix

Rol de conexión declarado en el handshake `identify` que decide quién recibe el feed global:

- `AuctionRole = 'predictor' | 'counterparty' | 'both'` (SDK).
- `ClientConnection.role`, con **default `predictor` al conectar** — un cliente que no controlamos, que conecta sin `identify`, queda fuera del feed. Opt-in explícito vía `counterparty`/`both`.
- `handleAuctionStart` saltea a los no-counterparty cuando el gating está activo (contador `skippedRole`).
- Flag **`AUCTION_FEED_ROLE_GATING` (default `false`)** → comportamiento idéntico al actual hasta prenderlo.
- App: sesiones de terminal/AutoBid se identifican como `both`, re-anunciado en reconexión.

`market-keeper` no consume `auction.started`, así que queda `predictor` por default (sin cambios). El bot counterparty es vault-bot (repo aparte, PR propio).

Un predictor igual recibe las pujas de su propia auction vía la suscripción `auction:${auctionId}`.

## Rollout

1. Mergear/deployar este PR (flag `false`, sin cambio de comportamiento).
2. Deployar app + vault-bot con su rol.
3. Prender `AUCTION_FEED_ROLE_GATING=true`.

## Tests

77/77 verdes (handlers + transport): gating on/off, parse de rol, upgrade vía re-`identify`, default `predictor` al conectar.

Nota: el test mockea el módulo `../config` porque envalid v8 devuelve un Proxy inmutable.