### PR TITLE
fix(v2): unblock vault/analytics/feed queries against v2 hardening limits

### DIFF
--- a/packages/api/src/core/config.ts
+++ b/packages/api/src/core/config.ts
@@ -28,8 +28,8 @@ const validators = {
     desc: 'Maximum allowed query complexity score for /v2/graphql. Tighter than v1 because v2 surfaces are flatter and deeply-nested fan-outs are not a legitimate v2 access pattern.',
   }),
   GRAPHQL_V2_MAX_DEPTH: num({
-    default: 6,
-    desc: 'Maximum selection-set depth for /v2/graphql. v1 allows 7; v2 trims one level on the assumption that Relay-wrapped two-deep entity fan-outs cover every legitimate v2 client. Override if a v2 query legitimately needs greater depth.',
+    default: 10,
+    desc: "Maximum selection-set depth for /v2/graphql. Relay connections cost two extra levels (edges -> node) over v1's flat lists, and legitimate v2 queries reach through that into pickConfig -> picks -> condition -> category (e.g. the activity feed, positions, forecasts), so the floor is ~8. 10 leaves headroom; query complexity (GRAPHQL_V2_MAX_COMPLEXITY) remains the primary fan-out guard.",
   }),
   GRAPHQL_V2_APQ_TTL_MS: num({
     default: 24 * 60 * 60 * 1000,

--- a/packages/sdk/queries/__tests__/protocol.test.ts
+++ b/packages/sdk/queries/__tests__/protocol.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
-import { fetchProtocolAnalytics, GET_PROTOCOL_ANALYTICS } from '../protocol';
+import {
+  fetchProtocolAnalytics,
+  GET_PROTOCOL_ANALYTICS,
+  GET_PROTOCOL_STATS_HISTORY_PAGE,
+} from '../protocol';
 
 const mockGraphqlRequestV2 = vi.fn();
 vi.mock('../client/graphqlClient', () => ({
@@ -25,7 +29,10 @@ const stat = (timestamp: number, overrides: Record<string, unknown> = {}) => ({
 const fullResponse = () => ({
   protocol: {
     stats: stat(1700000300),
-    statsHistory: { nodes: [stat(1700000100), stat(1700000200)] },
+    statsHistory: {
+      nodes: [stat(1700000100), stat(1700000200)],
+      pageInfo: { hasNextPage: false, endCursor: null },
+    },
     openInterestByCategory: [
       { category: { name: 'Crypto', slug: 'crypto' }, openInterest: '300' },
       { category: { name: 'Politics', slug: 'politics' }, openInterest: '200' },
@@ -58,8 +65,9 @@ describe('GET_PROTOCOL_ANALYTICS document', () => {
     expect(GET_PROTOCOL_ANALYTICS).toContain('protocol');
     expect(GET_PROTOCOL_ANALYTICS).toContain('stats');
     expect(GET_PROTOCOL_ANALYTICS).toContain(
-      'statsHistory(first: $historyFirst)'
+      'statsHistory(first: $first, after: $after)'
     );
+    expect(GET_PROTOCOL_ANALYTICS).toContain('hasNextPage');
     expect(GET_PROTOCOL_ANALYTICS).toContain('openInterestByCategory');
     expect(GET_PROTOCOL_ANALYTICS).toContain('openInterestByTimeToResolution');
   });
@@ -86,20 +94,49 @@ describe('GET_PROTOCOL_ANALYTICS document', () => {
 });
 
 describe('fetchProtocolAnalytics', () => {
-  test('requests 1000 history snapshots by default', async () => {
+  test('requests the first history page within the list-size cap (100)', async () => {
     mockGraphqlRequestV2.mockResolvedValue(fullResponse());
     await fetchProtocolAnalytics();
+    expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
     expect(mockGraphqlRequestV2).toHaveBeenCalledWith(GET_PROTOCOL_ANALYTICS, {
-      historyFirst: 1000,
+      first: 100,
+      after: null,
     });
   });
 
-  test('passes a custom history size', async () => {
-    mockGraphqlRequestV2.mockResolvedValue(fullResponse());
-    await fetchProtocolAnalytics(50);
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(GET_PROTOCOL_ANALYTICS, {
-      historyFirst: 50,
+  test('pages statsHistory on pageInfo until exhausted, then concatenates', async () => {
+    const page1 = fullResponse();
+    page1.protocol.statsHistory = {
+      nodes: [stat(1700000100), stat(1700000200)],
+      pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+    };
+    mockGraphqlRequestV2.mockResolvedValueOnce(page1).mockResolvedValueOnce({
+      protocol: {
+        statsHistory: {
+          nodes: [stat(1700000300)],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
     });
+
+    const result = await fetchProtocolAnalytics();
+
+    expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(2);
+    // First call: the combined analytics query, first page.
+    expect(mockGraphqlRequestV2).toHaveBeenNthCalledWith(
+      1,
+      GET_PROTOCOL_ANALYTICS,
+      { first: 100, after: null }
+    );
+    // Second call: the lighter history-only page query, threading the cursor.
+    expect(mockGraphqlRequestV2).toHaveBeenNthCalledWith(
+      2,
+      GET_PROTOCOL_STATS_HISTORY_PAGE,
+      { first: 100, after: 'cursor-1' }
+    );
+    expect(result.statsHistory.map((s) => s.timestamp)).toEqual([
+      1700000100, 1700000200, 1700000300,
+    ]);
   });
 
   test('unwraps the protocol payload, with history as a plain array', async () => {

--- a/packages/sdk/queries/__tests__/vault.test.ts
+++ b/packages/sdk/queries/__tests__/vault.test.ts
@@ -60,7 +60,7 @@ describe('fetchVaultStats', () => {
     expect(mockGraphqlRequestV2).toHaveBeenCalledWith(GET_VAULT_STATS, {
       address: '0xabcdef',
       chainId: 42161,
-      first: 365,
+      first: 100,
       after: null,
     });
   });

--- a/packages/sdk/queries/protocol.ts
+++ b/packages/sdk/queries/protocol.ts
@@ -63,17 +63,40 @@ export interface ProtocolAnalytics {
   openInterestByTimeToResolution: ProtocolTimeToResolutionBucket[];
 }
 
+const PROTOCOL_STAT_FIELDS = /* GraphQL */ `
+  fragment ProtocolStatFields on ProtocolStat {
+    timestamp
+    cumulativeVolume
+    cumulativeTradeCount
+    periodVolume
+    periodTradeCount
+    openInterest
+    escrowBalance
+    totalValueLocked
+  }
+`;
+
 // `Protocol.statsHistory` exposes no orderBy argument — the connection is
 // defined oldest-first in the SDL; the mapper still sorts defensively.
+//
+// `statsHistory` pages on `pageInfo`: `first` must stay <= the API's
+// GRAPHQL_MAX_LIST_SIZE (100) or the request is rejected pre-execution with
+// PAGINATION_LIMIT_EXCEEDED. The first page is fetched alongside the singular
+// stats/open-interest fields; `GET_PROTOCOL_STATS_HISTORY_PAGE` fetches the
+// remaining history pages on their own.
 export const GET_PROTOCOL_ANALYTICS = /* GraphQL */ `
-  query ProtocolAnalytics($historyFirst: Int!) {
+  query ProtocolAnalytics($first: Int!, $after: String) {
     protocol {
       stats {
         ...ProtocolStatFields
       }
-      statsHistory(first: $historyFirst) {
+      statsHistory(first: $first, after: $after) {
         nodes {
           ...ProtocolStatFields
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
         }
       }
       openInterestByCategory {
@@ -92,16 +115,25 @@ export const GET_PROTOCOL_ANALYTICS = /* GraphQL */ `
     }
   }
 
-  fragment ProtocolStatFields on ProtocolStat {
-    timestamp
-    cumulativeVolume
-    cumulativeTradeCount
-    periodVolume
-    periodTradeCount
-    openInterest
-    escrowBalance
-    totalValueLocked
+  ${PROTOCOL_STAT_FIELDS}
+`;
+
+export const GET_PROTOCOL_STATS_HISTORY_PAGE = /* GraphQL */ `
+  query ProtocolStatsHistoryPage($first: Int!, $after: String) {
+    protocol {
+      statsHistory(first: $first, after: $after) {
+        nodes {
+          ...ProtocolStatFields
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
   }
+
+  ${PROTOCOL_STAT_FIELDS}
 `;
 
 type WireStat = {
@@ -115,10 +147,15 @@ type WireStat = {
   totalValueLocked: string | number;
 };
 
+type StatsHistoryPage = {
+  nodes: WireStat[];
+  pageInfo: { hasNextPage: boolean; endCursor: string | null };
+};
+
 type ProtocolAnalyticsV2Response = {
   protocol: {
     stats: WireStat;
-    statsHistory: { nodes: WireStat[] };
+    statsHistory: StatsHistoryPage;
     openInterestByCategory: Array<{
       category: { name: string; slug: string };
       openInterest: string | number;
@@ -150,7 +187,8 @@ function toStat(node: WireStat): ProtocolAnalyticsStat {
 }
 
 function toProtocolAnalytics(
-  data: ProtocolAnalyticsV2Response | null
+  data: ProtocolAnalyticsV2Response | null,
+  historyNodes: WireStat[]
 ): ProtocolAnalytics {
   const protocol = data?.protocol;
   if (
@@ -167,7 +205,7 @@ function toProtocolAnalytics(
 
   return {
     stats: toStat(protocol.stats),
-    statsHistory: protocol.statsHistory.nodes
+    statsHistory: historyNodes
       .map(toStat)
       .sort((a, b) => a.timestamp - b.timestamp),
     openInterestByCategory: protocol.openInterestByCategory.map((row) => ({
@@ -190,12 +228,36 @@ function toProtocolAnalytics(
   };
 }
 
-export async function fetchProtocolAnalytics(
-  historyFirst = 1000
-): Promise<ProtocolAnalytics> {
+// Snapshot pages are capped at the API's GRAPHQL_MAX_LIST_SIZE (100). The
+// daily series is bounded, so a handful of pages covers all history; MAX_PAGES
+// guards against a non-progressing cursor.
+const HISTORY_PAGE_SIZE = 100;
+const MAX_HISTORY_PAGES = 50;
+
+export async function fetchProtocolAnalytics(): Promise<ProtocolAnalytics> {
   const data = await graphqlRequestV2<ProtocolAnalyticsV2Response>(
     GET_PROTOCOL_ANALYTICS,
-    { historyFirst }
+    { first: HISTORY_PAGE_SIZE, after: null }
   );
-  return toProtocolAnalytics(data);
+
+  const historyNodes: WireStat[] = [
+    ...(data?.protocol?.statsHistory?.nodes ?? []),
+  ];
+  let pageInfo = data?.protocol?.statsHistory?.pageInfo;
+
+  for (let page = 1; page < MAX_HISTORY_PAGES; page += 1) {
+    if (!pageInfo?.hasNextPage || !pageInfo.endCursor) break;
+    const next = await graphqlRequestV2<{
+      protocol: { statsHistory: StatsHistoryPage } | null;
+    }>(GET_PROTOCOL_STATS_HISTORY_PAGE, {
+      first: HISTORY_PAGE_SIZE,
+      after: pageInfo.endCursor,
+    });
+    const history = next?.protocol?.statsHistory;
+    if (!history || !Array.isArray(history.nodes)) break;
+    historyNodes.push(...history.nodes);
+    pageInfo = history.pageInfo;
+  }
+
+  return toProtocolAnalytics(data, historyNodes);
 }

--- a/packages/sdk/queries/vault.ts
+++ b/packages/sdk/queries/vault.ts
@@ -99,7 +99,10 @@ function toVaultStat(node: WireVaultStat): VaultStat {
 export async function fetchVaultStats(
   address: string,
   chainId?: number,
-  pageSize = 365
+  // Must stay <= the API's GRAPHQL_MAX_LIST_SIZE (100); a larger `first` is
+  // rejected pre-execution with PAGINATION_LIMIT_EXCEEDED. The loop below pages
+  // on `pageInfo`, so a 100-row page still yields the full series.
+  pageSize = 100
 ): Promise<VaultStat[]> {
   const nodes: WireVaultStat[] = [];
   let after: string | null = null;


### PR DESCRIPTION
## Problem

After the v2-consumer migration landed on `staging`, several pages render empty / error because the new v2 GraphQL queries trip two `/v2/graphql` hardening guards and get **400**s:

| Page | Query | Error |
|---|---|---|
| `/vaults?address=…` (charts) | `VaultStats` | `first: 365 exceeds maximum allowed value of 100` |
| `/analytics` | `ProtocolAnalytics` | `first: 1000 exceeds maximum allowed value of 100` |
| `/feed`, profile **Activity** tab | `AccountActivity` | `exceeds maximum operation depth of 6` |

Verified live against `https://api.staging.sapience.xyz/v2/graphql` — the data exists; the queries are rejected pre-execution.

## Root causes & fixes

**1. Operation depth (`GRAPHQL_V2_MAX_DEPTH` 6 → 10)** — *no client-side workaround.*
Relay connections cost two extra selection-set levels (`edges → node`) over v1's flat lists, and legitimate v2 queries reach through that into `pickConfig → picks → condition → category` (the activity feed, positions, forecasts) — ~depth 8. The config's own doc said to override when a query legitimately needs greater depth. Query complexity (`GRAPHQL_V2_MAX_COMPLEXITY`) remains the primary fan-out guard.

**2. Pagination cap (`GRAPHQL_MAX_LIST_SIZE` = 100)** — fixed on the client by paging instead of over-fetching one page:
- `fetchVaultStats`: page size `365 → 100`. It already loops on `pageInfo`, so it still returns the full series.
- `fetchProtocolAnalytics`: was a single `first: 1000` shot. Now fetches the first page (≤100) alongside the singular stats/open-interest fields, then pages `statsHistory` via a new `GET_PROTOCOL_STATS_HISTORY_PAGE` query until exhausted.

The 100 cap is left intact for every other list arg (everything else already requests ≤100).

## Deploy note
The depth error reported `max 6`, which matches the **code default** — so staging is using the default, not an env override. If `GRAPHQL_V2_MAX_DEPTH` is set explicitly in the staging environment, it must be raised there too (or removed) for the fix to take effect.

## Tests
- SDK suite green (722 passing). Updated `protocol.test.ts` (new paged query shape + a multi-page paging test) and `vault.test.ts` (page-size assertion 365 → 100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)