### PR TITLE
feat(app): add log scale toggle to vault Profit/Loss chart

### DIFF
--- a/packages/app/src/components/vaults/VaultPnlChart.tsx
+++ b/packages/app/src/components/vaults/VaultPnlChart.tsx
@@ -10,6 +10,7 @@ import {
   CartesianGrid,
   Tooltip,
   ResponsiveContainer,
+  type YAxisProps,
 } from 'recharts';
 import { Tabs, TabsTrigger } from '@sapience/ui/components/ui/tabs';
 import { Button } from '@sapience/ui/components/ui/button';
@@ -189,6 +190,9 @@ export default function VaultPnlChart({
   const period = externalPeriod ?? internalPeriod;
   const setPeriod = setInternalPeriod;
   const [displayMode, setDisplayMode] = useState<DisplayMode>('pct');
+  // 'symlog' rather than 'log': PnL deltas cross zero, where a pure log
+  // scale is undefined. Symlog stays linear near zero and log beyond it.
+  const [logScale, setLogScale] = useState(false);
 
   // Use internal fetch if no external data provided
   const { data: internalStats, isLoading: internalLoading } =
@@ -298,7 +302,7 @@ export default function VaultPnlChart({
         </div>
       )}
       <div
-        className={`${useFlexHeight ? 'flex-1' : ''} relative`}
+        className={`${useFlexHeight ? 'flex-1' : ''} relative group`}
         style={{
           height: useFlexHeight ? undefined : height,
           minHeight: height,
@@ -365,6 +369,13 @@ export default function VaultPnlChart({
                 />
                 <YAxis
                   {...CHART_AXIS_STYLE}
+                  // recharts resolves any d3-scale name at runtime, but its
+                  // ScaleType union omits 'symlog', hence the cast.
+                  scale={
+                    (logScale
+                      ? 'symlog'
+                      : 'linear') as unknown as YAxisProps['scale']
+                  }
                   domain={yDomain}
                   tickFormatter={(v) => {
                     if (v < 0) return '';
@@ -400,6 +411,18 @@ export default function VaultPnlChart({
                 />
               </AreaChart>
             </ResponsiveContainer>
+            <Button
+              variant="outline"
+              size="sm"
+              className={`absolute -bottom-0.5 -left-0.5 z-10 h-5 px-1.5 text-[10px] font-mono uppercase opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity hover:text-brand-white ${
+                logScale ? 'text-brand-white' : 'text-muted-foreground/60'
+              }`}
+              onClick={() => setLogScale((s) => !s)}
+              aria-pressed={logScale}
+              aria-label="Toggle logarithmic scale"
+            >
+              Log
+            </Button>
           </div>
         )}
       </div>

--- a/packages/app/src/components/vaults/__tests__/VaultPnlChartScaleToggle.test.tsx
+++ b/packages/app/src/components/vaults/__tests__/VaultPnlChartScaleToggle.test.tsx
@@ -1,0 +1,149 @@
+import { vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AreaChart: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  Area: () => <div />,
+  XAxis: () => <div />,
+  YAxis: (props: { scale?: string }) => (
+    <div data-testid="y-axis" data-scale={String(props.scale)} />
+  ),
+  CartesianGrid: () => <div />,
+  Tooltip: () => <div />,
+}));
+
+vi.mock('@sapience/sdk/constants', () => ({
+  DEFAULT_CHAIN_ID: 42161,
+  COLLATERAL_SYMBOLS: { 42161: 'USDe' },
+}));
+
+vi.mock('@sapience/ui/components/ui/tabs', () => ({
+  Tabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({ children }: { children: React.ReactNode }) => (
+    <button>{children}</button>
+  ),
+}));
+
+vi.mock('@sapience/ui/components/ui/button', () => ({
+  Button: (
+    props: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+      children: React.ReactNode;
+    }
+  ) => (
+    <button
+      onClick={props.onClick}
+      aria-label={props['aria-label']}
+      aria-pressed={props['aria-pressed']}
+      className={props.className}
+    >
+      {props.children}
+    </button>
+  ),
+}));
+
+vi.mock('~/components/shared/SegmentedTabsList', () => {
+  const SegmentedTabsList = ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  );
+  return { __esModule: true, default: SegmentedTabsList };
+});
+
+vi.mock('~/components/shared/Loader', () => {
+  const Loader = () => <div data-testid="loader" />;
+  return { __esModule: true, default: Loader };
+});
+
+vi.mock('~/hooks/graphql/useAnalytics', () => ({
+  useProtocolStats: () => ({ data: undefined, isLoading: false }),
+}));
+
+import VaultPnlChart from '~/components/vaults/VaultPnlChart';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const DAY = 24 * 60 * 60;
+const nowSec = Math.floor(Date.now() / 1000);
+
+const protocolStats = [
+  {
+    timestamp: nowSec - 2 * DAY,
+    vaultCumulativePnL: '0',
+    vaultBalance: (1000n * 10n ** 18n).toString(),
+    escrowBalance: '0',
+  },
+  {
+    timestamp: nowSec - DAY,
+    vaultCumulativePnL: (50n * 10n ** 18n).toString(),
+    vaultBalance: (1050n * 10n ** 18n).toString(),
+    escrowBalance: '0',
+  },
+  {
+    timestamp: nowSec,
+    vaultCumulativePnL: (120n * 10n ** 18n).toString(),
+    vaultBalance: (1120n * 10n ** 18n).toString(),
+    escrowBalance: '0',
+  },
+] as never[];
+
+function renderChart() {
+  return render(
+    <VaultPnlChart protocolStats={protocolStats} isLoading={false} />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('VaultPnlChart log scale toggle', () => {
+  it('renders a log scale toggle button, off by default', () => {
+    renderChart();
+    const toggle = screen.getByRole('button', {
+      name: /toggle logarithmic scale/i,
+    });
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByTestId('y-axis')).toHaveAttribute(
+      'data-scale',
+      'linear'
+    );
+  });
+
+  it('switches the Y axis to a symlog scale when toggled on', () => {
+    renderChart();
+    const toggle = screen.getByRole('button', {
+      name: /toggle logarithmic scale/i,
+    });
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('y-axis')).toHaveAttribute(
+      'data-scale',
+      'symlog'
+    );
+  });
+
+  it('returns to a linear scale when toggled off again', () => {
+    renderChart();
+    const toggle = screen.getByRole('button', {
+      name: /toggle logarithmic scale/i,
+    });
+    fireEvent.click(toggle);
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByTestId('y-axis')).toHaveAttribute(
+      'data-scale',
+      'linear'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds a log scale mode to the vault Profit/Loss chart (`VaultPnlChart`):

- A hover-revealed **LOG** button in the bottom-left corner of the chart (outside the axes) toggles the Y axis between linear and symlog scales. It fades in on chart hover (and on keyboard focus via `focus-visible`), and highlights white while log mode is active.
- Uses **symlog** rather than a pure log scale because the chart plots PnL deltas that can be zero or negative, where log is undefined — symlog is linear near zero and logarithmic beyond, so the toggle works in both % and $ display modes and on losing periods.
- recharts 2.15.4 resolves any d3-scale name at runtime but its `ScaleType` TS union omits `'symlog'`, hence a narrow cast via `YAxisProps['scale']` with an explanatory comment.

## Testing

- New component test `VaultPnlChartScaleToggle.test.tsx` (written first, TDD): renders the toggle off by default, switches the Y axis to symlog on click, and back to linear on a second click. All vault chart tests pass (13/13).
- Verified end-to-end in the running app with Playwright on `/vaults`: button is hidden until the chart is hovered (computed opacity 0 → 1), clicking flips `aria-pressed` and visibly re-scales the chart.
- `lint` and `type-check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)