### PR TITLE
fix(sdk): publish types/graphql.v2 subpath (build + exports) — unblocks #1860

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -82,6 +82,11 @@
       "import": "./dist/types/graphql.mjs",
       "require": "./dist/types/graphql.js"
     },
+    "./types/graphql.v2": {
+      "types": "./dist/types/graphql.v2.d.ts",
+      "import": "./dist/types/graphql.v2.mjs",
+      "require": "./dist/types/graphql.v2.js"
+    },
     "./types/escrow": {
       "types": "./dist/types/escrow.d.ts",
       "import": "./dist/types/escrow.mjs",
@@ -146,8 +151,8 @@
   },
   "scripts": {
     "prepare": "pnpm run build:lib",
-    "dev": "tsup index.ts auction/encoding.ts auction/escrowEncoding.ts auction/escrowSigning.ts auction/simulate.ts auction/secondarySigning.ts auction/secondaryValidation.ts auction/validation.ts auction/gossipValidation.ts auction/bidPreprocessor.ts auction/initiate.ts auction/buildAuctionPayload.ts auction/decodePredictedOutcomes.ts relayer/escrowAuctionWs.ts abis/index.ts constants/index.ts contracts/index.ts contracts/addresses.ts queries/index.ts queries/client/graphqlClient.ts types/index.ts types/escrow.ts types/secondary.ts types/graphql.ts session/index.ts utils/index.ts --format cjs,esm --dts --watch",
-    "build:lib": "tsup index.ts auction/encoding.ts auction/escrowEncoding.ts auction/escrowSigning.ts auction/simulate.ts auction/secondarySigning.ts auction/secondaryValidation.ts auction/validation.ts auction/gossipValidation.ts auction/bidPreprocessor.ts auction/initiate.ts auction/buildAuctionPayload.ts auction/decodePredictedOutcomes.ts relayer/escrowAuctionWs.ts abis/index.ts constants/index.ts contracts/index.ts contracts/addresses.ts queries/index.ts queries/client/graphqlClient.ts types/index.ts types/escrow.ts types/secondary.ts types/graphql.ts session/index.ts utils/index.ts --format cjs,esm --dts --tsconfig tsconfig.build.json",
+    "dev": "tsup index.ts auction/encoding.ts auction/escrowEncoding.ts auction/escrowSigning.ts auction/simulate.ts auction/secondarySigning.ts auction/secondaryValidation.ts auction/validation.ts auction/gossipValidation.ts auction/bidPreprocessor.ts auction/initiate.ts auction/buildAuctionPayload.ts auction/decodePredictedOutcomes.ts relayer/escrowAuctionWs.ts abis/index.ts constants/index.ts contracts/index.ts contracts/addresses.ts queries/index.ts queries/client/graphqlClient.ts types/index.ts types/escrow.ts types/secondary.ts types/graphql.ts types/graphql.v2.ts session/index.ts utils/index.ts --format cjs,esm --dts --watch",
+    "build:lib": "tsup index.ts auction/encoding.ts auction/escrowEncoding.ts auction/escrowSigning.ts auction/simulate.ts auction/secondarySigning.ts auction/secondaryValidation.ts auction/validation.ts auction/gossipValidation.ts auction/bidPreprocessor.ts auction/initiate.ts auction/buildAuctionPayload.ts auction/decodePredictedOutcomes.ts relayer/escrowAuctionWs.ts abis/index.ts constants/index.ts contracts/index.ts contracts/addresses.ts queries/index.ts queries/client/graphqlClient.ts types/index.ts types/escrow.ts types/secondary.ts types/graphql.ts types/graphql.v2.ts session/index.ts utils/index.ts --format cjs,esm --dts --tsconfig tsconfig.build.json",
     "build": "pnpm run build:lib",
     "lint": "eslint . --quiet",
     "lint:fix": "eslint . --fix --quiet && pnpm format",


### PR DESCRIPTION
## Fix: publish the `@sapience/sdk/types/graphql.v2` subpath

Addresses the change requested on #1860 (staging → main promotion).

### Problem
`packages/api/codegen.ts` directs v2 consumers to import `@sapience/sdk/types/graphql.v2`, and the source `packages/sdk/types/graphql.v2.ts` exists — but the SDK never **built or exported** that subpath:
- `build:lib` / `dev` tsup entry lists omitted `types/graphql.v2.ts`, so no `dist/types/graphql.v2.*` was emitted.
- `package.json#exports` had no `./types/graphql.v2` entry.

External consumers of the published package would fail to resolve the import. (It typechecks in-repo only because the workspace resolves the `.ts` source directly.)

### Fix
Mirror the v1 `types/graphql` packaging exactly:
- add `types/graphql.v2.ts` to the tsup `build:lib` **and** `dev` entry lists
- add the `./types/graphql.v2` export (`types` / `import` / `require`)

`files: ["dist/"]` already covers publishing the emitted artifacts.

### Verification
- `pnpm --filter @sapience/sdk run build:lib` now emits `dist/types/graphql.v2.{d.ts,d.mts,js,mjs}`.
- `graphql.v2.ts` is **types-only** (0 runtime exports) → empty `.mjs`, **identical shape to v1 `graphql.ts`** (whose `.mjs` is also 0 B); the 78 KB `.d.ts`/`.d.mts` carry the types consumers use.
- `require.resolve('@sapience/sdk/types/graphql.v2')` resolves via the new export map.
- prettier passes on `package.json`.

Credit: blocker identified during external review of #1860.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
