### PR TITLE
perf(api): speed up /analytics — memoize protocolStats + linearize series SQL

### DIFF
--- a/packages/api/src/graphql/sdl/resolvers/queries/analytics.series.integration.test.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/analytics.series.integration.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Integration test for `fetchProtocolSeriesAggregates` — the cumulative volume,
+ * cumulative trade count, and point-in-time open-interest series that back the
+ * /analytics charts.
+ *
+ * The sibling unit test mocks `$queryRaw` and so can only assert plumbing; this
+ * seeds a real Postgres schema and runs the actual production SQL, proving the
+ * *numbers*. It exists specifically to lock in that the running-sum rewrite
+ * (which replaced a per-boundary triangular range-join) is numerically
+ * identical to the old correlated-filter query — including the two subtle
+ * boundary rules:
+ *   • cumulative metrics include events landing *exactly on* a boundary (`<=`);
+ *   • open interest *releases* collateral for a prediction that settles exactly
+ *     on a boundary (old `settled > T` open condition → excluded at T).
+ *
+ * Requires a reachable Postgres (TEST_DATABASE_URL or a local server on :5432).
+ * Skips cleanly when none is available so it never breaks CI without a DB.
+ */
+import { describe, it, expect, afterAll } from 'vitest';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from '../../../../../generated/prisma';
+import { fetchProtocolSeriesAggregates } from './analytics';
+
+const BASE_URL =
+  process.env.TEST_DATABASE_URL ??
+  'postgresql://postgres@localhost:5432/postgres';
+
+const SCHEMA = `analytics_series_it_${process.pid}_${Date.now()}`;
+
+const CHAIN = 8453;
+const OTHER_CHAIN = 9999;
+
+// Minimal slices of the tables the series SQL touches. Collateral/price stay
+// text (the production columns are stringified wei); timestamps are bigint
+// epoch seconds.
+const DDL = `
+  CREATE TABLE "position" ("mintedAt" bigint, "totalCollateral" text, "chainId" integer);
+  CREATE TABLE "Prediction" ("onChainCreatedAt" bigint, "predictorCollateral" text, "counterpartyCollateral" text, "chainId" integer, "pickConfigId" text);
+  CREATE TABLE "secondary_trade" ("executedAt" bigint, price text, "chainId" integer);
+  CREATE TABLE "Picks" (id text PRIMARY KEY, "resolvedAt" bigint);
+`;
+
+let client: PrismaClient | undefined;
+let dbAvailable = false;
+
+{
+  const probe = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: BASE_URL }),
+  });
+  try {
+    await probe.$executeRawUnsafe(`CREATE SCHEMA IF NOT EXISTS "${SCHEMA}"`);
+    dbAvailable = true;
+  } catch {
+    dbAvailable = false;
+  } finally {
+    await probe.$disconnect();
+  }
+
+  if (dbAvailable) {
+    // Pin search_path so both the DDL/seeding AND the production query's
+    // unqualified table names resolve to this isolated schema. SCHEMA is a safe
+    // unquoted identifier (lowercase + digits + underscore).
+    client = new PrismaClient({
+      adapter: new PrismaPg({
+        connectionString: BASE_URL,
+        options: `-c search_path=${SCHEMA}`,
+      }),
+    });
+
+    for (const stmt of DDL.split(';')
+      .map((s) => s.trim())
+      .filter(Boolean)) {
+      await client.$executeRawUnsafe(stmt);
+    }
+
+    // ── Seed (timestamps in epoch seconds; boundaries probed at 1000..4000) ──
+    // Predictions: +collateral at creation, −collateral at settlement.
+    //   P1 created@1000 (100), settles@3000
+    //   P2 created@2000 (100), never settles
+    //   P3 created@2000 (100), settles@2000  (created & settled on same boundary)
+    await client.$executeRawUnsafe(`
+      INSERT INTO "Picks" (id, "resolvedAt") VALUES
+        ('pc1', 3000),
+        ('pc2', NULL),
+        ('pc3', 2000)
+    `);
+    await client.$executeRawUnsafe(`
+      INSERT INTO "Prediction" ("onChainCreatedAt", "predictorCollateral", "counterpartyCollateral", "chainId", "pickConfigId") VALUES
+        (1000, '40', '60', ${CHAIN}, 'pc1'),
+        (2000, '50', '50', ${CHAIN}, 'pc2'),
+        (2000, '30', '70', ${CHAIN}, 'pc3')
+    `);
+    // positions: one on-chain @1000 (100); one on a DIFFERENT chain that must
+    // be filtered out of every metric.
+    await client.$executeRawUnsafe(`
+      INSERT INTO "position" ("mintedAt", "totalCollateral", "chainId") VALUES
+        (1000, '100', ${CHAIN}),
+        (3000, '200', ${OTHER_CHAIN})
+    `);
+    // secondary trade @2000 (50).
+    await client.$executeRawUnsafe(`
+      INSERT INTO secondary_trade ("executedAt", price, "chainId") VALUES
+        (2000, '50', ${CHAIN})
+    `);
+  }
+}
+
+afterAll(async () => {
+  if (!client) return;
+  await client.$executeRawUnsafe(`DROP SCHEMA IF EXISTS "${SCHEMA}" CASCADE`);
+  await client.$disconnect();
+});
+
+describe.skipIf(!dbAvailable)(
+  'fetchProtocolSeriesAggregates (integration: real SQL)',
+  () => {
+    const boundaries = [1000, 2000, 3000, 4000];
+
+    it('computes cumulative volume, trade count and live open interest at each boundary', async () => {
+      const { volumeMap, tradeCountMap, oiMap } =
+        await fetchProtocolSeriesAggregates(boundaries, CHAIN, client!);
+
+      // Cumulative VOLUME = Σ(position.totalCollateral + prediction collateral +
+      // secondary price) created ≤ T. Wrong-chain position (200) excluded.
+      //   T1000: pos1(100) + P1(100)                     = 200
+      //   T2000: + P2(100) + P3(100) + st1(50)           = 450
+      expect(volumeMap.get(1000)).toBe('200'); // inclusive at the boundary
+      expect(volumeMap.get(2000)).toBe('450');
+      expect(volumeMap.get(3000)).toBe('450');
+      expect(volumeMap.get(4000)).toBe('450');
+
+      // Cumulative TRADE COUNT = predictions + secondary trades created ≤ T
+      // (positions are NOT trades).
+      //   T1000: P1                       = 1
+      //   T2000: P1,P2,P3,st1             = 4
+      expect(tradeCountMap.get(1000)).toBe('1');
+      expect(tradeCountMap.get(2000)).toBe('4');
+      expect(tradeCountMap.get(3000)).toBe('4');
+      expect(tradeCountMap.get(4000)).toBe('4');
+
+      // OPEN INTEREST = Σ prediction collateral where created ≤ T AND not yet
+      // settled at T.
+      //   T1000: P1(+100)                                         = 100
+      //   T2000: P1(100) + P2(100) + P3(+100−100 settled@2000)    = 200
+      //   T3000: P1(settled@3000 → released) + P2(100) + P3(0)    = 100
+      //   T4000: P2(100)                                          = 100
+      expect(oiMap.get(1000)).toBe('100');
+      expect(oiMap.get(2000)).toBe('200'); // P3 settling on the boundary releases
+      expect(oiMap.get(3000)).toBe('100'); // P1 settling on the boundary releases
+      expect(oiMap.get(4000)).toBe('100');
+    });
+
+    it('returns a row for every boundary even with no events on a chain', async () => {
+      const { volumeMap, tradeCountMap, oiMap } =
+        await fetchProtocolSeriesAggregates(boundaries, 123456, client!);
+
+      for (const b of boundaries) {
+        expect(volumeMap.get(b)).toBe('0');
+        expect(tradeCountMap.get(b)).toBe('0');
+        expect(oiMap.get(b)).toBe('0');
+      }
+    });
+  }
+);

--- a/packages/api/src/graphql/sdl/resolvers/queries/analytics.test.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/analytics.test.ts
@@ -29,7 +29,9 @@ vi.mock('../../../../lib/utils', () => ({
   getProviderForChain: vi.fn(),
 }));
 
-const { protocolStats } = await import('./analytics');
+const { protocolStats, __clearProtocolStatsCache } = await import(
+  './analytics'
+);
 
 type ProtocolStatsFn = (
   parent: unknown,
@@ -39,19 +41,17 @@ type ProtocolStatsFn = (
 ) => Promise<unknown[]>;
 const protocolStatsFn = protocolStats as unknown as ProtocolStatsFn;
 
+const PROTOCOL_VAULT = {
+  kind: 'protocol',
+  address: '0xprotocol',
+  config: { address: '0xprotocol', legacy: [] },
+};
+
 describe('Query.protocolStats', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetConfiguredVaults.mockReturnValue([
-      {
-        kind: 'protocol',
-        address: '0xprotocol',
-        config: {
-          address: '0xprotocol',
-          legacy: [],
-        },
-      },
-    ]);
+    __clearProtocolStatsCache();
+    mockGetConfiguredVaults.mockReturnValue([PROTOCOL_VAULT]);
   });
 
   it('returns [] for an unknown vaultAddress instead of falling back to all vaults', async () => {
@@ -144,5 +144,129 @@ describe('Query.protocolStats', () => {
     expect(result[1].periodPnL).toBe('-80');
     // Live candle: realizedPnL(-970) + unredeemed(988) + sold(7) - bought(5) = 20
     expect(result[2].vaultCumulativePnL).toBe('20');
+  });
+});
+
+describe('Query.protocolStats TTL cache', () => {
+  // Minimal happy-path mocks so a full compute can run end to end. The series
+  // SQL is mocked to [] (its correctness is covered by the integration test);
+  // here we only care how many times the underlying work is triggered.
+  const primeMocks = async () => {
+    mockGetConfiguredVaults.mockReturnValue([PROTOCOL_VAULT]);
+    mockGetProtocolStatsTimeSeries.mockResolvedValue([
+      {
+        vaultAddress: '0xprotocol',
+        timestamp: 1_000_000,
+        vaultBalance: '0',
+        vaultAvailableAssets: '0',
+        vaultDeployed: '0',
+        escrowBalance: '0',
+        vaultPositionsWon: 0,
+        vaultPositionsLost: 0,
+        vaultDeposits: '0',
+        vaultWithdrawals: '0',
+        vaultAirdropGains: '0',
+        vaultRealizedPnL: '0',
+        vaultUnredeemedClaim: '0',
+        vaultSecondaryBought: '0',
+        vaultSecondarySold: '0',
+      },
+    ]);
+    mockQueryRaw.mockResolvedValue([]);
+    const svc = await import('../../../../services/protocolStats');
+    vi.mocked(svc.fetchVaultTVL).mockResolvedValue(0n);
+    vi.mocked(svc.fetchVaultAvailableAssets).mockResolvedValue(0n);
+    vi.mocked(svc.fetchVaultDeployed).mockResolvedValue(0n);
+    vi.mocked(svc.sumEscrowBalancesAtBlock).mockResolvedValue(0n);
+    vi.mocked(svc.calculateVaultPnL).mockResolvedValue({
+      realizedPnL: 0n,
+      positionsWon: 0,
+      positionsLost: 0,
+      totalCollateralWon: 0n,
+      totalCollateralLost: 0n,
+    });
+    vi.mocked(svc.calculateVaultFlows).mockResolvedValue({
+      totalDeposits: 0n,
+      totalWithdrawals: 0n,
+    });
+    vi.mocked(svc.calculateVaultSecondaryFlows).mockResolvedValue({
+      bought: 0n,
+      sold: 0n,
+    });
+    vi.mocked(svc.calculateVaultAirdrops).mockResolvedValue(0n);
+    vi.mocked(svc.calculateVaultUnredeemedClaim).mockResolvedValue(0n);
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    __clearProtocolStatsCache();
+    await primeMocks();
+  });
+
+  const call = () =>
+    protocolStatsFn(
+      {} as never,
+      { vaultAddress: null },
+      {} as never,
+      {} as never
+    );
+
+  it('computes once and serves cached result on repeat calls within the TTL', async () => {
+    await call();
+    await call();
+    await call();
+
+    // The 3 series queries run on the first call only; later calls are cached.
+    expect(mockQueryRaw).toHaveBeenCalledTimes(3);
+    expect(mockGetProtocolStatsTimeSeries).toHaveBeenCalledTimes(1);
+  });
+
+  it('single-flights concurrent calls into one computation', async () => {
+    await Promise.all([call(), call(), call(), call()]);
+
+    // The dashboard's concurrent `stats` + `statsHistory` resolvers (and any
+    // overlapping refetch) collapse to a single DB+RPC pass.
+    expect(mockGetProtocolStatsTimeSeries).toHaveBeenCalledTimes(1);
+    expect(mockQueryRaw).toHaveBeenCalledTimes(3);
+  });
+
+  it('re-computes after the cache is cleared (TTL expiry)', async () => {
+    await call();
+    __clearProtocolStatsCache();
+    await call();
+
+    expect(mockGetProtocolStatsTimeSeries).toHaveBeenCalledTimes(2);
+  });
+
+  it('keys the cache by vault address — a different vault is not a cache hit', async () => {
+    mockGetConfiguredVaults.mockReturnValue([
+      PROTOCOL_VAULT,
+      {
+        kind: 'pyth',
+        address: '0xpyth',
+        config: { address: '0xpyth', legacy: [] },
+      },
+    ]);
+
+    await call();
+    await protocolStatsFn(
+      {} as never,
+      { vaultAddress: '0xpyth' },
+      {} as never,
+      {} as never
+    );
+
+    expect(mockGetProtocolStatsTimeSeries).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache a rejected computation', async () => {
+    mockGetProtocolStatsTimeSeries.mockRejectedValueOnce(new Error('db down'));
+
+    await expect(call()).rejects.toThrow('db down');
+    // Next call must retry rather than replay the cached rejection.
+    const result = await call();
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(mockGetProtocolStatsTimeSeries).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
@@ -66,9 +66,159 @@ const buildTimestampMap = <T extends { timestamp: bigint }>(
   return map;
 };
 
-export const protocolStats: NonNullable<
-  QueryResolvers['protocolStats']
-> = async (_parent, { vaultAddress: vaultAddressArg }) => {
+export interface ProtocolSeriesAggregates {
+  /** boundary ts → cumulative volume (wei, decimal string) as of that ts. */
+  volumeMap: Map<number, string>;
+  /** boundary ts → cumulative trade count as of that ts. */
+  tradeCountMap: Map<number, string>;
+  /** boundary ts → open interest (wei, decimal string) live at that ts. */
+  oiMap: Map<number, string>;
+}
+
+/**
+ * Cumulative volume, cumulative trade count, and point-in-time open interest
+ * evaluated at each timestamp in `queryTimestamps`.
+ *
+ * Rewritten from a per-boundary triangular range-join
+ * (`UNNEST(boundaries) LEFT JOIN <all events> ON created_ts <= boundary`,
+ * roughly O(boundaries × events) — which grew quadratically as both the
+ * snapshot count and the event history climbed) into an *as-of running sum*:
+ * union the events with the boundary rows, order by `(ts, is_boundary)` so an
+ * event landing exactly on a boundary's timestamp sorts *before* that boundary
+ * (preserving the old `<=` inclusivity), take a cumulative
+ * `SUM() OVER (ROWS UNBOUNDED PRECEDING)`, then read the value off each
+ * boundary row. One sort instead of a nested loop — O((events+boundaries)·log).
+ *
+ * Open interest is a point-in-time "currently open" total, not a monotonic
+ * cumulative: each prediction contributes +collateral at creation and
+ * −collateral at settlement, so the same running-sum-of-signed-deltas yields
+ * `Σ collateral WHERE created ≤ T AND (settled IS NULL OR settled > T)` — the
+ * exact predicate the old correlated filter expressed. A prediction settling
+ * exactly at boundary T is excluded (its −delta sorts before the boundary),
+ * matching the old `settled > T` open condition.
+ */
+export const fetchProtocolSeriesAggregates = async (
+  queryTimestamps: number[],
+  chainId: number,
+  db: Pick<typeof prisma, '$queryRaw'> = prisma
+): Promise<ProtocolSeriesAggregates> => {
+  const [cumulativeVolumes, cumulativeTradeCounts, openInterests] =
+    await Promise.all([
+      db.$queryRaw<CumulativeVolumeRow[]>`
+      WITH events AS (
+        SELECT "mintedAt" AS ts, CAST("totalCollateral" AS DECIMAL) AS vol
+        FROM position
+        WHERE "chainId" = ${chainId} AND "mintedAt" IS NOT NULL
+        UNION ALL
+        SELECT "onChainCreatedAt" AS ts,
+          CAST("predictorCollateral" AS DECIMAL) + CAST("counterpartyCollateral" AS DECIMAL) AS vol
+        FROM "Prediction"
+        WHERE "chainId" = ${chainId} AND "onChainCreatedAt" IS NOT NULL
+        UNION ALL
+        SELECT "executedAt" AS ts, CAST(price AS DECIMAL) AS vol
+        FROM secondary_trade
+        WHERE "chainId" = ${chainId} AND "executedAt" IS NOT NULL
+      ),
+      combined AS (
+        SELECT ts, vol, 0 AS is_boundary FROM events
+        UNION ALL
+        SELECT b AS ts, 0::DECIMAL AS vol, 1 AS is_boundary
+        FROM UNNEST(${queryTimestamps}::BIGINT[]) AS b
+      ),
+      running AS (
+        SELECT ts, is_boundary,
+          SUM(vol) OVER (
+            ORDER BY ts, is_boundary
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+          ) AS cum
+        FROM combined
+      )
+      SELECT ts AS timestamp, COALESCE(MAX(cum), 0)::TEXT AS cumulative_volume
+      FROM running
+      WHERE is_boundary = 1
+      GROUP BY ts
+      ORDER BY ts
+    `,
+      db.$queryRaw<CumulativeTradeCountRow[]>`
+      WITH events AS (
+        SELECT "onChainCreatedAt" AS ts
+        FROM "Prediction"
+        WHERE "chainId" = ${chainId} AND "onChainCreatedAt" IS NOT NULL
+        UNION ALL
+        SELECT "executedAt" AS ts
+        FROM secondary_trade
+        WHERE "chainId" = ${chainId} AND "executedAt" IS NOT NULL
+      ),
+      combined AS (
+        SELECT ts, 1::BIGINT AS cnt, 0 AS is_boundary FROM events
+        UNION ALL
+        SELECT b AS ts, 0::BIGINT AS cnt, 1 AS is_boundary
+        FROM UNNEST(${queryTimestamps}::BIGINT[]) AS b
+      ),
+      running AS (
+        SELECT ts, is_boundary,
+          SUM(cnt) OVER (
+            ORDER BY ts, is_boundary
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+          ) AS cum
+        FROM combined
+      )
+      SELECT ts AS timestamp, COALESCE(MAX(cum), 0) AS cumulative_trade_count
+      FROM running
+      WHERE is_boundary = 1
+      GROUP BY ts
+      ORDER BY ts
+    `,
+      db.$queryRaw<DailyOIRow[]>`
+      WITH oi_base AS (
+        SELECT p."onChainCreatedAt" AS created_ts, pk."resolvedAt" AS settled_ts,
+          CAST(p."predictorCollateral" AS DECIMAL) + CAST(p."counterpartyCollateral" AS DECIMAL) AS vol
+        FROM "Prediction" p
+        LEFT JOIN "Picks" pk ON pk.id = p."pickConfigId"
+        WHERE p."chainId" = ${chainId} AND p."onChainCreatedAt" IS NOT NULL
+      ),
+      deltas AS (
+        -- +collateral when the prediction is created …
+        SELECT created_ts AS ts, vol FROM oi_base
+        UNION ALL
+        -- … −collateral once it settles (open interest is released).
+        SELECT settled_ts AS ts, -vol AS vol FROM oi_base WHERE settled_ts IS NOT NULL
+      ),
+      combined AS (
+        SELECT ts, vol, 0 AS is_boundary FROM deltas
+        UNION ALL
+        SELECT b AS ts, 0::DECIMAL AS vol, 1 AS is_boundary
+        FROM UNNEST(${queryTimestamps}::BIGINT[]) AS b
+      ),
+      running AS (
+        SELECT ts, is_boundary,
+          SUM(vol) OVER (
+            ORDER BY ts, is_boundary
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+          ) AS cum
+        FROM combined
+      )
+      SELECT ts AS timestamp, COALESCE(MAX(cum), 0)::TEXT AS open_interest
+      FROM running
+      WHERE is_boundary = 1
+      GROUP BY ts
+      ORDER BY ts
+    `,
+    ]);
+
+  return {
+    volumeMap: buildTimestampMap(cumulativeVolumes, 'cumulative_volume'),
+    tradeCountMap: buildTimestampMap(
+      cumulativeTradeCounts,
+      'cumulative_trade_count'
+    ),
+    oiMap: buildTimestampMap(openInterests, 'open_interest'),
+  };
+};
+
+const computeProtocolStats = async (
+  vaultAddressArg: string | null | undefined
+): Promise<ProtocolStat[]> => {
   const chainId = DEFAULT_CHAIN_ID;
 
   // Resolve which vault category the caller wants. Without `vaultAddressArg`
@@ -152,75 +302,8 @@ export const protocolStats: NonNullable<
   const nowTimestamp = Math.floor(Date.now() / 1000);
   const queryTimestamps = [...snapshotTimestamps, nowTimestamp];
 
-  const [cumulativeVolumes, cumulativeTradeCounts, openInterests] =
-    await Promise.all([
-      prisma.$queryRaw<CumulativeVolumeRow[]>`
-      SELECT
-        ts.timestamp,
-        COALESCE(SUM(vol), 0)::TEXT as cumulative_volume
-      FROM UNNEST(${queryTimestamps}::BIGINT[]) AS ts(timestamp)
-      LEFT JOIN (
-        SELECT "mintedAt" AS created_ts, CAST("totalCollateral" AS DECIMAL) AS vol, "chainId"
-        FROM position
-        UNION ALL
-        SELECT "onChainCreatedAt" AS created_ts,
-          CAST("predictorCollateral" AS DECIMAL) + CAST("counterpartyCollateral" AS DECIMAL) AS vol,
-          "chainId"
-        FROM "Prediction"
-        UNION ALL
-        SELECT "executedAt" AS created_ts,
-          CAST(price AS DECIMAL) AS vol,
-          "chainId"
-        FROM secondary_trade
-      ) combined ON
-        combined.created_ts <= ts.timestamp
-        AND combined."chainId" = ${chainId}
-      GROUP BY ts.timestamp
-      ORDER BY ts.timestamp
-    `,
-      prisma.$queryRaw<CumulativeTradeCountRow[]>`
-      SELECT
-        ts.timestamp,
-        COALESCE(COUNT(combined.created_ts), 0) as cumulative_trade_count
-      FROM UNNEST(${queryTimestamps}::BIGINT[]) AS ts(timestamp)
-      LEFT JOIN (
-        SELECT "onChainCreatedAt" AS created_ts, "chainId"
-        FROM "Prediction"
-        UNION ALL
-        SELECT "executedAt" AS created_ts, "chainId"
-        FROM secondary_trade
-      ) combined ON
-        combined.created_ts <= ts.timestamp
-        AND combined."chainId" = ${chainId}
-      GROUP BY ts.timestamp
-      ORDER BY ts.timestamp
-    `,
-      prisma.$queryRaw<DailyOIRow[]>`
-      SELECT
-        ts.timestamp,
-        COALESCE(SUM(vol), 0)::TEXT as open_interest
-      FROM UNNEST(${queryTimestamps}::BIGINT[]) AS ts(timestamp)
-      LEFT JOIN (
-        SELECT p."onChainCreatedAt" AS created_ts, pk."resolvedAt" AS settled_ts,
-          CAST(p."predictorCollateral" AS DECIMAL) + CAST(p."counterpartyCollateral" AS DECIMAL) AS vol,
-          p."chainId"
-        FROM "Prediction" p
-        LEFT JOIN "Picks" pk ON pk.id = p."pickConfigId"
-      ) combined ON
-        combined.created_ts <= ts.timestamp
-        AND (combined.settled_ts IS NULL OR combined.settled_ts > ts.timestamp)
-        AND combined."chainId" = ${chainId}
-      GROUP BY ts.timestamp
-      ORDER BY ts.timestamp
-    `,
-    ]);
-
-  const volumeMap = buildTimestampMap(cumulativeVolumes, 'cumulative_volume');
-  const tradeCountMap = buildTimestampMap(
-    cumulativeTradeCounts,
-    'cumulative_trade_count'
-  );
-  const oiMap = buildTimestampMap(openInterests, 'open_interest');
+  const { volumeMap, tradeCountMap, oiMap } =
+    await fetchProtocolSeriesAggregates(queryTimestamps, chainId);
 
   // Display each bar one interval *before* the snapshot's capture timestamp
   // so the label reflects "the period/state represented" rather than "the
@@ -375,6 +458,51 @@ export const protocolStats: NonNullable<
   }
 
   return results;
+};
+
+const PROTOCOL_STATS_TTL_MS = 60_000;
+
+type ProtocolStatsCacheEntry = {
+  promise: Promise<ProtocolStat[]>;
+  expiresAt: number;
+};
+
+// Keyed by the requested vault family ('__default__' = the protocol family,
+// which is what the analytics page asks for). The value is the in-flight
+// promise, not the resolved array, so concurrent callers single-flight onto
+// one computation: the analytics dashboard fires `stats` and `statsHistory`
+// (sibling resolvers, evaluated concurrently) plus up to ~50 sequential
+// history-pagination requests, and every one re-runs this whole pipeline
+// (3 series queries + the live candle's on-chain RPC) with no dependence on
+// the page/cursor. Collapsing them to one DB+RPC pass per TTL window is the
+// dominant win for the dashboard's load time.
+const protocolStatsCache = new Map<string, ProtocolStatsCacheEntry>();
+
+/** Test hook — drop all memoized protocol-stats entries. */
+export const __clearProtocolStatsCache = (): void => {
+  protocolStatsCache.clear();
+};
+
+export const protocolStats: NonNullable<QueryResolvers['protocolStats']> = (
+  _parent,
+  { vaultAddress: vaultAddressArg }
+) => {
+  const key = vaultAddressArg ? vaultAddressArg.toLowerCase() : '__default__';
+  const now = Date.now();
+  const hit = protocolStatsCache.get(key);
+  if (hit && hit.expiresAt > now) return hit.promise;
+
+  // Don't cache rejections: evict on failure so a transient RPC/DB blip isn't
+  // pinned as the answer for the whole TTL window (the next caller retries).
+  const promise = computeProtocolStats(vaultAddressArg).catch((err) => {
+    protocolStatsCache.delete(key);
+    throw err;
+  });
+  protocolStatsCache.set(key, {
+    promise,
+    expiresAt: now + PROTOCOL_STATS_TTL_MS,
+  });
+  return promise;
 };
 
 interface CategoryOpenInterestRow {


### PR DESCRIPTION
## Why

`https://www.sapience.xyz/analytics` got slow. The dashboard loads through one query that **paginates** `statsHistory` (1 + up to ~50 sequential requests), and **both** `Protocol.stats` and `Protocol.statsHistory` call the full v1 `protocolStats` pipeline — none of which depends on the page/cursor. So a single page load re-ran the entire pipeline **~N+2 times back to back**, each including on-chain RPC. On top of that, the underlying SQL was getting quadratically slower as the protocol aged.

## What

**1. Single-flight TTL memo on `protocolStats`** (`analytics.ts`)
Keyed by vault family, 60s, the same `memoTtl`-style pattern the open-interest resolvers already use. The dashboard's concurrent `stats` + `statsHistory` resolvers and its sequential history pagination now collapse to **one DB+RPC pass per minute**. Rejections are not cached, so a transient DB/RPC blip isn't pinned for the whole window.

**2. Linearize the cumulative series SQL**
The three series queries (volume, trade count, open interest) were per-boundary triangular range-joins:
```
UNNEST(boundaries) LEFT JOIN <all events> ON created_ts <= boundary GROUP BY boundary
```
~`O(boundaries × events)` — quadratic as both the snapshot count and event history grow. Rewritten into a **single-sort running sum**: union events with boundary rows, order by `(ts, is_boundary)` so an event landing exactly on a boundary sorts *before* it (preserving `<=` inclusivity), take a cumulative `SUM() OVER (...)`, read the value off each boundary row.

Open interest is point-in-time, not monotonic, so it uses **signed deltas** (`+collateral` at creation, `−collateral` at settlement) — yielding `Σ collateral WHERE created ≤ T AND (settled IS NULL OR settled > T)`. A prediction settling exactly on a boundary releases its OI, matching the old `settled > T` condition.

The series SQL is extracted into `fetchProtocolSeriesAggregates(timestamps, chainId, db)`.

## Net effect

From `(pages + 2) × O(boundaries × events)` per load → **1 × one-sort pass per minute**. Cold first-load-per-minute is dramatically cheaper; subsequent loads within 60s are served from cache.

## Tests

- **`analytics.test.ts`** — new TTL-cache suite: caches within TTL, single-flights concurrent calls, re-computes after expiry, keys by vault address, does not cache rejections. (Existing PnL-netting test unchanged.)
- **`analytics.series.integration.test.ts`** (new) — seeds a real Postgres schema and asserts the rewritten SQL's *numbers* for cumulative volume, trade count, and live open interest at multiple boundaries, including the `<=` inclusivity and settle-on-boundary edge cases. Skips cleanly when no DB is reachable.

Type-check, lint, and all affected suites (incl. the v2 `Protocol.test.ts` consumer) pass.

## Notes for reviewers

- Behavior is unchanged at the API surface; the live candle is now up to 60s stale within a cache window, which matches the existing `CACHE_HINTS.SNAPSHOT_MINUTE` (60s) and the frontend's 60s `refetchInterval`.
- v1 `protocolStats` is only reached via the v2 `protocol` resolver now (vault pages migrated to v2 `vault.statsHistory`), always with the default protocol family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)