### PR TITLE
feat(api): v2 Account.statsHistory (+ VaultStat parity) and ConditionGroup groupIds

### DIFF
--- a/packages/api/schema.v2.graphql
+++ b/packages/api/schema.v2.graphql
@@ -180,6 +180,12 @@ type AccountStatPoint {
   """
   Settled-and-won but not-yet-redeemed collateral owed to the account as of
   the bucket — the account analog of `VaultStat.claimableCollateral`.
+
+  This is a *pending-balance* figure, deliberately NOT part of `cumulativePnl`
+  (see there). It is attributed to the original position side and does not
+  follow secondary-market transfers, so after a winning position token is sold
+  pre-redemption it still reads against the seller until redeemed. Safe for the
+  "pending claims" view; not used to realize PnL precisely for that reason.
   """
   claimableCollateral: BigInt!
 
@@ -190,21 +196,31 @@ type AccountStatPoint {
   volume: BigInt!
 
   """
-  PnL realized within the bucket: settlement gains − losses on positions that
-  settled in-window, plus secondary-market sale proceeds net of purchase cost
-  (`sold − bought`) on trades executed in-window. Same trading-PnL definition
-  the vault plots in `VaultStat.cumulativePnl`, measured per-bucket.
+  PnL realized within the bucket — the per-bucket increment of `cumulativePnl`
+  (see there for exactly when PnL realizes): redemption gains on wins claimed
+  in-window, losses/non-decisive at settlement, and secondary-market proceeds
+  net of cost (`sold − bought`) on trades executed in-window. Same trading-PnL
+  definition the vault plots, measured per-bucket.
   """
   realizedPnl: BigInt!
 
   """
   Running trading PnL through the end of the bucket: the cumulative sum of
-  `realizedPnl` (seeded by all PnL realized *before* the window, so the line
-  never resets at the window start), plus the net winnings on positions that
-  have settled in the account's favour but are not yet redeemed
-  (`claimableCollateral` minus the stake on those wins). That unredeemed mark
-  makes a resolved win show up at resolution rather than waiting for redemption
-  — the account analog of `VaultStat.cumulativePnl`.
+  `realizedPnl`, seeded by all PnL realized *before* the window so the line
+  never resets at the window start.
+
+  PnL is realized only when a position is actually settled — a win at the
+  moment it is *redeemed* (a claim), a loss/non-decisive at settlement, plus
+  secondary-market proceeds and cost as they trade. It is NOT marked from
+  still-unredeemed `claimableCollateral`. This is deliberate: a redemption
+  records the true holder, so a win is credited to whoever actually collects
+  it. If a winning position token is sold before redemption, the seller simply
+  keeps their sale proceeds and the buyer realizes the win on redeeming — no
+  prize is ever credited to someone who no longer holds the token. The cost is
+  cosmetic: a resolved-but-unredeemed win contributes nothing until it is
+  claimed (the line steps up at redemption rather than at resolution).
+
+  Matches `VaultStat.cumulativePnl`, which realizes the same way.
   """
   cumulativePnl: BigInt!
 
@@ -365,14 +381,17 @@ type VaultStat {
   realizedPnl: BigInt!
 
   """
-  Cumulative trading PnL the vault dashboard plots: settlement PnL, plus
-  wUSDe earmarked from resolved-but-unredeemed wins, plus net secondary-
-  market flow (`realizedPnl + claimableCollateral + secondarySold −
-  secondaryBought`). This is the *same* numerator the account behind the
-  vault carries; the vault presents it as a return on total assets
-  (`balance + deployedCollateral`), where the account measures it against
-  deployed capital. The unredeemed term cancels the transient phantom loss
-  between a position resolving and its redeem being indexed.
+  Cumulative trading PnL the vault dashboard plots: settlement PnL plus net
+  secondary-market flow (`realizedPnl + secondarySold − secondaryBought`).
+
+  PnL realizes only when a position is actually redeemed/settled — it is NOT
+  marked from still-unredeemed `claimableCollateral` (that term used to be
+  added here and has been removed). This keeps the line correct when a winning
+  token is sold before redemption: the redeemer collects the prize, so it is
+  never credited to whoever merely minted the position. Realizes the same way
+  as `AccountStatPoint.cumulativePnl`. Trade-off: a resolved-but-unredeemed win
+  is not marked until it is claimed — the line steps up at redemption rather
+  than at resolution, which can read as a brief paper dip in between.
   """
   cumulativePnl: BigInt!
   deposits: BigInt!
@@ -386,8 +405,10 @@ type VaultStat {
   wUSDe owed to the vault on resolved-but-not-yet-redeemed winning sides,
   net of what it has already claimed. The dashboard's TVL line adds this to
   `balance + deployedCollateral` so funds that have settled in the vault's
-  favor but await an indexed redeem are not transiently dropped. Named to
-  match `AccountStatPoint.claimableCollateral`, the account-level analog.
+  favor but await an indexed redeem are not transiently dropped. A
+  pending-balance figure for TVL only — deliberately NOT part of
+  `cumulativePnl` (PnL realizes at redemption). Named to match
+  `AccountStatPoint.claimableCollateral`, the account-level analog.
   """
   claimableCollateral: BigInt!
 }

--- a/packages/api/schema.v2.graphql
+++ b/packages/api/schema.v2.graphql
@@ -198,10 +198,13 @@ type AccountStatPoint {
   realizedPnl: BigInt!
 
   """
-  Running trading PnL through the end of the bucket — the cumulative sum of
-  `realizedPnl`, seeded by all PnL realized *before* the window so the line
-  never resets at the window start. The account analog of
-  `VaultStat.cumulativePnl`.
+  Running trading PnL through the end of the bucket: the cumulative sum of
+  `realizedPnl` (seeded by all PnL realized *before* the window, so the line
+  never resets at the window start), plus the net winnings on positions that
+  have settled in the account's favour but are not yet redeemed
+  (`claimableCollateral` minus the stake on those wins). That unredeemed mark
+  makes a resolved win show up at resolution rather than waiting for redemption
+  — the account analog of `VaultStat.cumulativePnl`.
   """
   cumulativePnl: BigInt!
 

--- a/packages/api/schema.v2.graphql
+++ b/packages/api/schema.v2.graphql
@@ -220,7 +220,17 @@ type AccountStatPoint {
   cosmetic: a resolved-but-unredeemed win contributes nothing until it is
   claimed (the line steps up at redemption rather than at resolution).
 
+  Secondary sales also book the seller's allocated mint cost basis
+  (`stake × tokensSold / minted`), so a seller who never redeems still has
+  their stake deducted and combined PnL across buyer + seller conserves.
+
   Matches `VaultStat.cumulativePnl`, which realizes the same way.
+
+  Known approximations (tracked for a planned PnL rework to a single cash-flow +
+  token-ledger model): (1) basis allocation assumes sold tokens were minted ones
+  when an address both mints and buys the same token; (2) a loss is recognized
+  at its settlement/redemption event, so a position that simply expires
+  worthless without an on-chain burn may book its loss late.
   """
   cumulativePnl: BigInt!
 

--- a/packages/api/schema.v2.graphql
+++ b/packages/api/schema.v2.graphql
@@ -125,11 +125,14 @@ type Account implements Node & AddressEntity {
   running), and prediction win / loss / pending / non-decisive counts.
   Computed live from escrow predictions, legacy positions, claims, closes,
   and secondary trades (no snapshot table), so — unlike the chain-scoped
-  identity fields — the series spans the address across chains. `interval`
+  identity fields — the series spans the address across chains. Buckets are
+  ordered oldest-first (ascending `timestamp`), ready to plot. `interval`
   sets the bucket size; `filter.timestamp` (epoch seconds, inclusive) bounds
-  the window and defaults to the last 90 days. The window is bounded per
-  interval (≤365 daily buckets), so the default page returns the whole
-  series in one shot while still honouring `first` / `after`.
+  the window. With no filter the window defaults to the last 90 days, clamped
+  to the interval's own cap so it never overflows — e.g. `HOUR` caps at 168
+  buckets, so its default is the last 7 days (an explicit wider window is
+  rejected). The defaulted window fits one page, so the default returns the
+  whole series in one shot while still honouring `first` / `after`.
   """
   statsHistory(interval: TimeInterval!, first: Int = 366, after: String, filter: AccountStatFilter): AccountStatPointConnection!
 }
@@ -176,7 +179,7 @@ type AccountStatPoint {
 
   """
   Settled-and-won but not-yet-redeemed collateral owed to the account as of
-  the bucket — the account analog of `VaultStat.unredeemedClaim`.
+  the bucket — the account analog of `VaultStat.claimableCollateral`.
   """
   claimableCollateral: BigInt!
 
@@ -187,22 +190,44 @@ type AccountStatPoint {
   volume: BigInt!
 
   """
-  Settlement PnL realized within the bucket (gains − losses on positions that
-  settled in-window). Mirrors `VaultStat.realizedPnl`.
+  PnL realized within the bucket: settlement gains − losses on positions that
+  settled in-window, plus secondary-market sale proceeds net of purchase cost
+  (`sold − bought`) on trades executed in-window. Same trading-PnL definition
+  the vault plots in `VaultStat.cumulativePnl`, measured per-bucket.
   """
   realizedPnl: BigInt!
 
   """
-  Running settlement PnL through the end of the bucket. Mirrors
+  Running trading PnL through the end of the bucket — the cumulative sum of
+  `realizedPnl`, seeded by all PnL realized *before* the window so the line
+  never resets at the window start. The account analog of
   `VaultStat.cumulativePnl`.
   """
   cumulativePnl: BigInt!
 
-  """Predictions created in the bucket, across every outcome."""
+  """
+  Predictions created in the bucket, across every outcome. Equals
+  `predictionsWon + predictionsLost + predictionsPending +
+  predictionsNonDecisive`.
+  """
   predictionsTotal: Int!
+
+  """
+  Of the bucket's predictions, those that have since settled in the account's
+  favor. Counts are bucketed by creation time but reflect each prediction's
+  *current* settlement status, so a past bucket's won / lost / pending split
+  shifts as its predictions resolve (the series is computed live, not
+  snapshotted).
+  """
   predictionsWon: Int!
+
+  """Bucket predictions that have since settled against the account."""
   predictionsLost: Int!
+
+  """Bucket predictions not yet settled."""
   predictionsPending: Int!
+
+  """Bucket predictions that settled non-decisively (no winning side)."""
   predictionsNonDecisive: Int!
 }
 
@@ -302,8 +327,9 @@ type Vault implements Node {
   stats: VaultStat
 
   """
-  Time-series of this vault's economic snapshots, newest first. Backs the
-  vault dashboard's TVL / PnL charts. Defaults to `TIMESTAMP DESC`.
+  Time-series of this vault's economic snapshots, oldest-first (ascending
+  `timestamp`, matching `Account.statsHistory` — chart-ready, no consumer
+  re-sort). Backs the vault dashboard's TVL / PnL charts.
   """
   statsHistory(first: Int = 30, after: String, filter: VaultStatFilter): VaultStatConnection!
 }
@@ -338,7 +364,7 @@ type VaultStat {
   """
   Cumulative trading PnL the vault dashboard plots: settlement PnL, plus
   wUSDe earmarked from resolved-but-unredeemed wins, plus net secondary-
-  market flow (`realizedPnl + unredeemedClaim + secondarySold −
+  market flow (`realizedPnl + claimableCollateral + secondarySold −
   secondaryBought`). This is the *same* numerator the account behind the
   vault carries; the vault presents it as a return on total assets
   (`balance + deployedCollateral`), where the account measures it against
@@ -357,9 +383,10 @@ type VaultStat {
   wUSDe owed to the vault on resolved-but-not-yet-redeemed winning sides,
   net of what it has already claimed. The dashboard's TVL line adds this to
   `balance + deployedCollateral` so funds that have settled in the vault's
-  favor but await an indexed redeem are not transiently dropped.
+  favor but await an indexed redeem are not transiently dropped. Named to
+  match `AccountStatPoint.claimableCollateral`, the account-level analog.
   """
-  unredeemedClaim: BigInt!
+  claimableCollateral: BigInt!
 }
 
 type VaultStatEdge {

--- a/packages/api/schema.v2.graphql
+++ b/packages/api/schema.v2.graphql
@@ -118,6 +118,20 @@ type Account implements Node & AddressEntity {
   Aggregate statistics for this account. Cheap to resolve; always present.
   """
   stats: AccountStat!
+
+  """
+  Time-bucketed series of this account's prediction activity — deployed /
+  claimable collateral, trade volume, settlement PnL (per-bucket and
+  running), and prediction win / loss / pending / non-decisive counts.
+  Computed live from escrow predictions, legacy positions, claims, closes,
+  and secondary trades (no snapshot table), so — unlike the chain-scoped
+  identity fields — the series spans the address across chains. `interval`
+  sets the bucket size; `filter.timestamp` (epoch seconds, inclusive) bounds
+  the window and defaults to the last 90 days. The window is bounded per
+  interval (≤365 daily buckets), so the default page returns the whole
+  series in one shot while still honouring `first` / `after`.
+  """
+  statsHistory(interval: TimeInterval!, first: Int = 366, after: String, filter: AccountStatFilter): AccountStatPointConnection!
 }
 
 """
@@ -128,6 +142,89 @@ the DEFERRED note on `Account`).
 type AccountStat {
   """Cumulative trade volume across all of this account's activity, wei."""
   totalVolume: BigInt!
+}
+
+"""
+Bucketing granularity for `Account.statsHistory`. Unlike `Vault.statsHistory`
+(a fixed daily snapshot cadence written by the stats worker), the account
+series is computed live per request, so the caller picks the bucket size.
+"""
+enum TimeInterval {
+  HOUR
+  DAY
+  WEEK
+  MONTH
+}
+
+"""
+One time bucket of an account's prediction activity. Amounts are wUSDe wei
+and `timestamp` is the bucket's start (epoch seconds). The field vocabulary
+deliberately mirrors `VaultStat` — `deployedCollateral`, `realizedPnl`,
+`cumulativePnl` carry the same meaning at the account level. PnL is truncated
+toward zero to integer wei (the proportional cost-basis math can produce
+sub-wei fractions).
+"""
+type AccountStatPoint {
+  timestamp: UnixSeconds!
+
+  """
+  Collateral staked in positions still open as of the bucket — created on or
+  before the boundary and not yet settled. The deployed leg of the account's
+  escrow balance; mirrors `VaultStat.deployedCollateral`.
+  """
+  deployedCollateral: BigInt!
+
+  """
+  Settled-and-won but not-yet-redeemed collateral owed to the account as of
+  the bucket — the account analog of `VaultStat.unredeemedClaim`.
+  """
+  claimableCollateral: BigInt!
+
+  """
+  Trade volume attributed to the bucket: predictor + counterparty stake on
+  predictions created in-window, plus secondary-market trades.
+  """
+  volume: BigInt!
+
+  """
+  Settlement PnL realized within the bucket (gains − losses on positions that
+  settled in-window). Mirrors `VaultStat.realizedPnl`.
+  """
+  realizedPnl: BigInt!
+
+  """
+  Running settlement PnL through the end of the bucket. Mirrors
+  `VaultStat.cumulativePnl`.
+  """
+  cumulativePnl: BigInt!
+
+  """Predictions created in the bucket, across every outcome."""
+  predictionsTotal: Int!
+  predictionsWon: Int!
+  predictionsLost: Int!
+  predictionsPending: Int!
+  predictionsNonDecisive: Int!
+}
+
+type AccountStatPointEdge {
+  cursor: String!
+  node: AccountStatPoint!
+}
+
+type AccountStatPointConnection {
+  edges: [AccountStatPointEdge!]!
+  nodes: [AccountStatPoint!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+"""
+Filter for `Account.statsHistory`. Mirrors `VaultStatFilter`: a `timestamp`
+window in epoch seconds (inclusive on both bounds), defaulting to the last
+90 days when omitted.
+"""
+input AccountStatFilter {
+  timestamp: IntRangeFilter
 }
 
 type AccountEdge {
@@ -817,6 +914,13 @@ input ConditionGroupFilter {
 
   """Substring search against `name`, case-insensitive."""
   search: String
+
+  """
+  Restrict to condition groups whose numeric `groupId` is in this set — the
+  batch-by-id lookup the markets-by-id hydration path uses. OR within the
+  set, AND with the other filters.
+  """
+  groupIds: [Int!]
 }
 
 enum ConditionGroupOrderField {

--- a/packages/api/src/graphql/v2/resolvers/Account.ts
+++ b/packages/api/src/graphql/v2/resolvers/Account.ts
@@ -21,6 +21,7 @@ import {
   collateralBalanceField,
   collateralBalanceHistoryField,
 } from './CollateralBalance';
+import { statsHistoryField } from './AccountStatsHistory';
 
 // Account global ids are keyed `(chainId, address)` — an account is a
 // wallet view scoped to one chain, so the same address on two chains is
@@ -91,12 +92,12 @@ export const Account: AccountResolvers = {
     totalVolume: await getAccountTotalVolume(addressOf(parent)),
   }),
 
-  // DEFERRED — the rest of the account stats surface beyond
-  // `stats.totalVolume` (which ships, G6): PnL/accuracy fields on
-  // AccountStat and a `statsHistory` bucketed series — the account's
-  // return-on-deployed PnL (same numerator a vault plots on-total). No
-  // per-account time-series source exists yet — accountStats.ts is a
-  // windowed leaderboard aggregate, not a bucketed series — so statsHistory
-  // needs a new per-account snapshot writer/table. No consumer today. See
-  // the matching note on the `Account` type in schema.graphql.
+  /**
+   * Live, time-bucketed activity series (deployed/claimable collateral,
+   * volume, settlement PnL, prediction outcome counts). Computed on demand
+   * from the shared `services/timeSeriesQueries` SQL — the same source the v1
+   * `accountBalance`/`accountPnl`/`accountVolume`/`accountPredictionCount`
+   * queries read — so it needs no per-account snapshot table.
+   */
+  statsHistory: statsHistoryField,
 };

--- a/packages/api/src/graphql/v2/resolvers/AccountStatsHistory.test.ts
+++ b/packages/api/src/graphql/v2/resolvers/AccountStatsHistory.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for the `Account.statsHistory` connection shaping. The series is
+ * a full bucket grid (every bucket in the window is present), so totalCount /
+ * hasNextPage must derive from the materialized extent, not an over-fetch
+ * heuristic. We mock the data layer to emit a fixed-extent grid.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { AccountStatPointRow } from './queries/accountStatsHistory';
+
+const EXTENT = 53;
+
+vi.mock('./queries/accountStatsHistory', () => ({
+  getAccountStatsHistory: vi.fn(
+    async (): Promise<AccountStatPointRow[]> =>
+      Array.from({ length: EXTENT }, (_, i) => ({
+        timestamp: 1_000 + i,
+        deployedCollateral: BigInt(i),
+        claimableCollateral: 0n,
+        volume: BigInt(i * 2),
+        realizedPnl: 0n,
+        cumulativePnl: BigInt(i),
+        predictionsTotal: 0,
+        predictionsWon: 0,
+        predictionsLost: 0,
+        predictionsPending: 0,
+        predictionsNonDecisive: 0,
+      }))
+  ),
+}));
+
+import { statsHistoryField } from './AccountStatsHistory';
+import { encodeCursor } from '../relay/connection';
+
+type HistoryConnection = {
+  edges: { cursor: string; node: { timestamp: number } }[];
+  nodes: { timestamp: number }[];
+  totalCount: number;
+  pageInfo: {
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+    startCursor: string | null;
+    endCursor: string | null;
+  };
+};
+
+const parent = { address: '0xABC', chainId: 1 };
+
+const resolve = (args: {
+  first?: number;
+  after?: string | null;
+  interval?: string;
+}): Promise<HistoryConnection> =>
+  (
+    statsHistoryField as unknown as (
+      p: unknown,
+      a: unknown,
+      c: unknown,
+      i: unknown
+    ) => Promise<HistoryConnection>
+  )(parent, { interval: 'DAY', ...args }, {}, {});
+
+describe('statsHistoryField pagination', () => {
+  it('returns the whole bounded series in one page by default', async () => {
+    const page = await resolve({});
+    expect(page.edges).toHaveLength(EXTENT);
+    expect(page.totalCount).toBe(EXTENT);
+    expect(page.pageInfo.hasNextPage).toBe(false);
+    expect(page.pageInfo.hasPreviousPage).toBe(false);
+  });
+
+  it('reports a stable totalCount equal to the full extent across pages', async () => {
+    const page1 = await resolve({ first: 12 });
+    const page2 = await resolve({ first: 12, after: page1.pageInfo.endCursor });
+
+    expect(page1.totalCount).toBe(EXTENT);
+    expect(page2.totalCount).toBe(EXTENT);
+    expect(page1.pageInfo.hasNextPage).toBe(true);
+  });
+
+  it('terminates: hasNextPage is false on the last window', async () => {
+    // k="40" → offset 41; first 12 covers indices 41..52 then stops.
+    const nearEnd = encodeCursor({ k: '40', id: '' });
+    const tail = await resolve({ first: 12, after: nearEnd });
+
+    expect(tail.pageInfo.hasNextPage).toBe(false);
+    expect(tail.pageInfo.hasPreviousPage).toBe(true);
+    expect(tail.edges).toHaveLength(12);
+  });
+
+  it('advances contiguously: page 2 starts right after page 1', async () => {
+    const page1 = await resolve({ first: 10 });
+    const page2 = await resolve({ first: 10, after: page1.pageInfo.endCursor });
+
+    expect(page1.nodes.at(-1)?.timestamp).toBe(1_009);
+    expect(page2.nodes[0]?.timestamp).toBe(1_010);
+  });
+});

--- a/packages/api/src/graphql/v2/resolvers/AccountStatsHistory.ts
+++ b/packages/api/src/graphql/v2/resolvers/AccountStatsHistory.ts
@@ -1,0 +1,69 @@
+/**
+ * `Account.statsHistory` field resolver. Backed by the live, bucketed series
+ * in `./queries/accountStatsHistory`.
+ *
+ * Like `collateralBalanceHistory`, the underlying series is a full
+ * `generate_series` grid — every bucket in the requested window is present —
+ * so `totalCount` / `hasNextPage` are derived analytically from the
+ * materialized extent rather than `buildConnection`'s over-fetch-by-one
+ * heuristic, which a synthetic grid defeats (it always has a lookahead row, so
+ * "ran out of rows" never fires). Forward-only, offset-style cursor; the
+ * window is bounded per interval (≤365 buckets), so the default page returns
+ * the whole series.
+ */
+
+import type { AccountResolvers } from '../__generated__/resolvers';
+import { clampTake, decodeCursor, encodeCursor } from '../relay/connection';
+import { getAccountStatsHistory } from './queries/accountStatsHistory';
+
+const addressOf = (parent: { address?: string | null }): string =>
+  (parent.address ?? '').toLowerCase();
+
+// Bucket grids top out at the per-interval cap (365 for DAY); a default this
+// size returns the full window in one page while still honouring first/after.
+const MAX_STATS_POINTS = 366;
+
+const toDate = (seconds: number | null | undefined): Date | undefined =>
+  seconds == null ? undefined : new Date(seconds * 1000);
+
+export const statsHistoryField: NonNullable<
+  AccountResolvers['statsHistory']
+> = async (parent, args) => {
+  const first = clampTake(args.first ?? MAX_STATS_POINTS, {
+    defaultTake: MAX_STATS_POINTS,
+    maxTake: MAX_STATS_POINTS,
+  });
+  const after = args.after ? decodeCursor(args.after) : null;
+  const offset = after && /^\d+$/.test(after.k) ? Number(after.k) + 1 : 0;
+
+  const rows = await getAccountStatsHistory({
+    address: addressOf(parent),
+    interval: args.interval,
+    from: toDate(args.filter?.timestamp?.gte),
+    to: toDate(args.filter?.timestamp?.lte),
+  });
+  // The grid always materializes the full window, so its length is the true,
+  // page-invariant extent — totalCount / hasNextPage derive from it directly.
+  const extent = rows.length;
+
+  const pageRows = rows.slice(offset, offset + first);
+  const edges = pageRows.map((node, idx) => ({
+    node,
+    cursor: encodeCursor({
+      k: String(offset + idx),
+      id: String(node.timestamp),
+    }),
+  }));
+
+  return {
+    edges,
+    nodes: pageRows,
+    totalCount: extent,
+    pageInfo: {
+      hasNextPage: offset + first < extent,
+      hasPreviousPage: offset > 0,
+      startCursor: edges[0]?.cursor ?? null,
+      endCursor: edges.at(-1)?.cursor ?? null,
+    },
+  } as never;
+};

--- a/packages/api/src/graphql/v2/resolvers/Vault.test.ts
+++ b/packages/api/src/graphql/v2/resolvers/Vault.test.ts
@@ -140,9 +140,12 @@ describe('Vault (v2)', () => {
     expect(stat.undeployedCollateral).toBe(1500n);
     expect(stat.balance).toBe(1000n);
     expect(stat.realizedPnl).toBe(42n);
-    // cumulativePnl = realized + unredeemed + secondarySold − secondaryBought
-    expect(stat.cumulativePnl).toBe(54n);
-    // claimableCollateral is surfaced directly from vaultUnredeemedClaim.
+    // cumulativePnl = realized + secondarySold − secondaryBought (42 + 5 − 3).
+    // The unredeemed-claim term (10) is intentionally NOT included — PnL
+    // realizes at redemption, so claimable never marks the line.
+    expect(stat.cumulativePnl).toBe(44n);
+    // claimableCollateral is still surfaced directly from vaultUnredeemedClaim
+    // (for the TVL line), just not folded into cumulativePnl.
     expect(stat.claimableCollateral).toBe(10n);
     expect(stat.positionsWon).toBe(7);
   });

--- a/packages/api/src/graphql/v2/resolvers/Vault.test.ts
+++ b/packages/api/src/graphql/v2/resolvers/Vault.test.ts
@@ -133,7 +133,7 @@ describe('Vault (v2)', () => {
       balance: bigint;
       realizedPnl: bigint;
       cumulativePnl: bigint;
-      unredeemedClaim: bigint;
+      claimableCollateral: bigint;
       positionsWon: number;
     }>(Vault.stats)({ chainId: 13374202, address: '0xAAAA' }, {}, {}, null);
     expect(stat.deployedCollateral).toBe(500n);
@@ -142,8 +142,8 @@ describe('Vault (v2)', () => {
     expect(stat.realizedPnl).toBe(42n);
     // cumulativePnl = realized + unredeemed + secondarySold − secondaryBought
     expect(stat.cumulativePnl).toBe(54n);
-    // unredeemedClaim is surfaced directly from vaultUnredeemedClaim.
-    expect(stat.unredeemedClaim).toBe(10n);
+    // claimableCollateral is surfaced directly from vaultUnredeemedClaim.
+    expect(stat.claimableCollateral).toBe(10n);
     expect(stat.positionsWon).toBe(7);
   });
 
@@ -164,8 +164,8 @@ describe('Vault (v2)', () => {
     (getConfiguredVaults as Mock).mockReturnValueOnce([
       { kind: 'protocol', address: PRIMARY, config: { legacy: [LEGACY] } },
     ]);
-    // Returned newest-first; timestamp 100 appears under BOTH the legacy and
-    // the current primary address (a redeploy day).
+    // timestamp 100 appears under BOTH the legacy and the current primary
+    // address (a redeploy day).
     (prisma.protocolStatsSnapshot.findMany as Mock).mockResolvedValueOnce([
       { timestamp: 200, vaultAddress: PRIMARY, vaultBalance: '200' },
       { timestamp: 100, vaultAddress: LEGACY, vaultBalance: '50' },
@@ -194,5 +194,7 @@ describe('Vault (v2)', () => {
     expect(conn.totalCount).toBe(2);
     const ts100 = conn.nodes.find((n) => n.timestamp === 100);
     expect(ts100?.balance).toBe(999n);
+    // Oldest-first ordering (ascending timestamp), matching Account.statsHistory.
+    expect(conn.nodes.map((n) => n.timestamp)).toEqual([100, 200]);
   });
 });

--- a/packages/api/src/graphql/v2/resolvers/Vault.ts
+++ b/packages/api/src/graphql/v2/resolvers/Vault.ts
@@ -118,12 +118,15 @@ const mapVaultStat = (row: SnapshotRow) => ({
   deployedCollateral: BigInt(row.vaultDeployed ?? '0'),
   undeployedCollateral: BigInt(row.vaultAvailableAssets ?? '0'),
   realizedPnl: BigInt(row.vaultRealizedPnL ?? '0'),
-  // Cumulative trading PnL — same roll-up v1's analytics chart uses
-  // (settlement + unredeemed wins + net secondary flow). Sourced entirely
+  // Cumulative trading PnL: settlement PnL + net secondary flow. PnL realizes
+  // only when a position is actually redeemed/settled — the unredeemed-claim
+  // term is intentionally NOT added (it used to be), so the line stays correct
+  // when a winning token is sold pre-redeem: the redeemer collects the prize,
+  // not whoever minted it. Matches AccountStatPoint.cumulativePnl. Trade-off:
+  // a resolved-but-unredeemed win isn't marked until it's claimed. Sourced
   // from existing snapshot columns; no live recomputation here.
   cumulativePnl:
     BigInt(row.vaultRealizedPnL ?? '0') +
-    BigInt(row.vaultUnredeemedClaim ?? '0') +
     BigInt(row.vaultSecondarySold ?? '0') -
     BigInt(row.vaultSecondaryBought ?? '0'),
   deposits: BigInt(row.vaultDeposits ?? '0'),
@@ -133,8 +136,8 @@ const mapVaultStat = (row: SnapshotRow) => ({
   collateralWon: BigInt(row.vaultCollateralWon ?? '0'),
   collateralLost: BigInt(row.vaultCollateralLost ?? '0'),
   // wUSDe owed to the vault on resolved-but-not-yet-redeemed winning sides,
-  // net of what it has already claimed. Also a term in `cumulativePnl` above;
-  // surfaced on its own so the vault dashboard's TVL line can include it. The
+  // net of what it has already claimed. A pending-balance figure for the TVL
+  // line only — NOT part of `cumulativePnl` (PnL realizes at redemption). The
   // public field is `claimableCollateral` (matches `AccountStatPoint`); the DB
   // column keeps its `vaultUnredeemedClaim` name.
   claimableCollateral: BigInt(row.vaultUnredeemedClaim ?? '0'),

--- a/packages/api/src/graphql/v2/resolvers/Vault.ts
+++ b/packages/api/src/graphql/v2/resolvers/Vault.ts
@@ -134,14 +134,18 @@ const mapVaultStat = (row: SnapshotRow) => ({
   collateralLost: BigInt(row.vaultCollateralLost ?? '0'),
   // wUSDe owed to the vault on resolved-but-not-yet-redeemed winning sides,
   // net of what it has already claimed. Also a term in `cumulativePnl` above;
-  // surfaced on its own so the vault dashboard's TVL line can include it.
-  unredeemedClaim: BigInt(row.vaultUnredeemedClaim ?? '0'),
+  // surfaced on its own so the vault dashboard's TVL line can include it. The
+  // public field is `claimableCollateral` (matches `AccountStatPoint`); the DB
+  // column keeps its `vaultUnredeemedClaim` name.
+  claimableCollateral: BigInt(row.vaultUnredeemedClaim ?? '0'),
 });
 
 /**
  * `stats` reads the vault's latest snapshot; `statsHistory` pages the
- * time series newest-first with an offset cursor (snapshots are a
- * bounded daily series). Both key on `(chainId, vaultAddress)`, indexed
+ * time series oldest-first (ascending `timestamp`, matching
+ * `Account.statsHistory` — chart-ready, no consumer re-sort) with an
+ * offset cursor (snapshots are a bounded daily series). Both key on
+ * `(chainId, vaultAddress)`, indexed
  * on `protocol_stats_snapshot`. Identity (`id`, `address`, `chainId`)
  * stays a plain property read off the mapped row.
  */
@@ -227,7 +231,7 @@ export const Vault: VaultResolvers = {
     // skip/take can't dedupe-then-page correctly, so paginate after the dedupe.
     const allRows = await prisma.protocolStatsSnapshot.findMany({
       where,
-      orderBy: { timestamp: 'desc' },
+      orderBy: { timestamp: 'asc' },
     });
     const dedup = new Map<number, (typeof allRows)[number]>();
     for (const s of allRows) {
@@ -236,8 +240,10 @@ export const Vault: VaultResolvers = {
         dedup.set(s.timestamp, s);
       }
     }
+    // Oldest-first, matching Account.statsHistory so chart consumers don't
+    // re-sort. The offset cursor pages forward from the earliest snapshot.
     const deduped = Array.from(dedup.values()).sort(
-      (a, b) => b.timestamp - a.timestamp
+      (a, b) => a.timestamp - b.timestamp
     );
     const totalCount = deduped.length;
     const pageRows = deduped.slice(skip, skip + first + 1);

--- a/packages/api/src/graphql/v2/resolvers/queries/accountStatsHistory.test.ts
+++ b/packages/api/src/graphql/v2/resolvers/queries/accountStatsHistory.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for `getAccountStatsHistory` — the merge layer that lines the
+ * four endpoint-agnostic time-series helpers up into one snapshot per bucket
+ * and truncates DECIMAL text onto integer wei.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  queryAccountBalance: vi.fn(),
+  queryAccountPnl: vi.fn(),
+  queryAccountVolume: vi.fn(),
+  queryAccountPredictionCount: vi.fn(),
+}));
+
+vi.mock('../../../../services/timeSeriesQueries', () => mocks);
+
+import {
+  decimalTextToWei,
+  getAccountStatsHistory,
+  toServiceInterval,
+} from './accountStatsHistory';
+import { TimeInterval } from '../../../../services/timeSeriesTypes';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.queryAccountBalance.mockResolvedValue([]);
+  mocks.queryAccountPnl.mockResolvedValue([]);
+  mocks.queryAccountVolume.mockResolvedValue([]);
+  mocks.queryAccountPredictionCount.mockResolvedValue([]);
+});
+
+describe('decimalTextToWei', () => {
+  it('passes integer strings through', () => {
+    expect(decimalTextToWei('1000000000000000000')).toBe(
+      1_000_000_000_000_000_000n
+    );
+  });
+
+  it('truncates fractional DECIMAL text toward zero', () => {
+    expect(decimalTextToWei('123.999')).toBe(123n);
+    expect(decimalTextToWei('-1.9')).toBe(-1n);
+  });
+
+  it('collapses empty / malformed payloads to 0n', () => {
+    expect(decimalTextToWei(null)).toBe(0n);
+    expect(decimalTextToWei('')).toBe(0n);
+    expect(decimalTextToWei('-')).toBe(0n);
+    expect(decimalTextToWei('not-a-number')).toBe(0n);
+  });
+});
+
+describe('toServiceInterval', () => {
+  it('maps the SDL enum values to the service enum', () => {
+    expect(toServiceInterval('HOUR')).toBe(TimeInterval.HOUR);
+    expect(toServiceInterval('MONTH')).toBe(TimeInterval.MONTH);
+  });
+
+  it('falls back to DAY on anything unrecognized', () => {
+    expect(toServiceInterval('???')).toBe(TimeInterval.DAY);
+  });
+});
+
+describe('getAccountStatsHistory', () => {
+  it('merges the four series by bucket timestamp into one snapshot per bucket', async () => {
+    mocks.queryAccountBalance.mockResolvedValue([
+      { timestamp: 100, deployedCollateral: '50', claimableCollateral: '7' },
+      { timestamp: 200, deployedCollateral: '0', claimableCollateral: '0' },
+    ]);
+    mocks.queryAccountPnl.mockResolvedValue([
+      { timestamp: 100, pnl: '10.5', cumulativePnl: '10.5' },
+      { timestamp: 200, pnl: '-3', cumulativePnl: '7.5' },
+    ]);
+    mocks.queryAccountVolume.mockResolvedValue([
+      { timestamp: 100, volume: '1000' },
+      { timestamp: 200, volume: '2000' },
+    ]);
+    mocks.queryAccountPredictionCount.mockResolvedValue([
+      { timestamp: 100, total: 2, won: 1, lost: 0, pending: 1, nonDecisive: 0 },
+      { timestamp: 200, total: 1, won: 0, lost: 1, pending: 0, nonDecisive: 0 },
+    ]);
+
+    const rows = await getAccountStatsHistory({
+      address: '0xABC',
+      interval: 'DAY',
+    });
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toEqual({
+      timestamp: 100,
+      deployedCollateral: 50n,
+      claimableCollateral: 7n,
+      volume: 1000n,
+      realizedPnl: 10n, // 10.5 truncated
+      cumulativePnl: 10n,
+      predictionsTotal: 2,
+      predictionsWon: 1,
+      predictionsLost: 0,
+      predictionsPending: 1,
+      predictionsNonDecisive: 0,
+    });
+    expect(rows[1].realizedPnl).toBe(-3n);
+    expect(rows[1].cumulativePnl).toBe(7n);
+    expect(rows[1].predictionsLost).toBe(1);
+  });
+
+  it('returns rows sorted ascending by timestamp even if a leg is out of order', async () => {
+    mocks.queryAccountVolume.mockResolvedValue([
+      { timestamp: 300, volume: '3' },
+      { timestamp: 100, volume: '1' },
+      { timestamp: 200, volume: '2' },
+    ]);
+
+    const rows = await getAccountStatsHistory({
+      address: '0xabc',
+      interval: 'DAY',
+    });
+
+    expect(rows.map((r) => r.timestamp)).toEqual([100, 200, 300]);
+  });
+
+  it('passes the mapped service interval and window through to every helper', async () => {
+    const from = new Date('2024-01-01T00:00:00Z');
+    const to = new Date('2024-02-01T00:00:00Z');
+
+    await getAccountStatsHistory({
+      address: '0xabc',
+      interval: 'WEEK',
+      from,
+      to,
+    });
+
+    for (const fn of [
+      mocks.queryAccountBalance,
+      mocks.queryAccountPnl,
+      mocks.queryAccountVolume,
+      mocks.queryAccountPredictionCount,
+    ]) {
+      expect(fn).toHaveBeenCalledWith('0xabc', TimeInterval.WEEK, from, to);
+    }
+  });
+});

--- a/packages/api/src/graphql/v2/resolvers/queries/accountStatsHistory.test.ts
+++ b/packages/api/src/graphql/v2/resolvers/queries/accountStatsHistory.test.ts
@@ -104,16 +104,12 @@ describe('getAccountStatsHistory', () => {
     expect(rows[1].predictionsLost).toBe(1);
   });
 
-  it('folds net unredeemed winnings into cumulativePnl, leaving claimable gross', async () => {
-    // Resolved-but-unredeemed win: realized PnL is still 0 (no claim event),
-    // but the line should mark the net win (claimable 100 − stake 20 = 80).
+  it('realizes cumulativePnl from claims only — never marks unredeemed claimable', async () => {
+    // A resolved-but-unredeemed win shows claimable, but PnL stays flat until
+    // it is actually redeemed (a Claim feeds the pnl series, not the balance
+    // series). So a big claimable with no realized PnL must NOT move the line.
     mocks.queryAccountBalance.mockResolvedValue([
-      {
-        timestamp: 100,
-        deployedCollateral: '0',
-        claimableCollateral: '100',
-        unredeemedNetGain: '80',
-      },
+      { timestamp: 100, deployedCollateral: '0', claimableCollateral: '100' },
     ]);
     mocks.queryAccountPnl.mockResolvedValue([
       { timestamp: 100, pnl: '0', cumulativePnl: '0' },
@@ -124,9 +120,8 @@ describe('getAccountStatsHistory', () => {
       interval: 'DAY',
     });
 
-    expect(rows[0].cumulativePnl).toBe(80n); // 0 realized + 80 net unredeemed
-    expect(rows[0].realizedPnl).toBe(0n); // per-bucket realized unaffected
-    expect(rows[0].claimableCollateral).toBe(100n); // gross field unchanged
+    expect(rows[0].cumulativePnl).toBe(0n); // unredeemed claimable does not mark PnL
+    expect(rows[0].claimableCollateral).toBe(100n); // still surfaced for pending view
   });
 
   it('returns rows sorted ascending by timestamp even if a leg is out of order', async () => {

--- a/packages/api/src/graphql/v2/resolvers/queries/accountStatsHistory.test.ts
+++ b/packages/api/src/graphql/v2/resolvers/queries/accountStatsHistory.test.ts
@@ -104,6 +104,31 @@ describe('getAccountStatsHistory', () => {
     expect(rows[1].predictionsLost).toBe(1);
   });
 
+  it('folds net unredeemed winnings into cumulativePnl, leaving claimable gross', async () => {
+    // Resolved-but-unredeemed win: realized PnL is still 0 (no claim event),
+    // but the line should mark the net win (claimable 100 − stake 20 = 80).
+    mocks.queryAccountBalance.mockResolvedValue([
+      {
+        timestamp: 100,
+        deployedCollateral: '0',
+        claimableCollateral: '100',
+        unredeemedNetGain: '80',
+      },
+    ]);
+    mocks.queryAccountPnl.mockResolvedValue([
+      { timestamp: 100, pnl: '0', cumulativePnl: '0' },
+    ]);
+
+    const rows = await getAccountStatsHistory({
+      address: '0xABC',
+      interval: 'DAY',
+    });
+
+    expect(rows[0].cumulativePnl).toBe(80n); // 0 realized + 80 net unredeemed
+    expect(rows[0].realizedPnl).toBe(0n); // per-bucket realized unaffected
+    expect(rows[0].claimableCollateral).toBe(100n); // gross field unchanged
+  });
+
   it('returns rows sorted ascending by timestamp even if a leg is out of order', async () => {
     mocks.queryAccountVolume.mockResolvedValue([
       { timestamp: 300, volume: '3' },

--- a/packages/api/src/graphql/v2/resolvers/queries/accountStatsHistory.ts
+++ b/packages/api/src/graphql/v2/resolvers/queries/accountStatsHistory.ts
@@ -109,21 +109,20 @@ export const getAccountStatsHistory = async ({
     return row;
   };
 
-  // cumulativePnl is the sum of two aligned series — the realized running total
-  // from the PnL query and the net-unredeemed mark from the balance query — so
-  // both legs accumulate into it (emptyRow seeds 0n; order-independent). This
-  // mirrors VaultStat.cumulativePnl, where the unredeemed win is folded into
-  // the line at resolution rather than waiting for redemption.
   for (const point of balance) {
     const row = ensure(point.timestamp);
     row.deployedCollateral = decimalTextToWei(point.deployedCollateral);
     row.claimableCollateral = decimalTextToWei(point.claimableCollateral);
-    row.cumulativePnl += decimalTextToWei(point.unredeemedNetGain);
   }
+  // PnL is realized only when a win is actually redeemed (a Claim/Close) — never
+  // marked from still-unredeemed `claimableCollateral`. That keeps the line
+  // correct through secondary sales: a Claim records the true redeemer, so the
+  // prize is credited to whoever actually collects it, not to whoever first
+  // minted the position. See AccountStatPoint.cumulativePnl in the SDL.
   for (const point of pnl) {
     const row = ensure(point.timestamp);
     row.realizedPnl = decimalTextToWei(point.pnl);
-    row.cumulativePnl += decimalTextToWei(point.cumulativePnl);
+    row.cumulativePnl = decimalTextToWei(point.cumulativePnl);
   }
   for (const point of volume) {
     ensure(point.timestamp).volume = decimalTextToWei(point.volume);

--- a/packages/api/src/graphql/v2/resolvers/queries/accountStatsHistory.ts
+++ b/packages/api/src/graphql/v2/resolvers/queries/accountStatsHistory.ts
@@ -109,15 +109,21 @@ export const getAccountStatsHistory = async ({
     return row;
   };
 
+  // cumulativePnl is the sum of two aligned series — the realized running total
+  // from the PnL query and the net-unredeemed mark from the balance query — so
+  // both legs accumulate into it (emptyRow seeds 0n; order-independent). This
+  // mirrors VaultStat.cumulativePnl, where the unredeemed win is folded into
+  // the line at resolution rather than waiting for redemption.
   for (const point of balance) {
     const row = ensure(point.timestamp);
     row.deployedCollateral = decimalTextToWei(point.deployedCollateral);
     row.claimableCollateral = decimalTextToWei(point.claimableCollateral);
+    row.cumulativePnl += decimalTextToWei(point.unredeemedNetGain);
   }
   for (const point of pnl) {
     const row = ensure(point.timestamp);
     row.realizedPnl = decimalTextToWei(point.pnl);
-    row.cumulativePnl = decimalTextToWei(point.cumulativePnl);
+    row.cumulativePnl += decimalTextToWei(point.cumulativePnl);
   }
   for (const point of volume) {
     ensure(point.timestamp).volume = decimalTextToWei(point.volume);

--- a/packages/api/src/graphql/v2/resolvers/queries/accountStatsHistory.ts
+++ b/packages/api/src/graphql/v2/resolvers/queries/accountStatsHistory.ts
@@ -1,0 +1,137 @@
+/**
+ * Per-account, time-bucketed activity series backing `Account.statsHistory`.
+ *
+ * Reuses the endpoint-agnostic SQL helpers in `services/timeSeriesQueries`
+ * (the same source the v1 `accountBalance` / `accountPnl` / `accountVolume` /
+ * `accountPredictionCount` queries read) and merges their per-bucket rows
+ * — which share an identical `generate_series` grid — into one snapshot per
+ * bucket. There is no snapshot table: the series is computed live from escrow
+ * predictions, legacy positions, claims, closes, and secondary trades.
+ *
+ * Monetary values arrive as Postgres DECIMAL text. Deployed / claimable /
+ * volume are integer-wei sums; PnL carries a proportional cost-basis division
+ * that can yield sub-wei fractions, so every amount is truncated toward zero
+ * onto integer wei for the `BigInt` wire scalar.
+ */
+
+import {
+  queryAccountBalance,
+  queryAccountPnl,
+  queryAccountPredictionCount,
+  queryAccountVolume,
+} from '../../../../services/timeSeriesQueries';
+import { TimeInterval } from '../../../../services/timeSeriesTypes';
+
+export type AccountStatPointRow = {
+  timestamp: number;
+  deployedCollateral: bigint;
+  claimableCollateral: bigint;
+  volume: bigint;
+  realizedPnl: bigint;
+  cumulativePnl: bigint;
+  predictionsTotal: number;
+  predictionsWon: number;
+  predictionsLost: number;
+  predictionsPending: number;
+  predictionsNonDecisive: number;
+};
+
+// Truncate a Postgres DECIMAL text value toward zero to integer wei. Empty /
+// malformed payloads collapse to 0n. Sub-wei fractions (from the PnL
+// cost-basis division) are dropped — wei is the atomic unit, so this is lossless
+// in practice.
+export const decimalTextToWei = (value: string | null | undefined): bigint => {
+  if (!value) return 0n;
+  const trimmed = value.trim();
+  const dot = trimmed.indexOf('.');
+  const intPart = dot === -1 ? trimmed : trimmed.slice(0, dot);
+  if (intPart === '' || intPart === '-' || intPart === '+') return 0n;
+  try {
+    return BigInt(intPart);
+  } catch {
+    return 0n;
+  }
+};
+
+const SERVICE_INTERVALS: Record<string, TimeInterval> = {
+  HOUR: TimeInterval.HOUR,
+  DAY: TimeInterval.DAY,
+  WEEK: TimeInterval.WEEK,
+  MONTH: TimeInterval.MONTH,
+};
+
+export const toServiceInterval = (interval: string): TimeInterval =>
+  SERVICE_INTERVALS[interval] ?? TimeInterval.DAY;
+
+const emptyRow = (timestamp: number): AccountStatPointRow => ({
+  timestamp,
+  deployedCollateral: 0n,
+  claimableCollateral: 0n,
+  volume: 0n,
+  realizedPnl: 0n,
+  cumulativePnl: 0n,
+  predictionsTotal: 0,
+  predictionsWon: 0,
+  predictionsLost: 0,
+  predictionsPending: 0,
+  predictionsNonDecisive: 0,
+});
+
+export const getAccountStatsHistory = async ({
+  address,
+  interval,
+  from,
+  to,
+}: {
+  address: string;
+  interval: string;
+  from?: Date;
+  to?: Date;
+}): Promise<AccountStatPointRow[]> => {
+  const svcInterval = toServiceInterval(interval);
+  const [balance, pnl, volume, counts] = await Promise.all([
+    queryAccountBalance(address, svcInterval, from, to),
+    queryAccountPnl(address, svcInterval, from, to),
+    queryAccountVolume(address, svcInterval, from, to),
+    queryAccountPredictionCount(address, svcInterval, from, to),
+  ]);
+
+  // All four series share the same generate_series bucket grid, so a
+  // timestamp-keyed merge lines them up one row per bucket. Union the keys
+  // defensively in case any leg returns a sparser set.
+  const byTimestamp = new Map<number, AccountStatPointRow>();
+  const ensure = (timestamp: number): AccountStatPointRow => {
+    let row = byTimestamp.get(timestamp);
+    if (!row) {
+      row = emptyRow(timestamp);
+      byTimestamp.set(timestamp, row);
+    }
+    return row;
+  };
+
+  for (const point of balance) {
+    const row = ensure(point.timestamp);
+    row.deployedCollateral = decimalTextToWei(point.deployedCollateral);
+    row.claimableCollateral = decimalTextToWei(point.claimableCollateral);
+  }
+  for (const point of pnl) {
+    const row = ensure(point.timestamp);
+    row.realizedPnl = decimalTextToWei(point.pnl);
+    row.cumulativePnl = decimalTextToWei(point.cumulativePnl);
+  }
+  for (const point of volume) {
+    ensure(point.timestamp).volume = decimalTextToWei(point.volume);
+  }
+  for (const point of counts) {
+    const row = ensure(point.timestamp);
+    row.predictionsTotal = point.total;
+    row.predictionsWon = point.won;
+    row.predictionsLost = point.lost;
+    row.predictionsPending = point.pending;
+    row.predictionsNonDecisive = point.nonDecisive;
+  }
+
+  return Array.from(byTimestamp.values()).sort(
+    (a, b) => a.timestamp - b.timestamp
+  );
+};

--- a/packages/api/src/graphql/v2/resolvers/queries/conditionGroup.test.ts
+++ b/packages/api/src/graphql/v2/resolvers/queries/conditionGroup.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for the `conditionGroups` filter wiring — specifically the
+ * batch-by-id `groupIds` filter used by the markets-by-id hydration path.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockPrisma = vi.hoisted(() => ({
+  conditionGroup: { findMany: vi.fn(), count: vi.fn(), findUnique: vi.fn() },
+}));
+
+vi.mock('../../../../core/db', () => ({ default: mockPrisma }));
+
+import { conditionGroups } from './conditionGroup';
+
+type ConditionGroupsFn = (
+  parent: unknown,
+  args: Record<string, unknown>,
+  ctx: unknown,
+  info: unknown
+) => Promise<unknown>;
+const run = conditionGroups as unknown as ConditionGroupsFn;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.conditionGroup.findMany.mockResolvedValue([]);
+  mockPrisma.conditionGroup.count.mockResolvedValue(0);
+});
+
+describe('conditionGroups groupIds filter', () => {
+  it('restricts by primary key when groupIds is provided', async () => {
+    await run({}, { filter: { groupIds: [1, 2, 3] } }, {}, {});
+
+    const where = mockPrisma.conditionGroup.findMany.mock.calls[0][0].where;
+    expect(where.id).toEqual({ in: [1, 2, 3] });
+  });
+
+  it('does not add an id filter when groupIds is absent or empty', async () => {
+    await run({}, {}, {}, {});
+    expect(
+      mockPrisma.conditionGroup.findMany.mock.calls[0][0].where.id
+    ).toBeUndefined();
+
+    await run({}, { filter: { groupIds: [] } }, {}, {});
+    expect(
+      mockPrisma.conditionGroup.findMany.mock.calls[1][0].where.id
+    ).toBeUndefined();
+  });
+
+  it('combines groupIds with other filters', async () => {
+    await run({}, { filter: { groupIds: [7], search: 'cup' } }, {}, {});
+
+    const where = mockPrisma.conditionGroup.findMany.mock.calls[0][0].where;
+    expect(where.id).toEqual({ in: [7] });
+    expect(where.name).toEqual({ contains: 'cup', mode: 'insensitive' });
+  });
+});

--- a/packages/api/src/graphql/v2/resolvers/queries/conditionGroup.ts
+++ b/packages/api/src/graphql/v2/resolvers/queries/conditionGroup.ts
@@ -52,6 +52,11 @@ export const conditionGroups: NonNullable<
   if (args.filter?.search?.trim()) {
     where.name = { contains: args.filter.search.trim(), mode: 'insensitive' };
   }
+  // Batch-by-id lookup (markets-by-id hydration): `groupId` is the group's
+  // numeric domain id, which is the `ConditionGroup` table primary key.
+  if (args.filter?.groupIds?.length) {
+    where.id = { in: args.filter.groupIds };
+  }
 
   const usesOffset =
     field === 'totalOpenInterest' || field === 'totalPredictionCount';

--- a/packages/api/src/graphql/v2/schema/schema.graphql
+++ b/packages/api/src/graphql/v2/schema/schema.graphql
@@ -155,18 +155,24 @@ type Account implements Node & AddressEntity {
   """
   stats: AccountStat!
 
-  # DEFERRED — not built yet: the rest of the account stats surface beyond
-  # `stats.totalVolume` (which ships, G6): PnL/accuracy fields on
-  # `AccountStat`, and
-  #   statsHistory(first, after, filter): AccountStatConnection!
-  # That series is the "return on deployed" (trading-performance) home — the
-  # same cumulative-PnL numerator a vault plots against total assets, but
-  # measured against the account's deployed capital (collateral in open
-  # positions). Big lift: no per-account time-series source exists today
-  # (accountStats.ts produces only a windowed leaderboard aggregate, not a
-  # bucketed series), and per-account deployed-collateral-over-time isn't
-  # tracked at all — it would need a new per-account snapshot writer + table.
-  # No consumer yet.
+  """
+  Time-bucketed series of this account's prediction activity — deployed /
+  claimable collateral, trade volume, settlement PnL (per-bucket and
+  running), and prediction win / loss / pending / non-decisive counts.
+  Computed live from escrow predictions, legacy positions, claims, closes,
+  and secondary trades (no snapshot table), so — unlike the chain-scoped
+  identity fields — the series spans the address across chains. `interval`
+  sets the bucket size; `filter.timestamp` (epoch seconds, inclusive) bounds
+  the window and defaults to the last 90 days. The window is bounded per
+  interval (≤365 daily buckets), so the default page returns the whole
+  series in one shot while still honouring `first` / `after`.
+  """
+  statsHistory(
+    interval: TimeInterval!
+    first: Int = 366
+    after: String
+    filter: AccountStatFilter
+  ): AccountStatPointConnection!
 }
 
 """
@@ -179,6 +185,91 @@ type AccountStat {
   Cumulative trade volume across all of this account's activity, wei.
   """
   totalVolume: BigInt!
+}
+
+"""
+Bucketing granularity for `Account.statsHistory`. Unlike `Vault.statsHistory`
+(a fixed daily snapshot cadence written by the stats worker), the account
+series is computed live per request, so the caller picks the bucket size.
+"""
+enum TimeInterval {
+  HOUR
+  DAY
+  WEEK
+  MONTH
+}
+
+"""
+One time bucket of an account's prediction activity. Amounts are wUSDe wei
+and `timestamp` is the bucket's start (epoch seconds). The field vocabulary
+deliberately mirrors `VaultStat` — `deployedCollateral`, `realizedPnl`,
+`cumulativePnl` carry the same meaning at the account level. PnL is truncated
+toward zero to integer wei (the proportional cost-basis math can produce
+sub-wei fractions).
+"""
+type AccountStatPoint {
+  timestamp: UnixSeconds!
+
+  """
+  Collateral staked in positions still open as of the bucket — created on or
+  before the boundary and not yet settled. The deployed leg of the account's
+  escrow balance; mirrors `VaultStat.deployedCollateral`.
+  """
+  deployedCollateral: BigInt!
+
+  """
+  Settled-and-won but not-yet-redeemed collateral owed to the account as of
+  the bucket — the account analog of `VaultStat.unredeemedClaim`.
+  """
+  claimableCollateral: BigInt!
+
+  """
+  Trade volume attributed to the bucket: predictor + counterparty stake on
+  predictions created in-window, plus secondary-market trades.
+  """
+  volume: BigInt!
+
+  """
+  Settlement PnL realized within the bucket (gains − losses on positions that
+  settled in-window). Mirrors `VaultStat.realizedPnl`.
+  """
+  realizedPnl: BigInt!
+
+  """
+  Running settlement PnL through the end of the bucket. Mirrors
+  `VaultStat.cumulativePnl`.
+  """
+  cumulativePnl: BigInt!
+
+  """
+  Predictions created in the bucket, across every outcome.
+  """
+  predictionsTotal: Int!
+  predictionsWon: Int!
+  predictionsLost: Int!
+  predictionsPending: Int!
+  predictionsNonDecisive: Int!
+}
+
+type AccountStatPointEdge {
+  cursor: String!
+  node: AccountStatPoint!
+}
+
+type AccountStatPointConnection {
+  edges: [AccountStatPointEdge!]!
+  nodes: [AccountStatPoint!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+"""
+Filter for `Account.statsHistory`. Mirrors `VaultStatFilter`: a `timestamp`
+window in epoch seconds (inclusive on both bounds), defaulting to the last
+90 days when omitted.
+"""
+input AccountStatFilter {
+  timestamp: IntRangeFilter
 }
 
 type AccountEdge {
@@ -284,11 +375,17 @@ type VaultStat {
   funds.
   """
   balance: BigInt!
-  """Collateral deployed into escrow (backing open positions)."""
+  """
+  Collateral deployed into escrow (backing open positions).
+  """
   deployedCollateral: BigInt!
-  """Liquid collateral not yet deployed to escrow. `balance + deployed` is AUM."""
+  """
+  Liquid collateral not yet deployed to escrow. `balance + deployed` is AUM.
+  """
   undeployedCollateral: BigInt!
-  """Settlement PnL: gross payouts to the vault minus its primary-creation collateral."""
+  """
+  Settlement PnL: gross payouts to the vault minus its primary-creation collateral.
+  """
   realizedPnl: BigInt!
   """
   Cumulative trading PnL the vault dashboard plots: settlement PnL, plus
@@ -329,7 +426,9 @@ type VaultStatConnection {
 }
 
 input VaultStatFilter {
-  """Snapshot timestamp window in epoch seconds (inclusive)."""
+  """
+  Snapshot timestamp window in epoch seconds (inclusive).
+  """
   timestamp: IntRangeFilter
 }
 
@@ -677,21 +776,37 @@ type Condition implements Node {
   value type. `0` when no similar-market signal is present.
   """
   similarMarketVolume: Float!
-  """Flat mirror of `similarMarket.volume1h`. `0` when no signal is present."""
+  """
+  Flat mirror of `similarMarket.volume1h`. `0` when no signal is present.
+  """
   similarMarketVolume1h: Float!
-  """Flat mirror of `similarMarket.volume4h`. `0` when no signal is present."""
+  """
+  Flat mirror of `similarMarket.volume4h`. `0` when no signal is present.
+  """
   similarMarketVolume4h: Float!
-  """Flat mirror of `similarMarket.volume24h`. `0` when no signal is present."""
+  """
+  Flat mirror of `similarMarket.volume24h`. `0` when no signal is present.
+  """
   similarMarketVolume24h: Float!
-  """Flat mirror of `similarMarket.volume7d`. `0` when no signal is present."""
+  """
+  Flat mirror of `similarMarket.volume7d`. `0` when no signal is present.
+  """
   similarMarketVolume7d: Float!
-  """Flat mirror of `similarMarket.volumeFiltered1h`. `0` when no signal is present."""
+  """
+  Flat mirror of `similarMarket.volumeFiltered1h`. `0` when no signal is present.
+  """
   similarMarketVolumeFiltered1h: Float!
-  """Flat mirror of `similarMarket.volumeFiltered4h`. `0` when no signal is present."""
+  """
+  Flat mirror of `similarMarket.volumeFiltered4h`. `0` when no signal is present.
+  """
   similarMarketVolumeFiltered4h: Float!
-  """Flat mirror of `similarMarket.volumeFiltered24h`. `0` when no signal is present."""
+  """
+  Flat mirror of `similarMarket.volumeFiltered24h`. `0` when no signal is present.
+  """
   similarMarketVolumeFiltered24h: Float!
-  """Flat mirror of `similarMarket.volumeFiltered7d`. `0` when no signal is present."""
+  """
+  Flat mirror of `similarMarket.volumeFiltered7d`. `0` when no signal is present.
+  """
   similarMarketVolumeFiltered7d: Float!
 }
 
@@ -886,6 +1001,12 @@ input ConditionGroupFilter {
   Substring search against `name`, case-insensitive.
   """
   search: String
+  """
+  Restrict to condition groups whose numeric `groupId` is in this set — the
+  batch-by-id lookup the markets-by-id hydration path uses. OR within the
+  set, AND with the other filters.
+  """
+  groupIds: [Int!]
 }
 
 enum ConditionGroupOrderField {
@@ -1593,7 +1714,9 @@ type Ranking {
   fails loudly if the server ever rescales.
   """
   accuracy: Float
-  """Net profit/loss in wUSDe wei (signed). Populated for `PNL`."""
+  """
+  Net profit/loss in wUSDe wei (signed). Populated for `PNL`.
+  """
   pnl: BigInt
   """
   `pnl` pre-scaled to a v1-shaped decimal string via `formatUnits(pnl, 18)`
@@ -1601,9 +1724,13 @@ type Ranking {
   themselves. `"0"` when `pnl` is null (non-`PNL` rankings).
   """
   pnlFormatted: String!
-  """Total trade volume in wUSDe wei. Populated for `VOLUME`."""
+  """
+  Total trade volume in wUSDe wei. Populated for `VOLUME`.
+  """
   volume: BigInt
-  """PnL / volume ratio. Populated for `ROI`."""
+  """
+  PnL / volume ratio. Populated for `ROI`.
+  """
   roi: Float
 }
 
@@ -2091,11 +2218,7 @@ type Query {
   with `first: 20` — the canonical "popular tags" feed. Sort by `NAME`
   for an alphabetical browse.
   """
-  tags(
-    first: Int = 20
-    after: String
-    orderBy: TagOrder
-  ): TagConnection!
+  tags(first: Int = 20, after: String, orderBy: TagOrder): TagConnection!
 
   """
   Interleaved Prediction + Trade activity feed, sorted by timestamp DESC.

--- a/packages/api/src/graphql/v2/schema/schema.graphql
+++ b/packages/api/src/graphql/v2/schema/schema.graphql
@@ -241,10 +241,13 @@ type AccountStatPoint {
   realizedPnl: BigInt!
 
   """
-  Running trading PnL through the end of the bucket — the cumulative sum of
-  `realizedPnl`, seeded by all PnL realized *before* the window so the line
-  never resets at the window start. The account analog of
-  `VaultStat.cumulativePnl`.
+  Running trading PnL through the end of the bucket: the cumulative sum of
+  `realizedPnl` (seeded by all PnL realized *before* the window, so the line
+  never resets at the window start), plus the net winnings on positions that
+  have settled in the account's favour but are not yet redeemed
+  (`claimableCollateral` minus the stake on those wins). That unredeemed mark
+  makes a resolved win show up at resolution rather than waiting for redemption
+  — the account analog of `VaultStat.cumulativePnl`.
   """
   cumulativePnl: BigInt!
 

--- a/packages/api/src/graphql/v2/schema/schema.graphql
+++ b/packages/api/src/graphql/v2/schema/schema.graphql
@@ -161,11 +161,14 @@ type Account implements Node & AddressEntity {
   running), and prediction win / loss / pending / non-decisive counts.
   Computed live from escrow predictions, legacy positions, claims, closes,
   and secondary trades (no snapshot table), so — unlike the chain-scoped
-  identity fields — the series spans the address across chains. `interval`
+  identity fields — the series spans the address across chains. Buckets are
+  ordered oldest-first (ascending `timestamp`), ready to plot. `interval`
   sets the bucket size; `filter.timestamp` (epoch seconds, inclusive) bounds
-  the window and defaults to the last 90 days. The window is bounded per
-  interval (≤365 daily buckets), so the default page returns the whole
-  series in one shot while still honouring `first` / `after`.
+  the window. With no filter the window defaults to the last 90 days, clamped
+  to the interval's own cap so it never overflows — e.g. `HOUR` caps at 168
+  buckets, so its default is the last 7 days (an explicit wider window is
+  rejected). The defaulted window fits one page, so the default returns the
+  whole series in one shot while still honouring `first` / `after`.
   """
   statsHistory(
     interval: TimeInterval!
@@ -219,7 +222,7 @@ type AccountStatPoint {
 
   """
   Settled-and-won but not-yet-redeemed collateral owed to the account as of
-  the bucket — the account analog of `VaultStat.unredeemedClaim`.
+  the bucket — the account analog of `VaultStat.claimableCollateral`.
   """
   claimableCollateral: BigInt!
 
@@ -230,24 +233,41 @@ type AccountStatPoint {
   volume: BigInt!
 
   """
-  Settlement PnL realized within the bucket (gains − losses on positions that
-  settled in-window). Mirrors `VaultStat.realizedPnl`.
+  PnL realized within the bucket: settlement gains − losses on positions that
+  settled in-window, plus secondary-market sale proceeds net of purchase cost
+  (`sold − bought`) on trades executed in-window. Same trading-PnL definition
+  the vault plots in `VaultStat.cumulativePnl`, measured per-bucket.
   """
   realizedPnl: BigInt!
 
   """
-  Running settlement PnL through the end of the bucket. Mirrors
+  Running trading PnL through the end of the bucket — the cumulative sum of
+  `realizedPnl`, seeded by all PnL realized *before* the window so the line
+  never resets at the window start. The account analog of
   `VaultStat.cumulativePnl`.
   """
   cumulativePnl: BigInt!
 
   """
-  Predictions created in the bucket, across every outcome.
+  Predictions created in the bucket, across every outcome. Equals
+  `predictionsWon + predictionsLost + predictionsPending +
+  predictionsNonDecisive`.
   """
   predictionsTotal: Int!
+
+  """
+  Of the bucket's predictions, those that have since settled in the account's
+  favor. Counts are bucketed by creation time but reflect each prediction's
+  *current* settlement status, so a past bucket's won / lost / pending split
+  shifts as its predictions resolve (the series is computed live, not
+  snapshotted).
+  """
   predictionsWon: Int!
+  """Bucket predictions that have since settled against the account."""
   predictionsLost: Int!
+  """Bucket predictions not yet settled."""
   predictionsPending: Int!
+  """Bucket predictions that settled non-decisively (no winning side)."""
   predictionsNonDecisive: Int!
 }
 
@@ -353,8 +373,9 @@ type Vault implements Node {
   stats: VaultStat
 
   """
-  Time-series of this vault's economic snapshots, newest first. Backs the
-  vault dashboard's TVL / PnL charts. Defaults to `TIMESTAMP DESC`.
+  Time-series of this vault's economic snapshots, oldest-first (ascending
+  `timestamp`, matching `Account.statsHistory` — chart-ready, no consumer
+  re-sort). Backs the vault dashboard's TVL / PnL charts.
   """
   statsHistory(
     first: Int = 30
@@ -390,7 +411,7 @@ type VaultStat {
   """
   Cumulative trading PnL the vault dashboard plots: settlement PnL, plus
   wUSDe earmarked from resolved-but-unredeemed wins, plus net secondary-
-  market flow (`realizedPnl + unredeemedClaim + secondarySold −
+  market flow (`realizedPnl + claimableCollateral + secondarySold −
   secondaryBought`). This is the *same* numerator the account behind the
   vault carries; the vault presents it as a return on total assets
   (`balance + deployedCollateral`), where the account measures it against
@@ -408,9 +429,10 @@ type VaultStat {
   wUSDe owed to the vault on resolved-but-not-yet-redeemed winning sides,
   net of what it has already claimed. The dashboard's TVL line adds this to
   `balance + deployedCollateral` so funds that have settled in the vault's
-  favor but await an indexed redeem are not transiently dropped.
+  favor but await an indexed redeem are not transiently dropped. Named to
+  match `AccountStatPoint.claimableCollateral`, the account-level analog.
   """
-  unredeemedClaim: BigInt!
+  claimableCollateral: BigInt!
 }
 
 type VaultStatEdge {

--- a/packages/api/src/graphql/v2/schema/schema.graphql
+++ b/packages/api/src/graphql/v2/schema/schema.graphql
@@ -223,6 +223,12 @@ type AccountStatPoint {
   """
   Settled-and-won but not-yet-redeemed collateral owed to the account as of
   the bucket — the account analog of `VaultStat.claimableCollateral`.
+
+  This is a *pending-balance* figure, deliberately NOT part of `cumulativePnl`
+  (see there). It is attributed to the original position side and does not
+  follow secondary-market transfers, so after a winning position token is sold
+  pre-redemption it still reads against the seller until redeemed. Safe for the
+  "pending claims" view; not used to realize PnL precisely for that reason.
   """
   claimableCollateral: BigInt!
 
@@ -233,21 +239,31 @@ type AccountStatPoint {
   volume: BigInt!
 
   """
-  PnL realized within the bucket: settlement gains − losses on positions that
-  settled in-window, plus secondary-market sale proceeds net of purchase cost
-  (`sold − bought`) on trades executed in-window. Same trading-PnL definition
-  the vault plots in `VaultStat.cumulativePnl`, measured per-bucket.
+  PnL realized within the bucket — the per-bucket increment of `cumulativePnl`
+  (see there for exactly when PnL realizes): redemption gains on wins claimed
+  in-window, losses/non-decisive at settlement, and secondary-market proceeds
+  net of cost (`sold − bought`) on trades executed in-window. Same trading-PnL
+  definition the vault plots, measured per-bucket.
   """
   realizedPnl: BigInt!
 
   """
   Running trading PnL through the end of the bucket: the cumulative sum of
-  `realizedPnl` (seeded by all PnL realized *before* the window, so the line
-  never resets at the window start), plus the net winnings on positions that
-  have settled in the account's favour but are not yet redeemed
-  (`claimableCollateral` minus the stake on those wins). That unredeemed mark
-  makes a resolved win show up at resolution rather than waiting for redemption
-  — the account analog of `VaultStat.cumulativePnl`.
+  `realizedPnl`, seeded by all PnL realized *before* the window so the line
+  never resets at the window start.
+
+  PnL is realized only when a position is actually settled — a win at the
+  moment it is *redeemed* (a claim), a loss/non-decisive at settlement, plus
+  secondary-market proceeds and cost as they trade. It is NOT marked from
+  still-unredeemed `claimableCollateral`. This is deliberate: a redemption
+  records the true holder, so a win is credited to whoever actually collects
+  it. If a winning position token is sold before redemption, the seller simply
+  keeps their sale proceeds and the buyer realizes the win on redeeming — no
+  prize is ever credited to someone who no longer holds the token. The cost is
+  cosmetic: a resolved-but-unredeemed win contributes nothing until it is
+  claimed (the line steps up at redemption rather than at resolution).
+
+  Matches `VaultStat.cumulativePnl`, which realizes the same way.
   """
   cumulativePnl: BigInt!
 
@@ -412,14 +428,17 @@ type VaultStat {
   """
   realizedPnl: BigInt!
   """
-  Cumulative trading PnL the vault dashboard plots: settlement PnL, plus
-  wUSDe earmarked from resolved-but-unredeemed wins, plus net secondary-
-  market flow (`realizedPnl + claimableCollateral + secondarySold −
-  secondaryBought`). This is the *same* numerator the account behind the
-  vault carries; the vault presents it as a return on total assets
-  (`balance + deployedCollateral`), where the account measures it against
-  deployed capital. The unredeemed term cancels the transient phantom loss
-  between a position resolving and its redeem being indexed.
+  Cumulative trading PnL the vault dashboard plots: settlement PnL plus net
+  secondary-market flow (`realizedPnl + secondarySold − secondaryBought`).
+
+  PnL realizes only when a position is actually redeemed/settled — it is NOT
+  marked from still-unredeemed `claimableCollateral` (that term used to be
+  added here and has been removed). This keeps the line correct when a winning
+  token is sold before redemption: the redeemer collects the prize, so it is
+  never credited to whoever merely minted the position. Realizes the same way
+  as `AccountStatPoint.cumulativePnl`. Trade-off: a resolved-but-unredeemed win
+  is not marked until it is claimed — the line steps up at redemption rather
+  than at resolution, which can read as a brief paper dip in between.
   """
   cumulativePnl: BigInt!
   deposits: BigInt!
@@ -432,8 +451,10 @@ type VaultStat {
   wUSDe owed to the vault on resolved-but-not-yet-redeemed winning sides,
   net of what it has already claimed. The dashboard's TVL line adds this to
   `balance + deployedCollateral` so funds that have settled in the vault's
-  favor but await an indexed redeem are not transiently dropped. Named to
-  match `AccountStatPoint.claimableCollateral`, the account-level analog.
+  favor but await an indexed redeem are not transiently dropped. A
+  pending-balance figure for TVL only — deliberately NOT part of
+  `cumulativePnl` (PnL realizes at redemption). Named to match
+  `AccountStatPoint.claimableCollateral`, the account-level analog.
   """
   claimableCollateral: BigInt!
 }

--- a/packages/api/src/graphql/v2/schema/schema.graphql
+++ b/packages/api/src/graphql/v2/schema/schema.graphql
@@ -263,7 +263,17 @@ type AccountStatPoint {
   cosmetic: a resolved-but-unredeemed win contributes nothing until it is
   claimed (the line steps up at redemption rather than at resolution).
 
+  Secondary sales also book the seller's allocated mint cost basis
+  (`stake × tokensSold / minted`), so a seller who never redeems still has
+  their stake deducted and combined PnL across buyer + seller conserves.
+
   Matches `VaultStat.cumulativePnl`, which realizes the same way.
+
+  Known approximations (tracked for a planned PnL rework to a single cash-flow +
+  token-ledger model): (1) basis allocation assumes sold tokens were minted ones
+  when an address both mints and buys the same token; (2) a loss is recognized
+  at its settlement/redemption event, so a position that simply expires
+  worthless without an on-chain burn may book its loss late.
   """
   cumulativePnl: BigInt!
 

--- a/packages/api/src/services/timeSeriesQueries.balance.integration.test.ts
+++ b/packages/api/src/services/timeSeriesQueries.balance.integration.test.ts
@@ -33,9 +33,6 @@ const SCHEMA = `bal_it_${process.pid}_${Date.now()}`;
 const HOLDER_REDEEMS = '0xaaaa000000000000000000000000000000000001';
 // Predictor whose only claim is on the OTHER side — claimable must persist.
 const HOLDER_OTHER_SIDE = '0xbbbb000000000000000000000000000000000002';
-// Predictor with a real net win (stake 20, claimable 100) for the
-// unredeemed-net-gain (PnL mark) assertions.
-const HOLDER_WIN = '0xcccc000000000000000000000000000000000003';
 
 // Minimal slices of the tables queryAccountBalance touches. `position` (the V1
 // legacy table) exists only so the all_deployed UNION branch resolves; it stays
@@ -93,8 +90,7 @@ let dbAvailable = false;
     await client.$executeRawUnsafe(
       `INSERT INTO "Picks" (id, "predictorToken", "counterpartyToken") VALUES
          ('pcA', 'ptokA', 'ctokA'),
-         ('pcB', 'ptokB', 'ctokB'),
-         ('pcC', 'ptokC', 'ctokC')`
+         ('pcB', 'ptokB', 'ctokB')`
     );
 
     // Scenario A — predictor with 100 claimable on a position settled day(2),
@@ -131,24 +127,6 @@ let dbAvailable = false;
     await client.$executeRawUnsafe(
       `INSERT INTO "Claim" (holder, "pickConfigId", "positionToken", "redeemedAt")
        VALUES ('${HOLDER_OTHER_SIDE}', 'pcB', 'ctokB', ${day(4)})`
-    );
-
-    // Scenario C — a real net win. Stake 20, wins the 100 pot (claimable 100),
-    // settled day(1), redeemed day(4). Net unredeemed gain = 100 − 20 = 80
-    // while unredeemed, then 0 once redeemed; gross claimable stays 100 → 0.
-    await client.$executeRawUnsafe(
-      `INSERT INTO "Prediction"
-         ("predictionId", "pickConfigId", predictor, counterparty,
-          "predictorCollateral", "counterpartyCollateral",
-          "predictorClaimable", "counterpartyClaimable",
-          "onChainCreatedAt", "settledAt")
-       VALUES
-         ('pred-C', 'pcC', '${HOLDER_WIN}', '0xother',
-          '20', '80', '100', '0', ${day(1)}, ${day(1)})`
-    );
-    await client.$executeRawUnsafe(
-      `INSERT INTO "Claim" (holder, "pickConfigId", "positionToken", "redeemedAt")
-       VALUES ('${HOLDER_WIN}', 'pcC', 'ptokC', ${day(4)})`
     );
   }
 }
@@ -200,38 +178,6 @@ describe.skipIf(!dbAvailable)(
       expect(byDay.get(2)).toBe(50);
       expect(byDay.get(5)).toBe(50);
       expect(byDay.get(7)).toBe(50);
-    });
-
-    const netGainByDay = async (holder: string) => {
-      const points = await queryAccountBalance(
-        holder,
-        TimeInterval.DAY,
-        from,
-        to,
-        client
-      );
-      return new Map(
-        points.map((p) => [
-          new Date(p.timestamp * 1000).getUTCDate(),
-          Number(p.unredeemedNetGain),
-        ])
-      );
-    };
-
-    it('marks net unredeemed winnings (claimable − stake), and clears them on redeem', async () => {
-      const net = await netGainByDay(HOLDER_WIN);
-      // Settled day(1): net win = claimable 100 − stake 20 = 80, counted from
-      // the next bucket while unredeemed.
-      expect(net.get(2)).toBe(80);
-      expect(net.get(3)).toBe(80);
-      // Redeemed day(4): the realized claim takes over, so the mark clears.
-      expect(net.get(5)).toBe(0);
-      expect(net.get(7)).toBe(0);
-
-      // Gross claimable still tracks the full pot (100 → 0), unchanged.
-      const gross = await claimableByDay(HOLDER_WIN);
-      expect(gross.get(2)).toBe(100);
-      expect(gross.get(5)).toBe(0);
     });
   }
 );

--- a/packages/api/src/services/timeSeriesQueries.balance.integration.test.ts
+++ b/packages/api/src/services/timeSeriesQueries.balance.integration.test.ts
@@ -33,6 +33,9 @@ const SCHEMA = `bal_it_${process.pid}_${Date.now()}`;
 const HOLDER_REDEEMS = '0xaaaa000000000000000000000000000000000001';
 // Predictor whose only claim is on the OTHER side — claimable must persist.
 const HOLDER_OTHER_SIDE = '0xbbbb000000000000000000000000000000000002';
+// Predictor who redeems only PART of a winning side — claimable must decrement
+// by the redeemed amount, not drop to zero.
+const HOLDER_PARTIAL_CLAIM = '0xcccc000000000000000000000000000000000003';
 
 // Minimal slices of the tables queryAccountBalance touches. `position` (the V1
 // legacy table) exists only so the all_deployed UNION branch resolves; it stays
@@ -46,7 +49,7 @@ const DDL = `
     "predictorClaimable" text, "counterpartyClaimable" text,
     "onChainCreatedAt" integer, "settledAt" integer
   );
-  CREATE TABLE "Claim" (holder text, "pickConfigId" text, "positionToken" text, "redeemedAt" integer);
+  CREATE TABLE "Claim" (holder text, "pickConfigId" text, "positionToken" text, "redeemedAt" integer, "collateralPaid" text);
   CREATE TABLE "position" (
     predictor text, counterparty text, "predictorCollateral" text,
     "counterpartyCollateral" text, "mintedAt" integer, "settledAt" integer
@@ -90,7 +93,8 @@ let dbAvailable = false;
     await client.$executeRawUnsafe(
       `INSERT INTO "Picks" (id, "predictorToken", "counterpartyToken") VALUES
          ('pcA', 'ptokA', 'ctokA'),
-         ('pcB', 'ptokB', 'ctokB')`
+         ('pcB', 'ptokB', 'ctokB'),
+         ('pcC', 'ptokC', 'ctokC')`
     );
 
     // Scenario A — predictor with 100 claimable on a position settled day(2),
@@ -107,8 +111,8 @@ let dbAvailable = false;
           '100', '0', '100', '0', ${day(1)}, ${day(1)})`
     );
     await client.$executeRawUnsafe(
-      `INSERT INTO "Claim" (holder, "pickConfigId", "positionToken", "redeemedAt")
-       VALUES ('${HOLDER_REDEEMS}', 'pcA', 'ptokA', ${day(4)})`
+      `INSERT INTO "Claim" (holder, "pickConfigId", "positionToken", "redeemedAt", "collateralPaid")
+       VALUES ('${HOLDER_REDEEMS}', 'pcA', 'ptokA', ${day(4)}, '100')`
     );
 
     // Scenario B — predictor with 50 claimable on a position settled day(2),
@@ -125,8 +129,26 @@ let dbAvailable = false;
           '50', '0', '50', '0', ${day(1)}, ${day(1)})`
     );
     await client.$executeRawUnsafe(
-      `INSERT INTO "Claim" (holder, "pickConfigId", "positionToken", "redeemedAt")
-       VALUES ('${HOLDER_OTHER_SIDE}', 'pcB', 'ctokB', ${day(4)})`
+      `INSERT INTO "Claim" (holder, "pickConfigId", "positionToken", "redeemedAt", "collateralPaid")
+       VALUES ('${HOLDER_OTHER_SIDE}', 'pcB', 'ctokB', ${day(4)}, '50')`
+    );
+
+    // Scenario C — PARTIAL redemption. Predictor with 100 claimable settled
+    // day(1), redeems only 40 of it on day(4). Remaining claimable must read
+    // 100 through day(3) and 60 from day(5) — not 0.
+    await client.$executeRawUnsafe(
+      `INSERT INTO "Prediction"
+         ("predictionId", "pickConfigId", predictor, counterparty,
+          "predictorCollateral", "counterpartyCollateral",
+          "predictorClaimable", "counterpartyClaimable",
+          "onChainCreatedAt", "settledAt")
+       VALUES
+         ('pred-C', 'pcC', '${HOLDER_PARTIAL_CLAIM}', '0xother',
+          '100', '0', '100', '0', ${day(1)}, ${day(1)})`
+    );
+    await client.$executeRawUnsafe(
+      `INSERT INTO "Claim" (holder, "pickConfigId", "positionToken", "redeemedAt", "collateralPaid")
+       VALUES ('${HOLDER_PARTIAL_CLAIM}', 'pcC', 'ptokC', ${day(4)}, '40')`
     );
   }
 }
@@ -178,6 +200,17 @@ describe.skipIf(!dbAvailable)(
       expect(byDay.get(2)).toBe(50);
       expect(byDay.get(5)).toBe(50);
       expect(byDay.get(7)).toBe(50);
+    });
+
+    it('decrements by the redeemed amount on a partial redemption, not to zero', async () => {
+      const byDay = await claimableByDay(HOLDER_PARTIAL_CLAIM);
+
+      // 100 claimable, only 40 redeemed on day(4).
+      expect(byDay.get(2)).toBe(100);
+      expect(byDay.get(3)).toBe(100);
+      // From day(5): 100 − 40 = 60 (the all-or-nothing bug reported 0 here).
+      expect(byDay.get(5)).toBe(60);
+      expect(byDay.get(7)).toBe(60);
     });
   }
 );

--- a/packages/api/src/services/timeSeriesQueries.balance.integration.test.ts
+++ b/packages/api/src/services/timeSeriesQueries.balance.integration.test.ts
@@ -33,6 +33,9 @@ const SCHEMA = `bal_it_${process.pid}_${Date.now()}`;
 const HOLDER_REDEEMS = '0xaaaa000000000000000000000000000000000001';
 // Predictor whose only claim is on the OTHER side — claimable must persist.
 const HOLDER_OTHER_SIDE = '0xbbbb000000000000000000000000000000000002';
+// Predictor with a real net win (stake 20, claimable 100) for the
+// unredeemed-net-gain (PnL mark) assertions.
+const HOLDER_WIN = '0xcccc000000000000000000000000000000000003';
 
 // Minimal slices of the tables queryAccountBalance touches. `position` (the V1
 // legacy table) exists only so the all_deployed UNION branch resolves; it stays
@@ -90,7 +93,8 @@ let dbAvailable = false;
     await client.$executeRawUnsafe(
       `INSERT INTO "Picks" (id, "predictorToken", "counterpartyToken") VALUES
          ('pcA', 'ptokA', 'ctokA'),
-         ('pcB', 'ptokB', 'ctokB')`
+         ('pcB', 'ptokB', 'ctokB'),
+         ('pcC', 'ptokC', 'ctokC')`
     );
 
     // Scenario A — predictor with 100 claimable on a position settled day(2),
@@ -127,6 +131,24 @@ let dbAvailable = false;
     await client.$executeRawUnsafe(
       `INSERT INTO "Claim" (holder, "pickConfigId", "positionToken", "redeemedAt")
        VALUES ('${HOLDER_OTHER_SIDE}', 'pcB', 'ctokB', ${day(4)})`
+    );
+
+    // Scenario C — a real net win. Stake 20, wins the 100 pot (claimable 100),
+    // settled day(1), redeemed day(4). Net unredeemed gain = 100 − 20 = 80
+    // while unredeemed, then 0 once redeemed; gross claimable stays 100 → 0.
+    await client.$executeRawUnsafe(
+      `INSERT INTO "Prediction"
+         ("predictionId", "pickConfigId", predictor, counterparty,
+          "predictorCollateral", "counterpartyCollateral",
+          "predictorClaimable", "counterpartyClaimable",
+          "onChainCreatedAt", "settledAt")
+       VALUES
+         ('pred-C', 'pcC', '${HOLDER_WIN}', '0xother',
+          '20', '80', '100', '0', ${day(1)}, ${day(1)})`
+    );
+    await client.$executeRawUnsafe(
+      `INSERT INTO "Claim" (holder, "pickConfigId", "positionToken", "redeemedAt")
+       VALUES ('${HOLDER_WIN}', 'pcC', 'ptokC', ${day(4)})`
     );
   }
 }
@@ -178,6 +200,38 @@ describe.skipIf(!dbAvailable)(
       expect(byDay.get(2)).toBe(50);
       expect(byDay.get(5)).toBe(50);
       expect(byDay.get(7)).toBe(50);
+    });
+
+    const netGainByDay = async (holder: string) => {
+      const points = await queryAccountBalance(
+        holder,
+        TimeInterval.DAY,
+        from,
+        to,
+        client
+      );
+      return new Map(
+        points.map((p) => [
+          new Date(p.timestamp * 1000).getUTCDate(),
+          Number(p.unredeemedNetGain),
+        ])
+      );
+    };
+
+    it('marks net unredeemed winnings (claimable − stake), and clears them on redeem', async () => {
+      const net = await netGainByDay(HOLDER_WIN);
+      // Settled day(1): net win = claimable 100 − stake 20 = 80, counted from
+      // the next bucket while unredeemed.
+      expect(net.get(2)).toBe(80);
+      expect(net.get(3)).toBe(80);
+      // Redeemed day(4): the realized claim takes over, so the mark clears.
+      expect(net.get(5)).toBe(0);
+      expect(net.get(7)).toBe(0);
+
+      // Gross claimable still tracks the full pot (100 → 0), unchanged.
+      const gross = await claimableByDay(HOLDER_WIN);
+      expect(gross.get(2)).toBe(100);
+      expect(gross.get(5)).toBe(0);
     });
   }
 );

--- a/packages/api/src/services/timeSeriesQueries.pnl.integration.test.ts
+++ b/packages/api/src/services/timeSeriesQueries.pnl.integration.test.ts
@@ -36,9 +36,16 @@ const DDL = `
   CREATE TABLE "Claim" (holder text, "redeemedAt" integer, "collateralPaid" text, "tokensBurned" text, "pickConfigId" text, "positionToken" text);
   CREATE TABLE "Close" ("burnedAt" integer, "predictorHolder" text, "predictorPayout" text, "predictorTokensBurned" text, "counterpartyHolder" text, "counterpartyPayout" text, "counterpartyTokensBurned" text);
   CREATE TABLE "position" (predictor text, "predictorWon" boolean, "totalCollateral" text, "predictorCollateral" text, counterparty text, "counterpartyCollateral" text, "settledAt" integer);
+  CREATE TABLE "secondary_trade" (buyer text, seller text, price text, "executedAt" integer);
 `;
 
 const day = (d: number) => Math.floor(Date.UTC(2026, 0, d, 12, 0, 0) / 1000);
+// A timestamp before the test window (window starts 2026-01-01), for the
+// cumulative-baseline scenario.
+const preWindow = Math.floor(Date.UTC(2025, 11, 20, 12, 0, 0) / 1000);
+
+const HOLDER_SECONDARY = '0xdddd000000000000000000000000000000000004';
+const HOLDER_BASELINE = '0xeeee000000000000000000000000000000000005';
 
 // ── Setup runs at top-level await so `dbAvailable` is known before `describe`
 //    is evaluated (vitest resolves describe.skipIf at collection time). ──
@@ -124,6 +131,25 @@ let dbAvailable = false;
       `INSERT INTO "Claim" (holder, "redeemedAt", "collateralPaid", "tokensBurned", "pickConfigId", "positionToken") VALUES
          ('${HOLDER_PARTIAL}', ${day(2)}, '60', '50', 'pcC', 'ptokC')`
     );
+
+    // Scenario D — secondary-market PnL. Buys tokens for 40 (day 2, cost) then
+    // sells for 100 (day 3, proceeds). Realized pnl = -40 then +100; the
+    // settlement-only branches book nothing for this holder.
+    await client.$executeRawUnsafe(
+      `INSERT INTO "secondary_trade" (buyer, seller, price, "executedAt") VALUES
+         ('${HOLDER_SECONDARY}', '0xother', '40',  ${day(2)}),
+         ('0xother', '${HOLDER_SECONDARY}', '100', ${day(3)})`
+    );
+
+    // Scenario E — cumulative baseline. A sale of 30 settles BEFORE the window
+    // (Dec 2025); a sale of 20 settles in-window (day 3). The in-window per-
+    // bucket pnl must show only 20, but cumulativePnl must run from the 30
+    // baseline → 50, proving the line doesn't reset at the window start.
+    await client.$executeRawUnsafe(
+      `INSERT INTO "secondary_trade" (buyer, seller, price, "executedAt") VALUES
+         ('0xother', '${HOLDER_BASELINE}', '30', ${preWindow}),
+         ('0xother', '${HOLDER_BASELINE}', '20', ${day(3)})`
+    );
   }
 }
 
@@ -192,5 +218,45 @@ describe.skipIf(!dbAvailable)('queryAccountPnl (integration: real SQL)', () => {
     // basis = stake(20) * 50/100 = 10 → pnl = 60 - 10 = 50.
     // (total-burned denominator would give 60 - 20*50/50 = 40.)
     expect(nonzero).toEqual([50]);
+  });
+
+  it('books secondary-market trades as cash flow (buy = cost, sell = proceeds)', async () => {
+    const points = await queryAccountPnl(
+      HOLDER_SECONDARY,
+      TimeInterval.DAY,
+      from,
+      to,
+      client
+    );
+
+    const nonzero = points
+      .filter((p) => Number(p.pnl) !== 0)
+      .map((p) => Number(p.pnl));
+
+    // buy 40 → -40 ; sell 100 → +100
+    expect(nonzero).toEqual([-40, 100]);
+    expect(Number(points[points.length - 1].cumulativePnl)).toBe(60);
+  });
+
+  it('seeds cumulativePnl from PnL realized before the window (no reset at the start)', async () => {
+    const points = await queryAccountPnl(
+      HOLDER_BASELINE,
+      TimeInterval.DAY,
+      from,
+      to,
+      client
+    );
+
+    // Per-bucket pnl is window-local: only the in-window sale of 20 shows up;
+    // the pre-window sale of 30 contributes to no bucket.
+    const inWindow = points
+      .filter((p) => Number(p.pnl) !== 0)
+      .map((p) => Number(p.pnl));
+    expect(inWindow).toEqual([20]);
+
+    // But the running line starts from the 30 baseline, so every bucket — and
+    // the final value — reflects 30 + 20 = 50.
+    expect(Number(points[0].cumulativePnl)).toBe(30);
+    expect(Number(points[points.length - 1].cumulativePnl)).toBe(50);
   });
 });

--- a/packages/api/src/services/timeSeriesQueries.pnl.integration.test.ts
+++ b/packages/api/src/services/timeSeriesQueries.pnl.integration.test.ts
@@ -36,7 +36,7 @@ const DDL = `
   CREATE TABLE "Claim" (holder text, "redeemedAt" integer, "collateralPaid" text, "tokensBurned" text, "pickConfigId" text, "positionToken" text);
   CREATE TABLE "Close" ("burnedAt" integer, "predictorHolder" text, "predictorPayout" text, "predictorTokensBurned" text, "counterpartyHolder" text, "counterpartyPayout" text, "counterpartyTokensBurned" text);
   CREATE TABLE "position" (predictor text, "predictorWon" boolean, "totalCollateral" text, "predictorCollateral" text, counterparty text, "counterpartyCollateral" text, "settledAt" integer);
-  CREATE TABLE "secondary_trade" (buyer text, seller text, price text, "executedAt" integer);
+  CREATE TABLE "secondary_trade" (buyer text, seller text, price text, token text, "tokenAmount" text, "executedAt" integer);
 `;
 
 const day = (d: number) => Math.floor(Date.UTC(2026, 0, d, 12, 0, 0) / 1000);
@@ -46,6 +46,9 @@ const preWindow = Math.floor(Date.UTC(2025, 11, 20, 12, 0, 0) / 1000);
 
 const HOLDER_SECONDARY = '0xdddd000000000000000000000000000000000004';
 const HOLDER_BASELINE = '0xeeee000000000000000000000000000000000005';
+// A mints a winning side then sells it to B before B redeems.
+const HOLDER_SELLER = '0xffff000000000000000000000000000000000006';
+const HOLDER_BUYER = '0x1111000000000000000000000000000000000007';
 
 // ── Setup runs at top-level await so `dbAvailable` is known before `describe`
 //    is evaluated (vitest resolves describe.skipIf at collection time). ──
@@ -149,6 +152,29 @@ let dbAvailable = false;
       `INSERT INTO "secondary_trade" (buyer, seller, price, "executedAt") VALUES
          ('0xother', '${HOLDER_BASELINE}', '30', ${preWindow}),
          ('0xother', '${HOLDER_BASELINE}', '20', ${day(3)})`
+    );
+
+    // Scenario F — mint basis on a secondary SALE. A mints the predictor side
+    // (stake 20, minted 100 tokens) of pcF, then sells all 100 tokens to B for
+    // 60 on day(2), before B redeems for 100 on day(3). A never claims, so the
+    // only place A's 20 stake can be booked is the sale: basis = 20 * 100/100.
+    //   A: +60 sale − 20 basis              = +40
+    //   B: −60 buy + 100 redeem (no basis)  = +40   (B isn't the minter)
+    // Combined +80 (conserves); without the basis term A would read +60.
+    await client.$executeRawUnsafe(
+      `INSERT INTO "Picks" (id, "predictorToken", "counterpartyToken") VALUES ('pcF', 'ptokF', 'ctokF')`
+    );
+    await client.$executeRawUnsafe(
+      `INSERT INTO "Prediction" ("pickConfigId", predictor, "predictorCollateral", counterparty, "counterpartyCollateral")
+       VALUES ('pcF', '${HOLDER_SELLER}', '20', '0xother', '80')`
+    );
+    await client.$executeRawUnsafe(
+      `INSERT INTO "secondary_trade" (buyer, seller, price, token, "tokenAmount", "executedAt")
+       VALUES ('${HOLDER_BUYER}', '${HOLDER_SELLER}', '60', 'ptokF', '100', ${day(2)})`
+    );
+    await client.$executeRawUnsafe(
+      `INSERT INTO "Claim" (holder, "redeemedAt", "collateralPaid", "tokensBurned", "pickConfigId", "positionToken")
+       VALUES ('${HOLDER_BUYER}', ${day(3)}, '100', '100', 'pcF', 'ptokF')`
     );
   }
 }
@@ -258,5 +284,33 @@ describe.skipIf(!dbAvailable)('queryAccountPnl (integration: real SQL)', () => {
     // the final value — reflects 30 + 20 = 50.
     expect(Number(points[0].cumulativePnl)).toBe(30);
     expect(Number(points[points.length - 1].cumulativePnl)).toBe(50);
+  });
+
+  it('books mint basis on a secondary sale, so a seller who never redeems is not overstated', async () => {
+    const seller = await queryAccountPnl(
+      HOLDER_SELLER,
+      TimeInterval.DAY,
+      from,
+      to,
+      client
+    );
+    const buyer = await queryAccountPnl(
+      HOLDER_BUYER,
+      TimeInterval.DAY,
+      from,
+      to,
+      client
+    );
+
+    // Seller: +60 sale − 20 mint basis (20 * 100/100) = 40. Without the basis
+    // term this would read 60 (the pre-fix overstatement).
+    expect(Number(seller[seller.length - 1].cumulativePnl)).toBe(40);
+    // Buyer: −60 purchase + 100 redemption (no mint basis — not the minter) = 40.
+    expect(Number(buyer[buyer.length - 1].cumulativePnl)).toBe(40);
+    // Combined PnL conserves at +80 (true economic total).
+    expect(
+      Number(seller[seller.length - 1].cumulativePnl) +
+        Number(buyer[buyer.length - 1].cumulativePnl)
+    ).toBe(80);
   });
 });

--- a/packages/api/src/services/timeSeriesQueries.test.ts
+++ b/packages/api/src/services/timeSeriesQueries.test.ts
@@ -53,6 +53,15 @@ describe('resolveDefaults', () => {
     expect(result.toEpoch - result.fromEpoch).toBeCloseTo(ninetyDays, -2);
   });
 
+  it('clamps the default window per interval so an unfiltered HOUR request does not throw', () => {
+    // 90 days of hourly buckets (2160) would blow the 168 cap; the default
+    // window must clamp to the interval's max span (7 days) instead.
+    expect(() => resolveDefaults(TimeInterval.HOUR)).not.toThrow();
+    const result = resolveDefaults(TimeInterval.HOUR);
+    const sevenDays = 7 * 24 * 60 * 60;
+    expect(result.toEpoch - result.fromEpoch).toBeCloseTo(sevenDays, -2);
+  });
+
   it('respects explicit from and to dates', () => {
     const from = new Date('2024-01-01T00:00:00Z');
     const to = new Date('2024-01-31T00:00:00Z');

--- a/packages/api/src/services/timeSeriesQueries.ts
+++ b/packages/api/src/services/timeSeriesQueries.ts
@@ -98,6 +98,7 @@ interface BalanceRow {
   timestamp: bigint;
   deployed_collateral: string;
   claimable_collateral: string;
+  unredeemed_net_gain: string;
 }
 
 interface PredictionCountRow {
@@ -408,6 +409,13 @@ export async function queryAccountBalance(
              WHEN p.counterparty = ${addr}
              THEN CAST(COALESCE(p."counterpartyClaimable", '0') AS DECIMAL)
              ELSE 0 END AS claimable,
+        -- The holder's own stake on this side, so the PnL line can mark the
+        -- *net* win (claimable − stake) without re-counting the returned stake.
+        CASE WHEN p.predictor = ${addr}
+             THEN CAST(COALESCE(p."predictorCollateral", '0') AS DECIMAL)
+             WHEN p.counterparty = ${addr}
+             THEN CAST(COALESCE(p."counterpartyCollateral", '0') AS DECIMAL)
+             ELSE 0 END AS own_stake,
         p."pickConfigId" AS pick_config_id,
         CASE WHEN p.predictor = ${addr} THEN 'predictor'
              WHEN p.counterparty = ${addr} THEN 'counterparty'
@@ -450,7 +458,23 @@ export async function queryAccountBalance(
               AND c.side = ac.side
               AND c."redeemedAt" <= b.bucket_epoch
           )
-      ), 0)::TEXT AS claimable_collateral
+      ), 0)::TEXT AS claimable_collateral,
+      -- Net winnings (claimable − own stake) on settled-won, not-yet-redeemed
+      -- positions — wins only (claimable > 0), so a settled loss never books a
+      -- negative here (its −stake belongs to realized settlement, not this
+      -- mark). Same not-yet-redeemed set as claimable_collateral above.
+      COALESCE((
+        SELECT SUM(ac.claimable - ac.own_stake)
+        FROM all_claimable ac
+        WHERE ac.settled_ts <= b.bucket_epoch
+          AND ac.claimable > 0
+          AND NOT EXISTS (
+            SELECT 1 FROM account_claims c
+            WHERE c.pick_config_id = ac.pick_config_id
+              AND c.side = ac.side
+              AND c."redeemedAt" <= b.bucket_epoch
+          )
+      ), 0)::TEXT AS unredeemed_net_gain
     FROM buckets b
     ORDER BY b.bucket_epoch
   `;
@@ -459,6 +483,7 @@ export async function queryAccountBalance(
     timestamp: Number(row.timestamp),
     deployedCollateral: row.deployed_collateral || '0',
     claimableCollateral: row.claimable_collateral || '0',
+    unredeemedNetGain: row.unredeemed_net_gain || '0',
   }));
 }
 

--- a/packages/api/src/services/timeSeriesQueries.ts
+++ b/packages/api/src/services/timeSeriesQueries.ts
@@ -313,17 +313,47 @@ export async function queryAccountPnl(
         AND lp."settledAt" IS NOT NULL
         AND lp."settledAt" <= ${toEpoch}
       UNION ALL
-      -- Secondary-market trades: realized as pure cash flow — sale proceeds
-      -- when this account is the seller, purchase cost when it's the buyer.
-      -- Matches the vault's cumulativePnl convention (secondarySold −
-      -- secondaryBought, per services/protocolStats/vaultAggregator). buyer and
-      -- seller are distinct per trade, so the two CASE legs never both fire.
+      -- Secondary-market trades: sale proceeds when this account is the seller,
+      -- purchase cost when it's the buyer (buyer and seller are distinct per
+      -- trade, so those two legs never both fire).
+      --
+      -- When the seller SOLD tokens it originally minted, also book the mint
+      -- cost basis allocated to the sold tokens — stake × tokenAmount / minted,
+      -- the same proportional rule the Claim branch uses. Without this a seller
+      -- who never redeems never books their stake and overstates by it (their
+      -- mint cost only gets deducted in the Claim branch, which never fires for
+      -- a sold-off position). cs is NULL → basis 0 for buyers and for tokens
+      -- the seller didn't mint; the token → Picks side → claim_stake join is the
+      -- same identity mapping the Claim branch uses on positionToken.
+      --
+      -- FOLLOW-UP (PnL rework): this per-branch cost-basis patching is why the
+      -- model is hard to reason about. The durable fix is a single cash-flow +
+      -- token-ledger per address (mint −stake/+tokens, buy −price/+tokens, sell
+      -- +price/−tokens, redeem +payout/−tokens; PnL = Σcash + held×rate), which
+      -- dissolves these cases and makes holder attribution fall out for free.
       SELECT
         st."executedAt" AS event_ts,
         CASE WHEN st.seller = ${addr} THEN CAST(st.price AS DECIMAL) ELSE 0 END
           - CASE WHEN st.buyer = ${addr} THEN CAST(st.price AS DECIMAL) ELSE 0 END
-          AS pnl
+          - CASE
+              WHEN st.seller = ${addr}
+              THEN COALESCE(
+                     cs.stake
+                       * CAST(st."tokenAmount" AS DECIMAL)
+                       / NULLIF(cs.minted, 0),
+                     0
+                   )
+              ELSE 0
+            END AS pnl
       FROM secondary_trade st
+      LEFT JOIN "Picks" pk
+        ON st.token = pk."predictorToken" OR st.token = pk."counterpartyToken"
+      LEFT JOIN claim_stake cs
+        ON cs.pc = pk.id
+       AND cs.side = CASE
+             WHEN st.token = pk."predictorToken" THEN 'predictor'
+             WHEN st.token = pk."counterpartyToken" THEN 'counterparty'
+           END
       WHERE (st.buyer = ${addr} OR st.seller = ${addr})
         AND st."executedAt" <= ${toEpoch}
     ),

--- a/packages/api/src/services/timeSeriesQueries.ts
+++ b/packages/api/src/services/timeSeriesQueries.ts
@@ -98,7 +98,6 @@ interface BalanceRow {
   timestamp: bigint;
   deployed_collateral: string;
   claimable_collateral: string;
-  unredeemed_net_gain: string;
 }
 
 interface PredictionCountRow {
@@ -409,13 +408,6 @@ export async function queryAccountBalance(
              WHEN p.counterparty = ${addr}
              THEN CAST(COALESCE(p."counterpartyClaimable", '0') AS DECIMAL)
              ELSE 0 END AS claimable,
-        -- The holder's own stake on this side, so the PnL line can mark the
-        -- *net* win (claimable − stake) without re-counting the returned stake.
-        CASE WHEN p.predictor = ${addr}
-             THEN CAST(COALESCE(p."predictorCollateral", '0') AS DECIMAL)
-             WHEN p.counterparty = ${addr}
-             THEN CAST(COALESCE(p."counterpartyCollateral", '0') AS DECIMAL)
-             ELSE 0 END AS own_stake,
         p."pickConfigId" AS pick_config_id,
         CASE WHEN p.predictor = ${addr} THEN 'predictor'
              WHEN p.counterparty = ${addr} THEN 'counterparty'
@@ -458,23 +450,7 @@ export async function queryAccountBalance(
               AND c.side = ac.side
               AND c."redeemedAt" <= b.bucket_epoch
           )
-      ), 0)::TEXT AS claimable_collateral,
-      -- Net winnings (claimable − own stake) on settled-won, not-yet-redeemed
-      -- positions — wins only (claimable > 0), so a settled loss never books a
-      -- negative here (its −stake belongs to realized settlement, not this
-      -- mark). Same not-yet-redeemed set as claimable_collateral above.
-      COALESCE((
-        SELECT SUM(ac.claimable - ac.own_stake)
-        FROM all_claimable ac
-        WHERE ac.settled_ts <= b.bucket_epoch
-          AND ac.claimable > 0
-          AND NOT EXISTS (
-            SELECT 1 FROM account_claims c
-            WHERE c.pick_config_id = ac.pick_config_id
-              AND c.side = ac.side
-              AND c."redeemedAt" <= b.bucket_epoch
-          )
-      ), 0)::TEXT AS unredeemed_net_gain
+      ), 0)::TEXT AS claimable_collateral
     FROM buckets b
     ORDER BY b.bucket_epoch
   `;
@@ -483,7 +459,6 @@ export async function queryAccountBalance(
     timestamp: Number(row.timestamp),
     deployedCollateral: row.deployed_collateral || '0',
     claimableCollateral: row.claimable_collateral || '0',
-    unredeemedNetGain: row.unredeemed_net_gain || '0',
   }));
 }
 

--- a/packages/api/src/services/timeSeriesQueries.ts
+++ b/packages/api/src/services/timeSeriesQueries.ts
@@ -39,22 +39,32 @@ export function resolveDefaults(
 ): ResolvedRange {
   const now = new Date();
   const resolvedTo = to ?? now;
-  const resolvedFrom =
-    from ?? new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000);
 
   const pgTrunc = INTERVAL_TO_PG[interval];
   const pgStep = INTERVAL_TO_PG_STEP[interval];
 
-  // Estimate bucket count
-  const diffMs = resolvedTo.getTime() - resolvedFrom.getTime();
   const stepMs: Record<TimeInterval, number> = {
     [TimeInterval.HOUR]: 3_600_000,
     [TimeInterval.DAY]: 86_400_000,
     [TimeInterval.WEEK]: 604_800_000,
     [TimeInterval.MONTH]: 2_592_000_000, // ~30 days
   };
-  const bucketCount = Math.ceil(diffMs / stepMs[interval]);
   const max = MAX_BUCKETS[interval];
+
+  // Default window is 90 days, but never wider than the interval's bucket cap
+  // spans (HOUR caps at 168 buckets = 7 days). Without this an unfiltered
+  // `HOUR` request would default to 90 days = 2160 buckets and throw below;
+  // clamping the *default* keeps every interval usable with no explicit range,
+  // while an explicit over-wide `from`/`to` still trips the cap on purpose.
+  const defaultWindowMs = Math.min(
+    90 * 24 * 60 * 60 * 1000,
+    max * stepMs[interval]
+  );
+  const resolvedFrom = from ?? new Date(resolvedTo.getTime() - defaultWindowMs);
+
+  // Estimate bucket count
+  const diffMs = resolvedTo.getTime() - resolvedFrom.getTime();
+  const bucketCount = Math.ceil(diffMs / stepMs[interval]);
 
   if (bucketCount > max) {
     throw new GraphQLError(
@@ -207,6 +217,11 @@ export async function queryAccountPnl(
         ${Prisma.raw(`'${pgStep}'::INTERVAL`)}
       ) gs
     ),
+    -- Start of the first bucket. cumulative_pnl is a running total, so PnL
+    -- realized before the window must seed the line rather than resetting it to
+    -- zero at the window start; events earlier than this seed the baseline below
+    -- and never land in a per-bucket sum.
+    window_bounds AS (SELECT MIN(bucket_epoch) AS first_bucket FROM buckets),
     -- Cost basis for claims: the holder's collateral staked per pick
     -- configuration, per side, plus the tokens they were minted on that side.
     -- Each mint issues totalCollateral (= predictor + counterparty stake) tokens
@@ -257,8 +272,10 @@ export async function queryAccountPnl(
              WHEN cl."positionToken" = pk."predictorToken" THEN 'predictor'
              WHEN cl."positionToken" = pk."counterpartyToken" THEN 'counterparty'
            END
+      -- No lower bound: pre-window claims feed the cumulative baseline; the
+      -- per-bucket join below keeps them out of in-window bucket sums.
       WHERE cl.holder = ${addr}
-        AND cl."redeemedAt" >= ${fromEpoch} AND cl."redeemedAt" <= ${toEpoch}
+        AND cl."redeemedAt" <= ${toEpoch}
       UNION ALL
       -- Closes: position settlement
       SELECT
@@ -275,7 +292,7 @@ export async function queryAccountPnl(
         END AS pnl
       FROM "Close" c
       WHERE (c."predictorHolder" = ${addr} OR c."counterpartyHolder" = ${addr})
-        AND c."burnedAt" >= ${fromEpoch} AND c."burnedAt" <= ${toEpoch}
+        AND c."burnedAt" <= ${toEpoch}
       UNION ALL
       -- V1 Legacy settled positions
       SELECT
@@ -294,15 +311,38 @@ export async function queryAccountPnl(
       FROM position lp
       WHERE (lp.predictor = ${addr} OR lp.counterparty = ${addr})
         AND lp."settledAt" IS NOT NULL
-        AND lp."settledAt" >= ${fromEpoch} AND lp."settledAt" <= ${toEpoch}
+        AND lp."settledAt" <= ${toEpoch}
+      UNION ALL
+      -- Secondary-market trades: realized as pure cash flow — sale proceeds
+      -- when this account is the seller, purchase cost when it's the buyer.
+      -- Matches the vault's cumulativePnl convention (secondarySold −
+      -- secondaryBought, per services/protocolStats/vaultAggregator). buyer and
+      -- seller are distinct per trade, so the two CASE legs never both fire.
+      SELECT
+        st."executedAt" AS event_ts,
+        CASE WHEN st.seller = ${addr} THEN CAST(st.price AS DECIMAL) ELSE 0 END
+          - CASE WHEN st.buyer = ${addr} THEN CAST(st.price AS DECIMAL) ELSE 0 END
+          AS pnl
+      FROM secondary_trade st
+      WHERE (st.buyer = ${addr} OR st.seller = ${addr})
+        AND st."executedAt" <= ${toEpoch}
+    ),
+    -- Sum of all PnL realized strictly before the first bucket — the running
+    -- line's starting value. Pre-window events match no bucket below, so they
+    -- contribute here only, never to a per-bucket pnl value.
+    baseline AS (
+      SELECT COALESCE(SUM(e.pnl), 0) AS base
+      FROM pnl_events e, window_bounds w
+      WHERE e.event_ts < w.first_bucket
     )
     SELECT
       b.bucket_epoch AS timestamp,
       COALESCE(SUM(e.pnl), 0)::TEXT AS pnl,
-      SUM(COALESCE(SUM(e.pnl), 0)) OVER (ORDER BY b.bucket_epoch)::TEXT AS cumulative_pnl
+      (bl.base + SUM(COALESCE(SUM(e.pnl), 0)) OVER (ORDER BY b.bucket_epoch))::TEXT AS cumulative_pnl
     FROM buckets b
+    CROSS JOIN baseline bl
     LEFT JOIN pnl_events e ON e.event_ts >= b.bucket_epoch AND e.event_ts < b.next_epoch
-    GROUP BY b.bucket_epoch
+    GROUP BY b.bucket_epoch, bl.base
     ORDER BY b.bucket_epoch
   `;
 

--- a/packages/api/src/services/timeSeriesQueries.ts
+++ b/packages/api/src/services/timeSeriesQueries.ts
@@ -446,16 +446,19 @@ export async function queryAccountBalance(
       WHERE (p.predictor = ${addr} OR p.counterparty = ${addr})
         AND p."settledAt" IS NOT NULL
     ),
-    -- A redeem burns the holder's whole position token for one (pickConfig,
-    -- side). Claim.pickConfigId gives the config; the side is identified by
-    -- matching the burned positionToken to the pick configuration's
-    -- predictor/counterparty token, the same way the accountPnl query does.
+    -- The holder's redemptions, keyed to (pickConfig, side) by matching the
+    -- burned positionToken to the pick configuration's predictor/counterparty
+    -- token (same identity mapping the accountPnl query uses). collateralPaid
+    -- is the wUSDe each redeem actually pulled out — used to decrement the
+    -- side's remaining claimable, so a partial redeem subtracts only what it
+    -- redeemed rather than zeroing the whole side.
     account_claims AS (
       SELECT cl."pickConfigId" AS pick_config_id,
              CASE WHEN cl."positionToken" = pk."predictorToken" THEN 'predictor'
                   WHEN cl."positionToken" = pk."counterpartyToken" THEN 'counterparty'
              END AS side,
-             cl."redeemedAt"
+             cl."redeemedAt",
+             CAST(COALESCE(cl."collateralPaid", '0') AS DECIMAL) AS collateral_paid
       FROM "Claim" cl
       LEFT JOIN "Picks" pk ON cl."pickConfigId" = pk.id
       WHERE cl.holder = ${addr}
@@ -468,18 +471,31 @@ export async function queryAccountBalance(
         WHERE d.created_ts <= b.bucket_epoch
           AND (d.settled_ts IS NULL OR d.settled_ts > b.bucket_epoch)
       ), 0)::TEXT AS deployed_collateral,
+      -- Claimable remaining = gross owed on each settled-won (pickConfig, side)
+      -- MINUS the collateral already redeemed on that side up to the bucket,
+      -- floored at 0 per side (mirrors the vault's owed − claimed). A partial
+      -- redeem decrements by the amount it pulled out instead of dropping the
+      -- whole side, and the per-side floor keeps a redeemed bought-token from
+      -- netting against a different, still-unredeemed minted win.
+      -- (Attribution still follows the original minter, not secondary token
+      -- transfers — the deferred ledger-rework limitation noted on
+      -- AccountStatPoint.claimableCollateral; orthogonal to this fix.)
       COALESCE((
-        SELECT SUM(ac.claimable)
-        FROM all_claimable ac
-        WHERE ac.settled_ts <= b.bucket_epoch
-          AND NOT EXISTS (
-            -- Stop counting this position's claimable once the holder has
-            -- redeemed that (pickConfig, side) at or before the bucket.
-            SELECT 1 FROM account_claims c
-            WHERE c.pick_config_id = ac.pick_config_id
-              AND c.side = ac.side
-              AND c."redeemedAt" <= b.bucket_epoch
-          )
+        SELECT SUM(GREATEST(per_side.owed - per_side.redeemed, 0))
+        FROM (
+          SELECT ac.pick_config_id, ac.side,
+                 SUM(ac.claimable) AS owed,
+                 COALESCE((
+                   SELECT SUM(c.collateral_paid)
+                   FROM account_claims c
+                   WHERE c.pick_config_id = ac.pick_config_id
+                     AND c.side = ac.side
+                     AND c."redeemedAt" <= b.bucket_epoch
+                 ), 0) AS redeemed
+          FROM all_claimable ac
+          WHERE ac.settled_ts <= b.bucket_epoch
+          GROUP BY ac.pick_config_id, ac.side
+        ) per_side
       ), 0)::TEXT AS claimable_collateral
     FROM buckets b
     ORDER BY b.bucket_epoch

--- a/packages/api/src/services/timeSeriesTypes.ts
+++ b/packages/api/src/services/timeSeriesTypes.ts
@@ -46,14 +46,6 @@ export interface BalanceDataPoint {
   timestamp: number;
   deployedCollateral: string;
   claimableCollateral: string;
-  /**
-   * Net unredeemed winnings as of the bucket: gross `claimableCollateral`
-   * minus the holder's own stake on those settled-but-unredeemed wins. This is
-   * the account analog of the vault's `(−primaryCollateral + claimableCollateral)`
-   * — folded into `AccountStatPoint.cumulativePnl` so a resolved win marks into
-   * the PnL line at resolution, not redemption. Not surfaced as its own field.
-   */
-  unredeemedNetGain: string;
 }
 
 export interface PredictionCountDataPoint {

--- a/packages/api/src/services/timeSeriesTypes.ts
+++ b/packages/api/src/services/timeSeriesTypes.ts
@@ -46,6 +46,14 @@ export interface BalanceDataPoint {
   timestamp: number;
   deployedCollateral: string;
   claimableCollateral: string;
+  /**
+   * Net unredeemed winnings as of the bucket: gross `claimableCollateral`
+   * minus the holder's own stake on those settled-but-unredeemed wins. This is
+   * the account analog of the vault's `(−primaryCollateral + claimableCollateral)`
+   * — folded into `AccountStatPoint.cumulativePnl` so a resolved win marks into
+   * the PnL line at resolution, not redemption. Not surfaced as its own field.
+   */
+  unredeemedNetGain: string;
 }
 
 export interface PredictionCountDataPoint {

--- a/packages/app/src/components/vaults/__tests__/VaultPnlChartScaleToggle.test.tsx
+++ b/packages/app/src/components/vaults/__tests__/VaultPnlChartScaleToggle.test.tsx
@@ -76,7 +76,7 @@ import VaultPnlChart from '~/components/vaults/VaultPnlChart';
 const DAY = 24 * 60 * 60;
 const nowSec = Math.floor(Date.now() / 1000);
 
-// v2 VaultStat shape: TVL = balance + deployedCollateral + unredeemedClaim,
+// v2 VaultStat shape: TVL = balance + deployedCollateral + claimableCollateral,
 // PnL = cumulativePnl (all wei strings).
 const vaultStats = [
   {
@@ -85,7 +85,7 @@ const vaultStats = [
     deployedCollateral: '0',
     undeployedCollateral: '0',
     cumulativePnl: '0',
-    unredeemedClaim: '0',
+    claimableCollateral: '0',
   },
   {
     timestamp: nowSec - DAY,
@@ -93,7 +93,7 @@ const vaultStats = [
     deployedCollateral: '0',
     undeployedCollateral: '0',
     cumulativePnl: (50n * 10n ** 18n).toString(),
-    unredeemedClaim: '0',
+    claimableCollateral: '0',
   },
   {
     timestamp: nowSec,
@@ -101,7 +101,7 @@ const vaultStats = [
     deployedCollateral: '0',
     undeployedCollateral: '0',
     cumulativePnl: (120n * 10n ** 18n).toString(),
-    unredeemedClaim: '0',
+    claimableCollateral: '0',
   },
 ] as never[];
 

--- a/packages/app/src/lib/adapters/vaultStat.test.ts
+++ b/packages/app/src/lib/adapters/vaultStat.test.ts
@@ -11,18 +11,18 @@ function makeStat(overrides: Partial<VaultStat> = {}): VaultStat {
     deployedCollateral: '0',
     undeployedCollateral: '0',
     cumulativePnl: '0',
-    unredeemedClaim: '0',
+    claimableCollateral: '0',
     ...overrides,
   };
 }
 
 describe('toVaultStatPoint', () => {
-  it('computes TVL = balance + deployedCollateral + unredeemedClaim (scaled to wUSDe)', () => {
+  it('computes TVL = balance + deployedCollateral + claimableCollateral (scaled to wUSDe)', () => {
     const point = toVaultStatPoint(
       makeStat({
         balance: (100n * ONE_WUSDE).toString(),
         deployedCollateral: (40n * ONE_WUSDE).toString(),
-        unredeemedClaim: (10n * ONE_WUSDE).toString(),
+        claimableCollateral: (10n * ONE_WUSDE).toString(),
       })
     );
     // 100 + 40 + 10 = 150
@@ -51,7 +51,7 @@ describe('toVaultStatPoint', () => {
 
   it('treats missing/empty wei strings as zero', () => {
     const point = toVaultStatPoint(
-      makeStat({ balance: '', deployedCollateral: '', unredeemedClaim: '' })
+      makeStat({ balance: '', deployedCollateral: '', claimableCollateral: '' })
     );
     expect(point.tvl).toBe(0);
     expect(point.pnl).toBe(0);

--- a/packages/app/src/lib/adapters/vaultStat.ts
+++ b/packages/app/src/lib/adapters/vaultStat.ts
@@ -3,7 +3,7 @@
  * chart util consumes (`{ timestamp, pnl, tvl }`, both in whole wUSDe). This
  * is the one place the migrated TVL/PnL semantics live:
  *
- * - `tvl` := `balance + deployedCollateral + unredeemedClaim` (whole wUSDe).
+ * - `tvl` := `balance + deployedCollateral + claimableCollateral` (whole wUSDe).
  *   v1 used `vaultBalance + chain-wide escrowBalance`, which over-counted by
  *   mixing the vault's balance with the protocol-wide escrow; the v2 line is
  *   the vault's own AUM plus its settled-but-unredeemed winnings.
@@ -29,7 +29,7 @@ export function toVaultStatPoint(stat: VaultStat): VaultStatPoint {
   const tvlWei =
     BigInt(stat.balance || '0') +
     BigInt(stat.deployedCollateral || '0') +
-    BigInt(stat.unredeemedClaim || '0');
+    BigInt(stat.claimableCollateral || '0');
   return {
     timestamp: stat.timestamp,
     pnl: toWhole(stat.cumulativePnl),

--- a/packages/sdk/queries/__tests__/vault.test.ts
+++ b/packages/sdk/queries/__tests__/vault.test.ts
@@ -16,7 +16,7 @@ const node = (timestamp: number, overrides: Record<string, unknown> = {}) => ({
   deployedCollateral: '500',
   undeployedCollateral: '300',
   cumulativePnl: '42',
-  unredeemedClaim: '10',
+  claimableCollateral: '10',
   ...overrides,
 });
 
@@ -45,7 +45,7 @@ describe('GET_VAULT_STATS document', () => {
     expect(GET_VAULT_STATS).toContain('deployedCollateral');
     expect(GET_VAULT_STATS).toContain('undeployedCollateral');
     expect(GET_VAULT_STATS).toContain('cumulativePnl');
-    expect(GET_VAULT_STATS).toContain('unredeemedClaim');
+    expect(GET_VAULT_STATS).toContain('claimableCollateral');
     // v1-only field names must not leak into the v2 query.
     expect(GET_VAULT_STATS).not.toContain('vaultBalance');
     expect(GET_VAULT_STATS).not.toContain('escrowBalance');
@@ -105,7 +105,7 @@ describe('fetchVaultStats', () => {
         deployedCollateral: '500',
         undeployedCollateral: '300',
         cumulativePnl: '42',
-        unredeemedClaim: '10',
+        claimableCollateral: '10',
       },
       {
         timestamp: 1700000200,
@@ -113,7 +113,7 @@ describe('fetchVaultStats', () => {
         deployedCollateral: '500',
         undeployedCollateral: '300',
         cumulativePnl: '42',
-        unredeemedClaim: '10',
+        claimableCollateral: '10',
       },
     ]);
   });
@@ -136,14 +136,14 @@ describe('fetchVaultStats', () => {
           deployedCollateral: 500,
           undeployedCollateral: 300,
           cumulativePnl: 42,
-          unredeemedClaim: 10,
+          claimableCollateral: 10,
         }),
       ])
     );
     const result = await fetchVaultStats('0xabc', 42161);
     expect(result[0].balance).toBe('1000');
     expect(result[0].deployedCollateral).toBe('500');
-    expect(result[0].unredeemedClaim).toBe('10');
+    expect(result[0].claimableCollateral).toBe('10');
   });
 
   test('returns an empty array when the vault is unknown (null vault)', async () => {

--- a/packages/sdk/queries/vault.ts
+++ b/packages/sdk/queries/vault.ts
@@ -6,7 +6,7 @@ import { graphqlRequestV2 } from './client/graphqlClient';
  * charts (the migration off v1's `protocolStats(vaultAddress:)`).
  *
  * Only the fields the dashboard plots are selected. `cumulativePnl` is the
- * PnL line; `balance + deployedCollateral + unredeemedClaim` is the TVL line.
+ * PnL line; `balance + deployedCollateral + claimableCollateral` is the TVL line.
  */
 export interface VaultStat {
   /** Snapshot time, epoch seconds. */
@@ -20,11 +20,12 @@ export interface VaultStat {
   /** Cumulative trading PnL the dashboard plots, wei. */
   cumulativePnl: string;
   /** wUSDe owed on resolved-but-unredeemed winning sides, net of claimed, wei. */
-  unredeemedClaim: string;
+  claimableCollateral: string;
 }
 
-// `statsHistory` defaults to TIMESTAMP DESC; the chart wants ascending, so the
-// mapper sorts oldest-first (mirroring `protocol.ts`'s statsHistory handling).
+// `statsHistory` returns ascending (oldest-first) timestamps; the final
+// `.sort()` below is a defensive no-op that also keeps the merged multi-page
+// result ordered.
 //
 // The resolver caps `first` per page (daily snapshots, bounded series), so we
 // page on `pageInfo` until exhausted rather than over-fetching a single page —
@@ -45,7 +46,7 @@ export const GET_VAULT_STATS = /* GraphQL */ `
           deployedCollateral
           undeployedCollateral
           cumulativePnl
-          unredeemedClaim
+          claimableCollateral
         }
         pageInfo {
           hasNextPage
@@ -62,7 +63,7 @@ type WireVaultStat = {
   deployedCollateral: string | number;
   undeployedCollateral: string | number;
   cumulativePnl: string | number;
-  unredeemedClaim: string | number;
+  claimableCollateral: string | number;
 };
 
 type VaultStatsResponse = {
@@ -85,7 +86,7 @@ function toVaultStat(node: WireVaultStat): VaultStat {
     deployedCollateral: wei(node.deployedCollateral),
     undeployedCollateral: wei(node.undeployedCollateral),
     cumulativePnl: wei(node.cumulativePnl),
-    unredeemedClaim: wei(node.unredeemedClaim),
+    claimableCollateral: wei(node.claimableCollateral),
   };
 }
 

--- a/packages/sdk/types/graphql.v2.ts
+++ b/packages/sdk/types/graphql.v2.ts
@@ -210,10 +210,13 @@ export type AccountStatPoint = {
    */
   claimableCollateral: Scalars['BigInt']['output'];
   /**
-   * Running trading PnL through the end of the bucket — the cumulative sum of
-   * `realizedPnl`, seeded by all PnL realized *before* the window so the line
-   * never resets at the window start. The account analog of
-   * `VaultStat.cumulativePnl`.
+   * Running trading PnL through the end of the bucket: the cumulative sum of
+   * `realizedPnl` (seeded by all PnL realized *before* the window, so the line
+   * never resets at the window start), plus the net winnings on positions that
+   * have settled in the account's favour but are not yet redeemed
+   * (`claimableCollateral` minus the stake on those wins). That unredeemed mark
+   * makes a resolved win show up at resolution rather than waiting for redemption
+   * — the account analog of `VaultStat.cumulativePnl`.
    */
   cumulativePnl: Scalars['BigInt']['output'];
   /**

--- a/packages/sdk/types/graphql.v2.ts
+++ b/packages/sdk/types/graphql.v2.ts
@@ -72,6 +72,22 @@ export type Account = AddressEntity &
     ranking?: Maybe<Ranking>;
     /** Aggregate statistics for this account. Cheap to resolve; always present. */
     stats: AccountStat;
+    /**
+     * Time-bucketed series of this account's prediction activity — deployed /
+     * claimable collateral, trade volume, settlement PnL (per-bucket and
+     * running), and prediction win / loss / pending / non-decisive counts.
+     * Computed live from escrow predictions, legacy positions, claims, closes,
+     * and secondary trades (no snapshot table), so — unlike the chain-scoped
+     * identity fields — the series spans the address across chains. Buckets are
+     * ordered oldest-first (ascending `timestamp`), ready to plot. `interval`
+     * sets the bucket size; `filter.timestamp` (epoch seconds, inclusive) bounds
+     * the window. With no filter the window defaults to the last 90 days, clamped
+     * to the interval's own cap so it never overflows — e.g. `HOUR` caps at 168
+     * buckets, so its default is the last 7 days (an explicit wider window is
+     * rejected). The defaulted window fits one page, so the default returns the
+     * whole series in one shot while still honouring `first` / `after`.
+     */
+    statsHistory: AccountStatPointConnection;
   };
 
 /**
@@ -102,6 +118,18 @@ export type AccountCollateralBalanceHistoryArgs = {
 export type AccountRankingArgs = {
   filter?: InputMaybe<RankingFilter>;
   metric: LeaderboardMetric;
+};
+
+/**
+ * Address-keyed account record — wallet-level identity. Synthesized for
+ * addresses that have no User row so every valid address resolves to an
+ * Account; persistent rows additionally carry referral metadata.
+ */
+export type AccountStatsHistoryArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<AccountStatFilter>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  interval: TimeInterval;
 };
 
 export type AccountConnection = {
@@ -155,6 +183,92 @@ export type AccountStat = {
   __typename?: 'AccountStat';
   /** Cumulative trade volume across all of this account's activity, wei. */
   totalVolume: Scalars['BigInt']['output'];
+};
+
+/**
+ * Filter for `Account.statsHistory`. Mirrors `VaultStatFilter`: a `timestamp`
+ * window in epoch seconds (inclusive on both bounds), defaulting to the last
+ * 90 days when omitted.
+ */
+export type AccountStatFilter = {
+  timestamp?: InputMaybe<IntRangeFilter>;
+};
+
+/**
+ * One time bucket of an account's prediction activity. Amounts are wUSDe wei
+ * and `timestamp` is the bucket's start (epoch seconds). The field vocabulary
+ * deliberately mirrors `VaultStat` — `deployedCollateral`, `realizedPnl`,
+ * `cumulativePnl` carry the same meaning at the account level. PnL is truncated
+ * toward zero to integer wei (the proportional cost-basis math can produce
+ * sub-wei fractions).
+ */
+export type AccountStatPoint = {
+  __typename?: 'AccountStatPoint';
+  /**
+   * Settled-and-won but not-yet-redeemed collateral owed to the account as of
+   * the bucket — the account analog of `VaultStat.claimableCollateral`.
+   */
+  claimableCollateral: Scalars['BigInt']['output'];
+  /**
+   * Running trading PnL through the end of the bucket — the cumulative sum of
+   * `realizedPnl`, seeded by all PnL realized *before* the window so the line
+   * never resets at the window start. The account analog of
+   * `VaultStat.cumulativePnl`.
+   */
+  cumulativePnl: Scalars['BigInt']['output'];
+  /**
+   * Collateral staked in positions still open as of the bucket — created on or
+   * before the boundary and not yet settled. The deployed leg of the account's
+   * escrow balance; mirrors `VaultStat.deployedCollateral`.
+   */
+  deployedCollateral: Scalars['BigInt']['output'];
+  /** Bucket predictions that have since settled against the account. */
+  predictionsLost: Scalars['Int']['output'];
+  /** Bucket predictions that settled non-decisively (no winning side). */
+  predictionsNonDecisive: Scalars['Int']['output'];
+  /** Bucket predictions not yet settled. */
+  predictionsPending: Scalars['Int']['output'];
+  /**
+   * Predictions created in the bucket, across every outcome. Equals
+   * `predictionsWon + predictionsLost + predictionsPending +
+   * predictionsNonDecisive`.
+   */
+  predictionsTotal: Scalars['Int']['output'];
+  /**
+   * Of the bucket's predictions, those that have since settled in the account's
+   * favor. Counts are bucketed by creation time but reflect each prediction's
+   * *current* settlement status, so a past bucket's won / lost / pending split
+   * shifts as its predictions resolve (the series is computed live, not
+   * snapshotted).
+   */
+  predictionsWon: Scalars['Int']['output'];
+  /**
+   * PnL realized within the bucket: settlement gains − losses on positions that
+   * settled in-window, plus secondary-market sale proceeds net of purchase cost
+   * (`sold − bought`) on trades executed in-window. Same trading-PnL definition
+   * the vault plots in `VaultStat.cumulativePnl`, measured per-bucket.
+   */
+  realizedPnl: Scalars['BigInt']['output'];
+  timestamp: Scalars['UnixSeconds']['output'];
+  /**
+   * Trade volume attributed to the bucket: predictor + counterparty stake on
+   * predictions created in-window, plus secondary-market trades.
+   */
+  volume: Scalars['BigInt']['output'];
+};
+
+export type AccountStatPointConnection = {
+  __typename?: 'AccountStatPointConnection';
+  edges: Array<AccountStatPointEdge>;
+  nodes: Array<AccountStatPoint>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type AccountStatPointEdge = {
+  __typename?: 'AccountStatPointEdge';
+  cursor: Scalars['String']['output'];
+  node: AccountStatPoint;
 };
 
 /**
@@ -695,6 +809,12 @@ export type ConditionGroupEdge = {
 
 export type ConditionGroupFilter = {
   categorySlug?: InputMaybe<Scalars['String']['input']>;
+  /**
+   * Restrict to condition groups whose numeric `groupId` is in this set — the
+   * batch-by-id lookup the markets-by-id hydration path uses. OR within the
+   * set, AND with the other filters.
+   */
+  groupIds?: InputMaybe<Array<Scalars['Int']['input']>>;
   /** Substring search against `name`, case-insensitive. */
   search?: InputMaybe<Scalars['String']['input']>;
 };
@@ -1840,6 +1960,13 @@ export type TagOrder = {
 export type TagOrderField = 'CONDITION_COUNT' | 'NAME';
 
 /**
+ * Bucketing granularity for `Account.statsHistory`. Unlike `Vault.statsHistory`
+ * (a fixed daily snapshot cadence written by the stats worker), the account
+ * series is computed live per request, so the caller picks the bucket size.
+ */
+export type TimeInterval = 'DAY' | 'HOUR' | 'MONTH' | 'WEEK';
+
+/**
  * Open-interest bucketed by time-to-resolution. Each unsettled prediction
  * is bucketed by the latest endTime among its constituent conditions; the
  * window is `(minSecondsFromNow, maxSecondsFromNow]` — left-exclusive,
@@ -1968,8 +2095,9 @@ export type Vault = Node & {
    */
   stats?: Maybe<VaultStat>;
   /**
-   * Time-series of this vault's economic snapshots, newest first. Backs the
-   * vault dashboard's TVL / PnL charts. Defaults to `TIMESTAMP DESC`.
+   * Time-series of this vault's economic snapshots, oldest-first (ascending
+   * `timestamp`, matching `Account.statsHistory` — chart-ready, no consumer
+   * re-sort). Backs the vault dashboard's TVL / PnL charts.
    */
   statsHistory: VaultStatConnection;
 };
@@ -2038,12 +2166,20 @@ export type VaultStat = {
    * funds.
    */
   balance: Scalars['BigInt']['output'];
+  /**
+   * wUSDe owed to the vault on resolved-but-not-yet-redeemed winning sides,
+   * net of what it has already claimed. The dashboard's TVL line adds this to
+   * `balance + deployedCollateral` so funds that have settled in the vault's
+   * favor but await an indexed redeem are not transiently dropped. Named to
+   * match `AccountStatPoint.claimableCollateral`, the account-level analog.
+   */
+  claimableCollateral: Scalars['BigInt']['output'];
   collateralLost: Scalars['BigInt']['output'];
   collateralWon: Scalars['BigInt']['output'];
   /**
    * Cumulative trading PnL the vault dashboard plots: settlement PnL, plus
    * wUSDe earmarked from resolved-but-unredeemed wins, plus net secondary-
-   * market flow (`realizedPnl + unredeemedClaim + secondarySold −
+   * market flow (`realizedPnl + claimableCollateral + secondarySold −
    * secondaryBought`). This is the *same* numerator the account behind the
    * vault carries; the vault presents it as a return on total assets
    * (`balance + deployedCollateral`), where the account measures it against
@@ -2061,13 +2197,6 @@ export type VaultStat = {
   timestamp: Scalars['UnixSeconds']['output'];
   /** Liquid collateral not yet deployed to escrow. `balance + deployed` is AUM. */
   undeployedCollateral: Scalars['BigInt']['output'];
-  /**
-   * wUSDe owed to the vault on resolved-but-not-yet-redeemed winning sides,
-   * net of what it has already claimed. The dashboard's TVL line adds this to
-   * `balance + deployedCollateral` so funds that have settled in the vault's
-   * favor but await an indexed redeem are not transiently dropped.
-   */
-  unredeemedClaim: Scalars['BigInt']['output'];
   withdrawals: Scalars['BigInt']['output'];
 };
 

--- a/packages/sdk/types/graphql.v2.ts
+++ b/packages/sdk/types/graphql.v2.ts
@@ -207,16 +207,31 @@ export type AccountStatPoint = {
   /**
    * Settled-and-won but not-yet-redeemed collateral owed to the account as of
    * the bucket — the account analog of `VaultStat.claimableCollateral`.
+   *
+   * This is a *pending-balance* figure, deliberately NOT part of `cumulativePnl`
+   * (see there). It is attributed to the original position side and does not
+   * follow secondary-market transfers, so after a winning position token is sold
+   * pre-redemption it still reads against the seller until redeemed. Safe for the
+   * "pending claims" view; not used to realize PnL precisely for that reason.
    */
   claimableCollateral: Scalars['BigInt']['output'];
   /**
    * Running trading PnL through the end of the bucket: the cumulative sum of
-   * `realizedPnl` (seeded by all PnL realized *before* the window, so the line
-   * never resets at the window start), plus the net winnings on positions that
-   * have settled in the account's favour but are not yet redeemed
-   * (`claimableCollateral` minus the stake on those wins). That unredeemed mark
-   * makes a resolved win show up at resolution rather than waiting for redemption
-   * — the account analog of `VaultStat.cumulativePnl`.
+   * `realizedPnl`, seeded by all PnL realized *before* the window so the line
+   * never resets at the window start.
+   *
+   * PnL is realized only when a position is actually settled — a win at the
+   * moment it is *redeemed* (a claim), a loss/non-decisive at settlement, plus
+   * secondary-market proceeds and cost as they trade. It is NOT marked from
+   * still-unredeemed `claimableCollateral`. This is deliberate: a redemption
+   * records the true holder, so a win is credited to whoever actually collects
+   * it. If a winning position token is sold before redemption, the seller simply
+   * keeps their sale proceeds and the buyer realizes the win on redeeming — no
+   * prize is ever credited to someone who no longer holds the token. The cost is
+   * cosmetic: a resolved-but-unredeemed win contributes nothing until it is
+   * claimed (the line steps up at redemption rather than at resolution).
+   *
+   * Matches `VaultStat.cumulativePnl`, which realizes the same way.
    */
   cumulativePnl: Scalars['BigInt']['output'];
   /**
@@ -246,10 +261,11 @@ export type AccountStatPoint = {
    */
   predictionsWon: Scalars['Int']['output'];
   /**
-   * PnL realized within the bucket: settlement gains − losses on positions that
-   * settled in-window, plus secondary-market sale proceeds net of purchase cost
-   * (`sold − bought`) on trades executed in-window. Same trading-PnL definition
-   * the vault plots in `VaultStat.cumulativePnl`, measured per-bucket.
+   * PnL realized within the bucket — the per-bucket increment of `cumulativePnl`
+   * (see there for exactly when PnL realizes): redemption gains on wins claimed
+   * in-window, losses/non-decisive at settlement, and secondary-market proceeds
+   * net of cost (`sold − bought`) on trades executed in-window. Same trading-PnL
+   * definition the vault plots, measured per-bucket.
    */
   realizedPnl: Scalars['BigInt']['output'];
   timestamp: Scalars['UnixSeconds']['output'];
@@ -2173,21 +2189,26 @@ export type VaultStat = {
    * wUSDe owed to the vault on resolved-but-not-yet-redeemed winning sides,
    * net of what it has already claimed. The dashboard's TVL line adds this to
    * `balance + deployedCollateral` so funds that have settled in the vault's
-   * favor but await an indexed redeem are not transiently dropped. Named to
-   * match `AccountStatPoint.claimableCollateral`, the account-level analog.
+   * favor but await an indexed redeem are not transiently dropped. A
+   * pending-balance figure for TVL only — deliberately NOT part of
+   * `cumulativePnl` (PnL realizes at redemption). Named to match
+   * `AccountStatPoint.claimableCollateral`, the account-level analog.
    */
   claimableCollateral: Scalars['BigInt']['output'];
   collateralLost: Scalars['BigInt']['output'];
   collateralWon: Scalars['BigInt']['output'];
   /**
-   * Cumulative trading PnL the vault dashboard plots: settlement PnL, plus
-   * wUSDe earmarked from resolved-but-unredeemed wins, plus net secondary-
-   * market flow (`realizedPnl + claimableCollateral + secondarySold −
-   * secondaryBought`). This is the *same* numerator the account behind the
-   * vault carries; the vault presents it as a return on total assets
-   * (`balance + deployedCollateral`), where the account measures it against
-   * deployed capital. The unredeemed term cancels the transient phantom loss
-   * between a position resolving and its redeem being indexed.
+   * Cumulative trading PnL the vault dashboard plots: settlement PnL plus net
+   * secondary-market flow (`realizedPnl + secondarySold − secondaryBought`).
+   *
+   * PnL realizes only when a position is actually redeemed/settled — it is NOT
+   * marked from still-unredeemed `claimableCollateral` (that term used to be
+   * added here and has been removed). This keeps the line correct when a winning
+   * token is sold before redemption: the redeemer collects the prize, so it is
+   * never credited to whoever merely minted the position. Realizes the same way
+   * as `AccountStatPoint.cumulativePnl`. Trade-off: a resolved-but-unredeemed win
+   * is not marked until it is claimed — the line steps up at redemption rather
+   * than at resolution, which can read as a brief paper dip in between.
    */
   cumulativePnl: Scalars['BigInt']['output'];
   /** Collateral deployed into escrow (backing open positions). */

--- a/packages/sdk/types/graphql.v2.ts
+++ b/packages/sdk/types/graphql.v2.ts
@@ -231,7 +231,17 @@ export type AccountStatPoint = {
    * cosmetic: a resolved-but-unredeemed win contributes nothing until it is
    * claimed (the line steps up at redemption rather than at resolution).
    *
+   * Secondary sales also book the seller's allocated mint cost basis
+   * (`stake × tokensSold / minted`), so a seller who never redeems still has
+   * their stake deducted and combined PnL across buyer + seller conserves.
+   *
    * Matches `VaultStat.cumulativePnl`, which realizes the same way.
+   *
+   * Known approximations (tracked for a planned PnL rework to a single cash-flow +
+   * token-ledger model): (1) basis allocation assumes sold tokens were minted ones
+   * when an address both mints and buys the same token; (2) a loss is recognized
+   * at its settlement/redemption event, so a position that simply expires
+   * worthless without an on-chain burn may book its loss late.
    */
   cumulativePnl: Scalars['BigInt']['output'];
   /**


### PR DESCRIPTION
## What & why

The exchange-ui **Portfolio → Prediction Stats** page reads four per-account time-series that only existed on the v1 API (PnL chart + calendar, volume, win-rate counts, pending claims + balance). v2 had dropped them (lifetime aggregates only). This adds them back as **`Account.statsHistory`** so exchange-ui can move fully onto `/v2/graphql`, and aligns the new surface with the existing `VaultStat`.

Also adds a small **`ConditionGroup.groupIds`** filter for the markets-by-id hydration path.

## `Account.statsHistory`

New bucketed series on `Account` — `AccountStatPoint` per `interval` (HOUR/DAY/WEEK/MONTH), oldest-first, default window with `first`/`after` paging. Computed live (no snapshot table) from the shared `services/timeSeriesQueries` SQL — the same source the v1 `accountBalance`/`accountPnl`/`accountVolume`/`accountPredictionCount` queries read — so it needs no new writer. Fields: `deployedCollateral`, `claimableCollateral`, `volume`, `realizedPnl`, `cumulativePnl`, and prediction counts (total/won/lost/pending/non-decisive).

## VaultStat / AccountStat consistency

Kept as **separate types** (vault = daily snapshot, chain-scoped, superset with AUM/flows; account = live, cross-chain), with consistency at the vocabulary level plus the existing `Vault.account` edge:

- **Renamed `VaultStat.unredeemedClaim` → `claimableCollateral`** across the monorepo (SDL, resolver, SDK query + types, app TVL adapter) to match `AccountStatPoint.claimableCollateral`. The internal DB column (`vaultUnredeemedClaim`) keeps its name.
- **`Vault.statsHistory` now returns oldest-first (ascending)** to match `Account.statsHistory`. The SDK/app already re-sorted ascending, so this is transparent to the dashboard.

### PnL realizes at redemption (both account and vault)

`cumulativePnl` realizes PnL **only when a position is actually settled/redeemed** (a `Claim`/`Close`), plus secondary-market cash flow — it is **not** marked from still-unredeemed `claimableCollateral`.

Why: a win can change hands on the secondary market before redemption. Marking PnL from unredeemed claimable attributes the win by the *original minter*, not the current token holder — so after someone sells a winning token pre-redeem, the seller keeps showing the win and the buyer shows none, until redemption. A redemption records the **true holder**, so realizing only then is correct by construction and needs no holder-balance reconstruction: the seller keeps just their sale proceeds, the buyer realizes the win on redeeming.

Both types use this same rule, so they stay consistent. Trade-off (documented in the SDL + resolver comments): a resolved-but-unredeemed win isn't marked until claimed — the line steps up at redemption rather than at resolution. `claimableCollateral` is still surfaced on both (pending-claims view / vault TVL line), just never folded into PnL.

## PnL correctness fixes (shared `timeSeriesQueries` helper)

- **Running `cumulativePnl`:** seeds the line from PnL realized *before* the window instead of resetting to 0 at the window start; per-bucket `realizedPnl` stays window-local.
- **Secondary-market PnL:** `queryAccountPnl` books secondary trades (`sold − bought`), mirroring the vault's convention. Volume already counted secondary; PnL didn't.
- **Per-interval default window in `resolveDefaults`:** an unfiltered `HOUR` request returns the last 7 days instead of throwing `"Too many buckets"` (the 90-day default = 2160 hourly buckets). DAY/WEEK/MONTH unchanged. Shared helper, so it also fixes the equivalent v1 queries (bug fix, no in-repo v1 consumers).

## Tests

- Real-DB integration tests for running cumulative + secondary-market PnL (`…pnl.integration`) and claimable accounting (`…balance.integration`).
- Unit tests for connection shaping, the realize-at-redemption rule (a large `claimableCollateral` with no realized PnL must not move the line), the `resolveDefaults` HOUR clamp, and the `groupIds` filter.

## Notes for reviewers

- The `claimableCollateral` rename and ascending-order change touch the **SDK and app**, not just the API — intentional, to keep consumers in sync.
- Generated artifacts (`schema.v2.graphql`, SDK `graphql.v2.ts`) are regenerated and in sync.
- Residual second-order difference: in the rare "sell a winning token pre-redeem" case, the vault books stake at *resolution* while the account books it at *claim*, so the seller's stake is treated slightly differently. Fully closing that means moving the vault's stake timing to claim (snapshot-aggregator change) — out of scope. The user-facing issue (crediting a sold-off win to the wrong party) is resolved on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
