### PR TITLE
feat(api/app): move referral reads off v1 GraphQL onto REST

### DIFF
--- a/packages/api/src/routes/referrals.test.ts
+++ b/packages/api/src/routes/referrals.test.ts
@@ -694,3 +694,80 @@ describe('GET /referrals/codes/:id', () => {
     });
   });
 });
+
+describe('GET /referrals/users/:address', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the no-referral shape (200) for an unknown user', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).get('/referrals/users/0xABC');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      address: '0xabc',
+      refCodeHash: null,
+      maxReferrals: 0,
+      referredBy: null,
+      referredByCode: null,
+      referrals: [],
+    });
+    // address is normalized to lowercase for the lookup
+    expect(mockPrisma.user.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { address: '0xabc' } })
+    );
+  });
+
+  it('maps status + referrals, exposing FK ids for referredBy/referredByCode', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue({
+      address: '0xabc',
+      refCodeHash: '0xhash',
+      maxReferrals: 5,
+      referredById: 11,
+      referredByCodeId: 22,
+      referrals: [
+        { address: '0xdef', createdAt: new Date('2026-01-01T00:00:00.000Z') },
+      ],
+    });
+
+    const res = await request(app).get('/referrals/users/0xabc');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      address: '0xabc',
+      refCodeHash: '0xhash',
+      maxReferrals: 5,
+      referredBy: { id: 11 },
+      referredByCode: { id: 22 },
+      referrals: [{ address: '0xdef', createdAt: '2026-01-01T00:00:00.000Z' }],
+    });
+  });
+
+  it('nulls referredBy/referredByCode when the user has neither', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue({
+      address: '0xabc',
+      refCodeHash: null,
+      maxReferrals: 0,
+      referredById: null,
+      referredByCodeId: null,
+      referrals: [],
+    });
+
+    const res = await request(app).get('/referrals/users/0xabc');
+
+    expect(res.status).toBe(200);
+    expect(res.body.referredBy).toBeNull();
+    expect(res.body.referredByCode).toBeNull();
+    expect(res.body.referrals).toEqual([]);
+  });
+
+  it('returns 500 when the lookup throws', async () => {
+    mockPrisma.user.findUnique.mockRejectedValue(new Error('db down'));
+
+    const res = await request(app).get('/referrals/users/0xabc');
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/packages/api/src/routes/referrals.ts
+++ b/packages/api/src/routes/referrals.ts
@@ -1,7 +1,8 @@
-import { Request, Response, Router } from 'express';
+import type { Request, Response } from 'express';
+import { Router } from 'express';
+import { recoverMessageAddress, type Address } from 'viem';
 import prisma from '../core/db';
 import { hashReferralCode } from '../services';
-import { recoverMessageAddress, type Address } from 'viem';
 import { adminAuth } from '../runtime/middleware';
 import { grantSponsorshipBudget } from '../services/sponsorship';
 import { createLogger } from '../core/logger';
@@ -557,6 +558,66 @@ router.get('/codes/:id', async (req: Request, res: Response) => {
     return res.status(200).json({ id, ...stats, claimants });
   } catch (e) {
     log.error({ err: e }, 'Error reading referral code analytics');
+    return res.status(500).json({ message: 'Internal Server Error' });
+  }
+});
+
+// GET /referrals/users/:address - per-user referral status + the user's own
+// referrals. Reads are public (referral data is attribution, not a credential)
+// and replace the v1 GraphQL `user(where:{address})` reads the frontend used
+// for the invite gate (Header/ConnectDialog) and the referrals dashboard
+// (useReferrals). A missing user resolves to the empty/no-referral shape (200,
+// not 404) so callers can read it unconditionally.
+router.get('/users/:address', async (req: Request, res: Response) => {
+  const address = (req.params.address || '').toLowerCase();
+  if (!address) {
+    return res.status(400).json({ message: 'Invalid address' });
+  }
+  try {
+    const user = await prisma.user.findUnique({
+      where: { address },
+      select: {
+        address: true,
+        refCodeHash: true,
+        maxReferrals: true,
+        referredById: true,
+        referredByCodeId: true,
+        referrals: {
+          select: { address: true, createdAt: true },
+          orderBy: { createdAt: 'desc' },
+        },
+      },
+    });
+
+    if (!user) {
+      return res.status(200).json({
+        address,
+        refCodeHash: null,
+        maxReferrals: 0,
+        referredBy: null,
+        referredByCode: null,
+        referrals: [],
+      });
+    }
+
+    return res.status(200).json({
+      address: user.address,
+      refCodeHash: user.refCodeHash,
+      maxReferrals: user.maxReferrals,
+      // The frontend only checks presence (the invite gate), so the FK id is
+      // a sufficient stand-in for the v1 `referredBy { id }` / `referredByCode
+      // { id }` selections.
+      referredBy: user.referredById != null ? { id: user.referredById } : null,
+      referredByCode:
+        user.referredByCodeId != null ? { id: user.referredByCodeId } : null,
+      referrals: user.referrals.map((r) => ({
+        address: r.address,
+        createdAt:
+          r.createdAt instanceof Date ? r.createdAt.toISOString() : r.createdAt,
+      })),
+    });
+  } catch (e) {
+    log.error({ err: e }, 'Error reading user referral status');
     return res.status(500).json({ message: 'Internal Server Error' });
   }
 });

--- a/packages/app/src/components/layout/ConnectDialog.tsx
+++ b/packages/app/src/components/layout/ConnectDialog.tsx
@@ -15,7 +15,7 @@ import {
   CHAIN_ID_ETHEREAL_TESTNET,
   DEFAULT_CHAIN_ID,
 } from '@sapience/sdk/constants';
-import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
+import { fetchUserReferralStatus } from '~/hooks/referrals/useReferrals';
 import { useAuth } from '~/lib/context/AuthContext';
 import { useSession } from '~/lib/context/SessionContext';
 import {
@@ -25,21 +25,6 @@ import {
 
 // On staging (Ethereal Testnet) we don't gate access behind an invite code.
 const IS_STAGING = DEFAULT_CHAIN_ID === CHAIN_ID_ETHEREAL_TESTNET;
-
-const USER_REFERRAL_STATUS_QUERY = `
-  query UserReferralStatus($wallet: String!) {
-    user(where: { address: $wallet }) {
-      address
-      refCodeHash
-      referredBy {
-        id
-      }
-      referredByCode {
-        id
-      }
-    }
-  }
-`;
 
 // EIP-6963 types
 interface EIP6963ProviderInfo {
@@ -255,27 +240,20 @@ export default function ConnectDialog({
 
           if (!IS_STAGING) {
             try {
-              const data = await graphqlRequest<{
-                user: {
-                  address: string;
-                  refCodeHash?: string | null;
-                  referredBy?: { id: number } | null;
-                  referredByCode?: { id: number } | null;
-                } | null;
-              }>(USER_REFERRAL_STATUS_QUERY, { wallet: currentAddress });
+              const status = await fetchUserReferralStatus(currentAddress);
 
-              const user = data?.user;
               hasReferral = !!(
-                user &&
-                (user.refCodeHash || user.referredBy || user.referredByCode)
+                status.refCodeHash ||
+                status.referredBy ||
+                status.referredByCode
               );
 
               console.debug('[ConnectDialog] Referral check:', {
                 currentAddress,
                 hasReferral,
-                refCodeHash: user?.refCodeHash,
-                referredBy: user?.referredBy,
-                referredByCode: user?.referredByCode,
+                refCodeHash: status.refCodeHash,
+                referredBy: status.referredBy,
+                referredByCode: status.referredByCode,
               });
             } catch (error) {
               console.error(

--- a/packages/app/src/components/layout/Header.tsx
+++ b/packages/app/src/components/layout/Header.tsx
@@ -44,8 +44,8 @@ import {
   CHAIN_ID_ETHEREAL_TESTNET,
   DEFAULT_CHAIN_ID,
 } from '@sapience/sdk/constants';
-import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
 import CollateralBalanceButton from './CollateralBalanceButton';
+import { fetchUserReferralStatus } from '~/hooks/referrals/useReferrals';
 import { useConnectedWallet } from '~/hooks/useConnectedWallet';
 import EnsAvatar from '~/components/shared/EnsAvatar';
 import GetAccessDialog from '~/components/shared/GetAccessDialog';
@@ -59,21 +59,6 @@ import {
   DEFAULT_CONNECTION_DURATION_HOURS,
 } from '~/lib/context/SettingsContext';
 import { StatusIndicators } from '~/components/layout/StatusIndicators';
-
-const USER_REFERRAL_STATUS_QUERY = `
-  query UserReferralStatus($wallet: String!) {
-    user(where: { address: $wallet }) {
-      address
-      refCodeHash
-      referredBy {
-        id
-      }
-      referredByCode {
-        id
-      }
-    }
-  }
-`;
 
 // On staging (Ethereal Testnet) we don't gate access behind an invite code.
 const IS_STAGING = DEFAULT_CHAIN_ID === CHAIN_ID_ETHEREAL_TESTNET;
@@ -348,21 +333,14 @@ const Header = () => {
       }
 
       try {
-        const data = await graphqlRequest<{
-          user: {
-            address: string;
-            refCodeHash?: string | null;
-            referredBy?: { id: number } | null;
-            referredByCode?: { id: number } | null;
-          } | null;
-        }>(USER_REFERRAL_STATUS_QUERY, { wallet: currentAddress });
+        const status = await fetchUserReferralStatus(currentAddress);
 
         if (cancelled) return;
 
-        const user = data?.user;
         const hasServerReferral = !!(
-          user &&
-          (user.refCodeHash || user.referredBy || user.referredByCode)
+          status.refCodeHash ||
+          status.referredBy ||
+          status.referredByCode
         );
 
         // Update ref only after successful check to avoid race conditions

--- a/packages/app/src/hooks/referrals/__tests__/useAdminReferralCodes.test.ts
+++ b/packages/app/src/hooks/referrals/__tests__/useAdminReferralCodes.test.ts
@@ -1,14 +1,10 @@
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
-const mockGraphqlRequest = vi.fn();
-
-vi.mock('@sapience/sdk/queries/client/graphqlClient', () => ({
-  graphqlRequest: (...args: unknown[]) => mockGraphqlRequest(...args),
-}));
-
+// useAdminApi.base ends in `/admin`; the read hooks strip that to derive the
+// API root, so reads hit `https://api.example/referrals/*`.
 vi.mock('~/hooks/useAdminApi', () => ({
   useAdminApi: () => ({
     base: 'https://api.example/admin',
@@ -42,42 +38,33 @@ const makeRow = (id: number) => ({
   totalPositions: 0,
 });
 
-const page = (
-  items: ReturnType<typeof makeRow>[],
-  nextCursor: number | null
-) => ({ referralCodes: { items, nextCursor } });
-
-beforeEach(() => {
-  vi.clearAllMocks();
-});
-
 const makeClaimant = (n: number) => ({
   address: `0x${n.toString(16).padStart(40, '0')}`,
   tradingVolume: '0',
   positionCount: 0,
 });
 
-const analyticsPage = (
-  claimants: ReturnType<typeof makeClaimant>[],
-  nextCursor: number | null
-) => ({
-  referralCodes: {
-    items: [
-      {
-        id: 1,
-        claimCount: 3,
-        totalVolume: '123',
-        totalPositions: 7,
-        claimants: { items: claimants, nextCursor },
-      },
-    ],
-  },
+const jsonResponse = (
+  body: unknown,
+  { ok = true, status = 200 }: { ok?: boolean; status?: number } = {}
+): Response => ({ ok, status, json: async () => body }) as unknown as Response;
+
+let mockFetch: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFetch = vi.fn();
+  vi.stubGlobal('fetch', mockFetch);
 });
 
-describe('useAdminReferralCodes — pagination', () => {
-  it('returns the single page when nextCursor is null', async () => {
-    mockGraphqlRequest.mockResolvedValueOnce(
-      page([makeRow(1), makeRow(2)], null)
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useAdminReferralCodes', () => {
+  it('returns every code from a single GET /referrals/codes', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ items: [makeRow(1), makeRow(2)] })
     );
 
     const { useAdminReferralCodes } = await import('../useAdminReferralCodes');
@@ -88,18 +75,14 @@ describe('useAdminReferralCodes — pagination', () => {
     await waitFor(() => {
       expect(result.current.data?.length).toBe(2);
     });
-    expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
-    expect(mockGraphqlRequest).toHaveBeenCalledWith(expect.any(String), {
-      limit: 100,
-      cursor: null,
-    });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.example/referrals/codes'
+    );
   });
 
-  it('follows nextCursor across multiple pages and concatenates results', async () => {
-    mockGraphqlRequest
-      .mockResolvedValueOnce(page([makeRow(10), makeRow(9)], 9))
-      .mockResolvedValueOnce(page([makeRow(8), makeRow(7)], 7))
-      .mockResolvedValueOnce(page([makeRow(6)], null));
+  it('tolerates a missing items array', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({}));
 
     const { useAdminReferralCodes } = await import('../useAdminReferralCodes');
     const { result } = renderHook(() => useAdminReferralCodes(), {
@@ -107,27 +90,14 @@ describe('useAdminReferralCodes — pagination', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.data?.map((r) => r.id)).toEqual([10, 9, 8, 7, 6]);
-    });
-    expect(mockGraphqlRequest).toHaveBeenCalledTimes(3);
-    expect(mockGraphqlRequest).toHaveBeenNthCalledWith(1, expect.any(String), {
-      limit: 100,
-      cursor: null,
-    });
-    expect(mockGraphqlRequest).toHaveBeenNthCalledWith(2, expect.any(String), {
-      limit: 100,
-      cursor: 9,
-    });
-    expect(mockGraphqlRequest).toHaveBeenNthCalledWith(3, expect.any(String), {
-      limit: 100,
-      cursor: 7,
+      expect(result.current.data).toEqual([]);
     });
   });
 
-  it('caps at MAX_PAGES so a non-progressing cursor cannot loop forever', async () => {
-    // Server pathologically keeps returning a non-null cursor.
-    mockGraphqlRequest.mockResolvedValue(page([makeRow(1)], 1));
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  it('surfaces a non-ok response as an error', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({}, { ok: false, status: 500 })
+    );
 
     const { useAdminReferralCodes } = await import('../useAdminReferralCodes');
     const { result } = renderHook(() => useAdminReferralCodes(), {
@@ -135,20 +105,21 @@ describe('useAdminReferralCodes — pagination', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.data).toBeDefined();
+      expect(result.current.isError).toBe(true);
     });
-    // 50 pages × 1 row each
-    expect(result.current.data?.length).toBe(50);
-    expect(mockGraphqlRequest).toHaveBeenCalledTimes(50);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('MAX_PAGES'));
-    warn.mockRestore();
   });
 });
 
-describe('useAdminReferralCodeAnalytics — claimants pagination', () => {
-  it('returns a single page of claimants when nextCursor is null', async () => {
-    mockGraphqlRequest.mockResolvedValueOnce(
-      analyticsPage([makeClaimant(1), makeClaimant(2)], null)
+describe('useAdminReferralCodeAnalytics', () => {
+  it('returns one code analytics from GET /referrals/codes/:id', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        id: 1,
+        claimCount: 3,
+        totalVolume: '123',
+        totalPositions: 7,
+        claimants: [makeClaimant(1), makeClaimant(2)],
+      })
     );
 
     const { useAdminReferralCodeAnalytics } = await import(
@@ -161,22 +132,24 @@ describe('useAdminReferralCodeAnalytics — claimants pagination', () => {
     await waitFor(() => {
       expect(result.current.data).toBeDefined();
     });
-    expect(result.current.data?.claimants.length).toBe(2);
     expect(result.current.data?.totalVolume).toBe('123');
-    expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
-    expect(mockGraphqlRequest).toHaveBeenCalledWith(expect.any(String), {
-      id: 1,
-      claimantsLimit: 100,
-      claimantsCursor: null,
-    });
+    expect(result.current.data?.claimants.length).toBe(2);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.example/referrals/codes/1'
+    );
   });
 
-  it('follows nextCursor across claimant pages and concatenates results', async () => {
-    mockGraphqlRequest
-      .mockResolvedValueOnce(
-        analyticsPage([makeClaimant(1), makeClaimant(2)], 2)
+  it('throws "Referral code not found" on a 404', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(
+        { message: 'Referral code not found' },
+        {
+          ok: false,
+          status: 404,
+        }
       )
-      .mockResolvedValueOnce(analyticsPage([makeClaimant(3)], null));
+    );
 
     const { useAdminReferralCodeAnalytics } = await import(
       '../useAdminReferralCodes'
@@ -186,42 +159,20 @@ describe('useAdminReferralCodeAnalytics — claimants pagination', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.data?.claimants.length).toBe(3);
+      expect(result.current.isError).toBe(true);
     });
-    expect(result.current.data?.claimants.map((c) => c.address)).toEqual([
-      makeClaimant(1).address,
-      makeClaimant(2).address,
-      makeClaimant(3).address,
-    ]);
-    expect(mockGraphqlRequest).toHaveBeenNthCalledWith(1, expect.any(String), {
-      id: 1,
-      claimantsLimit: 100,
-      claimantsCursor: null,
-    });
-    expect(mockGraphqlRequest).toHaveBeenNthCalledWith(2, expect.any(String), {
-      id: 1,
-      claimantsLimit: 100,
-      claimantsCursor: 2,
-    });
+    expect(result.current.error?.message).toBe('Referral code not found');
   });
 
-  it('caps at MAX_PAGES so a non-progressing claimants cursor cannot loop forever', async () => {
-    mockGraphqlRequest.mockResolvedValue(analyticsPage([makeClaimant(1)], 1));
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
+  it('is disabled until an id is provided', async () => {
     const { useAdminReferralCodeAnalytics } = await import(
       '../useAdminReferralCodes'
     );
-    const { result } = renderHook(() => useAdminReferralCodeAnalytics(1), {
+    renderHook(() => useAdminReferralCodeAnalytics(undefined), {
       wrapper: createWrapper(),
     });
 
-    await waitFor(() => {
-      expect(result.current.data).toBeDefined();
-    });
-    expect(result.current.data?.claimants.length).toBe(50);
-    expect(mockGraphqlRequest).toHaveBeenCalledTimes(50);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('MAX_PAGES'));
-    warn.mockRestore();
+    await new Promise((r) => setTimeout(r, 20));
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/hooks/referrals/__tests__/useReferrals.test.ts
+++ b/packages/app/src/hooks/referrals/__tests__/useReferrals.test.ts
@@ -1,0 +1,102 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children
+    );
+  };
+}
+
+const jsonResponse = (
+  body: unknown,
+  { ok = true, status = 200 }: { ok?: boolean; status?: number } = {}
+): Response => ({ ok, status, json: async () => body }) as unknown as Response;
+
+const STATUS = {
+  address: '0xabc',
+  refCodeHash: '0xhash',
+  maxReferrals: 5,
+  referredBy: null,
+  referredByCode: null,
+  referrals: [{ address: '0xdef', createdAt: '2026-01-01T00:00:00.000Z' }],
+};
+
+let mockFetch: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFetch = vi.fn();
+  vi.stubGlobal('fetch', mockFetch);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('fetchUserReferralStatus', () => {
+  it('GETs /referrals/users/:address (lowercased) and returns the body', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(STATUS));
+
+    const { fetchUserReferralStatus } = await import('../useReferrals');
+    const status = await fetchUserReferralStatus('0xABC');
+
+    expect(status).toEqual(STATUS);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.sapience.xyz/referrals/users/0xabc'
+    );
+  });
+
+  it('throws a ReferralApiError on a non-ok response', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({}, { ok: false, status: 500 })
+    );
+
+    const { fetchUserReferralStatus, ReferralApiError } = await import(
+      '../useReferrals'
+    );
+
+    await expect(fetchUserReferralStatus('0xabc')).rejects.toBeInstanceOf(
+      ReferralApiError
+    );
+  });
+});
+
+describe('useUserReferrals', () => {
+  it('maps the REST status into the { user } envelope the dashboard reads', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(STATUS));
+
+    const { useUserReferrals } = await import('../useReferrals');
+    const { result } = renderHook(() => useUserReferrals('0xabc', true), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toBeDefined();
+    });
+    expect(result.current.data?.user).toEqual({
+      address: '0xabc',
+      refCodeHash: '0xhash',
+      maxReferrals: 5,
+      referrals: [{ address: '0xdef', createdAt: '2026-01-01T00:00:00.000Z' }],
+    });
+  });
+
+  it('is disabled until a wallet address is provided', async () => {
+    const { useUserReferrals } = await import('../useReferrals');
+    renderHook(() => useUserReferrals(null, true), {
+      wrapper: createWrapper(),
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/hooks/referrals/useAdminReferralCodes.ts
+++ b/packages/app/src/hooks/referrals/useAdminReferralCodes.ts
@@ -8,7 +8,6 @@ import {
   type UseMutationResult,
   type UseQueryResult,
 } from '@tanstack/react-query';
-import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
 import { useAdminApi } from '~/hooks/useAdminApi';
 
 export type AdminReferralCodeRow = {
@@ -52,8 +51,9 @@ export type UpdateAdminReferralCodeInput = {
 
 const ADMIN_CODES_QUERY_KEY = ['admin', 'referralCodes'] as const;
 
-// useAdminApi.base ends in `/admin`; mutations stay there. Reads now go to
-// GraphQL, so we strip the suffix to derive the API root for fetch URLs.
+// useAdminApi.base ends in `/admin`; mutations stay there. Reads go to the
+// public `/referrals/*` REST surface, so we strip the suffix to derive the
+// API root for fetch URLs.
 function useApiBaseUrl(): string {
   const adminApi = useAdminApi();
   return useMemo(() => adminApi.base.replace(/\/admin$/, ''), [adminApi.base]);
@@ -92,104 +92,28 @@ function useReferralAdminMutate() {
   );
 }
 
-// Reads use public GraphQL intentionally. Referral analytics are public because
-// codes only affect attribution; create/update/delete mutations remain signed
-// admin REST requests.
-const REFERRAL_CODES_QUERY = `
-  query AdminReferralCodes($limit: Int!, $cursor: Int) {
-    referralCodes(limit: $limit, cursor: $cursor) {
-      items {
-        id
-        maxClaims
-        isActive
-        expiresAt
-        createdBy
-        creatorType
-        createdAt
-        claimCount
-        totalVolume
-        totalPositions
-      }
-      nextCursor
-    }
-  }
-`;
-
-// The API rejects any `limit` above GRAPHQL_MAX_LIST_SIZE (100) with a 400.
-// We auto-paginate so the admin UI doesn't silently truncate; MAX_PAGES is a
-// safety net against a buggy server returning a non-progressing cursor.
-const PAGE_SIZE = 100;
-const MAX_PAGES = 50;
-
-type ReferralCodesPageResponse = {
-  referralCodes: {
-    items: AdminReferralCodeRow[];
-    nextCursor: number | null;
-  };
-};
-
-type ReferralCodeAnalyticsResponse = {
-  referralCodes: {
-    items: Array<{
-      id: number;
-      claimCount: number;
-      totalVolume: string;
-      totalPositions: number;
-      claimants: {
-        items: Array<{
-          address: string;
-          tradingVolume: string;
-          positionCount: number;
-        }>;
-        nextCursor: number | null;
-      };
-    }>;
-  };
-};
-
-const REFERRAL_CODE_ANALYTICS_QUERY = `
-  query AdminReferralCodeAnalytics($id: Int!, $claimantsLimit: Int!, $claimantsCursor: Int) {
-    referralCodes(id: $id, limit: 1) {
-      items {
-        id
-        claimCount
-        totalVolume
-        totalPositions
-        claimants(limit: $claimantsLimit, cursor: $claimantsCursor) {
-          items {
-            address
-            tradingVolume
-            positionCount
-          }
-          nextCursor
-        }
-      }
-    }
-  }
-`;
+// Reads use the public `/referrals/*` REST surface intentionally. Referral
+// analytics are public because codes only affect attribution; create / update
+// / delete mutations remain signed admin REST requests.
+//
+// `GET /referrals/codes` returns every code with aggregate stats in one
+// response (capped server-side; the admin UI does not paginate), and
+// `GET /referrals/codes/:id` returns one code's analytics with its full
+// claimant breakdown — so neither read needs client-side pagination anymore.
 
 export function useAdminReferralCodes(): UseQueryResult<
   AdminReferralCodeRow[]
 > {
+  const apiBaseUrl = useApiBaseUrl();
   return useQuery<AdminReferralCodeRow[]>({
     queryKey: ADMIN_CODES_QUERY_KEY,
     queryFn: async () => {
-      const all: AdminReferralCodeRow[] = [];
-      let cursor: number | null = null;
-      for (let page = 0; page < MAX_PAGES; page += 1) {
-        const data: ReferralCodesPageResponse =
-          await graphqlRequest<ReferralCodesPageResponse>(
-            REFERRAL_CODES_QUERY,
-            { limit: PAGE_SIZE, cursor }
-          );
-        all.push(...data.referralCodes.items);
-        if (data.referralCodes.nextCursor == null) return all;
-        cursor = data.referralCodes.nextCursor;
+      const res = await fetch(`${apiBaseUrl}/referrals/codes`);
+      if (!res.ok) {
+        throw new Error(`Failed to load referral codes (${res.status})`);
       }
-      console.warn(
-        `useAdminReferralCodes: stopped at MAX_PAGES (${MAX_PAGES}); results may be truncated`
-      );
-      return all;
+      const data = (await res.json()) as { items: AdminReferralCodeRow[] };
+      return data.items ?? [];
     },
   });
 }
@@ -197,47 +121,20 @@ export function useAdminReferralCodes(): UseQueryResult<
 export function useAdminReferralCodeAnalytics(
   id: number | undefined
 ): UseQueryResult<AdminReferralAnalytics> {
+  const apiBaseUrl = useApiBaseUrl();
   return useQuery<AdminReferralAnalytics>({
     queryKey: ['admin', 'referralCodeAnalytics', id],
     queryFn: async () => {
-      const claimants: AdminReferralAnalytics['claimants'] = [];
-      let code: {
-        id: number;
-        claimCount: number;
-        totalVolume: string;
-        totalPositions: number;
-      } | null = null;
-      let cursor: number | null = null;
-      for (let page = 0; page < MAX_PAGES; page += 1) {
-        const data: ReferralCodeAnalyticsResponse =
-          await graphqlRequest<ReferralCodeAnalyticsResponse>(
-            REFERRAL_CODE_ANALYTICS_QUERY,
-            { id, claimantsLimit: PAGE_SIZE, claimantsCursor: cursor }
-          );
-        const item = data.referralCodes.items[0];
-        if (!item) {
-          throw new Error('Referral code not found');
-        }
-        code ??= item;
-        claimants.push(...item.claimants.items);
-        cursor = item.claimants.nextCursor;
-        if (cursor == null) break;
-        if (page === MAX_PAGES - 1) {
-          console.warn(
-            `useAdminReferralCodeAnalytics: stopped at MAX_PAGES (${MAX_PAGES}); claimants may be truncated`
-          );
-        }
-      }
-      if (!code) {
+      const res = await fetch(`${apiBaseUrl}/referrals/codes/${id}`);
+      if (res.status === 404) {
         throw new Error('Referral code not found');
       }
-      return {
-        id: code.id,
-        claimCount: code.claimCount,
-        totalVolume: code.totalVolume,
-        totalPositions: code.totalPositions,
-        claimants,
-      };
+      if (!res.ok) {
+        throw new Error(`Failed to load referral analytics (${res.status})`);
+      }
+      // `GET /referrals/codes/:id` already returns
+      // `{ id, claimCount, totalVolume, totalPositions, claimants }`.
+      return (await res.json()) as AdminReferralAnalytics;
     },
     enabled: typeof id === 'number',
   });

--- a/packages/app/src/hooks/referrals/useReferrals.ts
+++ b/packages/app/src/hooks/referrals/useReferrals.ts
@@ -6,10 +6,39 @@ import {
   type UseMutationResult,
   type UseQueryResult,
 } from '@tanstack/react-query';
-import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
 
 function getPublicApiBaseUrl(): string {
   return process.env.NEXT_PUBLIC_FOIL_API_URL || 'https://api.sapience.xyz';
+}
+
+/**
+ * Per-user referral status + referrals, from the public REST endpoint
+ * `GET /referrals/users/:address`. Referral data is attribution-only and v2
+ * GraphQL deliberately does not expose it, so all referral reads go through
+ * REST. A missing user resolves to the empty/no-referral shape (never null).
+ */
+export type UserReferralStatus = {
+  address: string;
+  refCodeHash: string | null;
+  maxReferrals: number;
+  referredBy: { id: number } | null;
+  referredByCode: { id: number } | null;
+  referrals: { address: string; createdAt: string }[];
+};
+
+export async function fetchUserReferralStatus(
+  walletAddress: string
+): Promise<UserReferralStatus> {
+  const response = await fetch(
+    `${getPublicApiBaseUrl()}/referrals/users/${walletAddress.toLowerCase()}`
+  );
+  if (!response.ok) {
+    throw new ReferralApiError(
+      response.status,
+      `Failed to load referral status (${response.status})`
+    );
+  }
+  return (await response.json()) as UserReferralStatus;
 }
 
 export class ReferralApiError extends Error {
@@ -117,30 +146,25 @@ export type UserReferralsData = {
   } | null;
 };
 
-const USER_REFERRALS_QUERY = `
-  query UserReferrals($wallet: String!) {
-    user(where: { address: $wallet }) {
-      address
-      refCodeHash
-      maxReferrals
-      referrals {
-        address
-        createdAt
-      }
-    }
-  }
-`;
-
 export function useUserReferrals(
   walletAddress: string | null | undefined,
   enabled: boolean
 ): UseQueryResult<UserReferralsData> {
   return useQuery<UserReferralsData>({
     queryKey: ['userReferrals', walletAddress?.toLowerCase() ?? null],
-    queryFn: () =>
-      graphqlRequest<UserReferralsData>(USER_REFERRALS_QUERY, {
-        wallet: (walletAddress ?? '').toLowerCase(),
-      }),
+    queryFn: async () => {
+      const status = await fetchUserReferralStatus(walletAddress ?? '');
+      // Preserve the `{ user }` envelope the dashboard reads; the REST
+      // endpoint always returns a (possibly empty) status object.
+      return {
+        user: {
+          address: status.address,
+          refCodeHash: status.refCodeHash,
+          maxReferrals: status.maxReferrals,
+          referrals: status.referrals,
+        },
+      };
+    },
     enabled: enabled && Boolean(walletAddress),
   });
 }


### PR DESCRIPTION
## Summary

v2 GraphQL **deliberately does not expose referral data** (the v2 `Account` resolver says so: *"Referral data lives on the REST surface (`/referrals/*`, `/admin/referrals/*`); v2 GraphQL does not expose it"*). The referral *mutations* already used REST; this PR moves the remaining referral **reads** off v1 `graphqlRequest`.

### API
- **New `GET /referrals/users/:address`** — per-user referral status (`refCodeHash`, `maxReferrals`, presence of `referredBy` / `referredByCode` via FK ids) plus the user's own `referrals`. Public (referral data is attribution, not a credential). A missing user returns the empty/no-referral shape at **200** (not 404) so callers can read it unconditionally. This is the one piece of backend work — the user-facing reads had no REST endpoint before.

### App
- `useReferrals`: `useUserReferrals` now fetches the new endpoint via a shared `fetchUserReferralStatus` helper instead of the `user(where:)` GraphQL query (kept the `{ user }` envelope the dashboard reads).
- `Header` / `ConnectDialog`: the invite-gate status check uses `fetchUserReferralStatus` instead of inline `graphqlRequest`.
- `useAdminReferralCodes`: the two admin reads now hit the **existing** `GET /referrals/codes` and `GET /referrals/codes/:id` (single request each — the server caps the list and the admin UI does not paginate), replacing the paginated `referralCodes` GraphQL queries. Mutations were already REST.
- Removes every `graphqlRequest` import from the referral hooks + layout components.

## v1 transport
Combined with the positions PR, this removes the **last** frontend `graphqlRequest` consumers. After both land (and the vault-stats PR), the v1 GraphQL transport in the SDK can be deleted — left as a follow-up since SDK `analytics.ts` still uses it until the vault PR merges.

## Tests
- API: `GET /referrals/users/:address` — unknown-user empty shape (200, lowercased lookup), full status + referrals mapping, null `referredBy`/`referredByCode`, 500 path. **30 route tests pass.**
- App: rewrote `useAdminReferralCodes.test.ts` for the single-request REST path (was testing the removed GraphQL cursor pagination); new `useReferrals.test.ts` covers `fetchUserReferralStatus` + the `useUserReferrals` envelope mapping. **Full app suite: 749 passed.** Type-check + lint clean (api + app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)