### PR TITLE
Raise vault deposit cap to 50k

### DIFF
--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -46,7 +46,7 @@ const DEPOSIT_WHITELIST: `0x${string}`[] = [
   '0x7BB4e4E4674c625b23C550A74cfcfF9Ec50064F3',
 ];
 
-const DEPOSIT_CAP = 20000;
+const DEPOSIT_CAP = 50000;
 
 type VaultOption = {
   address: `0x${string}`;


### PR DESCRIPTION
## Summary
- Raise the vault UI deposit cap from 20,000 to 50,000 assets.

## Testing
- `pnpm --filter @sapience/app lint`
- `pnpm --filter @sapience/app type-check`
