### PR TITLE
fix(api): v1 questionType no-op regression + wave-2 parity follow-ups

### DIFF
--- a/packages/api/src/graphql/sdl/resolvers/queries/questions.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/questions.ts
@@ -975,6 +975,10 @@ export const questions: NonNullable<QueryResolvers['questions']> = async (
     similarMarketVolumeWindow: args.similarMarketVolumeWindow ?? null,
     sortField: args.sortField ?? null,
     sortDirection: args.sortDirection ?? null,
+    // Must be forwarded explicitly like every other arg — omitting it
+    // silently no-ops the filter (RunQuestionsInput.questionType is
+    // optional), as the 2026-06-11 staging regression proved.
+    questionType: args.questionType ?? null,
   });
   return items;
 };

--- a/packages/api/src/graphql/v2/resolvers/ConditionGroup.test.ts
+++ b/packages/api/src/graphql/v2/resolvers/ConditionGroup.test.ts
@@ -130,6 +130,32 @@ describe('ConditionGroup (v2)', () => {
     expect(conn.totalCount).toBe(2);
   });
 
+  it('ConditionGroup.conditions: honors a feed-hydrated condition array (no refetch)', async () => {
+    // The questions feed attaches the FEED-FILTERED conditions to each
+    // group row (hydrateItems); the resolver must serve that narrowed set
+    // instead of refetching the whole group — v1 parity for filtered
+    // group cards. The visibility rule still applies on top.
+    const conn = await callResolver<{
+      nodes: { id: string }[];
+      totalCount: number;
+    }>(ConditionGroup.conditions)(
+      {
+        id: 1,
+        name: 'g',
+        condition: [
+          { id: '0xmatch1', public: true },
+          { id: '0xpriv', public: false },
+        ],
+      },
+      { first: 50 },
+      {},
+      null
+    );
+    expect(conn.nodes.map((c) => c.id)).toEqual(['0xmatch1']);
+    expect(conn.totalCount).toBe(1);
+    expect(mockPrisma.condition.findMany).not.toHaveBeenCalled();
+  });
+
   it('conditionGroups(orderBy OPEN_INTEREST): a non-numeric after cursor emits numeric cursors', async () => {
     mockPrisma.conditionGroup.findMany.mockResolvedValueOnce([
       { id: 10, name: 'a', createdAt: new Date(), totalOpenInterest: 5n },

--- a/packages/api/src/graphql/v2/resolvers/ConditionGroup.ts
+++ b/packages/api/src/graphql/v2/resolvers/ConditionGroup.ts
@@ -78,20 +78,31 @@ export const ConditionGroup: ConditionGroupResolvers = {
     // rather than NaN (which would slice to an empty page and emit "NaN").
     const skip = offsetFromCursor(args.after);
 
+    // A parent that arrived through the questions feed already carries
+    // its hydrated `condition` array, narrowed by the FEED's per-condition
+    // filters (hydrateItems in sdl/resolvers/queries/questions.ts) — honor
+    // it exactly like v1's resolver does, or filtered feed views would
+    // show every condition of the group instead of only the matching
+    // ones. Fresh fetches (node(), conditionGroups()) have no attached
+    // array and take the loader path.
+    const hydrated = (parent as { condition?: ConditionRow[] }).condition;
+
     // Conditions within a group order by displayOrder (nulls last) then
     // createdAt asc. Per-group sets are bounded; per-request loader
     // amortizes count+page across multiple parent rows in the same
     // selection.
-    const loaded: ConditionRow[] = ctx.loaders?.conditionsByGroupId
-      ? ((await ctx.loaders.conditionsByGroupId.load(parent.id)) ?? [])
-      : await prisma.condition.findMany({
-          where: { conditionGroupId: parent.id },
-          orderBy: [
-            { displayOrder: { sort: 'asc', nulls: 'last' } },
-            { createdAt: 'asc' },
-            { id: 'asc' },
-          ],
-        });
+    const loaded: ConditionRow[] = Array.isArray(hydrated)
+      ? hydrated
+      : ctx.loaders?.conditionsByGroupId
+        ? ((await ctx.loaders.conditionsByGroupId.load(parent.id)) ?? [])
+        : await prisma.condition.findMany({
+            where: { conditionGroupId: parent.id },
+            orderBy: [
+              { displayOrder: { sort: 'asc', nulls: 'last' } },
+              { createdAt: 'asc' },
+              { id: 'asc' },
+            ],
+          });
     // Hidden conditions never leak through the nested connection — the
     // same forced visibility rule as v1's ConditionGroup.conditions
     // resolver. Filtered post-load so it holds on both the loader path

--- a/packages/api/test/contract/operations/questions.test.ts
+++ b/packages/api/test/contract/operations/questions.test.ts
@@ -3,6 +3,31 @@ import { GET_QUESTIONS } from '../fixtures/v1-operations';
 import { executeOperation } from '../../helpers/testApollo';
 import { stabilize } from '../../helpers/stableSerializer';
 
+// The frozen GET_QUESTIONS predates the questionType arg (#1840/#1841);
+// this doc pins the filtered surface, which shipped with ZERO contract
+// coverage — the gap that let the arg silently no-op after the merged v1
+// resolver dropped it from its runner-input field list (staging
+// regression, 2026-06-11).
+const QUESTIONS_BY_TYPE = /* GraphQL */ `
+  query QuestionsByType($questionType: QuestionItemType, $take: Int! = 50) {
+    questions(questionType: $questionType, take: $take) {
+      questionType
+      condition {
+        id
+      }
+      group {
+        id
+      }
+    }
+  }
+`;
+
+interface QuestionEnvelope {
+  questionType: 'condition' | 'group';
+  condition: { id: string } | null;
+  group: { id: number } | null;
+}
+
 describe('Questions query', () => {
   it('matches the recorded contract', async () => {
     const result = await executeOperation(GET_QUESTIONS, {
@@ -15,5 +40,29 @@ describe('Questions query', () => {
     await expect(
       JSON.stringify(stabilize(result.data), null, 2)
     ).toMatchFileSnapshot('../__snapshots__/operations/questions.json');
+  });
+
+  it('questionType: condition returns only condition-rendered items', async () => {
+    const result = await executeOperation<{ questions: QuestionEnvelope[] }>(
+      QUESTIONS_BY_TYPE,
+      { questionType: 'condition' }
+    );
+    expect(result.errors).toBeUndefined();
+    const items = result.data?.questions ?? [];
+    expect(items.length).toBeGreaterThan(0);
+    // Behavioral pin, not a snapshot: with the filter dropped, the feed
+    // returns group items here and this fails loudly.
+    expect(items.filter((q) => q.questionType !== 'condition').length).toBe(0);
+  });
+
+  it('questionType: group returns only multi-condition group items', async () => {
+    const result = await executeOperation<{ questions: QuestionEnvelope[] }>(
+      QUESTIONS_BY_TYPE,
+      { questionType: 'group' }
+    );
+    expect(result.errors).toBeUndefined();
+    const items = result.data?.questions ?? [];
+    expect(items.length).toBeGreaterThan(0);
+    expect(items.filter((q) => q.questionType !== 'group').length).toBe(0);
   });
 });

--- a/packages/api/test/contract/parity/accountActivity.pair.test.ts
+++ b/packages/api/test/contract/parity/accountActivity.pair.test.ts
@@ -1,0 +1,431 @@
+import { describe, it, expect } from 'vitest';
+import { both, byKey, expectMonotonic, isoToEpochMs } from './util';
+
+/**
+ * Parity: v1 `accountActivity` (app-inline op, envelope array) vs v2
+ * `activity` (ActivityItem union connection).
+ *
+ * Canonical item = { kind, key, epochSeconds }: the v1 envelope's
+ * `type`/`prediction`/`trade` triple collapses to the v2 union member
+ * (`__typename`); key = `predictionId` | `tradeHash`.
+ *
+ * Time units / interleave key (the 2b contract):
+ * - v1 carries MIXED per-node units — `Trade.executedAt` is epoch seconds
+ *   while `Prediction.createdAt` is a DateTimeISO string. Canonical
+ *   normalizes BOTH to epoch seconds (floor for createdAt — v2's
+ *   `predictionTs` floors the same way, v2/resolvers/queries/activity.ts).
+ * - v2 exposes the interleave key per edge (`ActivityEdge.timestamp:
+ *   UnixSeconds!`, decision 2b — uniform activity time units). The pair
+ *   asserts edge.timestamp EQUALS the per-node time (trade executedAt /
+ *   floor(prediction createdAt)) on every edge, pinning that the edge
+ *   key is derived from the node and not a third clock.
+ * - DOCUMENTED KEY CHANGE, not projected from: v1's envelope `timestamp`
+ *   prefers `collateralDepositedAt ?? floor(createdAt)` for predictions
+ *   (sdl/resolvers/queries/activity.ts:174-175); v2 deliberately re-keys
+ *   to `floor(createdAt)` only (ActivityEdge.timestamp SDL doc). The
+ *   canonical `epochSeconds` therefore comes from the per-node fields on
+ *   BOTH sides; the v1 envelope value is used only to assert v1's own
+ *   ordering contract. Consequence: the two feeds may order/paginate
+ *   prediction items differently around their deposit time, so
+ *   cross-side comparisons here are full-set only (account-scoped set,
+ *   and the global set via union of both pages).
+ * - `isLegacy` (G10) Prediction-level parity rides here: this frozen op
+ *   selects `prediction.isLegacy` (usePositions' PREDICTIONS_QUERY does
+ *   not), so the canonical prediction item carries it.
+ * - totalCount: v1 exposes NO count for this surface (bare array), so v2
+ *   `totalCount` is checked against the v1 full-set size instead of a v1
+ *   count field.
+ * - DROPPED: numeric `Prediction.id`/`Trade.id` (Prisma row ids — v2
+ *   exposes opaque Node ids; identity via the on-chain keys) and the
+ *   envelope's nested pickConfig subtrees (pinned by predictions.pair /
+ *   trades.pair / pickConfigurations.pair on their own surfaces).
+ */
+
+// source: packages/app/src/hooks/graphql/useAccountActivity.ts @ 7799f7764
+// (ACCOUNT_ACTIVITY_QUERY — frozen copy, do not import from the app)
+const V1_ACCOUNT_ACTIVITY = /* GraphQL */ `
+  query AccountActivity(
+    $address: String
+    $take: Int
+    $skip: Int
+    $type: String
+    $pickConfigId: String
+    $conditionId: String
+  ) {
+    accountActivity(
+      address: $address
+      take: $take
+      skip: $skip
+      type: $type
+      pickConfigId: $pickConfigId
+      conditionId: $conditionId
+    ) {
+      type
+      timestamp
+      prediction {
+        id
+        predictionId
+        chainId
+        marketAddress
+        predictor
+        counterparty
+        predictorToken
+        counterpartyToken
+        predictorCollateral
+        counterpartyCollateral
+        collateralDeposited
+        collateralDepositedAt
+        settled
+        settledAt
+        settleTxHash
+        result
+        predictorClaimable
+        counterpartyClaimable
+        createTxHash
+        createdAt
+        refCode
+        isLegacy
+        pickConfig {
+          id
+          chainId
+          marketAddress
+          totalPredictorCollateral
+          totalCounterpartyCollateral
+          claimedPredictorCollateral
+          claimedCounterpartyCollateral
+          resolved
+          result
+          resolvedAt
+          predictorToken
+          counterpartyToken
+          endsAt
+          isLegacy
+          predictionId
+          picks {
+            id
+            pickConfigId
+            conditionResolver
+            conditionId
+            predictedOutcome
+            condition {
+              id
+              shortName
+              optionName
+              question
+              description
+              endTime
+              resolver
+              settled
+              resolvedToYes
+              nonDecisive
+              estimatedPrice
+              category {
+                slug
+              }
+            }
+          }
+        }
+      }
+      trade {
+        id
+        tradeHash
+        chainId
+        token
+        collateral
+        seller
+        buyer
+        tokenAmount
+        price
+        txHash
+        blockNumber
+        executedAt
+        pickConfig {
+          id
+          chainId
+          marketAddress
+          totalPredictorCollateral
+          totalCounterpartyCollateral
+          claimedPredictorCollateral
+          claimedCounterpartyCollateral
+          resolved
+          result
+          resolvedAt
+          predictorToken
+          counterpartyToken
+          endsAt
+          isLegacy
+          picks {
+            id
+            pickConfigId
+            conditionResolver
+            conditionId
+            predictedOutcome
+            condition {
+              id
+              shortName
+              optionName
+              question
+              description
+              endTime
+              resolver
+              settled
+              resolvedToYes
+              nonDecisive
+              estimatedPrice
+              category {
+                slug
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const V2_ACTIVITY = /* GraphQL */ `
+  query ActivityParity($account: Address, $first: Int!, $after: String) {
+    activity(first: $first, after: $after, filter: { account: $account }) {
+      totalCount
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      edges {
+        timestamp
+        node {
+          __typename
+          ... on Prediction {
+            predictionId
+            createdAt
+            isLegacy
+          }
+          ... on Trade {
+            tradeHash
+            executedAt
+          }
+        }
+      }
+    }
+  }
+`;
+
+// Fixture participant: 4 predictions (one with a NULL pickConfigId) and
+// 3 secondary trades (2 sells + 1 buy) — the only address on both sides
+// of the book, so the interleave is exercised with both kinds present.
+const PARTICIPANT = '0xefa0e8aa84a713f6a6d4de8cc761fe86c5957d72';
+
+interface Canonical {
+  kind: 'PREDICTION' | 'TRADE';
+  key: string;
+  epochSeconds: number;
+  /** Prediction-only (G10); null for trades. */
+  isLegacy: boolean | null;
+}
+
+interface V1Item {
+  type: 'prediction' | 'trade';
+  timestamp: number;
+  prediction: {
+    predictionId: string;
+    createdAt: string;
+    isLegacy: boolean;
+  } | null;
+  trade: { tradeHash: string; executedAt: number } | null;
+}
+
+type V2Node =
+  | {
+      __typename: 'Prediction';
+      predictionId: string;
+      createdAt: string;
+      isLegacy: boolean;
+    }
+  | { __typename: 'Trade'; tradeHash: string; executedAt: number };
+
+interface V2Edge {
+  timestamp: number;
+  node: V2Node;
+}
+
+const floorSeconds = (iso: string): number =>
+  Math.floor(isoToEpochMs(iso) / 1000);
+
+const projectV1 = (items: V1Item[]): Canonical[] =>
+  items.map((it): Canonical => {
+    if (it.type === 'prediction' && it.prediction) {
+      return {
+        kind: 'PREDICTION',
+        key: it.prediction.predictionId.toLowerCase(),
+        // Per-node time, NOT the envelope timestamp — see header.
+        epochSeconds: floorSeconds(it.prediction.createdAt),
+        isLegacy: it.prediction.isLegacy,
+      };
+    }
+    const t = it.trade!;
+    return {
+      kind: 'TRADE',
+      key: t.tradeHash.toLowerCase(),
+      epochSeconds: Number(t.executedAt),
+      isLegacy: null,
+    };
+  });
+
+const projectV2 = (edges: V2Edge[]): Canonical[] =>
+  edges.map((e): Canonical => {
+    if (e.node.__typename === 'Prediction') {
+      return {
+        kind: 'PREDICTION',
+        key: e.node.predictionId.toLowerCase(),
+        epochSeconds: e.timestamp,
+        isLegacy: e.node.isLegacy,
+      };
+    }
+    return {
+      kind: 'TRADE',
+      key: e.node.tradeHash.toLowerCase(),
+      epochSeconds: e.timestamp,
+      isLegacy: null,
+    };
+  });
+
+/** The 2b pin: every edge's timestamp IS the per-node interleave time. */
+const expectEdgeTimestampsMatchNodes = (edges: V2Edge[]): void => {
+  for (const e of edges) {
+    const nodeTime =
+      e.node.__typename === 'Prediction'
+        ? floorSeconds(e.node.createdAt)
+        : Number(e.node.executedAt);
+    expect(e.timestamp).toBe(nodeTime);
+  }
+};
+
+const canonKey = (c: Canonical): string => `${c.kind}:${c.key}`;
+
+type V1Data = { accountActivity: V1Item[] };
+type V2Data = {
+  activity: {
+    totalCount: number;
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    edges: V2Edge[];
+  };
+};
+
+describe('parity: account activity feed', () => {
+  it('account-scoped full set: kinds, keys, times and totalCount match', async () => {
+    const [d1, d2] = await both<V1Data, V2Data>(
+      {
+        query: V1_ACCOUNT_ACTIVITY,
+        variables: {
+          address: PARTICIPANT,
+          take: 50,
+          skip: 0,
+          type: null,
+          pickConfigId: null,
+          conditionId: null,
+        },
+      },
+      { query: V2_ACTIVITY, variables: { account: PARTICIPANT, first: 50 } }
+    );
+
+    const v1 = byKey(projectV1(d1.accountActivity), canonKey);
+    const v2 = byKey(projectV2(d2.activity.edges), canonKey);
+
+    expect(v1.length).toBeGreaterThan(0);
+    // Both union members participate — the interleave is real.
+    expect(new Set(v1.map((c) => c.kind))).toEqual(
+      new Set(['PREDICTION', 'TRADE'])
+    );
+    // v1 is `expected`: a failing diff reads as "v2 deviates from v1".
+    expect(v2).toEqual(v1);
+
+    // v1 has no count field — v2 totalCount is checked against the v1
+    // full-set size (the whole account history fits in one page).
+    expect(d2.activity.pageInfo.hasNextPage).toBe(false);
+    expect(d2.activity.totalCount).toBe(v1.length);
+
+    expectEdgeTimestampsMatchNodes(d2.activity.edges);
+
+    // Each side honors its own ordering contract on its raw order — v1 by
+    // its envelope timestamp (collateralDepositedAt-preferring), v2 by
+    // the edge timestamp (createdAt-keyed). See header.
+    expectMonotonic(
+      d1.accountActivity.map((it) => it.timestamp),
+      'desc'
+    );
+    expectMonotonic(
+      d2.activity.edges.map((e) => e.timestamp),
+      'desc'
+    );
+  });
+
+  it('global feed: cross-page dedupe on both sides; full-table sets match', async () => {
+    // Fixture totals: 194 predictions + 6 trades = 200 items. Each side
+    // pages 100+100 with its own mechanism (v1 offset, v2 cursor); the
+    // union of both pages must be duplicate-free and identical across
+    // endpoints even though the page BOUNDARIES may differ (interleave
+    // key change, see header).
+    const vars = (skip: number) => ({
+      address: null,
+      take: 100,
+      skip,
+      type: null,
+      pickConfigId: null,
+      conditionId: null,
+    });
+    const [d1p1, d2p1] = await both<V1Data, V2Data>(
+      { query: V1_ACCOUNT_ACTIVITY, variables: vars(0) },
+      { query: V2_ACTIVITY, variables: { account: null, first: 100 } }
+    );
+    expect(d2p1.activity.pageInfo.hasNextPage).toBe(true);
+    const [d1p2, d2p2] = await both<V1Data, V2Data>(
+      { query: V1_ACCOUNT_ACTIVITY, variables: vars(100) },
+      {
+        query: V2_ACTIVITY,
+        variables: {
+          account: null,
+          first: 100,
+          after: d2p1.activity.pageInfo.endCursor,
+        },
+      }
+    );
+
+    const v1p1 = projectV1(d1p1.accountActivity);
+    const v1p2 = projectV1(d1p2.accountActivity);
+    const v2p1 = projectV2(d2p1.activity.edges);
+    const v2p2 = projectV2(d2p2.activity.edges);
+
+    // Cross-page dedupe sanity, per side.
+    const v1Keys = [...v1p1, ...v1p2].map(canonKey);
+    const v2Keys = [...v2p1, ...v2p2].map(canonKey);
+    expect(new Set(v1Keys).size).toBe(v1Keys.length);
+    expect(new Set(v2Keys).size).toBe(v2Keys.length);
+
+    // Both sides exhausted the table; the full sets agree.
+    expect(d2p2.activity.pageInfo.hasNextPage).toBe(false);
+    const v1All = byKey([...v1p1, ...v1p2], canonKey);
+    const v2All = byKey([...v2p1, ...v2p2], canonKey);
+    expect(v1All.length).toBe(200);
+    expect(v2All).toEqual(v1All);
+
+    // v2 totalCount is the same number on every page of the query.
+    expect(d2p1.activity.totalCount).toBe(200);
+    expect(d2p2.activity.totalCount).toBe(200);
+
+    // 2b pin across both pages, and the cursor seam stays ordered.
+    expectEdgeTimestampsMatchNodes(d2p1.activity.edges);
+    expectEdgeTimestampsMatchNodes(d2p2.activity.edges);
+    expectMonotonic(
+      [...d2p1.activity.edges, ...d2p2.activity.edges].map((e) => e.timestamp),
+      'desc'
+    );
+    expectMonotonic(
+      d1p1.accountActivity.map((it) => it.timestamp),
+      'desc'
+    );
+    expectMonotonic(
+      d1p2.accountActivity.map((it) => it.timestamp),
+      'desc'
+    );
+  });
+});

--- a/packages/api/test/contract/parity/forecastByUid.pair.test.ts
+++ b/packages/api/test/contract/parity/forecastByUid.pair.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from 'vitest';
+import { both } from './util';
+
+/**
+ * Parity: v1 `attestations(where:{uid},take:1)` (app-inline SSR op — the
+ * /forecast/<uid> page + OG route lookup) vs v2 `forecast(uid:)` (G4).
+ *
+ * Documented differences encoded in the projection below:
+ * - DROPPED numeric `Attestation.id`: a Prisma row id, not exposed in v2
+ *   by design (PLAN.md identity model). Identity is the EAS `uid`.
+ * - Shape: v1 is a list query the consumer collapses with
+ *   `attestations[0] ?? null` (fetchAttestationByUid); v2 is the direct
+ *   single lookup. The pair replicates the consumer collapse.
+ * - Renames (G4): v1 `prediction` → v2 `value` (a probability STRING,
+ *   not a binary outcome); v1 `time` → v2 `attestedAt` (UnixSeconds).
+ * - Nested `condition`: compared INCLUDING the nested fields the v1 op
+ *   selects (v1 `condition.id` IS the CTF hash → v2 `conditionId`;
+ *   convenience booleans `settled`/`resolvedToYes` verbatim — v2 keeps
+ *   them as v1-compat fields derived from `outcome`, PR #1822).
+ * - FIXTURE CAVEAT (dangling FK, same as forecasts.pair): all 3 fixture
+ *   attestation rows carry a conditionId with NO matching condition row
+ *   (attestations were captured without scoping to the captured condition
+ *   set before the scripts/snapshotTestDb.ts WHERE fix). Both resolvers
+ *   null the relation on a missing row (v1 sdl Pick-style fallback /
+ *   v2 Forecast.condition loader), so nested-field parity is exercised
+ *   only as null ≡ null here; the conditionId column itself still
+ *   round-trips and is compared. The projection keeps the full nested
+ *   shape so a fixture refresh with a resolving row upgrades this pair
+ *   for free.
+ * - .toLowerCase() on attester / conditionId: the attester column stores
+ *   checksummed addresses (EAS indexer writes viem log args verbatim);
+ *   casing is not part of the consumer contract.
+ */
+
+// source: packages/app/src/lib/data/forecasts.ts @ 7799f7764
+// (ATTESTATION_BY_UID_QUERY — frozen copy, do not import from the app)
+const V1_ATTESTATION_BY_UID = /* GraphQL */ `
+  query FindAttestationByUid($where: AttestationWhereInput!) {
+    attestations(where: $where, take: 1) {
+      id
+      uid
+      attester
+      time
+      prediction
+      comment
+      conditionId
+      condition {
+        id
+        question
+        shortName
+        endTime
+        settled
+        resolvedToYes
+        resolver
+        category {
+          slug
+        }
+      }
+    }
+  }
+`;
+
+const V2_FORECAST_BY_UID = /* GraphQL */ `
+  query ForecastByUidParity($uid: String!) {
+    forecast(uid: $uid) {
+      uid
+      attester
+      attestedAt
+      value
+      comment
+      conditionId
+      condition {
+        conditionId
+        question
+        shortName
+        endTime
+        settled
+        resolvedToYes
+        resolver
+        category {
+          slug
+        }
+      }
+    }
+  }
+`;
+
+// All 3 fixture attestation uids (attestation COPY block) — every one is
+// exercised since the surface is a permalink lookup.
+const UIDS = [
+  '0x554d70a89bb75d5efda7f791641582f926e8f000402bb726798c538a34db2a03',
+  '0xfc517758b61b35c05e349f30c2c37bb8252209d03285595609a730343b0c59c5',
+  '0xba3aec08b03e403900140ca733f2ac46441d16d93a1818bd3f89a811bc663cfe',
+];
+const MISSING_UID =
+  '0x00000000000000000000000000000000000000000000000000000000000000aa';
+
+interface CanonCondition {
+  conditionId: string;
+  question: string;
+  shortName: string | null;
+  endTime: number;
+  settled: boolean;
+  resolvedToYes: boolean;
+  resolver: string | null;
+  categorySlug: string | null;
+}
+interface Canonical {
+  uid: string;
+  attester: string;
+  time: number;
+  value: string;
+  comment: string | null;
+  conditionId: string | null;
+  condition: CanonCondition | null;
+}
+
+interface RawCondition {
+  id?: string; // v1: CTF hash under `id`
+  conditionId?: string; // v2: CTF hash under `conditionId`
+  question: string;
+  shortName: string | null;
+  endTime: number;
+  settled: boolean;
+  resolvedToYes: boolean;
+  resolver: string | null;
+  category: { slug: string } | null;
+}
+interface V1Row {
+  id: number;
+  uid: string;
+  attester: string;
+  time: number;
+  prediction: string;
+  comment: string | null;
+  conditionId: string | null;
+  condition: RawCondition | null;
+}
+interface V2Row {
+  uid: string;
+  attester: string;
+  attestedAt: number;
+  value: string;
+  comment: string | null;
+  conditionId: string | null;
+  condition: RawCondition | null;
+}
+
+const projectCondition = (c: RawCondition | null): CanonCondition | null =>
+  c == null
+    ? null
+    : {
+        conditionId: (c.conditionId ?? c.id ?? '').toLowerCase(),
+        question: c.question,
+        shortName: c.shortName ?? null,
+        endTime: Number(c.endTime),
+        settled: c.settled,
+        resolvedToYes: c.resolvedToYes,
+        resolver: c.resolver ? c.resolver.toLowerCase() : null,
+        categorySlug: c.category?.slug ?? null,
+      };
+
+const projectV1 = (a: V1Row): Canonical => ({
+  uid: a.uid.toLowerCase(),
+  attester: a.attester.toLowerCase(),
+  time: a.time,
+  value: a.prediction, // G4 rename
+  comment: a.comment ?? null,
+  conditionId: a.conditionId ? a.conditionId.toLowerCase() : null,
+  condition: projectCondition(a.condition),
+});
+
+const projectV2 = (f: V2Row): Canonical => ({
+  uid: f.uid.toLowerCase(),
+  attester: f.attester.toLowerCase(),
+  time: f.attestedAt, // G4 rename
+  value: f.value,
+  comment: f.comment ?? null,
+  conditionId: f.conditionId ? f.conditionId.toLowerCase() : null,
+  condition: projectCondition(f.condition),
+});
+
+const runPair = (uid: string) =>
+  both<{ attestations: V1Row[] }, { forecast: V2Row | null }>(
+    {
+      query: V1_ATTESTATION_BY_UID,
+      variables: { where: { uid: { equals: uid } } },
+    },
+    { query: V2_FORECAST_BY_UID, variables: { uid } }
+  );
+
+describe('parity: forecast by uid (permalink lookup)', () => {
+  it('every fixture uid resolves identically (incl. nested condition shape)', async () => {
+    for (const uid of UIDS) {
+      const [d1, d2] = await runPair(uid);
+
+      // Replicate the consumer collapse: attestations[0] ?? null.
+      const a = d1.attestations[0] ?? null;
+      expect(a, `v1 missing attestation for ${uid}`).not.toBeNull();
+      expect(d2.forecast, `v2 missing forecast for ${uid}`).not.toBeNull();
+
+      const v1 = projectV1(a as V1Row);
+      const v2 = projectV2(d2.forecast as V2Row);
+      // v1 is `expected`: a failing diff reads as "v2 deviates from v1".
+      expect(v2).toEqual(v1);
+
+      // Fixture caveat pin (see header): the conditionId column round-trips
+      // while the relation dangles → null on BOTH sides. If a fixture
+      // refresh makes these resolve, the canonical compare above starts
+      // covering the nested fields automatically and this pin can go.
+      expect(v1.conditionId).not.toBeNull();
+      expect(v1.condition).toBeNull();
+      expect(v2.condition).toBeNull();
+    }
+  });
+
+  it('unknown uid: v1 empty list (consumer null) ↔ v2 null', async () => {
+    const [d1, d2] = await runPair(MISSING_UID);
+    expect(d1.attestations).toEqual([]);
+    expect(d1.attestations[0] ?? null).toBeNull();
+    expect(d2.forecast).toBeNull();
+  });
+});

--- a/packages/api/test/contract/parity/predictionById.pair.test.ts
+++ b/packages/api/test/contract/parity/predictionById.pair.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect } from 'vitest';
+import { both, byKey, isoToEpochMs } from './util';
+
+/**
+ * Parity: v1 `prediction(id:)` (app-inline SSR op) vs v2
+ * `prediction(predictionId:)` — the /prediction/<id> page + OG route
+ * single lookup.
+ *
+ * Documented differences encoded in the projection below:
+ * - DROPPED numeric `Prediction.id` / `Pick.id` (Prisma row ids): not
+ *   exposed in v2 by design (PLAN.md identity model); identity is the
+ *   on-chain `predictionId` (and `conditionId` within picks).
+ * - v1 `prediction(id:)` despite the arg name looks up by predictionId
+ *   (escrow.ts: `findUnique({ where: { predictionId: id } })`) → v2
+ *   renames the arg honestly to `prediction(predictionId:)`.
+ * - `marketAddress` → `escrow` rename (Prediction and PickConfiguration);
+ *   v1 `pickConfig.id` IS the pickConfig hash → v2 `pickConfigId`.
+ * - `result`: v1 SettlementResult! with an `UNRESOLVED` member ↔ v2
+ *   nullable enum where null = not settled. Canonical maps v1
+ *   'UNRESOLVED' → null. Both states are exercised (one settled id, one
+ *   unresolved id).
+ * - `settled`/`resolved`: v1 DB column ↔ v2 derived from `result != null`;
+ *   compared verbatim.
+ * - `predictedOutcome`: v1 Int (1/0) ↔ v2 BinaryOutcome enum
+ *   (1 → 'YES', 0 → 'NO'; v2/resolvers/PickConfiguration.ts).
+ * - `conditionResolver` → `resolver` rename on Pick.
+ * - tokens: v1 coalesces missing pickConfiguration tokens to ''
+ *   (escrow.ts `?? ''`); v2 keeps them null. Canonical maps '' → null.
+ * - Picks compare as a set by conditionId (v1 emits them in Prisma
+ *   include order with no declared contract).
+ */
+
+// source: packages/app/src/lib/data/predictions.ts @ 7799f7764
+// (PREDICTION_BY_ID_QUERY — frozen copy, do not import from the app)
+const V1_PREDICTION_BY_ID = /* GraphQL */ `
+  query Prediction($id: String!) {
+    prediction(id: $id) {
+      id
+      predictionId
+      chainId
+      marketAddress
+      predictor
+      counterparty
+      predictorToken
+      counterpartyToken
+      predictorCollateral
+      counterpartyCollateral
+      settled
+      settledAt
+      result
+      createdAt
+      pickConfig {
+        id
+        chainId
+        marketAddress
+        resolved
+        result
+        resolvedAt
+        endsAt
+        picks {
+          id
+          conditionResolver
+          conditionId
+          predictedOutcome
+        }
+      }
+    }
+  }
+`;
+
+const V2_PREDICTION_BY_ID = /* GraphQL */ `
+  query PredictionByIdParity($predictionId: Bytes32!) {
+    prediction(predictionId: $predictionId) {
+      predictionId
+      chainId
+      escrow
+      predictor
+      counterparty
+      predictorToken
+      counterpartyToken
+      predictorCollateral
+      counterpartyCollateral
+      settled
+      settledAt
+      result
+      createdAt
+      pickConfig {
+        pickConfigId
+        chainId
+        escrow
+        resolved
+        result
+        resolvedAt
+        endsAt
+        picks {
+          resolver
+          conditionId
+          predictedOutcome
+        }
+      }
+    }
+  }
+`;
+
+// Fixture predictionIds ("Prediction" COPY block):
+// - SETTLED_ID: settled, result COUNTERPARTY_WINS, 2 picks — exercises
+//   the terminal-result path (settledAt, resolved pickConfig).
+// - UNRESOLVED_ID: unsettled, result UNRESOLVED↔null, 3 picks.
+const SETTLED_ID =
+  '0x3c8bc8d668bb8c8f2b3c40b0d635e2035e563e6773afffefacbec88cc91a465d';
+const UNRESOLVED_ID =
+  '0xbc1d543ee2c9c7da95fb4d7a928eaaeca7aa31d6d96ababca94da02e18aaf60b';
+const MISSING_ID =
+  '0x00000000000000000000000000000000000000000000000000000000000000ff';
+
+interface CanonPick {
+  conditionId: string;
+  resolver: string;
+  predictedOutcome: 'YES' | 'NO';
+}
+interface Canonical {
+  predictionId: string;
+  chainId: number;
+  escrow: string;
+  predictor: string;
+  counterparty: string;
+  predictorToken: string | null;
+  counterpartyToken: string | null;
+  predictorCollateral: string;
+  counterpartyCollateral: string;
+  settled: boolean;
+  settledAt: number | null;
+  result: string | null;
+  createdAtMs: number;
+  pickConfig: {
+    pickConfigId: string;
+    chainId: number;
+    escrow: string;
+    resolved: boolean;
+    result: string | null;
+    resolvedAt: number | null;
+    endsAt: number | null;
+    picks: CanonPick[];
+  } | null;
+}
+
+interface V1Row {
+  id: number;
+  predictionId: string;
+  chainId: number;
+  marketAddress: string;
+  predictor: string;
+  counterparty: string;
+  predictorToken: string;
+  counterpartyToken: string;
+  predictorCollateral: string | number;
+  counterpartyCollateral: string | number;
+  settled: boolean;
+  settledAt: number | null;
+  result: string;
+  createdAt: string;
+  pickConfig: {
+    id: string;
+    chainId: number;
+    marketAddress: string;
+    resolved: boolean;
+    result: string;
+    resolvedAt: number | null;
+    endsAt: number | null;
+    picks: {
+      id: number;
+      conditionResolver: string;
+      conditionId: string;
+      predictedOutcome: number;
+    }[];
+  } | null;
+}
+
+interface V2Row {
+  predictionId: string;
+  chainId: number;
+  escrow: string;
+  predictor: string;
+  counterparty: string;
+  predictorToken: string | null;
+  counterpartyToken: string | null;
+  predictorCollateral: string | number;
+  counterpartyCollateral: string | number;
+  settled: boolean;
+  settledAt: number | null;
+  result: string | null;
+  createdAt: string;
+  pickConfig: {
+    pickConfigId: string;
+    chainId: number;
+    escrow: string;
+    resolved: boolean;
+    result: string | null;
+    resolvedAt: number | null;
+    endsAt: number | null;
+    picks: {
+      resolver: string;
+      conditionId: string;
+      predictedOutcome: 'YES' | 'NO';
+    }[];
+  } | null;
+}
+
+/** VALUE is the contract; wire representation (string vs number) is not. */
+const bn = (v: string | number): string => BigInt(v).toString();
+const lower = (v: string | null | undefined): string | null =>
+  v ? v.toLowerCase() : null;
+
+const projectV1 = (r: V1Row): Canonical => ({
+  predictionId: r.predictionId.toLowerCase(),
+  chainId: r.chainId,
+  escrow: r.marketAddress.toLowerCase(), // marketAddress → escrow
+  predictor: r.predictor.toLowerCase(),
+  counterparty: r.counterparty.toLowerCase(),
+  // v1 coalesces missing tokens to '' (escrow.ts `?? ''`); v2 is null.
+  predictorToken: r.predictorToken === '' ? null : lower(r.predictorToken),
+  counterpartyToken:
+    r.counterpartyToken === '' ? null : lower(r.counterpartyToken),
+  predictorCollateral: bn(r.predictorCollateral),
+  counterpartyCollateral: bn(r.counterpartyCollateral),
+  settled: r.settled,
+  settledAt: r.settledAt ?? null,
+  // v1 'UNRESOLVED' ↔ v2 null (v2 enum carries terminal outcomes only).
+  result: r.result === 'UNRESOLVED' ? null : r.result,
+  createdAtMs: isoToEpochMs(r.createdAt),
+  pickConfig: r.pickConfig
+    ? {
+        pickConfigId: r.pickConfig.id.toLowerCase(), // v1 id IS the hash
+        chainId: r.pickConfig.chainId,
+        escrow: r.pickConfig.marketAddress.toLowerCase(),
+        resolved: r.pickConfig.resolved,
+        result:
+          r.pickConfig.result === 'UNRESOLVED' ? null : r.pickConfig.result,
+        resolvedAt: r.pickConfig.resolvedAt ?? null,
+        endsAt: r.pickConfig.endsAt ?? null,
+        picks: byKey(
+          r.pickConfig.picks.map(
+            (p): CanonPick => ({
+              conditionId: p.conditionId.toLowerCase(),
+              resolver: p.conditionResolver.toLowerCase(), // rename
+              // v1 Int 1/0 → v2 BinaryOutcome enum.
+              predictedOutcome: p.predictedOutcome === 1 ? 'YES' : 'NO',
+            })
+          ),
+          (p) => p.conditionId
+        ),
+      }
+    : null,
+});
+
+const projectV2 = (r: V2Row): Canonical => ({
+  predictionId: r.predictionId.toLowerCase(),
+  chainId: r.chainId,
+  escrow: r.escrow.toLowerCase(),
+  predictor: r.predictor.toLowerCase(),
+  counterparty: r.counterparty.toLowerCase(),
+  predictorToken: lower(r.predictorToken),
+  counterpartyToken: lower(r.counterpartyToken),
+  predictorCollateral: bn(r.predictorCollateral),
+  counterpartyCollateral: bn(r.counterpartyCollateral),
+  settled: r.settled,
+  settledAt: r.settledAt ?? null,
+  result: r.result ?? null,
+  createdAtMs: isoToEpochMs(r.createdAt),
+  pickConfig: r.pickConfig
+    ? {
+        pickConfigId: r.pickConfig.pickConfigId.toLowerCase(),
+        chainId: r.pickConfig.chainId,
+        escrow: r.pickConfig.escrow.toLowerCase(),
+        resolved: r.pickConfig.resolved,
+        result: r.pickConfig.result ?? null,
+        resolvedAt: r.pickConfig.resolvedAt ?? null,
+        endsAt: r.pickConfig.endsAt ?? null,
+        picks: byKey(
+          r.pickConfig.picks.map(
+            (p): CanonPick => ({
+              conditionId: p.conditionId.toLowerCase(),
+              resolver: p.resolver.toLowerCase(),
+              predictedOutcome: p.predictedOutcome,
+            })
+          ),
+          (p) => p.conditionId
+        ),
+      }
+    : null,
+});
+
+const runPair = (id: string) =>
+  both<{ prediction: V1Row | null }, { prediction: V2Row | null }>(
+    { query: V1_PREDICTION_BY_ID, variables: { id } },
+    { query: V2_PREDICTION_BY_ID, variables: { predictionId: id } }
+  );
+
+describe('parity: prediction by id', () => {
+  it('settled prediction matches (terminal result path)', async () => {
+    const [d1, d2] = await runPair(SETTLED_ID);
+    expect(d1.prediction).not.toBeNull();
+    expect(d2.prediction).not.toBeNull();
+
+    const v1 = projectV1(d1.prediction as V1Row);
+    const v2 = projectV2(d2.prediction as V2Row);
+    // v1 is `expected`: a failing diff reads as "v2 deviates from v1".
+    expect(v2).toEqual(v1);
+
+    // The terminal path is actually exercised, not vacuous.
+    expect(v1.settled).toBe(true);
+    expect(v1.result).toBe('COUNTERPARTY_WINS');
+    expect(v1.pickConfig?.picks.length).toBeGreaterThan(0);
+  });
+
+  it('unresolved prediction matches (result UNRESOLVED ↔ null)', async () => {
+    const [d1, d2] = await runPair(UNRESOLVED_ID);
+    expect(d1.prediction).not.toBeNull();
+    expect(d2.prediction).not.toBeNull();
+
+    // The raw wire shapes differ exactly as documented...
+    expect((d1.prediction as V1Row).result).toBe('UNRESOLVED');
+    expect((d2.prediction as V2Row).result).toBeNull();
+
+    // ...and the canonical projections agree.
+    const v1 = projectV1(d1.prediction as V1Row);
+    const v2 = projectV2(d2.prediction as V2Row);
+    expect(v2).toEqual(v1);
+    expect(v1.settled).toBe(false);
+  });
+
+  it('unknown predictionId is null on both sides', async () => {
+    const [d1, d2] = await runPair(MISSING_ID);
+    expect(d1.prediction).toBeNull();
+    expect(d2.prediction).toBeNull();
+  });
+});

--- a/packages/api/test/contract/parity/predictions.pair.test.ts
+++ b/packages/api/test/contract/parity/predictions.pair.test.ts
@@ -1,0 +1,602 @@
+import { describe, it, expect } from 'vitest';
+import { both, byKey, expectMonotonic, isoToEpochMs } from './util';
+
+/**
+ * Parity: v1 `predictions(address:)` + `predictionCount` (app-inline ops)
+ * vs v2 `predictions(filter:{participant})` connection (+ first:0
+ * totalCount-only request).
+ *
+ * Documented differences encoded in the projections below:
+ * - DROPPED numeric `Prediction.id` / `Pick.id` (Prisma row ids): not
+ *   exposed in v2 by design (PLAN.md identity model). Identity is the
+ *   on-chain `predictionId`; picks key on `conditionId` within their
+ *   parent config.
+ * - DROPPED `Pick.pickConfigId`: redundant with the parent
+ *   `pickConfig.pickConfigId` (v2 omits it; picks are only fetched in
+ *   parent context).
+ * - DROPPED `pickConfig.predictionId`: v1 hard-nulls it on this surface
+ *   (escrow.ts `mapPickConfig` is called without the `extra` arg), and v2
+ *   moved the concept to `Position.prediction` (G5 decision 2). The v1
+ *   always-null fact is asserted below rather than silently dropped.
+ * - `marketAddress` → `escrow` rename (both Prediction and
+ *   PickConfiguration; v1 `pickConfig.id` IS the pickConfig hash → v2
+ *   `pickConfigId`).
+ * - `result`: v1 SettlementResult! with an `UNRESOLVED` member ↔ v2
+ *   nullable enum where null = not settled (v2/resolvers/Prediction.ts,
+ *   PickConfiguration.ts). Canonical maps v1 'UNRESOLVED' → null.
+ * - `settled`/`resolved` parity: v1 reads the DB column; v2 derives from
+ *   `result != null`. Compared verbatim (fixture: 0 rows disagree).
+ * - `isLegacy` parity (G10): the frozen consumer op selects it only at
+ *   `pickConfig.isLegacy` (no Prediction-level selection), so that's
+ *   where it's compared — verbatim, with both values present in the
+ *   participant's set. Prediction-level `isLegacy` (v2 native vs v1
+ *   column) is pinned by accountActivity.pair, whose frozen v1 op
+ *   selects it.
+ * - `predictedOutcome`: v1 Int (1/0) ↔ v2 BinaryOutcome enum; canonical
+ *   maps 1 → 'YES', 0 → 'NO' (v2/resolvers/PickConfiguration.ts Pick
+ *   resolver).
+ * - tokens: v1 coalesces missing pickConfiguration tokens to '' (escrow.ts
+ *   `?? ''`); v2 keeps them null. Canonical maps '' → null.
+ * - `conditionResolver` → `resolver` rename on Pick.
+ * - Ordering: v1 resolver default is `createdAt desc` (no tie-break; the
+ *   frozen op passes no orderBy); v2 doc passes CREATED_AT DESC explicitly
+ *   (v2 ties on row id). Rows compare as a set by predictionId; each
+ *   side's ordering contract asserted independently.
+ */
+
+// source: packages/app/src/hooks/graphql/usePositions.ts @ 7799f7764
+// (PREDICTIONS_QUERY with PICK_CONFIG_FRAGMENT / PICK_CONDITION_FRAGMENT
+// inlined — frozen copy, do not import from the SDK)
+const V1_PREDICTIONS = /* GraphQL */ `
+  query Predictions($address: String!, $chainId: Int, $take: Int, $skip: Int) {
+    predictions(address: $address, chainId: $chainId, take: $take, skip: $skip) {
+      id
+      predictionId
+      chainId
+      marketAddress
+      predictor
+      counterparty
+      predictorToken
+      counterpartyToken
+      predictorCollateral
+      counterpartyCollateral
+      collateralDeposited
+      collateralDepositedAt
+      settled
+      settledAt
+      settleTxHash
+      result
+      predictorClaimable
+      counterpartyClaimable
+      createTxHash
+      createdAt
+      refCode
+      pickConfig {
+        id
+        chainId
+        marketAddress
+        totalPredictorCollateral
+        totalCounterpartyCollateral
+        claimedPredictorCollateral
+        claimedCounterpartyCollateral
+        resolved
+        result
+        resolvedAt
+        predictorToken
+        counterpartyToken
+        endsAt
+        isLegacy
+        predictionId
+        picks {
+          id
+          pickConfigId
+          conditionResolver
+          conditionId
+          predictedOutcome
+          condition {
+            id
+            shortName
+            optionName
+            question
+            description
+            endTime
+            resolver
+            settled
+            resolvedToYes
+            nonDecisive
+            estimatedPrice
+            category {
+              slug
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+// source: packages/app/src/hooks/graphql/usePositions.ts @ 7799f7764
+// (PREDICTIONS_COUNT_QUERY — frozen copy)
+const V1_PREDICTIONS_COUNT = /* GraphQL */ `
+  query PredictionsCount($address: String!, $chainId: Int) {
+    predictionCount(address: $address, chainId: $chainId)
+  }
+`;
+
+const V2_PREDICTIONS = /* GraphQL */ `
+  query PredictionsParity($participant: Address!, $first: Int!) {
+    predictions(
+      first: $first
+      filter: { participant: $participant }
+      orderBy: { field: CREATED_AT, direction: DESC }
+    ) {
+      totalCount
+      nodes {
+        predictionId
+        chainId
+        escrow
+        predictor
+        counterparty
+        predictorToken
+        counterpartyToken
+        predictorCollateral
+        counterpartyCollateral
+        collateralDeposited
+        collateralDepositedAt
+        settled
+        settledAt
+        settleTxHash
+        result
+        predictorClaimable
+        counterpartyClaimable
+        createTxHash
+        createdAt
+        refCode
+        pickConfig {
+          pickConfigId
+          chainId
+          escrow
+          totalPredictorCollateral
+          totalCounterpartyCollateral
+          claimedPredictorCollateral
+          claimedCounterpartyCollateral
+          resolved
+          result
+          resolvedAt
+          predictorToken
+          counterpartyToken
+          endsAt
+          isLegacy
+          picks {
+            resolver
+            conditionId
+            predictedOutcome
+            condition {
+              conditionId
+              shortName
+              optionName
+              question
+              description
+              endTime
+              resolver
+              settled
+              resolvedToYes
+              nonDecisive
+              estimatedPrice
+              category {
+                slug
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+// Fixture participant ("Prediction" COPY block): predictor on 26 rows +
+// counterparty on 2 more (28 total — full set at take 50), spanning
+// settled and unsettled rows, legacy and non-legacy markets, and
+// UNRESOLVED / PREDICTOR_WINS / COUNTERPARTY_WINS results.
+const PARTICIPANT = '0x314ace01c6b2e5e16113036fb1f6286c509fc373';
+
+interface CanonPickCondition {
+  conditionId: string;
+  shortName: string | null;
+  optionName: string | null;
+  question: string;
+  description: string;
+  endTime: number;
+  resolver: string | null;
+  settled: boolean;
+  resolvedToYes: boolean;
+  nonDecisive: boolean;
+  estimatedPrice: number | null;
+  categorySlug: string | null;
+}
+interface CanonPick {
+  conditionId: string;
+  resolver: string;
+  predictedOutcome: 'YES' | 'NO';
+  condition: CanonPickCondition | null;
+}
+interface CanonPickConfig {
+  pickConfigId: string;
+  chainId: number;
+  escrow: string;
+  totalPredictorCollateral: string;
+  totalCounterpartyCollateral: string;
+  claimedPredictorCollateral: string;
+  claimedCounterpartyCollateral: string;
+  resolved: boolean;
+  result: string | null;
+  resolvedAt: number | null;
+  predictorToken: string | null;
+  counterpartyToken: string | null;
+  endsAt: number | null;
+  isLegacy: boolean;
+  picks: CanonPick[];
+}
+interface Canonical {
+  predictionId: string;
+  chainId: number;
+  escrow: string;
+  predictor: string;
+  counterparty: string;
+  predictorToken: string | null;
+  counterpartyToken: string | null;
+  predictorCollateral: string;
+  counterpartyCollateral: string;
+  collateralDeposited: string | null;
+  collateralDepositedAt: number | null;
+  settled: boolean;
+  settledAt: number | null;
+  settleTxHash: string | null;
+  result: string | null;
+  predictorClaimable: string | null;
+  counterpartyClaimable: string | null;
+  createTxHash: string;
+  createdAtMs: number;
+  refCode: string | null;
+  pickConfig: CanonPickConfig | null;
+}
+
+interface RawPickCondition {
+  id?: string; // v1: CTF hash under `id`
+  conditionId?: string; // v2: CTF hash under `conditionId`
+  shortName: string | null;
+  optionName: string | null;
+  question: string;
+  description: string;
+  endTime: number;
+  resolver: string | null;
+  settled: boolean;
+  resolvedToYes: boolean;
+  nonDecisive: boolean;
+  estimatedPrice: number | null;
+  category: { slug: string } | null;
+}
+interface V1Pick {
+  id: number;
+  pickConfigId: string;
+  conditionResolver: string;
+  conditionId: string;
+  predictedOutcome: number;
+  condition: RawPickCondition | null;
+}
+interface V2Pick {
+  resolver: string;
+  conditionId: string;
+  predictedOutcome: 'YES' | 'NO';
+  condition: RawPickCondition | null;
+}
+interface V1PickConfig {
+  id: string;
+  chainId: number;
+  marketAddress: string;
+  totalPredictorCollateral: string | number;
+  totalCounterpartyCollateral: string | number;
+  claimedPredictorCollateral: string | number;
+  claimedCounterpartyCollateral: string | number;
+  resolved: boolean;
+  result: string;
+  resolvedAt: number | null;
+  predictorToken: string | null;
+  counterpartyToken: string | null;
+  endsAt: number | null;
+  isLegacy: boolean;
+  predictionId: string | null;
+  picks: V1Pick[];
+}
+interface V2PickConfig {
+  pickConfigId: string;
+  chainId: number;
+  escrow: string;
+  totalPredictorCollateral: string | number;
+  totalCounterpartyCollateral: string | number;
+  claimedPredictorCollateral: string | number;
+  claimedCounterpartyCollateral: string | number;
+  resolved: boolean;
+  result: string | null;
+  resolvedAt: number | null;
+  predictorToken: string | null;
+  counterpartyToken: string | null;
+  endsAt: number | null;
+  isLegacy: boolean;
+  picks: V2Pick[];
+}
+interface V1Row {
+  id: number;
+  predictionId: string;
+  chainId: number;
+  marketAddress: string;
+  predictor: string;
+  counterparty: string;
+  predictorToken: string;
+  counterpartyToken: string;
+  predictorCollateral: string | number;
+  counterpartyCollateral: string | number;
+  collateralDeposited: string | number | null;
+  collateralDepositedAt: number | null;
+  settled: boolean;
+  settledAt: number | null;
+  settleTxHash: string | null;
+  result: string;
+  predictorClaimable: string | number | null;
+  counterpartyClaimable: string | number | null;
+  createTxHash: string;
+  createdAt: string;
+  refCode: string | null;
+  pickConfig: V1PickConfig | null;
+}
+interface V2Row {
+  predictionId: string;
+  chainId: number;
+  escrow: string;
+  predictor: string;
+  counterparty: string;
+  predictorToken: string | null;
+  counterpartyToken: string | null;
+  predictorCollateral: string | number;
+  counterpartyCollateral: string | number;
+  collateralDeposited: string | number | null;
+  collateralDepositedAt: number | null;
+  settled: boolean;
+  settledAt: number | null;
+  settleTxHash: string | null;
+  result: string | null;
+  predictorClaimable: string | number | null;
+  counterpartyClaimable: string | number | null;
+  createTxHash: string;
+  createdAt: string;
+  refCode: string | null;
+  pickConfig: V2PickConfig | null;
+}
+
+/** VALUE is the contract; wire representation (string vs number) is not. */
+const bn = (v: string | number | null | undefined): string | null =>
+  v == null ? null : BigInt(v).toString();
+
+const lower = (v: string | null | undefined): string | null =>
+  v ? v.toLowerCase() : null;
+
+const projectPickCondition = (
+  c: RawPickCondition | null
+): CanonPickCondition | null =>
+  c == null
+    ? null
+    : {
+        // v1 `id` IS the CTF hash; v2 names it `conditionId`.
+        conditionId: (c.conditionId ?? c.id ?? '').toLowerCase(),
+        shortName: c.shortName ?? null,
+        optionName: c.optionName ?? null,
+        question: c.question,
+        description: c.description,
+        endTime: Number(c.endTime),
+        resolver: lower(c.resolver),
+        settled: c.settled,
+        resolvedToYes: c.resolvedToYes,
+        nonDecisive: c.nonDecisive,
+        estimatedPrice: c.estimatedPrice ?? null,
+        categorySlug: c.category?.slug ?? null,
+      };
+
+const projectV1 = (rows: V1Row[]): Canonical[] =>
+  byKey(
+    rows.map(
+      (r): Canonical => ({
+        predictionId: r.predictionId.toLowerCase(),
+        chainId: r.chainId,
+        escrow: r.marketAddress.toLowerCase(), // marketAddress → escrow
+        predictor: r.predictor.toLowerCase(),
+        counterparty: r.counterparty.toLowerCase(),
+        // v1 coalesces missing tokens to '' (escrow.ts `?? ''`); v2 is null.
+        predictorToken: r.predictorToken === '' ? null : lower(r.predictorToken),
+        counterpartyToken:
+          r.counterpartyToken === '' ? null : lower(r.counterpartyToken),
+        predictorCollateral: bn(r.predictorCollateral) ?? '0',
+        counterpartyCollateral: bn(r.counterpartyCollateral) ?? '0',
+        collateralDeposited: bn(r.collateralDeposited),
+        collateralDepositedAt: r.collateralDepositedAt ?? null,
+        settled: r.settled,
+        settledAt: r.settledAt ?? null,
+        settleTxHash: lower(r.settleTxHash),
+        // v1 'UNRESOLVED' ↔ v2 null (v2 enum carries terminal outcomes only).
+        result: r.result === 'UNRESOLVED' ? null : r.result,
+        predictorClaimable: bn(r.predictorClaimable),
+        counterpartyClaimable: bn(r.counterpartyClaimable),
+        createTxHash: r.createTxHash.toLowerCase(),
+        createdAtMs: isoToEpochMs(r.createdAt),
+        refCode: r.refCode ?? null,
+        pickConfig: r.pickConfig
+          ? {
+              pickConfigId: r.pickConfig.id.toLowerCase(), // id IS the hash
+              chainId: r.pickConfig.chainId,
+              escrow: r.pickConfig.marketAddress.toLowerCase(),
+              totalPredictorCollateral:
+                bn(r.pickConfig.totalPredictorCollateral) ?? '0',
+              totalCounterpartyCollateral:
+                bn(r.pickConfig.totalCounterpartyCollateral) ?? '0',
+              claimedPredictorCollateral:
+                bn(r.pickConfig.claimedPredictorCollateral) ?? '0',
+              claimedCounterpartyCollateral:
+                bn(r.pickConfig.claimedCounterpartyCollateral) ?? '0',
+              resolved: r.pickConfig.resolved,
+              result:
+                r.pickConfig.result === 'UNRESOLVED'
+                  ? null
+                  : r.pickConfig.result,
+              resolvedAt: r.pickConfig.resolvedAt ?? null,
+              predictorToken: lower(r.pickConfig.predictorToken),
+              counterpartyToken: lower(r.pickConfig.counterpartyToken),
+              endsAt: r.pickConfig.endsAt ?? null,
+              isLegacy: r.pickConfig.isLegacy,
+              picks: byKey(
+                r.pickConfig.picks.map(
+                  (p): CanonPick => ({
+                    conditionId: p.conditionId.toLowerCase(),
+                    resolver: p.conditionResolver.toLowerCase(), // rename
+                    // v1 Int 1/0 → v2 BinaryOutcome enum.
+                    predictedOutcome: p.predictedOutcome === 1 ? 'YES' : 'NO',
+                    condition: projectPickCondition(p.condition),
+                  })
+                ),
+                (p) => p.conditionId
+              ),
+            }
+          : null,
+      })
+    ),
+    (r) => r.predictionId
+  );
+
+const projectV2 = (rows: V2Row[]): Canonical[] =>
+  byKey(
+    rows.map(
+      (r): Canonical => ({
+        predictionId: r.predictionId.toLowerCase(),
+        chainId: r.chainId,
+        escrow: r.escrow.toLowerCase(),
+        predictor: r.predictor.toLowerCase(),
+        counterparty: r.counterparty.toLowerCase(),
+        predictorToken: lower(r.predictorToken),
+        counterpartyToken: lower(r.counterpartyToken),
+        predictorCollateral: bn(r.predictorCollateral) ?? '0',
+        counterpartyCollateral: bn(r.counterpartyCollateral) ?? '0',
+        collateralDeposited: bn(r.collateralDeposited),
+        collateralDepositedAt: r.collateralDepositedAt ?? null,
+        settled: r.settled,
+        settledAt: r.settledAt ?? null,
+        settleTxHash: lower(r.settleTxHash),
+        result: r.result ?? null,
+        predictorClaimable: bn(r.predictorClaimable),
+        counterpartyClaimable: bn(r.counterpartyClaimable),
+        createTxHash: r.createTxHash.toLowerCase(),
+        createdAtMs: isoToEpochMs(r.createdAt),
+        refCode: r.refCode ?? null,
+        pickConfig: r.pickConfig
+          ? {
+              pickConfigId: r.pickConfig.pickConfigId.toLowerCase(),
+              chainId: r.pickConfig.chainId,
+              escrow: r.pickConfig.escrow.toLowerCase(),
+              totalPredictorCollateral:
+                bn(r.pickConfig.totalPredictorCollateral) ?? '0',
+              totalCounterpartyCollateral:
+                bn(r.pickConfig.totalCounterpartyCollateral) ?? '0',
+              claimedPredictorCollateral:
+                bn(r.pickConfig.claimedPredictorCollateral) ?? '0',
+              claimedCounterpartyCollateral:
+                bn(r.pickConfig.claimedCounterpartyCollateral) ?? '0',
+              resolved: r.pickConfig.resolved,
+              result: r.pickConfig.result ?? null,
+              resolvedAt: r.pickConfig.resolvedAt ?? null,
+              predictorToken: lower(r.pickConfig.predictorToken),
+              counterpartyToken: lower(r.pickConfig.counterpartyToken),
+              endsAt: r.pickConfig.endsAt ?? null,
+              isLegacy: r.pickConfig.isLegacy,
+              picks: byKey(
+                r.pickConfig.picks.map(
+                  (p): CanonPick => ({
+                    conditionId: p.conditionId.toLowerCase(),
+                    resolver: p.resolver.toLowerCase(),
+                    predictedOutcome: p.predictedOutcome,
+                    condition: projectPickCondition(p.condition),
+                  })
+                ),
+                (p) => p.conditionId
+              ),
+            }
+          : null,
+      })
+    ),
+    (r) => r.predictionId
+  );
+
+describe('parity: predictions (participant feed)', () => {
+  it('participant full set: v2 predictions matches v1 row-for-row', async () => {
+    const [d1, d2] = await both<
+      { predictions: V1Row[] },
+      { predictions: { totalCount: number; nodes: V2Row[] } }
+    >(
+      {
+        query: V1_PREDICTIONS,
+        variables: { address: PARTICIPANT, chainId: null, take: 50, skip: 0 },
+      },
+      { query: V2_PREDICTIONS, variables: { participant: PARTICIPANT, first: 50 } }
+    );
+
+    const v1 = projectV1(d1.predictions);
+    const v2 = projectV2(d2.predictions.nodes);
+
+    expect(v1.length).toBeGreaterThan(0); // fixture: 28 rows for PARTICIPANT
+    expect(v2.length).toBe(v1.length);
+    // v1 is `expected`: a failing diff reads as "v2 deviates from v1".
+    expect(v2).toEqual(v1);
+
+    // Result-state coverage is real: both unresolved (null) and terminal
+    // outcomes are present in the compared set.
+    const results = new Set(v1.map((r) => r.result));
+    expect(results.has(null)).toBe(true);
+    expect(results.size).toBeGreaterThan(1);
+
+    // isLegacy parity (G10), pinned via pickConfig (the v1 hook's doc
+    // only selected pickConfig.isLegacy): both values occur in the set.
+    const legacies = new Set(
+      v1.map((r) => r.pickConfig?.isLegacy).filter((x) => x != null)
+    );
+    expect(legacies).toEqual(new Set([true, false]));
+
+    // v1 hard-nulls pickConfig.predictionId on this surface (mapPickConfig
+    // without `extra`) — assert the drop encodes a constant, not data loss.
+    for (const r of d1.predictions)
+      expect(r.pickConfig?.predictionId ?? null).toBeNull();
+
+    // Each side honors its own ordering contract (raw, pre-sort order).
+    expectMonotonic(
+      d1.predictions.map((r) => isoToEpochMs(r.createdAt)),
+      'desc'
+    );
+    expectMonotonic(
+      d2.predictions.nodes.map((r) => isoToEpochMs(r.createdAt)),
+      'desc'
+    );
+  });
+
+  it('count: v1 predictionCount equals v2 totalCount (first:0 count-only)', async () => {
+    const [d1, d2] = await both<
+      { predictionCount: number },
+      { predictions: { totalCount: number; nodes: V2Row[] } }
+    >(
+      {
+        query: V1_PREDICTIONS_COUNT,
+        variables: { address: PARTICIPANT, chainId: null },
+      },
+      // first: 0 is the legal Relay "count only" request (clampTake keeps 0).
+      { query: V2_PREDICTIONS, variables: { participant: PARTICIPANT, first: 0 } }
+    );
+
+    expect(d1.predictionCount).toBeGreaterThan(0);
+    expect(d2.predictions.totalCount).toBe(d1.predictionCount);
+    expect(d2.predictions.nodes).toEqual([]); // count-only page is empty
+  });
+});

--- a/packages/api/test/contract/parity/questions.pair.test.ts
+++ b/packages/api/test/contract/parity/questions.pair.test.ts
@@ -1,0 +1,626 @@
+import { describe, it, expect } from 'vitest';
+import { GET_QUESTIONS } from '../fixtures/v1-operations';
+import { executeOperationV2 } from '../../helpers/testApolloV2';
+import { both, byKey, expectMonotonic, isoToEpochMs } from './util';
+
+/**
+ * Parity: v1 `questions` (GET_QUESTIONS) vs v2 `questions` union
+ * connection (QuestionItem = Condition | ConditionGroup).
+ *
+ * Documented differences encoded in the projections below:
+ * - v1 wraps each row in a `Question` envelope (`questionType` +
+ *   `condition`/`group`); v2 returns the discriminated entity directly.
+ *   Canonical kind = `__typename` (v1 `condition`→Condition,
+ *   `group`→ConditionGroup); canonical key = CTF `conditionId` for
+ *   Condition items, group `name` for group items.
+ * - DROPPED numeric `group.id` / `category.id`: Prisma row ids are not
+ *   exposed in v2 by design (PLAN.md identity model). v1's numeric
+ *   `conditionGroupId` is kept only as a `hasGroup` boolean — v2 carries
+ *   the same bit as `conditionGroup != null` (the unwrapped
+ *   single-condition-group items keep hasGroup=true on both sides).
+ * - DROPPED `assertionId`/`assertionTimestamp`: decided absent in v2
+ *   (SCHEMA_GAPS G9 — no render site exists).
+ * - `public` → `isPublic` rename; v1 flat `similarMarkets`/
+ *   `similarMarketImage` → v2 nested `similarMarket.markets`/`.image`
+ *   (flat volume mirrors kept by #1822).
+ * - Sort vocabulary: v1 camelCase (`openInterest`, `endTime`) → v2
+ *   SCREAMING_SNAKE (`OPEN_INTEREST`, `END_TIME`). The consumer default
+ *   is `openInterest desc` (useInfiniteQuestions @ 7799f7764).
+ * - Ordering: UNLIKE other pairs, raw order is compared ELEMENT-WISE.
+ *   Both endpoints delegate to the same `runQuestionsData` SQL UNION
+ *   (v2/resolvers/queries/questions.ts), whose ORDER BY is total
+ *   (sort_value, end_time, item_type, group_id, condition_id) — a
+ *   sequence diff is a delegation regression, not a tie-break artifact.
+ *   Nested group conditions still compare as a SET by conditionId (v1
+ *   hydration has no within-displayOrder tie-break; v2 ties on
+ *   createdAt/id).
+ * - Visibility: `questions` exposes no `public` arg on either side; both
+ *   force `public = true` in SQL parts A/B and in the nested condition
+ *   hydration/connection. Stated here per the README explicit-visibility
+ *   rule.
+ * - `QuestionConnection` is edges+pageInfo ONLY (no nodes/totalCount —
+ *   the UNION can't COUNT cheaply); pinned via introspection below.
+ *   hasNextPage parity: v1 has no flag, so the v1 side over-fetches
+ *   take = N+1 and derives it.
+ * - KNOWN DIVERGENCE (test skip-marked below, not projected around):
+ *   with a per-condition filter active (e.g. minEndTime), v1 hydrates a
+ *   group's nested `conditions` through the feed's condition-where
+ *   (sdl questions.ts `buildConditionWhere` → hydrateItems include), so
+ *   the group card lists only MATCHING conditions; v2's union node
+ *   resolves `ConditionGroup.conditions` independently and returns ALL
+ *   public conditions of the group (v2/resolvers/ConditionGroup.ts).
+ *   The filterless/search/category variants compared here reduce both
+ *   wheres to {public:true}, so membership agrees everywhere else.
+ */
+
+const V2_QUESTIONS = /* GraphQL */ `
+  query QuestionsParity(
+    $first: Int!
+    $filter: QuestionFilter
+    $orderBy: QuestionOrder!
+  ) {
+    questions(first: $first, filter: $filter, orderBy: $orderBy) {
+      pageInfo {
+        hasNextPage
+      }
+      edges {
+        node {
+          __typename
+          ... on Condition {
+            conditionId
+            createdAt
+            question
+            shortName
+            endTime
+            isPublic
+            description
+            tags
+            chainId
+            resolver
+            settled
+            resolvedToYes
+            nonDecisive
+            openInterest
+            estimatedPrice
+            similarMarketVolume
+            similarMarketVolume1h
+            similarMarketVolume4h
+            similarMarketVolume24h
+            similarMarketVolume7d
+            similarMarketVolumeFiltered1h
+            similarMarketVolumeFiltered4h
+            similarMarketVolumeFiltered24h
+            similarMarketVolumeFiltered7d
+            similarMarket {
+              image
+              markets
+            }
+            conditionGroup {
+              name
+            }
+            category {
+              name
+              slug
+            }
+          }
+          ... on ConditionGroup {
+            name
+            createdAt
+            category {
+              name
+              slug
+            }
+            conditions(first: 50) {
+              nodes {
+                conditionId
+                createdAt
+                question
+                shortName
+                optionName
+                endTime
+                isPublic
+                description
+                tags
+                chainId
+                resolver
+                settled
+                resolvedToYes
+                nonDecisive
+                openInterest
+                estimatedPrice
+                similarMarketVolume
+                similarMarketVolume1h
+                similarMarketVolume4h
+                similarMarketVolume24h
+                similarMarketVolume7d
+                similarMarketVolumeFiltered1h
+                similarMarketVolumeFiltered4h
+                similarMarketVolumeFiltered24h
+                similarMarketVolumeFiltered7d
+                similarMarket {
+                  image
+                  markets
+                }
+                conditionGroup {
+                  name
+                }
+                category {
+                  name
+                  slug
+                }
+                displayOrder
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+interface CanonCondition {
+  conditionId: string;
+  createdAtMs: number;
+  question: string;
+  shortName: string | null;
+  endTime: number;
+  isPublic: boolean;
+  description: string;
+  similarMarkets: string[];
+  tags: string[];
+  chainId: number;
+  resolver: string | null;
+  settled: boolean;
+  resolvedToYes: boolean;
+  nonDecisive: boolean;
+  openInterest: string;
+  estimatedPrice: number | null;
+  similarMarketVolume: number;
+  vol1h: number;
+  vol4h: number;
+  vol24h: number;
+  vol7d: number;
+  volF1h: number;
+  volF4h: number;
+  volF24h: number;
+  volF7d: number;
+  similarMarketImage: string | null;
+  hasGroup: boolean;
+  categoryName: string | null;
+  categorySlug: string | null;
+}
+
+interface CanonNestedCondition extends CanonCondition {
+  optionName: string | null;
+  displayOrder: number | null;
+}
+
+type CanonItem =
+  | { kind: 'Condition'; key: string; condition: CanonCondition }
+  | {
+      kind: 'ConditionGroup';
+      key: string;
+      group: {
+        name: string;
+        createdAtMs: number;
+        categoryName: string | null;
+        categorySlug: string | null;
+        conditions: CanonNestedCondition[];
+      };
+    };
+
+/** Fields shared by the v1 top-level `condition` and nested blocks. */
+interface V1ConditionCommon {
+  id: string;
+  createdAt: string;
+  question: string;
+  shortName: string | null;
+  endTime: number;
+  public: boolean;
+  description: string;
+  similarMarkets: string[];
+  tags: string[];
+  chainId: number;
+  resolver: string | null;
+  settled: boolean;
+  resolvedToYes: boolean;
+  nonDecisive: boolean;
+  openInterest: string | number;
+  estimatedPrice: number | null;
+  similarMarketVolume: number;
+  similarMarketImage: string | null;
+  similarMarketVolume1h: number;
+  similarMarketVolume4h: number;
+  similarMarketVolume24h: number;
+  similarMarketVolume7d: number;
+  similarMarketVolumeFiltered1h: number;
+  similarMarketVolumeFiltered4h: number;
+  similarMarketVolumeFiltered24h: number;
+  similarMarketVolumeFiltered7d: number;
+  conditionGroupId: number | null;
+  category: { id: number; name: string; slug: string } | null;
+}
+interface V1NestedCondition extends V1ConditionCommon {
+  optionName: string | null;
+  displayOrder: number | null;
+}
+interface V1Question {
+  questionType: 'condition' | 'group';
+  condition: V1ConditionCommon | null;
+  group: {
+    id: number;
+    createdAt: string;
+    name: string;
+    category: { id: number; name: string; slug: string } | null;
+    conditions: V1NestedCondition[];
+  } | null;
+}
+
+interface V2ConditionCommon {
+  conditionId: string;
+  createdAt: string;
+  question: string;
+  shortName: string | null;
+  endTime: number;
+  isPublic: boolean;
+  description: string;
+  tags: string[];
+  chainId: number;
+  resolver: string | null;
+  settled: boolean;
+  resolvedToYes: boolean;
+  nonDecisive: boolean;
+  openInterest: string | number;
+  estimatedPrice: number | null;
+  similarMarketVolume: number;
+  similarMarketVolume1h: number;
+  similarMarketVolume4h: number;
+  similarMarketVolume24h: number;
+  similarMarketVolume7d: number;
+  similarMarketVolumeFiltered1h: number;
+  similarMarketVolumeFiltered4h: number;
+  similarMarketVolumeFiltered24h: number;
+  similarMarketVolumeFiltered7d: number;
+  similarMarket: { image: string | null; markets: string[] } | null;
+  conditionGroup: { name: string } | null;
+  category: { name: string; slug: string } | null;
+}
+interface V2NestedCondition extends V2ConditionCommon {
+  optionName: string | null;
+  displayOrder: number | null;
+}
+type V2Node =
+  | ({ __typename: 'Condition' } & V2ConditionCommon)
+  | {
+      __typename: 'ConditionGroup';
+      name: string;
+      createdAt: string;
+      category: { name: string; slug: string } | null;
+      conditions: { nodes: V2NestedCondition[] };
+    };
+
+// Coercions per the README policy: .toLowerCase() on hashes/addresses
+// (v2 guarantees lowercase; casing not part of the contract);
+// BigInt(openInterest).toString() (value compare across BigInt scalar
+// serializers); Number(endTime) (Int vs UnixSeconds, same unit).
+const projectV1Condition = (c: V1ConditionCommon): CanonCondition => ({
+  conditionId: c.id.toLowerCase(),
+  createdAtMs: isoToEpochMs(c.createdAt),
+  question: c.question,
+  shortName: c.shortName ?? null,
+  endTime: Number(c.endTime),
+  isPublic: c.public, // `public` → `isPublic` rename
+  description: c.description,
+  similarMarkets: c.similarMarkets,
+  tags: c.tags,
+  chainId: c.chainId,
+  resolver: c.resolver ? c.resolver.toLowerCase() : null,
+  settled: c.settled,
+  resolvedToYes: c.resolvedToYes,
+  nonDecisive: c.nonDecisive,
+  openInterest: BigInt(c.openInterest).toString(),
+  estimatedPrice: c.estimatedPrice ?? null,
+  similarMarketVolume: c.similarMarketVolume,
+  vol1h: c.similarMarketVolume1h,
+  vol4h: c.similarMarketVolume4h,
+  vol24h: c.similarMarketVolume24h,
+  vol7d: c.similarMarketVolume7d,
+  volF1h: c.similarMarketVolumeFiltered1h,
+  volF4h: c.similarMarketVolumeFiltered4h,
+  volF24h: c.similarMarketVolumeFiltered24h,
+  volF7d: c.similarMarketVolumeFiltered7d,
+  similarMarketImage: c.similarMarketImage ?? null,
+  // numeric conditionGroupId DROPPED → presence bit only (see header).
+  hasGroup: c.conditionGroupId != null,
+  categoryName: c.category?.name ?? null,
+  categorySlug: c.category?.slug ?? null,
+});
+
+const projectV2Condition = (c: V2ConditionCommon): CanonCondition => ({
+  conditionId: c.conditionId.toLowerCase(),
+  createdAtMs: isoToEpochMs(c.createdAt),
+  question: c.question,
+  shortName: c.shortName ?? null,
+  endTime: Number(c.endTime),
+  isPublic: c.isPublic,
+  description: c.description,
+  similarMarkets: c.similarMarket?.markets ?? [],
+  tags: c.tags,
+  chainId: c.chainId,
+  resolver: c.resolver ? c.resolver.toLowerCase() : null,
+  settled: c.settled,
+  resolvedToYes: c.resolvedToYes,
+  nonDecisive: c.nonDecisive,
+  openInterest: BigInt(c.openInterest).toString(),
+  estimatedPrice: c.estimatedPrice ?? null,
+  similarMarketVolume: c.similarMarketVolume,
+  vol1h: c.similarMarketVolume1h,
+  vol4h: c.similarMarketVolume4h,
+  vol24h: c.similarMarketVolume24h,
+  vol7d: c.similarMarketVolume7d,
+  volF1h: c.similarMarketVolumeFiltered1h,
+  volF4h: c.similarMarketVolumeFiltered4h,
+  volF24h: c.similarMarketVolumeFiltered24h,
+  volF7d: c.similarMarketVolumeFiltered7d,
+  similarMarketImage: c.similarMarket?.image ?? null,
+  hasGroup: c.conditionGroup != null,
+  categoryName: c.category?.name ?? null,
+  categorySlug: c.category?.slug ?? null,
+});
+
+/** ORDER-PRESERVING — raw order is comparable here (shared runner). */
+const projectV1 = (qs: V1Question[]): CanonItem[] =>
+  qs.map((q): CanonItem => {
+    if (q.questionType === 'condition' && q.condition) {
+      return {
+        kind: 'Condition',
+        key: q.condition.id.toLowerCase(),
+        condition: projectV1Condition(q.condition),
+      };
+    }
+    const g = q.group!;
+    return {
+      kind: 'ConditionGroup',
+      key: g.name,
+      group: {
+        name: g.name,
+        createdAtMs: isoToEpochMs(g.createdAt),
+        categoryName: g.category?.name ?? null,
+        categorySlug: g.category?.slug ?? null,
+        conditions: byKey(
+          g.conditions.map((c) => ({
+            ...projectV1Condition(c),
+            optionName: c.optionName ?? null,
+            displayOrder: c.displayOrder ?? null,
+          })),
+          (c) => c.conditionId
+        ),
+      },
+    };
+  });
+
+const projectV2 = (nodes: V2Node[]): CanonItem[] =>
+  nodes.map((n): CanonItem => {
+    if (n.__typename === 'Condition') {
+      return {
+        kind: 'Condition',
+        key: n.conditionId.toLowerCase(),
+        condition: projectV2Condition(n),
+      };
+    }
+    return {
+      kind: 'ConditionGroup',
+      key: n.name,
+      group: {
+        name: n.name,
+        createdAtMs: isoToEpochMs(n.createdAt),
+        categoryName: n.category?.name ?? null,
+        categorySlug: n.category?.slug ?? null,
+        conditions: byKey(
+          n.conditions.nodes.map((c) => ({
+            ...projectV2Condition(c),
+            optionName: c.optionName ?? null,
+            displayOrder: c.displayOrder ?? null,
+          })),
+          (c) => c.conditionId
+        ),
+      },
+    };
+  });
+
+type V1Data = { questions: V1Question[] };
+type V2Data = {
+  questions: { pageInfo: { hasNextPage: boolean }; edges: { node: V2Node }[] };
+};
+
+const runPair = (
+  v1Vars: Record<string, unknown>,
+  v2Vars: Record<string, unknown>
+) =>
+  both<V1Data, V2Data>(
+    { query: GET_QUESTIONS, variables: v1Vars },
+    { query: V2_QUESTIONS, variables: v2Vars }
+  );
+
+const itemKeys = (items: CanonItem[]): string[] =>
+  items.map((i) => `${i.kind}:${i.key}`);
+
+/** Per-item end-time the runner sorts by: condition endTime, group max. */
+const itemEndTime = (i: CanonItem): number =>
+  i.kind === 'Condition'
+    ? i.condition.endTime
+    : Math.max(...i.group.conditions.map((c) => c.endTime));
+
+describe('parity: questions feed (union connection)', () => {
+  it('OPEN_INTEREST DESC (consumer default sort) page matches element-wise', async () => {
+    const [d1, d2] = await runPair(
+      { take: 12, skip: 0, sortField: 'openInterest', sortDirection: 'desc' },
+      { first: 12, orderBy: { field: 'OPEN_INTEREST', direction: 'DESC' } }
+    );
+
+    const v1 = projectV1(d1.questions);
+    const v2 = projectV2(d2.questions.edges.map((e) => e.node));
+
+    expect(v1.length).toBe(12); // fixture sanity — full page, not vacuous
+    // Keys first for a readable diff, then the full per-variant fields.
+    expect(itemKeys(v2)).toEqual(itemKeys(v1));
+    // v1 is `expected`: a failing diff reads as "v2 deviates from v1".
+    expect(v2).toEqual(v1);
+  });
+
+  it('END_TIME ASC page matches element-wise; per-item end-time monotonic', async () => {
+    const [d1, d2] = await runPair(
+      { take: 12, skip: 0, sortField: 'endTime', sortDirection: 'asc' },
+      { first: 12, orderBy: { field: 'END_TIME', direction: 'ASC' } }
+    );
+
+    const v1 = projectV1(d1.questions);
+    const v2 = projectV2(d2.questions.edges.map((e) => e.node));
+
+    expect(v1.length).toBe(12);
+    expect(itemKeys(v2)).toEqual(itemKeys(v1));
+    expect(v2).toEqual(v1);
+
+    // Each side honors the declared sort on its own raw order (group sort
+    // key = max public condition endTime; fixture aggregates verified
+    // fresh against the trigger-maintained columns).
+    expectMonotonic(v1.map(itemEndTime), 'asc');
+    expectMonotonic(v2.map(itemEndTime), 'asc');
+  });
+
+  it('search narrows identically (search: "bitcoin")', async () => {
+    const [d1, d2] = await runPair(
+      {
+        take: 50,
+        skip: 0,
+        sortField: 'endTime',
+        sortDirection: 'asc',
+        search: 'bitcoin',
+      },
+      {
+        first: 50,
+        filter: { search: 'bitcoin' },
+        orderBy: { field: 'END_TIME', direction: 'ASC' },
+      }
+    );
+
+    const v1 = projectV1(d1.questions);
+    const v2 = projectV2(d2.questions.edges.map((e) => e.node));
+
+    expect(v1.length).toBeGreaterThan(0); // fixture: 22 public matches
+    expect(itemKeys(v2)).toEqual(itemKeys(v1));
+    expect(v2).toEqual(v1);
+  });
+
+  it('categorySlugs filter matches (crypto + sports)', async () => {
+    const slugs = ['crypto', 'sports'];
+    const [d1, d2] = await runPair(
+      {
+        take: 12,
+        skip: 0,
+        sortField: 'openInterest',
+        sortDirection: 'desc',
+        categorySlugs: slugs,
+      },
+      {
+        first: 12,
+        filter: { categorySlugs: slugs },
+        orderBy: { field: 'OPEN_INTEREST', direction: 'DESC' },
+      }
+    );
+
+    const v1 = projectV1(d1.questions);
+    const v2 = projectV2(d2.questions.edges.map((e) => e.node));
+
+    expect(v1.length).toBeGreaterThan(0);
+    expect(itemKeys(v2)).toEqual(itemKeys(v1));
+    expect(v2).toEqual(v1);
+
+    // The filter actually bites: every surfaced item is in the slug set.
+    for (const i of v1) {
+      const slug =
+        i.kind === 'Condition' ? i.condition.categorySlug : i.group.categorySlug;
+      expect(slugs).toContain(slug);
+    }
+  });
+
+  it('hasNextPage parity: v1 take N+1 over-fetch vs v2 pageInfo.hasNextPage', async () => {
+    // True branch: the unfiltered feed has far more than 12 items.
+    const [d1, d2] = await runPair(
+      { take: 13, skip: 0, sortField: 'openInterest', sortDirection: 'desc' },
+      { first: 12, orderBy: { field: 'OPEN_INTEREST', direction: 'DESC' } }
+    );
+    expect(d2.questions.pageInfo.hasNextPage).toBe(d1.questions.length > 12);
+    expect(d2.questions.pageInfo.hasNextPage).toBe(true);
+    // Shared total order ⇒ the over-fetch prefix is exactly v2's page.
+    expect(itemKeys(projectV2(d2.questions.edges.map((e) => e.node)))).toEqual(
+      itemKeys(projectV1(d1.questions.slice(0, 12)))
+    );
+
+    // False branch: the bitcoin search set fits in one page.
+    const [s1, s2] = await runPair(
+      {
+        take: 51,
+        skip: 0,
+        sortField: 'endTime',
+        sortDirection: 'asc',
+        search: 'bitcoin',
+      },
+      {
+        first: 50,
+        filter: { search: 'bitcoin' },
+        orderBy: { field: 'END_TIME', direction: 'ASC' },
+      }
+    );
+    expect(s2.questions.pageInfo.hasNextPage).toBe(s1.questions.length > 50);
+    expect(s2.questions.pageInfo.hasNextPage).toBe(false);
+  });
+
+  it('QuestionConnection is edges + pageInfo ONLY (no nodes/totalCount)', async () => {
+    const res = await executeOperationV2<{
+      __type: { fields: { name: string }[] } | null;
+    }>(/* GraphQL */ `
+      query {
+        __type(name: "QuestionConnection") {
+          fields {
+            name
+          }
+        }
+      }
+    `);
+    expect(res.errors).toBeUndefined();
+    const names = (res.data?.__type?.fields ?? []).map((f) => f.name).sort();
+    expect(names).toEqual(['edges', 'pageInfo']);
+  });
+
+  // Was a REAL DIVERGENCE (caught 2026-06-10): v1 narrows a surfaced
+  // group's nested `conditions` to the rows matching the feed filter
+  // (minEndTime here) via hydrateItems' attached `condition` array, while
+  // v2's union node re-fetched ALL public conditions of the group (4 vs
+  // 22 on the fixture's "Peru Presidential Election" group). Fixed: the
+  // v2 ConditionGroup.conditions resolver now honors a feed-attached
+  // hydrated array exactly like v1's resolver — this test is the
+  // regression pin.
+  it('minEndTime filter: nested group membership matches', async () => {
+    const [d1, d2] = await runPair(
+      {
+        take: 10,
+        skip: 0,
+        sortField: 'endTime',
+        sortDirection: 'asc',
+        search: 'Peru',
+        minEndTime: 1777000000,
+      },
+      {
+        first: 10,
+        filter: { search: 'Peru', endsAt: { gte: 1777000000 } },
+        orderBy: { field: 'END_TIME', direction: 'ASC' },
+      }
+    );
+
+    const v1 = projectV1(d1.questions);
+    const v2 = projectV2(d2.questions.edges.map((e) => e.node));
+    expect(v1.length).toBeGreaterThan(0);
+    expect(v2).toEqual(v1);
+  });
+});

--- a/packages/api/vitest.contract.config.ts
+++ b/packages/api/vitest.contract.config.ts
@@ -25,6 +25,16 @@ export default defineConfig({
     env: {
       DATABASE_URL: testDbUrl,
       TEST_DATABASE_URL: testDbUrl,
+      // Vitest isolates each test FILE into a fresh module registry, so
+      // every file instantiates its own Prisma singleton (src/core/db) and
+      // its own pg pool. At the production default (CONNECTION_POOL_SIZE
+      // 60, idleTimeoutMillis 10s) the connection-hungry pairs (questions
+      // hydration, activity's per-pick category N+1) leave dozens of idle
+      // connections per file that outlive the ~3s suite, blowing past a
+      // local Postgres max_connections=100 mid-run ("too many clients
+      // already" in unrelated files). A small per-file cap keeps the whole
+      // suite well under the server limit; an explicit env var still wins.
+      CONNECTION_POOL_SIZE: process.env.CONNECTION_POOL_SIZE ?? '5',
     },
     testTimeout: 30_000,
     hookTimeout: 90_000,


### PR DESCRIPTION
  The 1804 merge replaced #1840's wiring with #1841's, which never
  forwarded the arg from the v1 resolver into runQuestionsData — the
  filter silently no-opped. Adds behavioral contract pins for the
  previously uncovered surface, the nested group-conditions feed-filter
  fix, wave-2 parity pairs, and the contract-suite connection-pool cap.
