### PR TITLE
feat(app): migrate position balances to /v2/graphql positions connection

### DIFF
--- a/packages/app/src/components/positions/PositionsTable.tsx
+++ b/packages/app/src/components/positions/PositionsTable.tsx
@@ -124,9 +124,11 @@ function PositionRow({
     ((isPredictorToken && result === 'COUNTERPARTY_WINS') ||
       (!isPredictorToken && result === 'PREDICTOR_WINS'));
 
-  // Synthetic sell rows have ids like `${dbId}-sell-${tradeHash}`; the open
-  // / parent row is just `${dbId}`.
-  const isSoldRow = position.id.includes('-sell-');
+  // v2 surfaces an explicit SOLD discriminator. (v1 encoded it in the id shape
+  // `${dbId}-sell-${tradeHash}`; the id fallback keeps any pre-migration row
+  // working.)
+  const isSoldRow =
+    position.status === 'SOLD' || position.id.includes('-sell-');
   const isClosed = !isResolved && BigInt(position.balance) === 0n;
   const realizedPnLFormatted =
     position.realizedPnL != null

--- a/packages/app/src/hooks/graphql/__tests__/usePositions.test.ts
+++ b/packages/app/src/hooks/graphql/__tests__/usePositions.test.ts
@@ -3,10 +3,12 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
-const mockGraphqlRequest = vi.fn();
+const mockGraphqlRequestV2 = vi.fn();
 
+// The position hooks page via `useCursorPagination`, which issues its requests
+// through `graphqlRequestV2`. Mock that single transport export.
 vi.mock('@sapience/sdk/queries/client/graphqlClient', () => ({
-  graphqlRequest: (...args: unknown[]) => mockGraphqlRequest(...args),
+  graphqlRequestV2: (...args: unknown[]) => mockGraphqlRequestV2(...args),
 }));
 
 function createWrapper() {
@@ -35,38 +37,51 @@ async function getHooks() {
 const HOLDER = '0xabc';
 const CONDITION_ID = '0xcond';
 
-const makePosition = (id: string) => ({
+// A v2 `Position` node (the adapter maps it to a PositionBalance).
+const makeNode = (id: string) => ({
   id,
   chainId: 1,
-  tokenAddress: '0xtok',
-  pickConfigId: 'pc1',
-  isPredictorToken: true,
   holder: HOLDER,
+  pickConfigId: 'pc1',
+  token: '0xtok',
+  side: 'PREDICTOR' as const,
+  status: 'OPEN' as const,
   balance: '100',
+  userCollateral: null,
+  totalPayout: null,
+  realizedPnl: null,
   createdAt: '2026-01-01',
   updatedAt: '2026-01-01',
   pickConfig: null,
 });
 
-const page = (items: ReturnType<typeof makePosition>[], hasMore: boolean) => ({
-  positionsPage: { items, hasMore },
+// A Relay `PositionConnection` page. Per the v2 contract, an all-synthesized-
+// away page still reports an advancing `endCursor` while more raw rows exist,
+// so `endCursor` is independent of whether `nodes` is empty.
+const conn = (
+  nodes: ReturnType<typeof makeNode>[],
+  hasNextPage: boolean,
+  endCursor: string | null = nodes.length ? `c${nodes.length - 1}` : null
+) => ({
+  positions: {
+    edges: nodes.map((node, i) => ({ node, cursor: `c${i}` })),
+    pageInfo: { hasNextPage, endCursor },
+    totalCount: nodes.length,
+  },
 });
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockGraphqlRequest.mockResolvedValue(page([], false));
+  mockGraphqlRequestV2.mockResolvedValue(conn([], false));
 });
 
 describe('usePositionBalances — pagination', () => {
-  it('stops paginating when the server reports hasMore=false', async () => {
-    // Server-truth: synthesized item count is unreliable (zero-balance
-    // unresolved positions with no sells produce empty pages). Trust
-    // hasMore from the API.
+  it('stops paginating when the server reports hasNextPage=false', async () => {
     const { usePositionBalances } = await getHooks();
 
-    mockGraphqlRequest
-      .mockResolvedValueOnce(page([makePosition('1')], true))
-      .mockResolvedValueOnce(page([], false));
+    mockGraphqlRequestV2
+      .mockResolvedValueOnce(conn([makeNode('1')], true))
+      .mockResolvedValueOnce(conn([], false));
 
     const { result } = renderHook(
       () => usePositionBalances({ holder: HOLDER, pageSize: 1 }),
@@ -82,27 +97,26 @@ describe('usePositionBalances — pagination', () => {
       result.current.fetchMore();
     });
     await waitFor(() => {
-      expect(mockGraphqlRequest).toHaveBeenCalledTimes(2);
+      expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(2);
     });
 
     expect(result.current.hasMore).toBe(false);
   });
 
-  it('keeps paginating across pages with zero synthesized items so long as the server still reports more', async () => {
-    // The whole point of moving to server-truth pagination: a page can
-    // have items=[] but more raw rows behind it.
+  it('keeps paginating across pages with zero synthesized nodes so long as hasNextPage stays true', async () => {
+    // A page can have edges=[] but an advancing endCursor with more raw rows
+    // behind it — page on pageInfo, never on node count.
     const { usePositionBalances } = await getHooks();
 
-    mockGraphqlRequest
-      .mockResolvedValueOnce(page([], true)) // empty synthesized page, more raw rows behind
-      .mockResolvedValueOnce(page([makePosition('99')], false));
+    mockGraphqlRequestV2
+      .mockResolvedValueOnce(conn([], true, 'cursor-after-empty'))
+      .mockResolvedValueOnce(conn([makeNode('99')], false));
 
     const { result } = renderHook(
       () => usePositionBalances({ holder: HOLDER, pageSize: 15 }),
       { wrapper: createWrapper() }
     );
 
-    // Empty synthesized page, but hasMore=true means we should still fetch.
     await waitFor(() => {
       expect(result.current.hasMore).toBe(true);
     });
@@ -117,7 +131,7 @@ describe('usePositionBalances — pagination', () => {
     expect(result.current.hasMore).toBe(false);
   });
 
-  it('passes holder/chainId/settled/pagination params through', async () => {
+  it('passes a PositionFilter + cursor page args through', async () => {
     const { usePositionBalances } = await getHooks();
 
     renderHook(
@@ -132,14 +146,27 @@ describe('usePositionBalances — pagination', () => {
     );
 
     await waitFor(() => {
-      expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
+      expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
     });
-    expect(mockGraphqlRequest.mock.calls[0][1]).toMatchObject({
+    expect(mockGraphqlRequestV2.mock.calls[0][1]).toMatchObject({
+      filter: { holder: HOLDER, chainId: 42, settled: true },
+      first: 25,
+      after: null,
+    });
+  });
+
+  it('omits chainId/settled from the filter when not provided', async () => {
+    const { usePositionBalances } = await getHooks();
+
+    renderHook(() => usePositionBalances({ holder: HOLDER }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
+    });
+    expect(mockGraphqlRequestV2.mock.calls[0][1].filter).toEqual({
       holder: HOLDER,
-      chainId: 42,
-      settled: true,
-      take: 25,
-      skip: 0,
     });
   });
 
@@ -149,17 +176,17 @@ describe('usePositionBalances — pagination', () => {
     renderHook(() => usePositionBalances({}), { wrapper: createWrapper() });
 
     await new Promise((r) => setTimeout(r, 20));
-    expect(mockGraphqlRequest).not.toHaveBeenCalled();
+    expect(mockGraphqlRequestV2).not.toHaveBeenCalled();
   });
 });
 
 describe('usePositionBalancesByConditionId — pagination', () => {
-  it('stops paginating when hasMore=false (same rule as the holder hook)', async () => {
+  it('stops paginating when hasNextPage=false (same rule as the holder hook)', async () => {
     const { usePositionBalancesByConditionId } = await getHooks();
 
-    mockGraphqlRequest
-      .mockResolvedValueOnce(page([makePosition('1')], true))
-      .mockResolvedValueOnce(page([], false));
+    mockGraphqlRequestV2
+      .mockResolvedValueOnce(conn([makeNode('1')], true))
+      .mockResolvedValueOnce(conn([], false));
 
     const { result } = renderHook(
       () =>
@@ -179,8 +206,24 @@ describe('usePositionBalancesByConditionId — pagination', () => {
       result.current.fetchMore();
     });
     await waitFor(() => {
-      expect(mockGraphqlRequest).toHaveBeenCalledTimes(2);
+      expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(2);
     });
     expect(result.current.hasMore).toBe(false);
+  });
+
+  it('filters by conditionIds', async () => {
+    const { usePositionBalancesByConditionId } = await getHooks();
+
+    renderHook(
+      () => usePositionBalancesByConditionId({ conditionId: CONDITION_ID }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
+    });
+    expect(mockGraphqlRequestV2.mock.calls[0][1].filter).toEqual({
+      conditionIds: [CONDITION_ID],
+    });
   });
 });

--- a/packages/app/src/hooks/graphql/usePositions.ts
+++ b/packages/app/src/hooks/graphql/usePositions.ts
@@ -1,16 +1,19 @@
 'use client';
 
-import { useCallback, useMemo } from 'react';
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
-import {
-  graphqlRequest,
-  graphqlRequestV2,
-} from '@sapience/sdk/queries/client/graphqlClient';
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { graphqlRequestV2 } from '@sapience/sdk/queries/client/graphqlClient';
 import {
   PICK_CONFIGURATION_V2_FIELDS,
   toPickConfigData,
   type PickConfigurationV2Node,
 } from '~/lib/adapters/pickConfig';
+import {
+  POSITION_V2_FIELDS,
+  toPositionBalance,
+  type PositionV2Node,
+} from '~/lib/adapters/position';
+import { useCursorPagination } from '~/hooks/useCursorPagination';
 
 /**
  * Prediction - individual prediction record. v2 drops the numeric Prisma
@@ -99,16 +102,6 @@ export type PickConfigData = {
 };
 
 /**
- * Server-truth paginated wrapper. `hasMore` reflects whether at least one
- * more raw position row exists past this page; trust this over
- * `items.length`, which the resolver can return as 0 for non-final pages.
- */
-export type PositionBalancePage = {
-  items: PositionBalance[];
-  hasMore: boolean;
-};
-
-/**
  * Position Balance - ERC20 token balance for a user
  */
 export type PositionBalance = {
@@ -122,63 +115,14 @@ export type PositionBalance = {
   userCollateral?: string | null;
   totalPayout?: string | null;
   realizedPnL?: string | null;
+  /** v2 lifecycle discriminator. v1 encoded SOLD rows implicitly in the id
+   *  shape (`<rowId>-sell-<tradeHash>`); v2 surfaces it explicitly. Absent on
+   *  rows not produced by the positions synthesis. */
+  status?: 'OPEN' | 'SOLD' | null;
   createdAt: string;
   updatedAt: string;
   pickConfig?: PickConfigData | null;
 };
-
-// GraphQL queries
-//
-// `picks.condition` is fetched inline so consumers can render the full
-// row without a follow-up `useConditionsByIds` round trip. The server
-// pre-loads conditions per request — see Pick resolver + escrow/activity
-// resolvers.
-const PICK_CONDITION_FRAGMENT = `
-  condition {
-    id
-    shortName
-    optionName
-    question
-    description
-    endTime
-    resolver
-    settled
-    resolvedToYes
-    nonDecisive
-    estimatedPrice
-    category {
-      slug
-    }
-  }
-`;
-
-const PICK_CONFIG_FRAGMENT = `
-  pickConfig {
-    id
-    chainId
-    marketAddress
-    totalPredictorCollateral
-    totalCounterpartyCollateral
-    claimedPredictorCollateral
-    claimedCounterpartyCollateral
-    resolved
-    result
-    resolvedAt
-    predictorToken
-    counterpartyToken
-    endsAt
-    isLegacy
-    predictionId
-    picks {
-      id
-      pickConfigId
-      conditionResolver
-      conditionId
-      predictedOutcome
-      ${PICK_CONDITION_FRAGMENT}
-    }
-  }
-`;
 
 // ─── v2 prediction documents + mapper ────────────────────────────────────────
 //
@@ -418,74 +362,27 @@ export const PREDICTION_QUERY = `
   }
 `;
 
-// Server-truth paginated query. The resolver synthesizes events per raw
-// position and can emit zero rows for some pages (zero-balance unresolved
-// positions with no sells), so the client-side `lastPage.length === 0`
-// stop signal is unsafe — use the response's `hasMore` flag instead.
-const POSITION_BALANCES_QUERY = /* GraphQL */ `
-  query Positions(
-    $holder: String!
-    $chainId: Int
-    $settled: Boolean
-    $take: Int
-    $skip: Int
-  ) {
-    positionsPage(
-      holder: $holder
-      chainId: $chainId
-      settled: $settled
-      take: $take
-      skip: $skip
-    ) {
-      hasMore
-      items {
-        id
-        chainId
-        tokenAddress
-        pickConfigId
-        isPredictorToken
-        holder
-        balance
-        userCollateral
-        totalPayout
-        realizedPnL
-        createdAt
-        updatedAt
-        ${PICK_CONFIG_FRAGMENT}
+// v2 connection over synthesized position rows — replaces v1's skip/take
+// `positionsPage`. Both the by-holder and by-condition hooks share this
+// document; only the `PositionFilter` differs (passed as a variable).
+//
+// `pageInfo.hasNextPage` is raw-row truth: a page whose rows all synthesized
+// away still reports `true` while more underlying rows exist, so always page
+// on `pageInfo` (which `useCursorPagination` does), never on node count.
+export const POSITIONS_V2_QUERY = `
+  query Positions($filter: PositionFilter, $first: Int!, $after: String) {
+    positions(filter: $filter, first: $first, after: $after) {
+      edges {
+        node {
+          ${POSITION_V2_FIELDS}
+        }
+        cursor
       }
-    }
-  }
-`;
-
-const POSITION_BALANCES_BY_CONDITION_QUERY = /* GraphQL */ `
-  query PositionsByCondition(
-    $conditionId: String!
-    $take: Int
-    $skip: Int
-    $settled: Boolean
-  ) {
-    positionsPage(
-      conditionId: $conditionId
-      take: $take
-      skip: $skip
-      settled: $settled
-    ) {
-      hasMore
-      items {
-        id
-        chainId
-        tokenAddress
-        pickConfigId
-        isPredictorToken
-        holder
-        balance
-        userCollateral
-        totalPayout
-        realizedPnL
-        createdAt
-        updatedAt
-        ${PICK_CONFIG_FRAGMENT}
+      pageInfo {
+        hasNextPage
+        endCursor
       }
+      totalCount
     }
   }
 `;
@@ -574,61 +471,41 @@ export function usePositionBalances(params: {
     settled,
     pageSize = DEFAULT_POSITIONS_PAGE_SIZE,
   } = params;
-  const enabled = Boolean(holder);
+
+  const filter = useMemo(() => {
+    const f: Record<string, unknown> = { holder };
+    if (chainId != null) f.chainId = chainId;
+    if (settled != null) f.settled = settled;
+    return f;
+  }, [holder, chainId, settled]);
 
   const {
-    data,
+    data: nodes,
     isLoading,
+    isFetchingMore,
     isFetching,
-    isFetchingNextPage,
-    fetchNextPage,
     hasNextPage,
+    loadMore,
     error,
     refetch,
-  } = useInfiniteQuery({
-    queryKey: ['positionBalances', holder, chainId, settled, pageSize],
-    enabled,
-    staleTime: 30_000,
-    gcTime: 5 * 60 * 1000,
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
-    initialPageParam: 0,
-    // The server uses a `take + 1` raw-row trick to compute hasMore
-    // server-truth. Synthesized event-stream rows from the resolver can be
-    // empty for some pages (zero-balance unresolved positions with no
-    // sells), so we cannot infer "exhausted" from `items.length === 0`.
-    // Trust the API's hasMore flag.
-    getNextPageParam: (lastPage: PositionBalancePage, allPages) =>
-      lastPage.hasMore ? allPages.length * pageSize : undefined,
-    queryFn: async ({ pageParam = 0 }) => {
-      const resp = await graphqlRequest<{
-        positionsPage: PositionBalancePage;
-      }>(POSITION_BALANCES_QUERY, {
-        holder,
-        chainId: chainId ?? null,
-        settled: settled ?? null,
-        take: pageSize,
-        skip: pageParam,
-      });
-      return resp?.positionsPage ?? { items: [], hasMore: false };
-    },
+  } = useCursorPagination<PositionV2Node>({
+    queryKey: ['positionBalances', holder, chainId, settled],
+    query: POSITIONS_V2_QUERY,
+    connectionKey: 'positions',
+    pageSize,
+    variables: { filter },
+    enabled: Boolean(holder),
   });
 
-  const items = useMemo(
-    () => data?.pages.flatMap((p) => p.items) ?? [],
-    [data]
-  );
-  const fetchMore = useCallback(() => {
-    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+  const items = useMemo(() => nodes.map(toPositionBalance), [nodes]);
 
   return {
     data: items,
-    isLoading: !!enabled && isLoading,
-    isFetchingMore: isFetchingNextPage,
-    isFetching: !!enabled && isFetching,
-    hasMore: Boolean(hasNextPage),
-    fetchMore,
+    isLoading,
+    isFetchingMore,
+    isFetching,
+    hasMore: hasNextPage,
+    fetchMore: loadMore,
     error,
     refetch,
   };
@@ -647,56 +524,40 @@ export function usePositionBalancesByConditionId(params: {
     pageSize = DEFAULT_POSITIONS_PAGE_SIZE,
     settled,
   } = params;
-  const enabled = Boolean(conditionId);
+
+  const filter = useMemo(() => {
+    const f: Record<string, unknown> = { conditionIds: [conditionId] };
+    if (settled != null) f.settled = settled;
+    return f;
+  }, [conditionId, settled]);
 
   const {
-    data,
+    data: nodes,
     isLoading,
+    isFetchingMore,
     isFetching,
-    isFetchingNextPage,
-    fetchNextPage,
     hasNextPage,
+    loadMore,
     error,
     refetch,
-  } = useInfiniteQuery({
-    queryKey: ['positionBalancesByCondition', conditionId, pageSize, settled],
-    enabled,
-    staleTime: 30_000,
-    gcTime: 5 * 60 * 1000,
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
-    initialPageParam: 0,
-    // Same hasMore-from-server signal — see `usePositionBalances` for why.
-    getNextPageParam: (lastPage: PositionBalancePage, allPages) =>
-      lastPage.hasMore ? allPages.length * pageSize : undefined,
-    queryFn: async ({ pageParam = 0 }) => {
-      const resp = await graphqlRequest<{
-        positionsPage: PositionBalancePage;
-      }>(POSITION_BALANCES_BY_CONDITION_QUERY, {
-        conditionId,
-        take: pageSize,
-        skip: pageParam,
-        settled: settled ?? null,
-      });
-      return resp?.positionsPage ?? { items: [], hasMore: false };
-    },
+  } = useCursorPagination<PositionV2Node>({
+    queryKey: ['positionBalancesByCondition', conditionId, settled],
+    query: POSITIONS_V2_QUERY,
+    connectionKey: 'positions',
+    pageSize,
+    variables: { filter },
+    enabled: Boolean(conditionId),
   });
 
-  const items = useMemo(
-    () => data?.pages.flatMap((p) => p.items) ?? [],
-    [data]
-  );
-  const fetchMore = useCallback(() => {
-    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+  const items = useMemo(() => nodes.map(toPositionBalance), [nodes]);
 
   return {
     data: items,
-    isLoading: !!enabled && isLoading,
-    isFetchingMore: isFetchingNextPage,
-    isFetching: !!enabled && isFetching,
-    hasMore: Boolean(hasNextPage),
-    fetchMore,
+    isLoading,
+    isFetchingMore,
+    isFetching,
+    hasMore: hasNextPage,
+    fetchMore: loadMore,
     error,
     refetch,
   };

--- a/packages/app/src/lib/adapters/position.test.ts
+++ b/packages/app/src/lib/adapters/position.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from 'vitest';
+import {
+  POSITION_V2_FIELDS,
+  toPositionBalance,
+  type PositionV2Node,
+} from './position';
+import { PICK_CONFIGURATION_V2_FIELDS } from './pickConfig';
+
+function makeNode(overrides: Partial<PositionV2Node> = {}): PositionV2Node {
+  return {
+    id: 'cG9zaXRpb246MQ==',
+    chainId: 8453,
+    holder: '0xholder',
+    pickConfigId: '0xpickconfig',
+    token: '0xtoken',
+    side: 'PREDICTOR',
+    status: 'OPEN',
+    balance: '1000000000000000000',
+    userCollateral: '500000000000000000',
+    totalPayout: null,
+    realizedPnl: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-02T00:00:00.000Z',
+    pickConfig: {
+      pickConfigId: '0xpickconfig',
+      chainId: 8453,
+      escrow: '0xescrow',
+      totalPredictorCollateral: '1',
+      totalCounterpartyCollateral: '2',
+      claimedPredictorCollateral: '0',
+      claimedCounterpartyCollateral: '0',
+      resolved: false,
+      result: null,
+      resolvedAt: null,
+      predictorToken: '0xpred',
+      counterpartyToken: '0xcounter',
+      endsAt: 1760000000,
+      isLegacy: false,
+      picks: [
+        {
+          conditionId: '0xcond1',
+          resolver: '0xresolver1',
+          predictedOutcome: 'YES',
+          condition: null,
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+describe('toPositionBalance', () => {
+  test('renames token → tokenAddress and passes through identity fields', () => {
+    const bal = toPositionBalance(makeNode());
+    expect(bal.id).toBe('cG9zaXRpb246MQ==');
+    expect(bal.chainId).toBe(8453);
+    expect(bal.holder).toBe('0xholder');
+    expect(bal.tokenAddress).toBe('0xtoken');
+    expect(bal.pickConfigId).toBe('0xpickconfig');
+    expect(bal.createdAt).toBe('2026-01-01T00:00:00.000Z');
+    expect(bal.updatedAt).toBe('2026-01-02T00:00:00.000Z');
+  });
+
+  test('derives isPredictorToken from side', () => {
+    expect(
+      toPositionBalance(makeNode({ side: 'PREDICTOR' })).isPredictorToken
+    ).toBe(true);
+    expect(
+      toPositionBalance(makeNode({ side: 'COUNTERPARTY' })).isPredictorToken
+    ).toBe(false);
+  });
+
+  test('surfaces the explicit OPEN/SOLD status (v1 encoded it in the id)', () => {
+    expect(toPositionBalance(makeNode({ status: 'OPEN' })).status).toBe('OPEN');
+    expect(toPositionBalance(makeNode({ status: 'SOLD' })).status).toBe('SOLD');
+  });
+
+  test('renames realizedPnl → realizedPnL', () => {
+    const bal = toPositionBalance(makeNode({ realizedPnl: '42' }));
+    expect(bal.realizedPnL).toBe('42');
+  });
+
+  test('normalizes BigInt scalars (number | string) to decimal strings', () => {
+    const bal = toPositionBalance(
+      makeNode({ balance: 1000 as unknown as number, userCollateral: 500 })
+    );
+    expect(bal.balance).toBe('1000');
+    expect(bal.userCollateral).toBe('500');
+  });
+
+  test('preserves nulls for optional wei fields', () => {
+    const bal = toPositionBalance(
+      makeNode({ userCollateral: null, totalPayout: null, realizedPnl: null })
+    );
+    expect(bal.userCollateral).toBeNull();
+    expect(bal.totalPayout).toBeNull();
+    expect(bal.realizedPnL).toBeNull();
+  });
+
+  test('delegates pickConfig mapping to toPickConfigData', () => {
+    const bal = toPositionBalance(makeNode());
+    expect(bal.pickConfig?.id).toBe('0xpickconfig');
+    expect(bal.pickConfig?.marketAddress).toBe('0xescrow');
+    // pick row id re-keyed to the stable `${pickConfigId}:${conditionId}` string
+    expect(bal.pickConfig?.picks[0].id).toBe('0xpickconfig:0xcond1');
+    expect(bal.pickConfig?.picks[0].conditionResolver).toBe('0xresolver1');
+  });
+
+  test('returns null pickConfig when absent', () => {
+    const bal = toPositionBalance(makeNode({ pickConfig: null }));
+    expect(bal.pickConfig).toBeNull();
+  });
+});
+
+describe('POSITION_V2_FIELDS', () => {
+  test('selects the v2 names the mapper reads', () => {
+    for (const field of [
+      'token',
+      'side',
+      'status',
+      'pickConfigId',
+      'balance',
+      'userCollateral',
+      'totalPayout',
+      'realizedPnl',
+    ]) {
+      expect(POSITION_V2_FIELDS).toContain(field);
+    }
+  });
+
+  test('embeds the shared pickConfig selection set', () => {
+    expect(POSITION_V2_FIELDS).toContain(PICK_CONFIGURATION_V2_FIELDS.trim());
+  });
+});

--- a/packages/app/src/lib/adapters/position.test.ts
+++ b/packages/app/src/lib/adapters/position.test.ts
@@ -21,6 +21,7 @@ function makeNode(overrides: Partial<PositionV2Node> = {}): PositionV2Node {
     realizedPnl: null,
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-02T00:00:00.000Z',
+    prediction: { predictionId: '0xprediction' },
     pickConfig: {
       pickConfigId: '0xpickconfig',
       chainId: 8453,
@@ -109,6 +110,16 @@ describe('toPositionBalance', () => {
   test('returns null pickConfig when absent', () => {
     const bal = toPositionBalance(makeNode({ pickConfig: null }));
     expect(bal.pickConfig).toBeNull();
+  });
+
+  test('backfills pickConfig.predictionId from the holder prediction (claim/permalink)', () => {
+    const bal = toPositionBalance(makeNode());
+    expect(bal.pickConfig?.predictionId).toBe('0xprediction');
+  });
+
+  test('predictionId is null when the position has no holder prediction', () => {
+    const bal = toPositionBalance(makeNode({ prediction: null }));
+    expect(bal.pickConfig?.predictionId).toBeNull();
   });
 });
 

--- a/packages/app/src/lib/adapters/position.ts
+++ b/packages/app/src/lib/adapters/position.ts
@@ -8,7 +8,11 @@
  * - `status`           := v2's explicit `OPEN`/`SOLD` discriminator. v1 encoded
  *   SOLD rows implicitly in the id shape (`<rowId>-sell-<tradeHash>`); v2 makes
  *   it explicit, so consumers stop parsing the opaque Relay id.
- * - `pickConfig`       := `toPickConfigData(node.pickConfig)` (shared mapper)
+ * - `pickConfig`       := `toPickConfigData(node.pickConfig)` (shared mapper),
+ *   with `predictionId` backfilled from `node.prediction` — v2 dropped the v1
+ *   `pickConfig.predictionId` field, but claim/redeem (`handleClaim`) and the
+ *   prediction permalink still read it, so the holder's prediction id is
+ *   surfaced via `Position.prediction` and grafted back on.
  *
  * BigInt scalars can arrive as string or number over the wire; normalized to
  * decimal strings so consumers can `BigInt()` them (v1 returned strings).
@@ -36,6 +40,9 @@ export type PositionV2Node = {
   createdAt: string;
   updatedAt: string;
   pickConfig?: PickConfigurationV2Node | null;
+  // The holder's prediction for this pickConfig — v2's home for the id that v1
+  // carried on `pickConfig.predictionId` (claim/redeem + permalink read it).
+  prediction?: { predictionId: string } | null;
 };
 
 /**
@@ -58,6 +65,9 @@ export const POSITION_V2_FIELDS = `
   updatedAt
   pickConfig {
     ${PICK_CONFIGURATION_V2_FIELDS}
+  }
+  prediction {
+    predictionId
   }
 `;
 
@@ -82,6 +92,13 @@ export function toPositionBalance(node: PositionV2Node): PositionBalance {
     status: node.status,
     createdAt: node.createdAt,
     updatedAt: node.updatedAt,
-    pickConfig: node.pickConfig ? toPickConfigData(node.pickConfig) : null,
+    pickConfig: node.pickConfig
+      ? {
+          ...toPickConfigData(node.pickConfig),
+          // v2 dropped pickConfig.predictionId; graft it back from the
+          // holder's prediction so claim/redeem + permalinks keep working.
+          predictionId: node.prediction?.predictionId ?? null,
+        }
+      : null,
   };
 }

--- a/packages/app/src/lib/adapters/position.ts
+++ b/packages/app/src/lib/adapters/position.ts
@@ -1,0 +1,87 @@
+/**
+ * Shared adapter: v2 `Position` node → the app-side `PositionBalance` shape
+ * (usePositions). The v1→v2 renames live here in one place:
+ *
+ * - `tokenAddress`     := `token`
+ * - `isPredictorToken` := `side === 'PREDICTOR'`
+ * - `realizedPnL`      := `realizedPnl` (case-only rename)
+ * - `status`           := v2's explicit `OPEN`/`SOLD` discriminator. v1 encoded
+ *   SOLD rows implicitly in the id shape (`<rowId>-sell-<tradeHash>`); v2 makes
+ *   it explicit, so consumers stop parsing the opaque Relay id.
+ * - `pickConfig`       := `toPickConfigData(node.pickConfig)` (shared mapper)
+ *
+ * BigInt scalars can arrive as string or number over the wire; normalized to
+ * decimal strings so consumers can `BigInt()` them (v1 returned strings).
+ */
+import {
+  PICK_CONFIGURATION_V2_FIELDS,
+  toPickConfigData,
+  type PickConfigurationV2Node,
+} from '~/lib/adapters/pickConfig';
+import type { PositionBalance } from '~/hooks/graphql/usePositions';
+
+/** v2 wire shape of a `Position` node (BigInt scalars may arrive as numbers). */
+export type PositionV2Node = {
+  id: string;
+  chainId: number;
+  holder: string;
+  pickConfigId: string;
+  token: string;
+  side: 'PREDICTOR' | 'COUNTERPARTY';
+  status: 'OPEN' | 'SOLD';
+  balance: string | number;
+  userCollateral?: string | number | null;
+  totalPayout?: string | number | null;
+  realizedPnl?: string | number | null;
+  createdAt: string;
+  updatedAt: string;
+  pickConfig?: PickConfigurationV2Node | null;
+};
+
+/**
+ * Selection set for a v2 `Position` node, matching {@link PositionV2Node}.
+ * Interpolate inside a connection's `edges { node { ... } }` selection.
+ */
+export const POSITION_V2_FIELDS = `
+  id
+  chainId
+  holder
+  pickConfigId
+  token
+  side
+  status
+  balance
+  userCollateral
+  totalPayout
+  realizedPnl
+  createdAt
+  updatedAt
+  pickConfig {
+    ${PICK_CONFIGURATION_V2_FIELDS}
+  }
+`;
+
+// The BigInt scalar serializes as string or number depending on the transport;
+// normalize present values to decimal strings, keep nulls null (v1 parity).
+const wei = (value: string | number | null | undefined): string | null =>
+  value == null ? null : String(value);
+
+/** Pure mapper: v2 `Position` node → app `PositionBalance`. */
+export function toPositionBalance(node: PositionV2Node): PositionBalance {
+  return {
+    id: node.id,
+    chainId: node.chainId,
+    tokenAddress: node.token,
+    pickConfigId: node.pickConfigId,
+    isPredictorToken: node.side === 'PREDICTOR',
+    holder: node.holder,
+    balance: String(node.balance ?? '0'),
+    userCollateral: wei(node.userCollateral),
+    totalPayout: wei(node.totalPayout),
+    realizedPnL: wei(node.realizedPnl),
+    status: node.status,
+    createdAt: node.createdAt,
+    updatedAt: node.updatedAt,
+    pickConfig: node.pickConfig ? toPickConfigData(node.pickConfig) : null,
+  };
+}


### PR DESCRIPTION
## Summary

Migrates the two position-balance hooks off v1's skip/take `positionsPage` onto the v2 Relay `positions` connection. **Consumer-only** — the v2 `positions` surface already exists and synthesizes rows with v1 parity, so no API/schema changes.

- `usePositionBalances` (by holder) and `usePositionBalancesByConditionId` (by condition) now go through `graphqlRequestV2` + the shared `useCursorPagination` helper (forward cursor paging on `pageInfo`, not offset/`hasMore`).
- New `lib/adapters/position.ts` centralizes the v1→v2 renames in one place:
  - `token` → `tokenAddress`
  - `side` → `isPredictorToken` (`'PREDICTOR'`)
  - `realizedPnl` → `realizedPnL`
  - surfaces v2's explicit `status` (OPEN/SOLD)
  - delegates `pickConfig` to the existing `toPickConfigData`
  - normalizes BigInt scalars (string|number) → decimal strings
- `PositionsTable` now detects sold rows via `status === 'SOLD'` instead of parsing the (now opaque) Relay row id. The `-sell-` id check stays as a fallback.
- Removes the v1 `positionsPage` documents, the orphaned `PICK_CONFIG_FRAGMENT` / `PICK_CONDITION_FRAGMENT` / `PositionBalancePage`, and the v1 `graphqlRequest` import from this module.

## Parity notes
- The v2 `positions` connection synthesizes the same OPEN/SOLD rows as v1 (per the schema's documented G5 parity), including the case where a page's rows all synthesize away but `pageInfo.hasNextPage` stays `true` with an advancing `endCursor`. The cursor helper pages on `pageInfo`, so this is preserved — covered by a test.
- `PositionsTable` is the only consumer of these two hooks.

## v1 transport
This removes `usePositions`' v1 `graphqlRequest` usage. The v1 transport itself stays (still used by Header, ConnectDialog, and the referral hooks) — that's the next migration.

## Tests
- `lib/adapters/position.test.ts` — adapter mapping (renames, status, BigInt normalization, null handling, pickConfig delegation, selection set).
- `hooks/graphql/__tests__/usePositions.test.ts` — rewritten for the v2 connection: cursor pagination, the empty-page-with-advancing-cursor case, filter/`first`/`after` variables, disabled-until-arg.
- Full app suite: **757 passed**. Type-check + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)