### PR TITLE
fix(market-keeper): drop empty/invalid conditionIds before checkExistingConditions query

### DIFF
--- a/packages/market-keeper/src/__tests__/exclude-existing-fetch.test.ts
+++ b/packages/market-keeper/src/__tests__/exclude-existing-fetch.test.ts
@@ -63,6 +63,36 @@ describe('checkExistingConditions', () => {
     expect(fetchCalls).toHaveLength(0);
   });
 
+  it('drops empty/invalid conditionIds before querying (one bad id must not poison the chunk)', async () => {
+    // The v2 `conditionIds` filter is a strict Bytes scalar: a single ''/non-hex
+    // element 500s the ENTIRE variable, skipping the whole 100-id chunk. So bad
+    // ids must be filtered out before the query, leaving the valid ones intact.
+    fetchQueue.push(() => conditionsPage([makeNode('0x1'), makeNode('0x2')]));
+
+    await checkExistingConditions('https://api.example.com', [
+      '0x1',
+      '', // empty — Polymarket market with no conditionId
+      '0x2',
+      'not-hex', // malformed
+    ]);
+
+    expect(fetchCalls).toHaveLength(1);
+    const filter = JSON.parse(fetchCalls[0].init!.body as string).variables
+      .filter;
+    expect(filter.conditionIds).toEqual(['0x1', '0x2']);
+  });
+
+  it('makes no request and returns empty when every id is invalid', async () => {
+    const result = await checkExistingConditions('https://api.example.com', [
+      '',
+      '   ',
+      'nope',
+    ]);
+
+    expect(fetchCalls).toHaveLength(0);
+    expect(result.size).toBe(0);
+  });
+
   it('matches public and hidden rows in one id-filtered query (no public filter)', async () => {
     // Both public and private rows count as pre-existing so the pipeline
     // never tries to recreate them. An id lookup is exempt from the listing's

--- a/packages/market-keeper/src/generate/pipeline/filters/exclude-existing.ts
+++ b/packages/market-keeper/src/generate/pipeline/filters/exclude-existing.ts
@@ -92,15 +92,28 @@ export async function checkExistingConditions(
   apiUrl: string,
   conditionIds: string[]
 ): Promise<Map<string, ExistingCondition>> {
-  if (conditionIds.length === 0) {
+  // Drop empty/malformed ids before querying. The v2 `conditionIds` filter is a
+  // strict `Bytes` scalar that 500s the ENTIRE variable if any element isn't
+  // valid hex — so one bad id (e.g. a Polymarket market with no conditionId)
+  // would poison its whole 100-id chunk, the catch below would skip all 100,
+  // and the pipeline would treat those existing markets as new and re-create
+  // them. Log the drop so a real upstream data problem still surfaces.
+  const valid = conditionIds.filter((id) => /^0x[0-9a-fA-F]+$/.test(id));
+  const dropped = conditionIds.length - valid.length;
+  if (dropped > 0) {
+    console.warn(
+      `[API] Skipping ${dropped} market(s) with missing/invalid conditionId`
+    );
+  }
+  if (valid.length === 0) {
     return new Map();
   }
 
   const url = graphqlUrl(apiUrl);
   const PAGE_SIZE = 100;
   const chunks: string[][] = [];
-  for (let i = 0; i < conditionIds.length; i += PAGE_SIZE) {
-    chunks.push(conditionIds.slice(i, i + PAGE_SIZE));
+  for (let i = 0; i < valid.length; i += PAGE_SIZE) {
+    chunks.push(valid.slice(i, i + PAGE_SIZE));
   }
   const existing = new Map<string, ExistingCondition>();
 
@@ -146,7 +159,7 @@ export async function checkExistingConditions(
   }
 
   console.log(
-    `[API] Found ${existing.size}/${conditionIds.length} conditions already exist`
+    `[API] Found ${existing.size}/${valid.length} conditions already exist`
   );
   return existing;
 }


### PR DESCRIPTION
## Symptom

On staging, generate/relist spam:

```
[Retry] HTTP 500, retrying — https://api.staging.sapience.xyz/v2/graphql —
Variable "$filter" got invalid value "" at "filter.conditionIds[43]";
Expected type "Bytes". Bytes has invalid format
```

## Root cause

A Polymarket market with a missing `conditionId` becomes an empty string when generate ([grouping.ts:336](packages/market-keeper/src/generate/grouping.ts#L336)) and relist ([relist/index.ts:101](packages/market-keeper/src/relist/index.ts#L101)) map markets → ids with no validation. That `""` flows into [`checkExistingConditions`](packages/market-keeper/src/generate/pipeline/filters/exclude-existing.ts).

The v2 `conditionIds` filter is a strict **`Bytes`** scalar, so a single invalid element **500s the entire variable** — poisoning the whole 100-id chunk it sits in. The blast radius is worse than the log noise:

1. The chunk 500s → `fetchWithRetry` retries it **10×** with backoff (the spam).
2. The `catch` then skips the chunk → all **100 conditions in it are treated as "not existing"**.
3. The pipeline thinks those 100 existing markets are new → tries to **re-create** them.

Almost certainly a **v2-migration regression** — the old v1 query tolerated the empty value; v2's strict `Bytes` scalar rejects it.

## Fix

Filter `conditionIds` to valid `0x` hex before chunking/querying, in the single choke point shared by both generate and relist. One bad id can no longer poison its chunk. Drops are **logged** (`Skipping N market(s) with missing/invalid conditionId`), not swallowed, so a genuine upstream data problem still surfaces.

## Tests

`exclude-existing-fetch.test.ts`: a bad id (`''`, non-hex) never reaches the query variables while valid ids still get queried; an all-invalid list makes no request and returns empty. Full suite **505 green**, type-check clean.

## Note

This is independent of the cron-split PR (#1858) — it's a pre-existing data-validation regression that #1858's `start:discovery` cron happened to surface on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)