### PR TITLE
feat(market-keeper): match today-tag against description, not just question

### DIFF
--- a/packages/market-keeper/src/__tests__/imminent-tag-fetch.test.ts
+++ b/packages/market-keeper/src/__tests__/imminent-tag-fetch.test.ts
@@ -53,12 +53,22 @@ describe('fetchAllUnsettledConditions', () => {
     expect(body.query).toMatch(/DESC/);
   });
 
-  it('maps nodes onto PageItem, defaulting tags to []', async () => {
+  it('maps nodes onto PageItem, defaulting tags to [] and description to ""', async () => {
     fetchQueue.push(() =>
       conditionsPage(
         [
-          { conditionId: '0x1', question: 'Q1?', tags: ['sports'] },
-          { conditionId: '0x2', question: 'Q2?', tags: null },
+          {
+            conditionId: '0x1',
+            question: 'Q1?',
+            description: 'D1',
+            tags: ['sports'],
+          },
+          {
+            conditionId: '0x2',
+            question: 'Q2?',
+            description: null,
+            tags: null,
+          },
         ],
         { hasNextPage: false, endCursor: null }
       )
@@ -70,9 +80,20 @@ describe('fetchAllUnsettledConditions', () => {
     );
 
     expect(out).toEqual([
-      { id: '0x1', question: 'Q1?', tags: ['sports'] },
-      { id: '0x2', question: 'Q2?', tags: [] },
+      { id: '0x1', question: 'Q1?', description: 'D1', tags: ['sports'] },
+      { id: '0x2', question: 'Q2?', description: '', tags: [] },
     ]);
+  });
+
+  it('requests the description field in the GraphQL query', async () => {
+    fetchQueue.push(() =>
+      conditionsPage([], { hasNextPage: false, endCursor: null })
+    );
+
+    await fetchAllUnsettledConditions('https://api.example.com', null);
+
+    const body = JSON.parse(fetchCalls[0].init!.body as string);
+    expect(body.query).toMatch(/description/);
   });
 
   it('paginates via the relay cursor until exhausted', async () => {

--- a/packages/market-keeper/src/refresh-imminent-tag/fetch.ts
+++ b/packages/market-keeper/src/refresh-imminent-tag/fetch.ts
@@ -16,6 +16,7 @@ import { graphqlUrl, walkConnection, type Connection } from '../utils/graphql';
 export interface PageItem {
   id: string;
   question: string;
+  description: string;
   tags: string[];
 }
 
@@ -30,6 +31,7 @@ const IMMINENT_TAG_CANDIDATES_QUERY = `
       nodes {
         conditionId
         question
+        description
         tags
       }
       pageInfo {
@@ -43,6 +45,7 @@ const IMMINENT_TAG_CANDIDATES_QUERY = `
 type CandidateNode = {
   conditionId: string;
   question: string;
+  description: string | null;
   tags: string[] | null;
 };
 
@@ -72,6 +75,7 @@ export async function fetchAllUnsettledConditions(
         out.push({
           id: c.conditionId,
           question: c.question,
+          description: c.description ?? '',
           tags: c.tags ?? [],
         });
         if (maxResults !== null && out.length >= maxResults) {

--- a/packages/market-keeper/src/refresh-imminent-tag/index.ts
+++ b/packages/market-keeper/src/refresh-imminent-tag/index.ts
@@ -1,6 +1,6 @@
 /**
- * Refresh the "today" tag on conditions whose question text mentions
- * today's or tomorrow's UTC date.
+ * Refresh the "today" tag on conditions whose question OR description
+ * text mentions today's or tomorrow's UTC date.
  *
  * Designed to run once daily from start.js. Idempotent — re-running the
  * same day reports zero updates. The day after, yesterday's matches drop
@@ -22,7 +22,7 @@ import {
 import { submitMetadataUpdates } from '../generate/api';
 import { fetchAllUnsettledConditions } from './fetch';
 import {
-  questionMentionsImminentDate,
+  conditionMentionsImminentDate,
   computeDesiredTags,
   TODAY_TAG,
 } from './match';
@@ -57,9 +57,9 @@ function showHelp(): void {
   console.log(`
 Usage: tsx scripts/refresh-imminent-tag.ts [options]
 
-Tags every public + unsettled condition whose question references today's
-or tomorrow's UTC date (literal "today"/"tomorrow", "May 18"/"18 May",
-ISO "2026-05-18") with the "${TODAY_TAG}" tag, and strips the tag from
+Tags every public + unsettled condition whose question or description
+references today's or tomorrow's UTC date (literal "today"/"tomorrow",
+"May 18"/"18 May", ISO "2026-05-18") with the "${TODAY_TAG}" tag, and strips the tag from
 markets that no longer match. (The tag string is "${TODAY_TAG}" — the
 match logic also covers tomorrow, since markets resolving tomorrow are
 imminent enough that users want them in the same UI bucket.)
@@ -143,7 +143,9 @@ export async function main(): Promise<void> {
     }
   }
 
-  log(`[TodayTag] [2/3] Matching questions against reference dates...`);
+  log(
+    `[TodayTag] [2/3] Matching question + description against reference dates...`
+  );
   type Update = {
     id: string;
     question: string;
@@ -155,7 +157,11 @@ export async function main(): Promise<void> {
   let matchedCount = 0;
 
   for (const c of conditions) {
-    const matched = questionMentionsImminentDate(c.question, now);
+    const matched = conditionMentionsImminentDate(
+      c.question,
+      c.description,
+      now
+    );
     if (matched) matchedCount++;
     const desired = computeDesiredTags(c.tags, matched);
     if (!tagsEqual(c.tags, desired)) {

--- a/packages/market-keeper/src/refresh-imminent-tag/match.test.ts
+++ b/packages/market-keeper/src/refresh-imminent-tag/match.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   questionMentionsImminentDate,
+  conditionMentionsImminentDate,
   computeDesiredTags,
   TODAY_TAG,
 } from './match';
@@ -162,6 +163,68 @@ describe('questionMentionsImminentDate', () => {
     it('returns false for empty question', () => {
       expect(questionMentionsImminentDate('', NOW)).toBe(false);
     });
+  });
+});
+
+describe('conditionMentionsImminentDate (question OR description)', () => {
+  it('matches when only the question mentions the date', () => {
+    expect(
+      conditionMentionsImminentDate(
+        'Will SpaceX launch on May 18?',
+        'Resolves to the launch outcome.',
+        NOW
+      )
+    ).toBe(true);
+  });
+
+  it('matches when only the description mentions the date', () => {
+    expect(
+      conditionMentionsImminentDate(
+        'Will SpaceX launch this week?',
+        'This market resolves YES if a launch occurs on or before 2026-05-19.',
+        NOW
+      )
+    ).toBe(true);
+  });
+
+  it('matches when the description uses the literal word "today"', () => {
+    expect(
+      conditionMentionsImminentDate(
+        'Will the Fed cut rates?',
+        'Resolution is based on the announcement made today.',
+        NOW
+      )
+    ).toBe(true);
+  });
+
+  it('returns false when neither question nor description matches', () => {
+    expect(
+      conditionMentionsImminentDate(
+        'Will SpaceX launch this year?',
+        'Resolves based on the May 20 launch window.',
+        NOW
+      )
+    ).toBe(false);
+  });
+
+  it('does not straddle the question/description boundary', () => {
+    // Question ends with the month, description starts with the day —
+    // scanning them separately must NOT read this as "May 18".
+    expect(
+      conditionMentionsImminentDate('Will it happen in May', '18 markets?', NOW)
+    ).toBe(false);
+  });
+
+  it('tolerates a null/undefined/empty description', () => {
+    expect(
+      conditionMentionsImminentDate('Will it rain today?', null, NOW)
+    ).toBe(true);
+    expect(
+      conditionMentionsImminentDate('Will it rain today?', undefined, NOW)
+    ).toBe(true);
+    expect(conditionMentionsImminentDate('Nothing imminent', '', NOW)).toBe(
+      false
+    );
   });
 });
 

--- a/packages/market-keeper/src/refresh-imminent-tag/match.ts
+++ b/packages/market-keeper/src/refresh-imminent-tag/match.ts
@@ -121,6 +121,26 @@ export function questionMentionsImminentDate(
 }
 
 /**
+ * Condition-level matcher: a market is "imminent" when EITHER its
+ * question OR its description mentions today's/tomorrow's UTC date.
+ *
+ * Question and description are scanned independently (not concatenated)
+ * so a date can't straddle the boundary between them — e.g. a question
+ * ending in "May" and a description starting with "18" must not be read
+ * as "May 18". A null/undefined/empty description simply never matches.
+ */
+export function conditionMentionsImminentDate(
+  question: string,
+  description: string | null | undefined,
+  now: Date
+): boolean {
+  return (
+    questionMentionsImminentDate(question, now) ||
+    questionMentionsImminentDate(description ?? '', now)
+  );
+}
+
+/**
  * Compute the desired tag set for a condition given its current tags and
  * whether the question matched. Always strip-then-re-add so yesterday's
  * tag gets cleaned up on markets that no longer match.


### PR DESCRIPTION
## What

The daily **"today" tag** refresh ([refresh-imminent-tag](packages/market-keeper/src/refresh-imminent-tag/)) previously scanned only a condition's **question** for today's/tomorrow's UTC date. Markets whose imminent date lives in the **description** (e.g. *"resolves YES if X happens by 2026-05-19"*) were missed and never got the `Today` tag.

This change scans the description too.

## How

- **`match.ts`** — new `conditionMentionsImminentDate(question, description, now)` that ORs the question and description through the existing `questionMentionsImminentDate` matcher. The two fields are scanned **independently (not concatenated)** so a date can't straddle the question/description boundary (a question ending in `"May"` + a description starting with `"18"` must not read as `"May 18"`). Null/undefined/empty descriptions simply never match.
- **`fetch.ts`** — request `description` in the imminent-tag candidates GraphQL query and carry it on `PageItem` (null → `""`).
- **`index.ts`** — call the new matcher in the refresh loop; update help/log copy to say "question + description".

## Tests

Added cases in `match.test.ts` for: description-only match, the literal `"today"` word in a description, the boundary-straddle guard, and null/empty descriptions. Updated `imminent-tag-fetch.test.ts` to assert the query requests `description` and that it maps onto `PageItem`. **39 tests green**, type-check clean.

## Note

Descriptions are longer prose, so literal `today`/`tomorrow` in boilerplate could yield a few more false positives than question-only matching did. The today/tomorrow-only specific-date window keeps this small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)