### PR TITLE
fix(app): raise vault deposit cap to 20k

### DIFF
--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -42,7 +42,7 @@ const DEPOSIT_WHITELIST: `0x${string}`[] = [
   '0x7BB4e4E4674c625b23C550A74cfcfF9Ec50064F3',
 ];
 
-const DEPOSIT_CAP = 10000;
+const DEPOSIT_CAP = 20000;
 
 type VaultOption = {
   address: `0x${string}`;


### PR DESCRIPTION
## Summary
- `DEPOSIT_CAP` in `VaultsPageContent.tsx` was hardcoded at 10000, gating deposits ("Exceeds Vault Capacity") and the capacity meter.
- Raised to 20000 to match the keeper-side cap now active on prod `vault-deposit-manager` (`MAX_ASSETS=20000e18`; that env had been unset, so the keeper cap was previously unenforced).
- Replaces #1848 (was based on staging; conflicted after base change to main).
- Follow-up worth considering: derive the cap from config/API so UI and keeper can't drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)