### PR TITLE
Support direct URL for single-leg vault

### DIFF
--- a/packages/api/src/services/protocolStats/vaultConfig.test.ts
+++ b/packages/api/src/services/protocolStats/vaultConfig.test.ts
@@ -19,7 +19,13 @@ vi.mock('@sapience/sdk/contracts', () => ({
       },
     },
     pythPredictionMarketVault: {},
-    singleLegVault: {},
+    singleLegVault: {
+      42161: {
+        address: '0xSingleLegVault',
+        blockCreated: 200,
+        legacy: [],
+      },
+    },
     predictionMarketVaultStrategyB: {},
   },
   normalizeLegacyEntry: (
@@ -30,7 +36,10 @@ vi.mock('@sapience/sdk/contracts', () => ({
       : entry,
 }));
 
-import { getConfiguredVaultDeploymentAddresses } from './vaultConfig';
+import {
+  getConfiguredVaultDeploymentAddresses,
+  getConfiguredVaults,
+} from './vaultConfig';
 
 describe('getConfiguredVaultDeploymentAddresses', () => {
   it('includes current and legacy vault deployments', () => {
@@ -38,6 +47,21 @@ describe('getConfiguredVaultDeploymentAddresses', () => {
       '0xvault',
       '0xlegacyvault',
       '0xtuplelegacyvault',
+      '0xsinglelegvault',
     ]);
+  });
+});
+
+describe('getConfiguredVaults', () => {
+  it('includes the single-leg vault so protocol stats cron/backfills index it', () => {
+    expect(getConfiguredVaults(42161)).toContainEqual({
+      kind: 'single-leg',
+      config: {
+        address: '0xSingleLegVault',
+        blockCreated: 200,
+        legacy: [],
+      },
+      address: '0xsinglelegvault',
+    });
   });
 });

--- a/packages/api/src/services/protocolStats/vaultConfig.test.ts
+++ b/packages/api/src/services/protocolStats/vaultConfig.test.ts
@@ -19,13 +19,7 @@ vi.mock('@sapience/sdk/contracts', () => ({
       },
     },
     pythPredictionMarketVault: {},
-    singleLegVault: {
-      42161: {
-        address: '0xSingleLegVault',
-        blockCreated: 200,
-        legacy: [],
-      },
-    },
+    singleLegVault: {},
     predictionMarketVaultStrategyB: {},
   },
   normalizeLegacyEntry: (
@@ -36,10 +30,7 @@ vi.mock('@sapience/sdk/contracts', () => ({
       : entry,
 }));
 
-import {
-  getConfiguredVaultDeploymentAddresses,
-  getConfiguredVaults,
-} from './vaultConfig';
+import { getConfiguredVaultDeploymentAddresses } from './vaultConfig';
 
 describe('getConfiguredVaultDeploymentAddresses', () => {
   it('includes current and legacy vault deployments', () => {
@@ -47,21 +38,6 @@ describe('getConfiguredVaultDeploymentAddresses', () => {
       '0xvault',
       '0xlegacyvault',
       '0xtuplelegacyvault',
-      '0xsinglelegvault',
     ]);
-  });
-});
-
-describe('getConfiguredVaults', () => {
-  it('includes the single-leg vault so protocol stats cron/backfills index it', () => {
-    expect(getConfiguredVaults(42161)).toContainEqual({
-      kind: 'single-leg',
-      config: {
-        address: '0xSingleLegVault',
-        blockCreated: 200,
-        legacy: [],
-      },
-      address: '0xsinglelegvault',
-    });
   });
 });

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -63,7 +63,7 @@ const VaultsPageContent = () => {
   const searchParams = useSearchParams();
   const VAULT_CHAIN_ID = DEFAULT_CHAIN_ID;
 
-  const visibleVaultOptions = useMemo<VaultOption[]>(() => {
+  const vaultOptions = useMemo<VaultOption[]>(() => {
     const entries: Array<[`0x${string}` | undefined, string]> = [
       [
         predictionMarketVault[VAULT_CHAIN_ID]?.address as
@@ -94,12 +94,9 @@ const VaultsPageContent = () => {
       | `0x${string}`
       | undefined;
     return singleLegAddr
-      ? [
-          ...visibleVaultOptions,
-          { address: singleLegAddr, label: 'Single Leg Vault' },
-        ]
-      : visibleVaultOptions;
-  }, [VAULT_CHAIN_ID, visibleVaultOptions]);
+      ? [...vaultOptions, { address: singleLegAddr, label: 'Single Leg Vault' }]
+      : vaultOptions;
+  }, [VAULT_CHAIN_ID, vaultOptions]);
 
   const queryVault = normalizeAddress(searchParams.get(VAULT_QUERY_PARAM));
   const hasVaultQueryParam = queryVault !== '';
@@ -107,8 +104,8 @@ const VaultsPageContent = () => {
     const match = knownVaultOptions.find(
       (v) => normalizeAddress(v.address) === queryVault
     );
-    return match ?? visibleVaultOptions[0];
-  }, [queryVault, knownVaultOptions, visibleVaultOptions]);
+    return match ?? vaultOptions[0];
+  }, [queryVault, knownVaultOptions, vaultOptions]);
 
   useEffect(() => {
     if (!selectedVault || !hasVaultQueryParam) return;
@@ -134,13 +131,12 @@ const VaultsPageContent = () => {
   const selectedVaultValue = selectedVault?.address ?? '';
   const collateralSymbol = COLLATERAL_SYMBOLS[VAULT_CHAIN_ID] || 'testUSDe';
 
-  // Separate reads for each configured vault so the Vault Rewards calc can sum
-  // across all vaults regardless of which tab is selected. Hooks must be called
-  // unconditionally, so missing addresses are handled inside the hook via the
-  // `enabled` flag.
+  // Separate reads for each of the (up to) three vaults so the Vault Rewards
+  // calc can sum across all vaults regardless of which tab is selected. Hooks
+  // must be called unconditionally, so missing addresses are handled inside
+  // the hook via the `enabled` flag.
   const coreAddr = predictionMarketVault[VAULT_CHAIN_ID]?.address;
   const optionsAddr = pythPredictionMarketVault[VAULT_CHAIN_ID]?.address;
-  const singleLegAddr = singleLegVault[VAULT_CHAIN_ID]?.address;
   const edgeAddr = predictionMarketVaultStrategyB[VAULT_CHAIN_ID]?.address;
 
   const coreVault = usePassiveLiquidityVault({
@@ -151,10 +147,6 @@ const VaultsPageContent = () => {
     vaultAddress: optionsAddr,
     chainId: VAULT_CHAIN_ID,
   });
-  const singleLegVaultData = usePassiveLiquidityVault({
-    vaultAddress: singleLegAddr,
-    chainId: VAULT_CHAIN_ID,
-  });
   const edgeVault = usePassiveLiquidityVault({
     vaultAddress: edgeAddr,
     chainId: VAULT_CHAIN_ID,
@@ -162,7 +154,6 @@ const VaultsPageContent = () => {
 
   const { data: coreStats } = useProtocolStats(coreAddr);
   const { data: optionsStats } = useProtocolStats(optionsAddr);
-  const { data: singleLegStats } = useProtocolStats(singleLegAddr);
   const { data: edgeStats } = useProtocolStats(edgeAddr);
 
   const {
@@ -652,7 +643,6 @@ const VaultsPageContent = () => {
     const vaultEntries = [
       [coreVault.vaultData, coreStats] as const,
       [optionsVault.vaultData, optionsStats] as const,
-      [singleLegVaultData.vaultData, singleLegStats] as const,
       [edgeVault.vaultData, edgeStats] as const,
     ];
     const totalVaultTvlWei = vaultEntries.reduce((sum, [v, stats]) => {
@@ -709,11 +699,9 @@ const VaultsPageContent = () => {
   }, [
     coreVault.vaultData,
     optionsVault.vaultData,
-    singleLegVaultData.vaultData,
     edgeVault.vaultData,
     coreStats,
     optionsStats,
-    singleLegStats,
     edgeStats,
     formatAssetAmount,
   ]);
@@ -727,7 +715,7 @@ const VaultsPageContent = () => {
           </h1>
           <Tabs value={selectedVaultValue} onValueChange={handleVaultChange}>
             <TabsList className="h-auto p-1">
-              {visibleVaultOptions.map((option) => (
+              {vaultOptions.map((option) => (
                 <TabsTrigger
                   key={option.address}
                   value={option.address}

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -77,12 +77,6 @@ const VaultsPageContent = () => {
           | undefined,
         'Edge Vault',
       ],
-      [
-        pythPredictionMarketVault[VAULT_CHAIN_ID]?.address as
-          | `0x${string}`
-          | undefined,
-        'Options Vault',
-      ],
     ];
     return entries
       .filter((entry): entry is [`0x${string}`, string] => Boolean(entry[0]))
@@ -90,12 +84,22 @@ const VaultsPageContent = () => {
   }, [VAULT_CHAIN_ID]);
 
   const knownVaultOptions = useMemo<VaultOption[]>(() => {
-    const singleLegAddr = singleLegVault[VAULT_CHAIN_ID]?.address as
-      | `0x${string}`
-      | undefined;
-    return singleLegAddr
-      ? [...vaultOptions, { address: singleLegAddr, label: 'Singles Vault' }]
-      : vaultOptions;
+    const hiddenEntries: Array<[`0x${string}` | undefined, string]> = [
+      [
+        pythPredictionMarketVault[VAULT_CHAIN_ID]?.address as
+          | `0x${string}`
+          | undefined,
+        'Options Vault',
+      ],
+      [
+        singleLegVault[VAULT_CHAIN_ID]?.address as `0x${string}` | undefined,
+        'Singles Vault',
+      ],
+    ];
+    const hiddenVaultOptions = hiddenEntries
+      .filter((entry): entry is [`0x${string}`, string] => Boolean(entry[0]))
+      .map(([address, label]) => ({ address, label }));
+    return [...vaultOptions, ...hiddenVaultOptions];
   }, [VAULT_CHAIN_ID, vaultOptions]);
 
   const queryVault = normalizeAddress(searchParams.get(VAULT_QUERY_PARAM));

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -3,7 +3,7 @@
 import {
   predictionMarketVault,
   predictionMarketVaultStrategyB,
-  pythPredictionMarketVault,
+  singleLegVault,
 } from '@sapience/sdk/contracts';
 import { Button } from '@sapience/ui/components/ui/button';
 import { Card, CardContent } from '@sapience/ui/components/ui/card';
@@ -77,10 +77,8 @@ const VaultsPageContent = () => {
         'Edge Vault',
       ],
       [
-        pythPredictionMarketVault[VAULT_CHAIN_ID]?.address as
-          | `0x${string}`
-          | undefined,
-        'Options Vault',
+        singleLegVault[VAULT_CHAIN_ID]?.address as `0x${string}` | undefined,
+        'Single Leg Vault',
       ],
     ];
     return entries
@@ -126,15 +124,15 @@ const VaultsPageContent = () => {
   // must be called unconditionally, so missing addresses are handled inside
   // the hook via the `enabled` flag.
   const coreAddr = predictionMarketVault[VAULT_CHAIN_ID]?.address;
-  const optionsAddr = pythPredictionMarketVault[VAULT_CHAIN_ID]?.address;
+  const singleLegAddr = singleLegVault[VAULT_CHAIN_ID]?.address;
   const edgeAddr = predictionMarketVaultStrategyB[VAULT_CHAIN_ID]?.address;
 
   const coreVault = usePassiveLiquidityVault({
     vaultAddress: coreAddr,
     chainId: VAULT_CHAIN_ID,
   });
-  const optionsVault = usePassiveLiquidityVault({
-    vaultAddress: optionsAddr,
+  const singleLegVaultData = usePassiveLiquidityVault({
+    vaultAddress: singleLegAddr,
     chainId: VAULT_CHAIN_ID,
   });
   const edgeVault = usePassiveLiquidityVault({
@@ -143,7 +141,7 @@ const VaultsPageContent = () => {
   });
 
   const { data: coreStats } = useProtocolStats(coreAddr);
-  const { data: optionsStats } = useProtocolStats(optionsAddr);
+  const { data: singleLegStats } = useProtocolStats(singleLegAddr);
   const { data: edgeStats } = useProtocolStats(edgeAddr);
 
   const {
@@ -632,7 +630,7 @@ const VaultsPageContent = () => {
     // tab is selected — sum TVL across all deployed vaults.
     const vaultEntries = [
       [coreVault.vaultData, coreStats] as const,
-      [optionsVault.vaultData, optionsStats] as const,
+      [singleLegVaultData.vaultData, singleLegStats] as const,
       [edgeVault.vaultData, edgeStats] as const,
     ];
     const totalVaultTvlWei = vaultEntries.reduce((sum, [v, stats]) => {
@@ -688,10 +686,10 @@ const VaultsPageContent = () => {
     };
   }, [
     coreVault.vaultData,
-    optionsVault.vaultData,
+    singleLegVaultData.vaultData,
     edgeVault.vaultData,
     coreStats,
-    optionsStats,
+    singleLegStats,
     edgeStats,
     formatAssetAmount,
   ]);

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -17,7 +17,7 @@ import {
 } from '@sapience/ui/components/ui/tabs';
 import { Clock } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
-import { isAddress, parseUnits } from 'viem';
+import { parseUnits } from 'viem';
 import { formatDuration, intervalToDuration } from 'date-fns';
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
@@ -63,7 +63,7 @@ const VaultsPageContent = () => {
   const searchParams = useSearchParams();
   const VAULT_CHAIN_ID = DEFAULT_CHAIN_ID;
 
-  const vaultOptions = useMemo<VaultOption[]>(() => {
+  const visibleVaultOptions = useMemo<VaultOption[]>(() => {
     const entries: Array<[`0x${string}` | undefined, string]> = [
       [
         predictionMarketVault[VAULT_CHAIN_ID]?.address as
@@ -89,21 +89,26 @@ const VaultsPageContent = () => {
       .map(([address, label]) => ({ address, label }));
   }, [VAULT_CHAIN_ID]);
 
+  const knownVaultOptions = useMemo<VaultOption[]>(() => {
+    const singleLegAddr = singleLegVault[VAULT_CHAIN_ID]?.address as
+      | `0x${string}`
+      | undefined;
+    return singleLegAddr
+      ? [
+          ...visibleVaultOptions,
+          { address: singleLegAddr, label: 'Single Leg Vault' },
+        ]
+      : visibleVaultOptions;
+  }, [VAULT_CHAIN_ID, visibleVaultOptions]);
+
   const queryVault = normalizeAddress(searchParams.get(VAULT_QUERY_PARAM));
   const hasVaultQueryParam = queryVault !== '';
   const selectedVault = useMemo(() => {
-    const match = vaultOptions.find(
+    const match = knownVaultOptions.find(
       (v) => normalizeAddress(v.address) === queryVault
     );
-    if (match) return match;
-    if (hasVaultQueryParam && isAddress(queryVault)) {
-      return {
-        address: queryVault,
-        label: 'Custom Vault',
-      } satisfies VaultOption;
-    }
-    return vaultOptions[0];
-  }, [queryVault, hasVaultQueryParam, vaultOptions]);
+    return match ?? visibleVaultOptions[0];
+  }, [queryVault, knownVaultOptions, visibleVaultOptions]);
 
   useEffect(() => {
     if (!selectedVault || !hasVaultQueryParam) return;
@@ -722,7 +727,7 @@ const VaultsPageContent = () => {
           </h1>
           <Tabs value={selectedVaultValue} onValueChange={handleVaultChange}>
             <TabsList className="h-auto p-1">
-              {vaultOptions.map((option) => (
+              {visibleVaultOptions.map((option) => (
                 <TabsTrigger
                   key={option.address}
                   value={option.address}

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -3,6 +3,7 @@
 import {
   predictionMarketVault,
   predictionMarketVaultStrategyB,
+  pythPredictionMarketVault,
   singleLegVault,
 } from '@sapience/sdk/contracts';
 import { Button } from '@sapience/ui/components/ui/button';
@@ -16,7 +17,7 @@ import {
 } from '@sapience/ui/components/ui/tabs';
 import { Clock } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
-import { parseUnits } from 'viem';
+import { isAddress, parseUnits } from 'viem';
 import { formatDuration, intervalToDuration } from 'date-fns';
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
@@ -77,8 +78,10 @@ const VaultsPageContent = () => {
         'Edge Vault',
       ],
       [
-        singleLegVault[VAULT_CHAIN_ID]?.address as `0x${string}` | undefined,
-        'Single Leg Vault',
+        pythPredictionMarketVault[VAULT_CHAIN_ID]?.address as
+          | `0x${string}`
+          | undefined,
+        'Options Vault',
       ],
     ];
     return entries
@@ -92,8 +95,15 @@ const VaultsPageContent = () => {
     const match = vaultOptions.find(
       (v) => normalizeAddress(v.address) === queryVault
     );
-    return match ?? vaultOptions[0];
-  }, [queryVault, vaultOptions]);
+    if (match) return match;
+    if (hasVaultQueryParam && isAddress(queryVault)) {
+      return {
+        address: queryVault,
+        label: 'Custom Vault',
+      } satisfies VaultOption;
+    }
+    return vaultOptions[0];
+  }, [queryVault, hasVaultQueryParam, vaultOptions]);
 
   useEffect(() => {
     if (!selectedVault || !hasVaultQueryParam) return;
@@ -119,16 +129,21 @@ const VaultsPageContent = () => {
   const selectedVaultValue = selectedVault?.address ?? '';
   const collateralSymbol = COLLATERAL_SYMBOLS[VAULT_CHAIN_ID] || 'testUSDe';
 
-  // Separate reads for each of the (up to) three vaults so the Vault Rewards
-  // calc can sum across all vaults regardless of which tab is selected. Hooks
-  // must be called unconditionally, so missing addresses are handled inside
-  // the hook via the `enabled` flag.
+  // Separate reads for each configured vault so the Vault Rewards calc can sum
+  // across all vaults regardless of which tab is selected. Hooks must be called
+  // unconditionally, so missing addresses are handled inside the hook via the
+  // `enabled` flag.
   const coreAddr = predictionMarketVault[VAULT_CHAIN_ID]?.address;
+  const optionsAddr = pythPredictionMarketVault[VAULT_CHAIN_ID]?.address;
   const singleLegAddr = singleLegVault[VAULT_CHAIN_ID]?.address;
   const edgeAddr = predictionMarketVaultStrategyB[VAULT_CHAIN_ID]?.address;
 
   const coreVault = usePassiveLiquidityVault({
     vaultAddress: coreAddr,
+    chainId: VAULT_CHAIN_ID,
+  });
+  const optionsVault = usePassiveLiquidityVault({
+    vaultAddress: optionsAddr,
     chainId: VAULT_CHAIN_ID,
   });
   const singleLegVaultData = usePassiveLiquidityVault({
@@ -141,6 +156,7 @@ const VaultsPageContent = () => {
   });
 
   const { data: coreStats } = useProtocolStats(coreAddr);
+  const { data: optionsStats } = useProtocolStats(optionsAddr);
   const { data: singleLegStats } = useProtocolStats(singleLegAddr);
   const { data: edgeStats } = useProtocolStats(edgeAddr);
 
@@ -630,6 +646,7 @@ const VaultsPageContent = () => {
     // tab is selected — sum TVL across all deployed vaults.
     const vaultEntries = [
       [coreVault.vaultData, coreStats] as const,
+      [optionsVault.vaultData, optionsStats] as const,
       [singleLegVaultData.vaultData, singleLegStats] as const,
       [edgeVault.vaultData, edgeStats] as const,
     ];
@@ -686,9 +703,11 @@ const VaultsPageContent = () => {
     };
   }, [
     coreVault.vaultData,
+    optionsVault.vaultData,
     singleLegVaultData.vaultData,
     edgeVault.vaultData,
     coreStats,
+    optionsStats,
     singleLegStats,
     edgeStats,
     formatAssetAmount,

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -94,7 +94,7 @@ const VaultsPageContent = () => {
       | `0x${string}`
       | undefined;
     return singleLegAddr
-      ? [...vaultOptions, { address: singleLegAddr, label: 'Single Leg Vault' }]
+      ? [...vaultOptions, { address: singleLegAddr, label: 'Singles Vault' }]
       : vaultOptions;
   }, [VAULT_CHAIN_ID, vaultOptions]);
 

--- a/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
+++ b/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
@@ -165,7 +165,6 @@ vi.mock('lucide-react', () => ({
 }));
 
 vi.mock('viem', () => ({
-  isAddress: (value: string) => /^0x[a-fA-F0-9]{40}$/.test(value),
   parseUnits: (value: string, decimals: number) => {
     const n = Number(value);
     if (!Number.isFinite(n)) return 0n;
@@ -370,9 +369,9 @@ describe('VaultsPageContent geofence', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('accepts an arbitrary vault address from the URL without rewriting it', () => {
-    const customVault = '0x0000000000000000000000000000000000000abc';
-    mockSearchParamsToString.mockReturnValue(`address=${customVault}`);
+  it('accepts a hidden known/indexed vault address from the URL without rewriting it', () => {
+    const singleLegVault = '0xSingleLegVault';
+    mockSearchParamsToString.mockReturnValue(`address=${singleLegVault}`);
     mockUseRestrictedJurisdiction.mockReturnValue({
       isRestricted: false,
       isPermitLoading: false,
@@ -382,15 +381,33 @@ describe('VaultsPageContent geofence', () => {
 
     render(<VaultsPageContent />);
 
-    expect(screen.getByText('Custom Vault')).toBeInTheDocument();
+    expect(screen.getByText('Single Leg Vault')).toBeInTheDocument();
     expect(mockRouterReplace).not.toHaveBeenCalled();
     expect(
       mockUsePassiveLiquidityVault.mock.calls.some(
         ([args]) =>
-          (args as { vaultAddress?: string }).vaultAddress === customVault
+          (args as { vaultAddress?: string }).vaultAddress === singleLegVault
       )
     ).toBe(true);
-    expect(mockUseProtocolStats).toHaveBeenCalledWith(customVault);
+    expect(mockUseProtocolStats).toHaveBeenCalledWith(singleLegVault);
+  });
+
+  it('rewrites an unknown vault address to the default vault', () => {
+    const unknownVault = '0x0000000000000000000000000000000000000abc';
+    mockSearchParamsToString.mockReturnValue(`address=${unknownVault}`);
+    mockUseRestrictedJurisdiction.mockReturnValue({
+      isRestricted: false,
+      isPermitLoading: false,
+      permitData: { permitted: true },
+      permitError: null,
+    });
+
+    render(<VaultsPageContent />);
+
+    expect(screen.queryByText('Custom Vault')).not.toBeInTheDocument();
+    expect(mockRouterReplace).toHaveBeenCalledWith('/vaults?address=0xvault', {
+      scroll: false,
+    });
   });
 
   it('defaults to the first vault tab without rewriting the URL when no address query param is present', () => {

--- a/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
+++ b/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
@@ -365,7 +365,7 @@ describe('VaultsPageContent geofence', () => {
       screen.getByRole('button', { name: 'Options Vault' })
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('button', { name: 'Single Leg Vault' })
+      screen.queryByRole('button', { name: 'Singles Vault' })
     ).not.toBeInTheDocument();
   });
 
@@ -381,7 +381,7 @@ describe('VaultsPageContent geofence', () => {
 
     render(<VaultsPageContent />);
 
-    expect(screen.getByText('Single Leg Vault')).toBeInTheDocument();
+    expect(screen.getByText('Singles Vault')).toBeInTheDocument();
     expect(mockRouterReplace).not.toHaveBeenCalled();
     expect(
       mockUsePassiveLiquidityVault.mock.calls.some(

--- a/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
+++ b/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
@@ -30,7 +30,8 @@ vi.mock('~/hooks/useRestrictedJurisdiction', () => ({
 }));
 
 vi.mock('~/hooks/contract/usePassiveLiquidityVault', () => ({
-  usePassiveLiquidityVault: () => mockUsePassiveLiquidityVault(),
+  usePassiveLiquidityVault: (args: unknown) =>
+    mockUsePassiveLiquidityVault(args),
 }));
 
 vi.mock('~/hooks/blockchain/useCurrentAddress', () => ({
@@ -38,7 +39,8 @@ vi.mock('~/hooks/blockchain/useCurrentAddress', () => ({
 }));
 
 vi.mock('~/hooks/graphql/useAnalytics', () => ({
-  useProtocolStats: () => mockUseProtocolStats(),
+  useProtocolStats: (vaultAddress: string | undefined) =>
+    mockUseProtocolStats(vaultAddress),
   getProtocolTvlWei: (
     stat: { escrowBalance?: string; vaultAvailableAssets?: string } | null
   ) =>
@@ -163,6 +165,7 @@ vi.mock('lucide-react', () => ({
 }));
 
 vi.mock('viem', () => ({
+  isAddress: (value: string) => /^0x[a-fA-F0-9]{40}$/.test(value),
   parseUnits: (value: string, decimals: number) => {
     const n = Number(value);
     if (!Number.isFinite(n)) return 0n;
@@ -343,7 +346,7 @@ describe('VaultsPageContent geofence', () => {
     expect(depositBtn).not.toBeDisabled();
   });
 
-  it('renders the single-leg vault tab instead of the options vault tab', () => {
+  it('keeps the options vault tab visible and single-leg hidden from tabs', () => {
     mockUseRestrictedJurisdiction.mockReturnValue({
       isRestricted: false,
       isPermitLoading: false,
@@ -360,11 +363,34 @@ describe('VaultsPageContent geofence', () => {
       screen.getByRole('button', { name: 'Edge Vault' })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'Single Leg Vault' })
+      screen.getByRole('button', { name: 'Options Vault' })
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('button', { name: 'Options Vault' })
+      screen.queryByRole('button', { name: 'Single Leg Vault' })
     ).not.toBeInTheDocument();
+  });
+
+  it('accepts an arbitrary vault address from the URL without rewriting it', () => {
+    const customVault = '0x0000000000000000000000000000000000000abc';
+    mockSearchParamsToString.mockReturnValue(`address=${customVault}`);
+    mockUseRestrictedJurisdiction.mockReturnValue({
+      isRestricted: false,
+      isPermitLoading: false,
+      permitData: { permitted: true },
+      permitError: null,
+    });
+
+    render(<VaultsPageContent />);
+
+    expect(screen.getByText('Custom Vault')).toBeInTheDocument();
+    expect(mockRouterReplace).not.toHaveBeenCalled();
+    expect(
+      mockUsePassiveLiquidityVault.mock.calls.some(
+        ([args]) =>
+          (args as { vaultAddress?: string }).vaultAddress === customVault
+      )
+    ).toBe(true);
+    expect(mockUseProtocolStats).toHaveBeenCalledWith(customVault);
   });
 
   it('defaults to the first vault tab without rewriting the URL when no address query param is present', () => {

--- a/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
+++ b/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
@@ -345,7 +345,7 @@ describe('VaultsPageContent geofence', () => {
     expect(depositBtn).not.toBeDisabled();
   });
 
-  it('keeps the options vault tab visible and single-leg hidden from tabs', () => {
+  it('hides the options and singles vaults from tabs', () => {
     mockUseRestrictedJurisdiction.mockReturnValue({
       isRestricted: false,
       isPermitLoading: false,
@@ -362,8 +362,8 @@ describe('VaultsPageContent geofence', () => {
       screen.getByRole('button', { name: 'Edge Vault' })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'Options Vault' })
-    ).toBeInTheDocument();
+      screen.queryByRole('button', { name: 'Options Vault' })
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: 'Singles Vault' })
     ).not.toBeInTheDocument();
@@ -390,6 +390,26 @@ describe('VaultsPageContent geofence', () => {
       )
     ).toBe(true);
     expect(mockUseProtocolStats).toHaveBeenCalledWith(singleLegVault);
+  });
+
+  it('accepts the hidden options vault address from the URL without showing its tab', () => {
+    const optionsVault = '0xOptionsVault';
+    mockSearchParamsToString.mockReturnValue(`address=${optionsVault}`);
+    mockUseRestrictedJurisdiction.mockReturnValue({
+      isRestricted: false,
+      isPermitLoading: false,
+      permitData: { permitted: true },
+      permitError: null,
+    });
+
+    render(<VaultsPageContent />);
+
+    expect(screen.getByText('Options Vault')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Options Vault' })
+    ).not.toBeInTheDocument();
+    expect(mockRouterReplace).not.toHaveBeenCalled();
+    expect(mockUseProtocolStats).toHaveBeenCalledWith(optionsVault);
   });
 
   it('rewrites an unknown vault address to the default vault', () => {

--- a/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
+++ b/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
@@ -67,7 +67,7 @@ vi.mock('@sapience/sdk/contracts', () => ({
   predictionMarketVaultStrategyB: {
     42161: { address: '0xStrategyBVault' },
   },
-  singleLegVault: {},
+  singleLegVault: { 42161: { address: '0xSingleLegVault' } },
 }));
 
 vi.mock('@sapience/sdk/constants', () => ({
@@ -341,6 +341,30 @@ describe('VaultsPageContent geofence', () => {
     // Deposit button should be enabled (all other conditions satisfied by mocks)
     const depositBtn = screen.getByRole('button', { name: /Submit Deposit/ });
     expect(depositBtn).not.toBeDisabled();
+  });
+
+  it('renders the single-leg vault tab instead of the options vault tab', () => {
+    mockUseRestrictedJurisdiction.mockReturnValue({
+      isRestricted: false,
+      isPermitLoading: false,
+      permitData: { permitted: true },
+      permitError: null,
+    });
+
+    render(<VaultsPageContent />);
+
+    expect(
+      screen.getByRole('button', { name: 'Core Vault' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Edge Vault' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Single Leg Vault' })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Options Vault' })
+    ).not.toBeInTheDocument();
   });
 
   it('defaults to the first vault tab without rewriting the URL when no address query param is present', () => {

--- a/packages/app/src/components/vaults/vaultAnchors.ts
+++ b/packages/app/src/components/vaults/vaultAnchors.ts
@@ -2,6 +2,7 @@ import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
 import {
   predictionMarketVault,
   predictionMarketVaultStrategyB,
+  singleLegVault,
 } from '@sapience/sdk/contracts';
 
 // Per-vault "start of visible history" for the Vault PnL chart. A vault may
@@ -12,6 +13,7 @@ import {
 const CORE_VAULT_ADDRESS = predictionMarketVault[DEFAULT_CHAIN_ID]?.address;
 const EDGE_VAULT_ADDRESS =
   predictionMarketVaultStrategyB[DEFAULT_CHAIN_ID]?.address;
+const SINGLE_LEG_VAULT_ADDRESS = singleLegVault[DEFAULT_CHAIN_ID]?.address;
 
 export const VAULT_PNL_ANCHORS_SEC: Record<string, number> = {
   ...(CORE_VAULT_ADDRESS && {
@@ -22,6 +24,11 @@ export const VAULT_PNL_ANCHORS_SEC: Record<string, number> = {
   ...(EDGE_VAULT_ADDRESS && {
     [EDGE_VAULT_ADDRESS.toLowerCase()]: Math.floor(
       Date.UTC(2026, 4, 13) / 1000
+    ),
+  }),
+  ...(SINGLE_LEG_VAULT_ADDRESS && {
+    [SINGLE_LEG_VAULT_ADDRESS.toLowerCase()]: Math.floor(
+      Date.UTC(2026, 5, 4) / 1000
     ),
   }),
 };


### PR DESCRIPTION
## Summary
- show only Core / Edge in the visible vault tabs
- keep Options hidden from tabs while preserving direct URL support for `/vaults?address=...`
- allow the indexed Single Leg vault address to resolve from `/vaults?address=...` even though it is hidden from tabs
- display that directly-opened vault as `Singles Vault`
- clamp the Singles Vault PnL chart history to start on 2026-06-04 UTC
- leave unknown/unindexed addresses on the existing fallback path

## Notes
- `0x1B03b3F20CAA6Fc8CC7f6d9ae73D634804fe7f59` is already in the SDK as `singleLegVault[5064014]`
- the API protocol-stats config already fans out over `contracts.singleLegVault[chainId]`, so cron/backfill indexing already includes it once deployed/running

## Test plan
- `pnpm --filter @sapience/app exec vitest run src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx`
- `pnpm --filter @sapience/app lint`
- `pnpm --filter @sapience/app type-check`
