### PR TITLE
fix(sdk): buffer vault deposit share requests

### DIFF
--- a/packages/sdk/onchain/__tests__/vault.test.ts
+++ b/packages/sdk/onchain/__tests__/vault.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest';
-import { parseAbi } from 'viem';
+import { parseAbi, decodeFunctionData } from 'viem';
 import type { Abi } from 'abitype';
 import type { Address } from 'viem';
 import {
@@ -235,8 +235,9 @@ describe('buildDepositCalls', () => {
     expect(calls).toHaveLength(1);
   });
 
-  test('share calculation correctness with pps=2', () => {
-    // amount=10, pps=2 → expected shares = 10e18 * 1e18 / 2e18 = 5e18
+  test('share calculation applies 10 bps buffer with pps=2', () => {
+    // amount=10, pps=2 → raw shares would be 5e18; with the 10 bps buffer
+    // the request asks for 10e18 * 1e18 * 10000 / (2e18 * 10010)
     const calls = buildDepositCalls({
       amount: '10',
       assetAddress,
@@ -247,8 +248,13 @@ describe('buildDepositCalls', () => {
       currentAllowance: 100_000_000_000_000_000_000n,
     });
     expect(calls).toHaveLength(1);
-    // The requestDeposit calldata is encoded — just verify it doesn't throw
-    expect(calls[0].data).toBeTruthy();
+    const decoded = decodeFunctionData({
+      abi: vaultAbi,
+      data: calls[0].data,
+    });
+    expect(decoded.functionName).toBe('requestDeposit');
+    expect(decoded.args?.[0]).toBe(10_000_000_000_000_000_000n);
+    expect(decoded.args?.[1]).toBe(4_995_004_995_004_995_004n);
   });
 });
 

--- a/packages/sdk/onchain/vault.ts
+++ b/packages/sdk/onchain/vault.ts
@@ -19,6 +19,15 @@ export const ZERO_ADDRESS: Address = zeroAddress;
 
 export const VAULT_ASSET_DECIMALS = 18;
 
+/**
+ * Safety buffer applied to deposit share requests, in basis points.
+ * The vault manager rejects a deposit when `assets / requestedShares` falls
+ * below the share value at processing time, so a slightly stale (low) PPS
+ * quote would make the request ask for too many shares. Requesting 10 bps
+ * fewer shares tolerates normal quote staleness and rounding drift.
+ */
+export const DEFAULT_DEPOSIT_SHARE_BUFFER_BPS = 10n;
+
 export function abiHasFunction(
   abi: readonly unknown[],
   name: string,
@@ -89,8 +98,15 @@ export function buildDepositCalls(
     pricePerShare && pricePerShare !== '0' ? pricePerShare : '1',
     decimals
   );
+  // Request slightly fewer shares than the raw PPS quote implies (equivalent
+  // to pricing the deposit at pricePerShare * (1 + buffer)), so the request
+  // still clears the manager's share-value check if PPS drifts up slightly
+  // before processing.
   const expectedSharesWei =
-    ppsScaled === 0n ? 0n : (amountWei * 10n ** BigInt(decimals)) / ppsScaled;
+    ppsScaled === 0n
+      ? 0n
+      : (amountWei * 10n ** BigInt(decimals) * 10_000n) /
+        (ppsScaled * (10_000n + DEFAULT_DEPOSIT_SHARE_BUFFER_BPS));
 
   const requestDepositCalldata = encodeFunctionData({
     abi: vaultAbi,


### PR DESCRIPTION
## Summary
- Add a 10 bps safety buffer to SDK vault deposit share calculations
- Deposit requests now ask for slightly fewer shares to tolerate small PPS/shareValue drift before vault-claimer processing
- Leave withdrawal expected-asset calculation unchanged

## Why
Vault-claimer rejects deposits when `assets / requestedShares` is below current share value. We observed skipped deposits where the UI/SDK PPS was only a few bps stale, causing requested shares to be too high.

## Test Plan
- pnpm --filter @sapience/sdk run build:lib
- pnpm --filter @sapience/sdk run type-check
- pnpm --filter @sapience/sdk run lint
- pnpm --filter @sapience/sdk run test -- onchain/__tests__/vault.test.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)