### PR TITLE
fix(app): retry vault reads on RPC flake instead of rendering zeros

### DIFF
--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -559,6 +559,10 @@ const VaultsPageContent = () => {
   // so we add the deployed cost basis back here to show true total.
   const tvlWei = liquidWei + deployedWei;
 
+  // The two terms come from different sources (on-chain read vs GraphQL);
+  // until both have loaded, the sum is a misleading partial figure.
+  const isBalanceReady = !!vaultData && !!protocolStats;
+
   const utilizationPercent = useMemo(() => {
     if (tvlWei <= 0n) return 0;
     const bps = Number((deployedWei * 10000n) / tvlWei);
@@ -745,63 +749,78 @@ const VaultsPageContent = () => {
                         <h4 className="font-mono text-base uppercase tracking-wider text-brand-white mb-3 sm:mb-2">
                           Vault Balance
                           <br className="sm:hidden" />{' '}
-                          <span className="font-medium text-[hsl(var(--ethena))]">
-                            {tvlDisplay} {collateralSymbol}
-                          </span>
+                          {isBalanceReady && (
+                            <span className="font-medium text-[hsl(var(--ethena))]">
+                              {tvlDisplay} {collateralSymbol}
+                            </span>
+                          )}
                         </h4>
                         <div className="relative">
-                          {tvlWei <= VAULT_CAPACITY_WEI && (
-                            <div className="absolute -top-4 right-0 font-mono text-[10px] text-muted-foreground/50 uppercase">
-                              {depositCapDisplay} cap
-                            </div>
-                          )}
-                          <div className="w-full h-3 rounded-sm bg-[hsl(var(--primary)/_0.09)] overflow-hidden shadow-inner relative">
-                            <div
-                              className="h-3 bg-accent-gold rounded-sm transition-all gold-sheen"
-                              style={{
-                                width: `${tvlWei > VAULT_CAPACITY_WEI ? 100 : tvlPercentOfCap}%`,
-                              }}
-                            />
-                            <div
-                              className="absolute top-0 left-0 h-3 rounded-sm bg-brand-white transition-all"
-                              style={{
-                                width: `${tvlWei > VAULT_CAPACITY_WEI ? deployedPercentOfCap : Math.min(deployedPercentOfCap, tvlPercentOfCap)}%`,
-                              }}
-                            />
-                          </div>
-                          {tvlWei > VAULT_CAPACITY_WEI && (
+                          {isBalanceReady ? (
                             <>
+                              {tvlWei <= VAULT_CAPACITY_WEI && (
+                                <div className="absolute -top-4 right-0 font-mono text-[10px] text-muted-foreground/50 uppercase">
+                                  {depositCapDisplay} cap
+                                </div>
+                              )}
                               <div
-                                className="absolute top-0 h-3 vault-excess-rainbow rounded-r-sm"
-                                style={{
-                                  left: `${capPercentOfTvl}%`,
-                                  width: `${100 - capPercentOfTvl}%`,
-                                }}
-                              />
-                              <div
-                                className="absolute top-0 w-px h-3 border-l-2 border-background/70"
-                                style={{ left: `${capPercentOfTvl}%` }}
-                              />
-                              <div
-                                className="absolute -top-7 sm:-top-4 font-mono text-[10px] text-brand-white uppercase -translate-x-1/2 text-center sm:whitespace-nowrap"
-                                style={{ left: `${capPercentOfTvl}%` }}
+                                data-testid="vault-balance-bar"
+                                className="w-full h-3 rounded-sm bg-[hsl(var(--primary)/_0.09)] overflow-hidden shadow-inner relative"
                               >
-                                <span className="sm:hidden">
-                                  deposit
-                                  <br />
-                                  cap
-                                </span>
-                                <span className="hidden sm:inline">
-                                  deposit cap
-                                </span>
+                                <div
+                                  className="h-3 bg-accent-gold rounded-sm transition-all gold-sheen"
+                                  style={{
+                                    width: `${tvlWei > VAULT_CAPACITY_WEI ? 100 : tvlPercentOfCap}%`,
+                                  }}
+                                />
+                                <div
+                                  className="absolute top-0 left-0 h-3 rounded-sm bg-brand-white transition-all"
+                                  style={{
+                                    width: `${tvlWei > VAULT_CAPACITY_WEI ? deployedPercentOfCap : Math.min(deployedPercentOfCap, tvlPercentOfCap)}%`,
+                                  }}
+                                />
                               </div>
+                              {tvlWei > VAULT_CAPACITY_WEI && (
+                                <>
+                                  <div
+                                    className="absolute top-0 h-3 vault-excess-rainbow rounded-r-sm"
+                                    style={{
+                                      left: `${capPercentOfTvl}%`,
+                                      width: `${100 - capPercentOfTvl}%`,
+                                    }}
+                                  />
+                                  <div
+                                    className="absolute top-0 w-px h-3 border-l-2 border-background/70"
+                                    style={{ left: `${capPercentOfTvl}%` }}
+                                  />
+                                  <div
+                                    className="absolute -top-7 sm:-top-4 font-mono text-[10px] text-brand-white uppercase -translate-x-1/2 text-center sm:whitespace-nowrap"
+                                    style={{ left: `${capPercentOfTvl}%` }}
+                                  >
+                                    <span className="sm:hidden">
+                                      deposit
+                                      <br />
+                                      cap
+                                    </span>
+                                    <span className="hidden sm:inline">
+                                      deposit cap
+                                    </span>
+                                  </div>
+                                </>
+                              )}
                             </>
+                          ) : (
+                            <div className="w-full h-3 rounded-sm bg-[hsl(var(--primary)/_0.09)] animate-pulse" />
                           )}
                         </div>
                         <div className="mt-2 flex flex-col items-start sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-0 text-sm">
                           <span className="font-mono text-muted-foreground uppercase">
-                            {deployedDisplay} {collateralSymbol} (
-                            {utilizationDisplay}) deployed
+                            {isBalanceReady && (
+                              <>
+                                {deployedDisplay} {collateralSymbol} (
+                                {utilizationDisplay}) deployed
+                              </>
+                            )}
                           </span>
                           <Link
                             href={`/profile/${VAULT_ADDRESS}`}

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -750,12 +750,14 @@ const VaultsPageContent = () => {
                           Vault Balance
                           <br className="sm:hidden" />{' '}
                           {isBalanceReady && (
-                            <span className="font-medium text-[hsl(var(--ethena))]">
+                            <span className="font-medium text-[hsl(var(--ethena))] animate-in fade-in duration-200">
                               {tvlDisplay} {collateralSymbol}
                             </span>
                           )}
                         </h4>
-                        <div className="relative">
+                        <div
+                          className={`relative ${isBalanceReady ? 'animate-in fade-in duration-200' : ''}`}
+                        >
                           {isBalanceReady ? (
                             <>
                               {tvlWei <= VAULT_CAPACITY_WEI && (
@@ -814,7 +816,9 @@ const VaultsPageContent = () => {
                           )}
                         </div>
                         <div className="mt-2 flex flex-col items-start sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-0 text-sm">
-                          <span className="font-mono text-muted-foreground uppercase">
+                          <span
+                            className={`font-mono text-muted-foreground uppercase ${isBalanceReady ? 'animate-in fade-in duration-200' : ''}`}
+                          >
                             {isBalanceReady && (
                               <>
                                 {deployedDisplay} {collateralSymbol} (

--- a/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
+++ b/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
@@ -383,6 +383,17 @@ describe('VaultsPageContent vault balance display', () => {
     expect(screen.getByText(/deployed/)).toBeInTheDocument();
   });
 
+  it('fades the balance, bar, and deployed line in once loaded', () => {
+    render(<VaultsPageContent />);
+
+    const fadeIn = 'animate-in fade-in duration-200';
+    expect(screen.getByText('1,500.00 USDe').className).toContain(fadeIn);
+    expect(
+      screen.getByTestId('vault-balance-bar').parentElement?.className
+    ).toContain(fadeIn);
+    expect(screen.getByText(/deployed/).className).toContain(fadeIn);
+  });
+
   it('hides the balance number and progress bar until the on-chain read has loaded', () => {
     mockUsePassiveLiquidityVault.mockReturnValue({
       ...passiveVaultDefaults(),

--- a/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
+++ b/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
@@ -248,13 +248,8 @@ import VaultsPageContent from '../VaultsPageContent';
 // blocked by the whitelist check.
 const WHITELISTED_ADDRESS = '0xdb5af497a73620d881561edb508012a5f84e9ba2';
 
-function setDefaults() {
-  mockUseCurrentAddress.mockReturnValue({
-    currentAddress: WHITELISTED_ADDRESS,
-    isConnected: true,
-  });
-
-  mockUsePassiveLiquidityVault.mockReturnValue({
+function passiveVaultDefaults() {
+  return {
     vaultData: { totalLiquidValue: 1000n * 10n ** 18n, paused: false },
     userData: { balance: 100n * 10n ** 18n },
     pendingRequest: null,
@@ -274,7 +269,16 @@ function setDefaults() {
     interactionDelay: 0n,
     isInteractionDelayActive: false,
     lastInteractionAt: 0n,
+  };
+}
+
+function setDefaults() {
+  mockUseCurrentAddress.mockReturnValue({
+    currentAddress: WHITELISTED_ADDRESS,
+    isConnected: true,
   });
+
+  mockUsePassiveLiquidityVault.mockReturnValue(passiveVaultDefaults());
 
   mockUseProtocolStats.mockReturnValue({
     data: [],
@@ -350,5 +354,62 @@ describe('VaultsPageContent geofence', () => {
     render(<VaultsPageContent />);
 
     expect(mockRouterReplace).not.toHaveBeenCalled();
+  });
+});
+
+describe('VaultsPageContent vault balance display', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParamsToString.mockReturnValue('');
+    setDefaults();
+    mockUseRestrictedJurisdiction.mockReturnValue({
+      isRestricted: false,
+      isPermitLoading: false,
+      permitData: { permitted: true },
+      permitError: null,
+    });
+    // Liquid (on-chain) = 1,000; deployed (GraphQL) = 500 -> balance 1,500.
+    mockUseProtocolStats.mockReturnValue({
+      data: [{ vaultDeployed: (500n * 10n ** 18n).toString() }],
+      isLoading: false,
+    });
+  });
+
+  it('renders the balance and progress bar once both sources have loaded', () => {
+    render(<VaultsPageContent />);
+
+    expect(screen.getByText('1,500.00 USDe')).toBeInTheDocument();
+    expect(screen.getByTestId('vault-balance-bar')).toBeInTheDocument();
+    expect(screen.getByText(/deployed/)).toBeInTheDocument();
+  });
+
+  it('hides the balance number and progress bar until the on-chain read has loaded', () => {
+    mockUsePassiveLiquidityVault.mockReturnValue({
+      ...passiveVaultDefaults(),
+      vaultData: null,
+    });
+
+    render(<VaultsPageContent />);
+
+    // Without the liquid value, the sum would misleadingly show only the
+    // deployed portion (500.00) - it must not render at all.
+    expect(screen.queryByText('500.00 USDe')).toBeNull();
+    expect(screen.queryByTestId('vault-balance-bar')).toBeNull();
+    expect(screen.queryByText(/deployed/)).toBeNull();
+  });
+
+  it('hides the balance number and progress bar until protocol stats have loaded', () => {
+    mockUseProtocolStats.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+
+    render(<VaultsPageContent />);
+
+    // Without the deployed value, the sum would misleadingly show only the
+    // liquid portion (1,000.00) - it must not render at all.
+    expect(screen.queryByText('1,000.00 USDe')).toBeNull();
+    expect(screen.queryByTestId('vault-balance-bar')).toBeNull();
+    expect(screen.queryByText(/deployed/)).toBeNull();
   });
 });

--- a/packages/app/src/hooks/contract/usePassiveLiquidityVault.test.ts
+++ b/packages/app/src/hooks/contract/usePassiveLiquidityVault.test.ts
@@ -1,0 +1,195 @@
+import { vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+// Mock wagmi
+const mockUseReadContracts = vi.fn();
+const mockUseReadContract = vi.fn();
+const mockUseBalance = vi.fn();
+vi.mock('wagmi', () => ({
+  useReadContracts: (...args: unknown[]) => mockUseReadContracts(...args),
+  useReadContract: (...args: unknown[]) => mockUseReadContract(...args),
+  useBalance: (...args: unknown[]) => mockUseBalance(...args),
+}));
+
+// Mock viem - avoid jsdom issues
+vi.mock('viem', () => ({
+  erc20Abi: [],
+  verifyMessage: vi.fn(async () => true),
+}));
+
+vi.mock('@sapience/sdk/contracts', () => ({
+  predictionMarketVault: { 5064014: { address: '0xVau1t' } },
+  collateralToken: { 5064014: { address: '0xC011ateral' } },
+}));
+vi.mock('@sapience/sdk/constants', () => ({
+  DEFAULT_CHAIN_ID: 5064014,
+}));
+vi.mock('@sapience/sdk/abis', () => ({
+  predictionMarketVaultAbi: [],
+}));
+
+const mockParsePendingRequest = vi.fn(() => null);
+vi.mock('@sapience/sdk', () => ({
+  formatVaultAssetAmount: vi.fn(() => '0'),
+  formatVaultSharesAmount: vi.fn(() => '0'),
+  formatUtilizationRate: vi.fn(() => '0'),
+  formatInteractionDelay: vi.fn(() => ''),
+  buildDepositCalls: vi.fn(() => []),
+  buildWithdrawalCall: vi.fn(() => ({})),
+  parsePendingRequest: (...args: unknown[]) => mockParsePendingRequest(...args),
+  computeInteractionDelayRemaining: vi.fn(() => 0),
+  buildVaultQuoteMessage: vi.fn(() => ''),
+}));
+
+vi.mock('~/hooks/blockchain/useSapienceWriteContract', () => ({
+  useSapienceWriteContract: () => ({
+    writeContract: vi.fn(),
+    sendCalls: vi.fn(),
+    isPending: false,
+  }),
+}));
+vi.mock('~/hooks/blockchain/useCurrentAddress', () => ({
+  useCurrentAddress: () => ({
+    currentAddress: '0x1234567890abcdef1234567890abcdef12345678',
+    isCalculating: false,
+  }),
+}));
+vi.mock('~/hooks/ws/useVaultShareQuoteWs', () => ({
+  useVaultShareQuoteWs: () => ({ vaultCollateralPerShare: '1.0', raw: null }),
+}));
+
+import { usePassiveLiquidityVault } from './usePassiveLiquidityVault';
+
+const VAULT_ADDRESS = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as const;
+const MANAGER = '0x1111111111111111111111111111111111111111';
+const ASSET = '0x2222222222222222222222222222222222222222';
+
+// Raw values as returned by useReadContracts with allowFailure: false,
+// in the same order as the contracts array in the hook.
+const VAULT_VALUES: unknown[] = [
+  100n, // availableAssets
+  200n, // totalSupply
+  2000n * 10n ** 18n, // getTotalLiquidValue
+  false, // paused
+  MANAGER, // manager
+  ASSET, // asset
+  60n, // depositInteractionDelay
+  0n, // expirationTime
+];
+
+const PENDING_TUPLE = [1n, 2n, 3n, MANAGER, true, false];
+
+function setupReadContracts(
+  overrides: { vaultValues?: unknown[]; vaultData?: unknown } = {}
+) {
+  mockUseReadContracts.mockImplementation((params: unknown) => {
+    const { contracts } = params as {
+      contracts?: { functionName?: string }[];
+    };
+    const fn = contracts?.[0]?.functionName;
+    if (fn === 'availableAssets') {
+      return {
+        data:
+          'vaultData' in overrides
+            ? overrides.vaultData
+            : (overrides.vaultValues ?? VAULT_VALUES),
+        isLoading: false,
+        refetch: vi.fn(),
+      };
+    }
+    if (fn === 'balanceOf') {
+      return { data: [42n], isLoading: false, refetch: vi.fn() };
+    }
+    if (fn === 'pendingRequests') {
+      return { data: [PENDING_TUPLE], isLoading: false, refetch: vi.fn() };
+    }
+    if (fn === 'lastUserInteractionTimestamp') {
+      return { data: [0n], isPending: false };
+    }
+    return { data: undefined, isLoading: false, refetch: vi.fn() };
+  });
+}
+
+function setupDefaults() {
+  setupReadContracts();
+  mockUseBalance.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    refetch: vi.fn(),
+  });
+  mockUseReadContract.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    refetch: vi.fn(),
+  });
+}
+
+function render() {
+  return renderHook(() =>
+    usePassiveLiquidityVault({ vaultAddress: VAULT_ADDRESS, chainId: 5064014 })
+  );
+}
+
+describe('usePassiveLiquidityVault', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaults();
+  });
+
+  it('uses all-or-nothing reads (allowFailure: false) so a flaky RPC call fails and retries the whole query instead of rendering zeros', () => {
+    render();
+
+    const callsWithContracts = mockUseReadContracts.mock.calls.filter(
+      ([params]) => (params as { contracts?: unknown[] }).contracts?.length
+    );
+    expect(callsWithContracts.length).toBeGreaterThan(0);
+    for (const [params] of callsWithContracts) {
+      expect((params as { allowFailure?: boolean }).allowFailure).toBe(false);
+    }
+  });
+
+  it('parses vault data from raw all-or-nothing results', () => {
+    const { result } = render();
+
+    expect(result.current.vaultData).toEqual({
+      availableAssets: 100n,
+      totalSupply: 200n,
+      totalLiquidValue: 2000n * 10n ** 18n,
+      paused: false,
+      manager: MANAGER,
+      asset: ASSET,
+      depositInteractionDelay: 60n,
+      expirationTime: 0n,
+    });
+  });
+
+  it('handles tuple-shaped getTotalLiquidValue results', () => {
+    const values = [...VAULT_VALUES];
+    values[2] = [555n];
+    setupReadContracts({ vaultValues: values });
+
+    const { result } = render();
+
+    expect(result.current.vaultData?.totalLiquidValue).toBe(555n);
+  });
+
+  it('returns null vault data while the query has no data (failed or loading)', () => {
+    setupReadContracts({ vaultData: undefined });
+
+    const { result } = render();
+
+    expect(result.current.vaultData).toBeNull();
+  });
+
+  it('parses the user balance from raw results', () => {
+    const { result } = render();
+
+    expect(result.current.userData).toEqual({ balance: 42n });
+  });
+
+  it('passes the raw pending request struct to parsePendingRequest', () => {
+    render();
+
+    expect(mockParsePendingRequest).toHaveBeenCalledWith(PENDING_TUPLE);
+  });
+});

--- a/packages/app/src/hooks/contract/usePassiveLiquidityVault.ts
+++ b/packages/app/src/hooks/contract/usePassiveLiquidityVault.ts
@@ -57,6 +57,10 @@ export function usePassiveLiquidityVault(
     isLoading: isLoadingVaultData,
     refetch: refetchVaultData,
   } = useReadContracts({
+    // All-or-nothing: a failed sub-read must fail (and retry) the whole
+    // query. With the default allowFailure: true, a single flaky RPC call
+    // silently parses as 0 and renders a wrong vault balance.
+    allowFailure: false,
     contracts: [
       {
         abi: VAULT_ABI,
@@ -117,6 +121,7 @@ export function usePassiveLiquidityVault(
     isLoading: isLoadingUserData,
     refetch: refetchUserData,
   } = useReadContracts({
+    allowFailure: false,
     contracts: currentAddress
       ? [
           {
@@ -168,6 +173,7 @@ export function usePassiveLiquidityVault(
 
   const { data: pendingMapping, refetch: refetchPendingMapping } =
     useReadContracts({
+      allowFailure: false,
       contracts: currentAddress
         ? [
             {
@@ -186,6 +192,7 @@ export function usePassiveLiquidityVault(
 
   const { data: lastInteractionData, isPending: isLastInteractionPending } =
     useReadContracts({
+      allowFailure: false,
       contracts: currentAddress
         ? [
             {
@@ -221,27 +228,26 @@ export function usePassiveLiquidityVault(
 
   const parsedVaultData: VaultData | null = vaultData
     ? {
-        availableAssets: (vaultData[0]?.result as bigint) || 0n,
-        totalSupply: (vaultData[1]?.result as bigint) || 0n,
+        availableAssets: (vaultData[0] as bigint) || 0n,
+        totalSupply: (vaultData[1] as bigint) || 0n,
         totalLiquidValue: (() => {
-          const r = vaultData[2]?.result;
+          const r = vaultData[2];
           if (Array.isArray(r)) return (r as bigint[])[0] ?? 0n;
           return (r as bigint) || 0n;
         })(),
-        paused: (vaultData[3]?.result as boolean) || false,
+        paused: (vaultData[3] as boolean) || false,
         manager:
-          (vaultData[4]?.result as Address) ||
+          (vaultData[4] as Address) ||
           '0x0000000000000000000000000000000000000000',
         asset:
-          (vaultData[5]?.result as Address) ||
+          (vaultData[5] as Address) ||
           '0x0000000000000000000000000000000000000000',
-        depositInteractionDelay: (vaultData[6]?.result as bigint) || 0n,
-        expirationTime: (vaultData[7]?.result as bigint) || 0n,
+        depositInteractionDelay: (vaultData[6] as bigint) || 0n,
+        expirationTime: (vaultData[7] as bigint) || 0n,
       }
     : null;
 
-  const lastInteractionAt: bigint =
-    (lastInteractionData?.[0]?.result as bigint) || 0n;
+  const lastInteractionAt: bigint = (lastInteractionData?.[0] as bigint) || 0n;
 
   const interactionDelay: bigint =
     parsedVaultData?.depositInteractionDelay || 0n;
@@ -257,7 +263,7 @@ export function usePassiveLiquidityVault(
     interactionDelayRemainingSec > 0;
 
   const parsedUserData = userData
-    ? { balance: (userData[0]?.result as bigint) || 0n }
+    ? { balance: (userData[0] as bigint) || 0n }
     : null;
 
   const assetDecimals = 18;
@@ -271,7 +277,7 @@ export function usePassiveLiquidityVault(
     typeof wusdeAllowance === 'bigint' ? wusdeAllowance : 0n;
 
   const pendingRequest = useMemo(
-    () => parsePendingRequest(pendingMapping?.[0]?.result),
+    () => parsePendingRequest(pendingMapping?.[0]),
     [pendingMapping]
   );
 


### PR DESCRIPTION
## Problem

The vault page balance was seen dipping from ~10.2k to ~8.2k and back within seconds. The vault balance hook reads 8 contract values via `useReadContracts`, which defaults to `allowFailure: true`. On Ethereal there is no multicall3 configured, so wagmi sends the reads as individual `eth_call`s — when one of them flakes, its result silently becomes `undefined`, the parsing falls back to `0n`, and the page renders a wrong partial sum until the next 5s poll happens to succeed.

## Fix

Set `allowFailure: false` on all `useReadContracts` batches in `usePassiveLiquidityVault` (vault data, user balance, pending requests, last interaction). A single failed sub-read now fails the whole query, so react-query keeps showing the previous data and retries with backoff (default: 3 attempts) instead of rendering zeros.

With `allowFailure: false` the results are raw values rather than `{ status, result }` objects, so the parsing accessors are updated accordingly. Hook return shape is unchanged.

## Testing

- New unit tests for `usePassiveLiquidityVault` (written first, red → green): asserts all read batches are all-or-nothing and that raw results parse correctly, including the tuple-shaped `getTotalLiquidValue` case.
- Full app suite passes (645 tests), `lint` and `type-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)