### PR TITLE
Staging -> Main

### DIFF
--- a/packages/api/schema.v2.graphql
+++ b/packages/api/schema.v2.graphql
@@ -1358,6 +1358,14 @@ input PositionFilter {
 enum PositionOrderField {
   CREATED_AT
   UPDATED_AT
+
+  """
+  When the position's pickConfiguration resolved on Sapience
+  (`PickConfiguration.resolvedAt`). Ordering by this field restricts the
+  connection to resolved positions (`resolvedAt` non-null) so it pages
+  cleanly across the whole resolved set, newest-resolved first by default.
+  """
+  RESOLVED_AT
 }
 
 input PositionOrder {

--- a/packages/api/src/graphql/v2/resolvers/queries/position.test.ts
+++ b/packages/api/src/graphql/v2/resolvers/queries/position.test.ts
@@ -507,24 +507,22 @@ describe('positions (v2) — ordering', () => {
 });
 
 describe('positions (v2) — RESOLVED_AT ordering (across pages)', () => {
-  it('orders by pickConfiguration.resolvedAt and restricts to resolved positions', async () => {
+  it('orders by pickConfiguration.resolvedAt NULLS LAST without filtering out pending', async () => {
     await callPositions({
       orderBy: { field: 'RESOLVED_AT', direction: 'DESC' },
     });
 
     const callArgs = mockPrisma.position.findMany.mock.calls[0][0];
     expect(callArgs.orderBy).toEqual([
-      { pickConfiguration: { resolvedAt: 'desc' } },
+      { pickConfiguration: { resolvedAt: { sort: 'desc', nulls: 'last' } } },
       { id: 'desc' },
     ]);
-    // resolved-only filter merged into the pickConfiguration where so the
-    // keyset never straddles a NULL boundary.
-    expect(callArgs.where.pickConfiguration).toMatchObject({
-      resolvedAt: { not: null },
-    });
+    // Sorting must NOT become filtering: unresolved positions are kept
+    // (ordered to the tail), so no resolvedAt restriction is added.
+    expect(callArgs.where.pickConfiguration?.resolvedAt).toBeUndefined();
   });
 
-  it('emits a resolvedAt-based cursor (k = resolvedAt seconds, not a date)', async () => {
+  it('emits a resolvedAt-based cursor for a resolved row (k = seconds)', async () => {
     mockPrisma.position.findMany.mockResolvedValue([
       makePosition({
         balance: '200',
@@ -547,7 +545,32 @@ describe('positions (v2) — RESOLVED_AT ordering (across pages)', () => {
     });
   });
 
-  it('applies a relation keyset on resolvedAt when `after` is provided', async () => {
+  it('emits an empty-k cursor for a pending (null resolvedAt) row', async () => {
+    // A still-open position sorts into the NULLS LAST tail; its cursor must
+    // carry the null-phase sentinel (k = '') so the next page continues
+    // through the remaining pending rows by id.
+    mockPrisma.position.findMany.mockResolvedValue([
+      makePosition({
+        balance: '200',
+        pickConfiguration: makePickConfig({
+          resolved: false,
+          resolvedAt: null,
+          predictions: [makePrediction()],
+        }),
+      }),
+    ]);
+
+    const result = await callPositions({
+      orderBy: { field: 'RESOLVED_AT', direction: 'DESC' },
+    });
+
+    expect(decodeCursor(result.pageInfo.endCursor ?? '')).toEqual({
+      k: '',
+      id: '1',
+    });
+  });
+
+  it('keyset (non-null cursor): later non-nulls, the id tie-break, and ALL nulls', async () => {
     const after = encodeCursor({ k: '1700000000', id: '5' });
 
     await callPositions({
@@ -563,6 +586,27 @@ describe('positions (v2) — RESOLVED_AT ordering (across pages)', () => {
     });
     expect(keyset.OR[1].AND).toEqual([
       { pickConfiguration: { resolvedAt: 1700000000 } },
+      { id: { lt: 5 } },
+    ]);
+    // All null-resolvedAt rows sort after any non-null in NULLS LAST.
+    expect(keyset.OR[2]).toEqual({
+      pickConfiguration: { resolvedAt: null },
+    });
+  });
+
+  it('keyset (null-phase cursor, k=""): only further null rows by id', async () => {
+    const after = encodeCursor({ k: '', id: '5' });
+
+    await callPositions({
+      orderBy: { field: 'RESOLVED_AT', direction: 'DESC' },
+      after,
+    });
+
+    const callArgs = mockPrisma.position.findMany.mock.calls[0][0];
+    const keyset = callArgs.where.AND[1];
+    expect(keyset.OR).toBeUndefined();
+    expect(keyset.AND).toEqual([
+      { pickConfiguration: { resolvedAt: null } },
       { id: { lt: 5 } },
     ]);
   });

--- a/packages/api/src/graphql/v2/resolvers/queries/position.test.ts
+++ b/packages/api/src/graphql/v2/resolvers/queries/position.test.ts
@@ -506,6 +506,68 @@ describe('positions (v2) — ordering', () => {
   });
 });
 
+describe('positions (v2) — RESOLVED_AT ordering (across pages)', () => {
+  it('orders by pickConfiguration.resolvedAt and restricts to resolved positions', async () => {
+    await callPositions({
+      orderBy: { field: 'RESOLVED_AT', direction: 'DESC' },
+    });
+
+    const callArgs = mockPrisma.position.findMany.mock.calls[0][0];
+    expect(callArgs.orderBy).toEqual([
+      { pickConfiguration: { resolvedAt: 'desc' } },
+      { id: 'desc' },
+    ]);
+    // resolved-only filter merged into the pickConfiguration where so the
+    // keyset never straddles a NULL boundary.
+    expect(callArgs.where.pickConfiguration).toMatchObject({
+      resolvedAt: { not: null },
+    });
+  });
+
+  it('emits a resolvedAt-based cursor (k = resolvedAt seconds, not a date)', async () => {
+    mockPrisma.position.findMany.mockResolvedValue([
+      makePosition({
+        balance: '200',
+        pickConfiguration: makePickConfig({
+          resolved: true,
+          result: 'PREDICTOR_WINS',
+          resolvedAt: 1_700_000_000,
+          predictions: [makePrediction()],
+        }),
+      }),
+    ]);
+
+    const result = await callPositions({
+      orderBy: { field: 'RESOLVED_AT', direction: 'DESC' },
+    });
+
+    expect(decodeCursor(result.pageInfo.endCursor ?? '')).toEqual({
+      k: '1700000000',
+      id: '1',
+    });
+  });
+
+  it('applies a relation keyset on resolvedAt when `after` is provided', async () => {
+    const after = encodeCursor({ k: '1700000000', id: '5' });
+
+    await callPositions({
+      orderBy: { field: 'RESOLVED_AT', direction: 'DESC' },
+      after,
+    });
+
+    const callArgs = mockPrisma.position.findMany.mock.calls[0][0];
+    expect(callArgs.where.AND).toHaveLength(2);
+    const keyset = callArgs.where.AND[1];
+    expect(keyset.OR[0]).toEqual({
+      pickConfiguration: { resolvedAt: { lt: 1700000000 } },
+    });
+    expect(keyset.OR[1].AND).toEqual([
+      { pickConfiguration: { resolvedAt: 1700000000 } },
+      { id: { lt: 5 } },
+    ]);
+  });
+});
+
 describe('positions (v2) — query shape', () => {
   it('pushes the holder filter into the predictions include', async () => {
     // Without this, every prediction on the pickConfiguration is loaded —

--- a/packages/api/src/graphql/v2/resolvers/queries/position.ts
+++ b/packages/api/src/graphql/v2/resolvers/queries/position.ts
@@ -34,6 +34,7 @@ import {
   encodeCursor,
   normalizeDirection,
   withCursorWhere,
+  type OrderDirection,
 } from '../../relay/connection';
 import { tryFromGlobalIdV2 } from '../../relay/nodeRegistry';
 
@@ -59,9 +60,19 @@ export const position: NonNullable<QueryResolvers['position']> = async (
   });
 };
 
-const FIELD_TO_PRISMA: Record<string, 'createdAt' | 'updatedAt'> = {
+/**
+ * CREATED_AT / UPDATED_AT keyset on a Date column of the Position row
+ * itself. RESOLVED_AT orders by the related `pickConfiguration.resolvedAt`
+ * (Unix seconds, nullable) — handled on a separate branch in `positions`
+ * because it keysets through the relation and restricts to resolved rows.
+ */
+const FIELD_TO_PRISMA: Record<
+  string,
+  'createdAt' | 'updatedAt' | 'resolvedAt'
+> = {
   CREATED_AT: 'createdAt',
   UPDATED_AT: 'updatedAt',
+  RESOLVED_AT: 'resolvedAt',
 };
 
 /** Raw Position row as fetched for synthesis (predictions included). */
@@ -93,7 +104,17 @@ export type WacFields = {
     | null;
   /** Trade hash of the sale this SOLD row represents; null on OPEN rows. */
   soldTradeHash: string | null;
-  cursorRow: { id: number; createdAt: Date; updatedAt: Date };
+  /**
+   * Order/keyset values pinned to the underlying RAW row. `resolvedAt`
+   * (from the pickConfiguration, Unix seconds) travels alongside the Date
+   * columns so the RESOLVED_AT keyset cursor can read it directly.
+   */
+  cursorRow: {
+    id: number;
+    createdAt: Date;
+    updatedAt: Date;
+    resolvedAt: number | null;
+  };
 };
 
 export type SynthesizedPositionRow = RawPositionRow & WacFields;
@@ -265,7 +286,12 @@ const synthesizeWacRows = async (
           status: 'SOLD',
           prediction,
           soldTradeHash: d.tradeHash,
-          cursorRow: r,
+          cursorRow: {
+            id: r.id,
+            createdAt: r.createdAt,
+            updatedAt: r.updatedAt,
+            resolvedAt: r.pickConfiguration?.resolvedAt ?? null,
+          },
         });
       }
     }
@@ -285,7 +311,12 @@ const synthesizeWacRows = async (
         status: 'OPEN',
         prediction,
         soldTradeHash: null,
-        cursorRow: r,
+        cursorRow: {
+          id: r.id,
+          createdAt: r.createdAt,
+          updatedAt: r.updatedAt,
+          resolvedAt: r.pickConfiguration?.resolvedAt ?? null,
+        },
       });
     }
   }
@@ -293,13 +324,45 @@ const synthesizeWacRows = async (
   return synthesized;
 };
 
+/**
+ * Keyset predicate for RESOLVED_AT ordering — the canonical
+ * `(orderField, id)` keyset, but `orderField` lives on the to-one
+ * `pickConfiguration` relation rather than the Position row, so it can't go
+ * through the flat `buildKeysetWhere`. The base where already pins
+ * `resolvedAt` non-null, so the cursor value is always a real number.
+ */
+const buildResolvedAtKeyset = (
+  value: number,
+  idValue: number,
+  direction: OrderDirection
+): Prisma.PositionWhereInput => {
+  const op = direction === 'desc' ? 'lt' : 'gt';
+  return {
+    OR: [
+      { pickConfiguration: { resolvedAt: { [op]: value } } },
+      {
+        AND: [
+          { pickConfiguration: { resolvedAt: value } },
+          { id: { [op]: idValue } },
+        ],
+      },
+    ],
+  };
+};
+
 export const positions: NonNullable<QueryResolvers['positions']> = async (
   _parent,
   args
 ) => {
   const first = clampTake(args.first ?? 50, { defaultTake: 50, maxTake: 100 });
-  const field = FIELD_TO_PRISMA[args.orderBy?.field ?? 'UPDATED_AT'];
+  const orderField = FIELD_TO_PRISMA[args.orderBy?.field ?? 'UPDATED_AT'];
   const direction = normalizeDirection(args.orderBy?.direction, 'desc');
+  // RESOLVED_AT orders by the related pickConfiguration.resolvedAt; the
+  // others keyset on a Date column of the Position row itself.
+  const byResolvedAt = orderField === 'resolvedAt';
+  const dateField = byResolvedAt
+    ? null
+    : (orderField as 'createdAt' | 'updatedAt');
   const holderLower = args.filter?.holder?.toLowerCase();
 
   const where: Prisma.PositionWhereInput = {};
@@ -337,18 +400,27 @@ export const positions: NonNullable<QueryResolvers['positions']> = async (
     pickConfigFilter.endsAt = r;
     hasPickConfigFilter = true;
   }
+  // RESOLVED_AT ordering only makes sense for resolved positions; pinning
+  // resolvedAt non-null also keeps the keyset clean (no NULL boundary).
+  if (byResolvedAt) {
+    pickConfigFilter.resolvedAt = { not: null };
+    hasPickConfigFilter = true;
+  }
   if (hasPickConfigFilter) where.pickConfiguration = pickConfigFilter;
 
   const cursor = args.after ? decodeCursor(args.after) : null;
-  const cursorWhere = cursor
-    ? buildKeysetWhere<Prisma.PositionWhereInput>({
-        orderField: field,
-        orderValue: new Date(cursor.k),
-        idField: 'id',
-        idValue: Number(cursor.id),
-        direction,
-      })
-    : null;
+  let cursorWhere: Prisma.PositionWhereInput | null = null;
+  if (cursor) {
+    cursorWhere = byResolvedAt
+      ? buildResolvedAtKeyset(Number(cursor.k), Number(cursor.id), direction)
+      : buildKeysetWhere<Prisma.PositionWhereInput>({
+          orderField: dateField as string,
+          orderValue: new Date(cursor.k),
+          idField: 'id',
+          idValue: Number(cursor.id),
+          direction,
+        });
+  }
 
   // escrow.ts L380-392: we only need the rows where the holder is a party
   // to compute their cost basis, so push the filter into the include and
@@ -363,16 +435,22 @@ export const positions: NonNullable<QueryResolvers['positions']> = async (
       }
     : true;
 
+  const orderBy: Prisma.PositionOrderByWithRelationInput[] = byResolvedAt
+    ? [{ pickConfiguration: { resolvedAt: direction } }, { id: direction }]
+    : [
+        {
+          [dateField as string]: direction,
+        } as Prisma.PositionOrderByWithRelationInput,
+        { id: direction },
+      ];
+
   // escrow.ts L394-411: fetch first+1 raw rows to derive hasNextPage
   // without a count query. Synthesized pages can be empty (zero-balance
   // unresolved rows with no sells), so emitted-row count is unreliable as
   // a stop signal — pagination is raw-row truth.
   const rawRows = (await prisma.position.findMany({
     where: withCursorWhere(where, cursorWhere),
-    orderBy: [
-      { [field]: direction } as Prisma.PositionOrderByWithRelationInput,
-      { id: direction },
-    ],
+    orderBy,
     include: {
       pickConfiguration: {
         include: { picks: true, predictions: predictionsInclude },
@@ -391,9 +469,12 @@ export const positions: NonNullable<QueryResolvers['positions']> = async (
   // escrow.ts L625-633: re-sort by the requested field. Synthetic SOLD
   // rows carry the trade's executedAt as their updatedAt, so without this
   // they'd appear grouped under their parent rather than interleaved by
-  // recency.
+  // recency. (RESOLVED_AT is resolved-only, so it emits no SOLD rows; we
+  // sort those by the raw row's resolvedAt.)
+  const sortValue = (row: SynthesizedPositionRow): number =>
+    dateField ? row[dateField].getTime() : (row.cursorRow.resolvedAt ?? 0);
   items.sort((a, b) => {
-    const diff = b[field].getTime() - a[field].getTime();
+    const diff = sortValue(b) - sortValue(a);
     return direction === 'asc' ? -diff : diff;
   });
 
@@ -401,13 +482,29 @@ export const positions: NonNullable<QueryResolvers['positions']> = async (
   // parent's cursor): resuming `after:` a synthesized row resumes after
   // the raw row that produced it — the same granularity v1's skip-based
   // paging had.
-  const rowCursor = (row: { id: number; createdAt: Date; updatedAt: Date }) =>
-    encodeCursor({ k: row[field].toISOString(), id: String(row.id) });
+  const rowCursor = (row: {
+    id: number;
+    createdAt: Date;
+    updatedAt: Date;
+    resolvedAt: number | null;
+  }) =>
+    encodeCursor({
+      k: dateField ? row[dateField].toISOString() : String(row.resolvedAt ?? 0),
+      id: String(row.id),
+    });
   const edges = items.map((node) => ({
     node,
     cursor: rowCursor(node.cursorRow),
   }));
   const lastRawRow = pageRows.at(-1);
+  const lastCursorRow = lastRawRow
+    ? {
+        id: lastRawRow.id,
+        createdAt: lastRawRow.createdAt,
+        updatedAt: lastRawRow.updatedAt,
+        resolvedAt: lastRawRow.pickConfiguration?.resolvedAt ?? null,
+      }
+    : null;
 
   // v1 positionCount semantics (escrow.ts L75-90): drop zero-balance
   // unresolved rows (off-platform transfers/burns) so the count matches
@@ -434,7 +531,7 @@ export const positions: NonNullable<QueryResolvers['positions']> = async (
       // The cursor advances past the raw rows this page CONSUMED, not the
       // rows it emitted — a page can synthesize zero nodes while more raw
       // rows exist (the empty-page/hasNextPage contract above).
-      endCursor: lastRawRow ? rowCursor(lastRawRow) : null,
+      endCursor: lastCursorRow ? rowCursor(lastCursorRow) : null,
     },
   };
 };

--- a/packages/api/src/graphql/v2/resolvers/queries/position.ts
+++ b/packages/api/src/graphql/v2/resolvers/queries/position.ts
@@ -325,18 +325,36 @@ const synthesizeWacRows = async (
 };
 
 /**
- * Keyset predicate for RESOLVED_AT ordering — the canonical
- * `(orderField, id)` keyset, but `orderField` lives on the to-one
- * `pickConfiguration` relation rather than the Position row, so it can't go
- * through the flat `buildKeysetWhere`. The base where already pins
- * `resolvedAt` non-null, so the cursor value is always a real number.
+ * Keyset predicate for RESOLVED_AT ordering. `resolvedAt` lives on the
+ * to-one `pickConfiguration` relation (not the Position row), and is
+ * nullable — unresolved positions are kept and ordered NULLS LAST so
+ * sorting never silently drops them (sorting must not become filtering).
+ *
+ * The cursor `k` is the resolvedAt seconds, or '' for a null-resolvedAt row
+ * (the "null phase" at the tail of the ordering):
+ *
+ *   - cursor in the non-null phase → later non-null rows, the id tie-break,
+ *     PLUS every null row (all nulls sort after any non-null in NULLS LAST).
+ *   - cursor in the null phase → only further null rows by id.
  */
 const buildResolvedAtKeyset = (
-  value: number,
+  cursorK: string,
   idValue: number,
   direction: OrderDirection
 ): Prisma.PositionWhereInput => {
   const op = direction === 'desc' ? 'lt' : 'gt';
+
+  if (cursorK === '') {
+    // Null phase: continue through the remaining null-resolvedAt rows by id.
+    return {
+      AND: [
+        { pickConfiguration: { resolvedAt: null } },
+        { id: { [op]: idValue } },
+      ],
+    };
+  }
+
+  const value = Number(cursorK);
   return {
     OR: [
       { pickConfiguration: { resolvedAt: { [op]: value } } },
@@ -346,6 +364,7 @@ const buildResolvedAtKeyset = (
           { id: { [op]: idValue } },
         ],
       },
+      { pickConfiguration: { resolvedAt: null } },
     ],
   };
 };
@@ -400,19 +419,15 @@ export const positions: NonNullable<QueryResolvers['positions']> = async (
     pickConfigFilter.endsAt = r;
     hasPickConfigFilter = true;
   }
-  // RESOLVED_AT ordering only makes sense for resolved positions; pinning
-  // resolvedAt non-null also keeps the keyset clean (no NULL boundary).
-  if (byResolvedAt) {
-    pickConfigFilter.resolvedAt = { not: null };
-    hasPickConfigFilter = true;
-  }
+  // RESOLVED_AT keeps unresolved positions (ordered NULLS LAST) — it must
+  // not filter them out, so no resolvedAt-non-null restriction here.
   if (hasPickConfigFilter) where.pickConfiguration = pickConfigFilter;
 
   const cursor = args.after ? decodeCursor(args.after) : null;
   let cursorWhere: Prisma.PositionWhereInput | null = null;
   if (cursor) {
     cursorWhere = byResolvedAt
-      ? buildResolvedAtKeyset(Number(cursor.k), Number(cursor.id), direction)
+      ? buildResolvedAtKeyset(cursor.k, Number(cursor.id), direction)
       : buildKeysetWhere<Prisma.PositionWhereInput>({
           orderField: dateField as string,
           orderValue: new Date(cursor.k),
@@ -436,7 +451,14 @@ export const positions: NonNullable<QueryResolvers['positions']> = async (
     : true;
 
   const orderBy: Prisma.PositionOrderByWithRelationInput[] = byResolvedAt
-    ? [{ pickConfiguration: { resolvedAt: direction } }, { id: direction }]
+    ? [
+        // NULLS LAST so unresolved positions sink to the tail instead of
+        // being filtered out.
+        {
+          pickConfiguration: { resolvedAt: { sort: direction, nulls: 'last' } },
+        },
+        { id: direction },
+      ]
     : [
         {
           [dateField as string]: direction,
@@ -466,22 +488,27 @@ export const positions: NonNullable<QueryResolvers['positions']> = async (
 
   const items = await synthesizeWacRows(pageRows);
 
-  // escrow.ts L625-633: re-sort by the requested field. Synthetic SOLD
-  // rows carry the trade's executedAt as their updatedAt, so without this
-  // they'd appear grouped under their parent rather than interleaved by
-  // recency. (RESOLVED_AT is resolved-only, so it emits no SOLD rows; we
-  // sort those by the raw row's resolvedAt.)
-  const sortValue = (row: SynthesizedPositionRow): number =>
-    dateField ? row[dateField].getTime() : (row.cursorRow.resolvedAt ?? 0);
-  items.sort((a, b) => {
-    const diff = sortValue(b) - sortValue(a);
-    return direction === 'asc' ? -diff : diff;
-  });
+  // escrow.ts L625-633: for the Date orderings, re-sort by the requested
+  // field — synthetic SOLD rows carry the trade's executedAt as their
+  // updatedAt, so without this they'd group under their parent rather than
+  // interleave by recency. RESOLVED_AT is left in DB order: all synthesized
+  // rows from one raw row share that row's resolvedAt, so the page is
+  // already correctly ordered (NULLS LAST) and re-sorting would only risk
+  // disturbing the null tie-break.
+  if (dateField) {
+    items.sort((a, b) => {
+      const diff = b[dateField].getTime() - a[dateField].getTime();
+      return direction === 'asc' ? -diff : diff;
+    });
+  }
 
   // Cursors always point at the underlying RAW row (SOLD rows share their
   // parent's cursor): resuming `after:` a synthesized row resumes after
   // the raw row that produced it — the same granularity v1's skip-based
   // paging had.
+  // For RESOLVED_AT, `k` is the resolvedAt seconds, or '' for a
+  // null-resolvedAt row — the sentinel that puts the cursor in the keyset's
+  // null phase (see buildResolvedAtKeyset).
   const rowCursor = (row: {
     id: number;
     createdAt: Date;
@@ -489,7 +516,11 @@ export const positions: NonNullable<QueryResolvers['positions']> = async (
     resolvedAt: number | null;
   }) =>
     encodeCursor({
-      k: dateField ? row[dateField].toISOString() : String(row.resolvedAt ?? 0),
+      k: dateField
+        ? row[dateField].toISOString()
+        : row.resolvedAt == null
+          ? ''
+          : String(row.resolvedAt),
       id: String(row.id),
     });
   const edges = items.map((node) => ({

--- a/packages/api/src/graphql/v2/schema/schema.graphql
+++ b/packages/api/src/graphql/v2/schema/schema.graphql
@@ -1467,6 +1467,13 @@ input PositionFilter {
 enum PositionOrderField {
   CREATED_AT
   UPDATED_AT
+  """
+  When the position's pickConfiguration resolved on Sapience
+  (`PickConfiguration.resolvedAt`). Ordering by this field restricts the
+  connection to resolved positions (`resolvedAt` non-null) so it pages
+  cleanly across the whole resolved set, newest-resolved first by default.
+  """
+  RESOLVED_AT
 }
 
 input PositionOrder {

--- a/packages/api/src/workers/indexers/conditionSettled/resolvePickConfigs.test.ts
+++ b/packages/api/src/workers/indexers/conditionSettled/resolvePickConfigs.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi } from 'vitest';
 import { OutcomeSide } from '@sapience/sdk/types';
 import {
   computeSettlementResult,
+  determineResolvedAt,
+  resolvePickConfig,
   resolvePickConfigsForCondition,
 } from './resolvePickConfigs';
 
@@ -194,12 +196,75 @@ describe('computeSettlementResult', () => {
   });
 });
 
+// --- determineResolvedAt tests ---
+
+describe('determineResolvedAt', () => {
+  const settled = (
+    resolvedToYes: boolean,
+    settledAt: number | null,
+    nonDecisive = false
+  ) => ({ id: 'x', settled: true, resolvedToYes, nonDecisive, settledAt });
+
+  it('PREDICTOR_WINS → latest settledAt across all legs (last leg decides a win)', () => {
+    const picks = [
+      { conditionId: 'c1', predictedOutcome: OutcomeSide.YES },
+      { conditionId: 'c2', predictedOutcome: OutcomeSide.NO },
+    ];
+    const map = new Map([
+      ['c1', { ...settled(true, 100), id: 'c1' }],
+      ['c2', { ...settled(false, 250), id: 'c2' }],
+    ]);
+    expect(determineResolvedAt(picks, map, 'PREDICTOR_WINS')).toBe(250);
+  });
+
+  it('COUNTERPARTY_WINS → earliest settledAt among adverse legs (first loss decides)', () => {
+    // c1 is adverse (predicted YES, resolved NO) and settled at 100;
+    // c2 is adverse too but settled later at 300 — first loss is 100.
+    const picks = [
+      { conditionId: 'c1', predictedOutcome: OutcomeSide.YES },
+      { conditionId: 'c2', predictedOutcome: OutcomeSide.YES },
+    ];
+    const map = new Map([
+      ['c1', { ...settled(false, 100), id: 'c1' }],
+      ['c2', { ...settled(false, 300), id: 'c2' }],
+    ]);
+    expect(determineResolvedAt(picks, map, 'COUNTERPARTY_WINS')).toBe(100);
+  });
+
+  it('COUNTERPARTY_WINS ignores a winning leg even if it settled earlier', () => {
+    // c1 is correct (winning leg) settled at 50; c2 is the losing leg at 200.
+    // The determining moment is the loss (200), not the earlier win (50).
+    const picks = [
+      { conditionId: 'c1', predictedOutcome: OutcomeSide.YES },
+      { conditionId: 'c2', predictedOutcome: OutcomeSide.YES },
+    ];
+    const map = new Map([
+      ['c1', { ...settled(true, 50), id: 'c1' }],
+      ['c2', { ...settled(false, 200), id: 'c2' }],
+    ]);
+    expect(determineResolvedAt(picks, map, 'COUNTERPARTY_WINS')).toBe(200);
+  });
+
+  it('COUNTERPARTY_WINS treats a non-decisive leg as adverse', () => {
+    const picks = [{ conditionId: 'c1', predictedOutcome: OutcomeSide.YES }];
+    const map = new Map([['c1', { ...settled(true, 175, true), id: 'c1' }]]);
+    expect(determineResolvedAt(picks, map, 'COUNTERPARTY_WINS')).toBe(175);
+  });
+
+  it('falls back to the trigger timestamp when leg settledAt is missing', () => {
+    const picks = [{ conditionId: 'c1', predictedOutcome: OutcomeSide.NO }];
+    const map = new Map([['c1', { ...settled(true, null), id: 'c1' }]]);
+    expect(determineResolvedAt(picks, map, 'COUNTERPARTY_WINS', 999)).toBe(999);
+  });
+});
+
 // --- resolvePickConfigsForCondition tests ---
 
 function createMockTx(overrides: Record<string, unknown> = {}) {
   return {
     picks: {
       findMany: vi.fn().mockResolvedValue([]),
+      findUnique: vi.fn().mockResolvedValue(null),
       update: vi.fn().mockResolvedValue({}),
     },
     condition: {
@@ -368,6 +433,155 @@ describe('resolvePickConfigsForCondition', () => {
     });
 
     await resolvePickConfigsForCondition(tx, 'c1', 1000);
+    expect(tx.picks.update).not.toHaveBeenCalled();
+  });
+
+  it('writes a leg-derived resolvedAt, not the triggering timestamp', async () => {
+    // A late condition (c2) settles at 5000 and triggers this pass, but the
+    // combo was already doomed by c1's adverse settlement at 1200. resolvedAt
+    // must reflect the first loss (1200), not the trigger (5000).
+    const tx = createMockTx({
+      picks: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: 'pc1',
+            picks: [
+              { conditionId: 'c1', predictedOutcome: OutcomeSide.YES }, // adverse
+              { conditionId: 'c2', predictedOutcome: OutcomeSide.YES },
+            ],
+          },
+        ]),
+        findUnique: vi.fn(),
+        update: vi.fn().mockResolvedValue({}),
+      },
+      condition: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: 'c1',
+            settled: true,
+            resolvedToYes: false,
+            nonDecisive: false,
+            settledAt: 1200,
+          },
+          {
+            id: 'c2',
+            settled: true,
+            resolvedToYes: true,
+            nonDecisive: false,
+            settledAt: 5000,
+          },
+        ]),
+      },
+    });
+
+    await resolvePickConfigsForCondition(tx, 'c2', 5000);
+    expect(tx.picks.update).toHaveBeenCalledWith({
+      where: { id: 'pc1' },
+      data: { resolved: true, result: 'COUNTERPARTY_WINS', resolvedAt: 1200 },
+    });
+  });
+});
+
+describe('resolvePickConfig (resolve-at-mint)', () => {
+  it('resolves a config whose conditions already settled before it was minted', async () => {
+    // Both legs already settled (one adverse) before the config existed.
+    // Without this path the config would never resolve — no future
+    // settlement event fires for already-settled conditions.
+    const tx = createMockTx({
+      picks: {
+        findMany: vi.fn(),
+        findUnique: vi.fn().mockResolvedValue({
+          id: 'pc1',
+          resolved: false,
+          picks: [
+            { conditionId: 'c1', predictedOutcome: OutcomeSide.YES }, // adverse
+            { conditionId: 'c2', predictedOutcome: OutcomeSide.NO },
+          ],
+        }),
+        update: vi.fn().mockResolvedValue({}),
+      },
+      condition: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: 'c1',
+            settled: true,
+            resolvedToYes: false,
+            nonDecisive: false,
+            settledAt: 800,
+          },
+          {
+            id: 'c2',
+            settled: true,
+            resolvedToYes: false,
+            nonDecisive: false,
+            settledAt: 900,
+          },
+        ]),
+      },
+    });
+
+    await resolvePickConfig(tx, 'pc1');
+    expect(tx.picks.update).toHaveBeenCalledWith({
+      where: { id: 'pc1' },
+      data: { resolved: true, result: 'COUNTERPARTY_WINS', resolvedAt: 800 },
+    });
+  });
+
+  it('does nothing when conditions have not settled yet at mint time', async () => {
+    const tx = createMockTx({
+      picks: {
+        findMany: vi.fn(),
+        findUnique: vi.fn().mockResolvedValue({
+          id: 'pc1',
+          resolved: false,
+          picks: [{ conditionId: 'c1', predictedOutcome: OutcomeSide.YES }],
+        }),
+        update: vi.fn(),
+      },
+      condition: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: 'c1',
+            settled: false,
+            resolvedToYes: false,
+            nonDecisive: false,
+            settledAt: null,
+          },
+        ]),
+      },
+    });
+
+    await resolvePickConfig(tx, 'pc1');
+    expect(tx.picks.update).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the config is already resolved', async () => {
+    const tx = createMockTx({
+      picks: {
+        findMany: vi.fn(),
+        findUnique: vi.fn().mockResolvedValue({
+          id: 'pc1',
+          resolved: true,
+          picks: [{ conditionId: 'c1', predictedOutcome: OutcomeSide.YES }],
+        }),
+        update: vi.fn(),
+      },
+    });
+
+    await resolvePickConfig(tx, 'pc1');
+    expect(tx.picks.update).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the config does not exist', async () => {
+    const tx = createMockTx({
+      picks: {
+        findMany: vi.fn(),
+        findUnique: vi.fn().mockResolvedValue(null),
+        update: vi.fn(),
+      },
+    });
+
+    await resolvePickConfig(tx, 'missing');
     expect(tx.picks.update).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/workers/indexers/conditionSettled/resolvePickConfigs.ts
+++ b/packages/api/src/workers/indexers/conditionSettled/resolvePickConfigs.ts
@@ -11,21 +11,39 @@ interface ConditionOutcome {
   settled: boolean;
   resolvedToYes: boolean;
   nonDecisive: boolean;
+  /** Unix seconds when the condition settled on-chain; null if not settled. */
+  settledAt?: number | null;
 }
+
+type PickInput = { conditionId: string; predictedOutcome: number };
+
+type LoadedConfig = { id: string; picks: PickInput[] };
+
+const CONDITION_SELECT = {
+  id: true,
+  settled: true,
+  resolvedToYes: true,
+  nonDecisive: true,
+  settledAt: true,
+} as const;
 
 /**
  * After a condition settles, find all pickConfigs that reference it
- * and resolve any whose conditions are now ALL settled.
+ * and resolve any whose outcome is now determined.
  *
  * Designed to run inside an existing Prisma $transaction so it sees
  * the just-updated condition.settled = true (read-your-own-writes).
+ *
+ * `triggerSettledAt` is the settledAt of the condition that triggered this
+ * pass; it is only used as a fallback when leg-level settledAt values are
+ * missing (e.g. legacy rows). The authoritative resolvedAt is derived from
+ * the legs themselves — see determineResolvedAt.
  */
 export async function resolvePickConfigsForCondition(
   tx: TxClient,
   conditionId: string,
-  settledAt: number
+  triggerSettledAt: number
 ): Promise<void> {
-  // 1. Find unresolved pickConfigs that have a pick referencing this condition
   const unresolvedConfigs = await tx.picks.findMany({
     where: {
       resolved: false,
@@ -36,11 +54,45 @@ export async function resolvePickConfigsForCondition(
     },
   });
 
-  if (unresolvedConfigs.length === 0) return;
+  await resolveLoadedConfigs(tx, unresolvedConfigs, triggerSettledAt);
+}
 
-  // 2. Batch-load all referenced conditions in a single query
+/**
+ * Resolve a single pickConfig if its outcome is already determined.
+ *
+ * Called at mint time (PredictionCreated) so a config whose conditions
+ * already settled before it was created does not wait indefinitely for a
+ * settlement event that will never fire again. No-ops when the config is
+ * already resolved or its outcome is not yet determined.
+ */
+export async function resolvePickConfig(
+  tx: TxClient,
+  pickConfigId: string
+): Promise<void> {
+  const config = await tx.picks.findUnique({
+    where: { id: pickConfigId },
+    include: { picks: true },
+  });
+
+  if (!config || config.resolved) return;
+
+  await resolveLoadedConfigs(tx, [config]);
+}
+
+/**
+ * Shared resolution core: batch-load the conditions referenced by the
+ * given configs, compute each result, and persist resolved configs with a
+ * leg-derived resolvedAt.
+ */
+async function resolveLoadedConfigs(
+  tx: TxClient,
+  configs: LoadedConfig[],
+  triggerSettledAt?: number
+): Promise<void> {
+  if (configs.length === 0) return;
+
   const allConditionIds = new Set<string>();
-  for (const config of unresolvedConfigs) {
+  for (const config of configs) {
     for (const pick of config.picks) {
       allConditionIds.add(pick.conditionId);
     }
@@ -48,22 +100,14 @@ export async function resolvePickConfigsForCondition(
 
   const conditions = await tx.condition.findMany({
     where: { id: { in: [...allConditionIds] } },
-    select: {
-      id: true,
-      settled: true,
-      resolvedToYes: true,
-      nonDecisive: true,
-    },
+    select: CONDITION_SELECT,
   });
 
   const conditionMap = new Map<string, ConditionOutcome>(
     conditions.map((c) => [c.id, c])
   );
 
-  // 3. For each unresolved config, compute result.
-  //    Early-exits on definitive losses (any settled pick that is wrong or
-  //    non-decisive) even when other conditions haven't settled yet.
-  for (const config of unresolvedConfigs) {
+  for (const config of configs) {
     const result = computeSettlementResult(config.picks, conditionMap);
 
     if (result === null) {
@@ -71,18 +115,24 @@ export async function resolvePickConfigsForCondition(
       continue;
     }
 
-    // 4. Update the pickConfig
+    const resolvedAt = determineResolvedAt(
+      config.picks,
+      conditionMap,
+      result,
+      triggerSettledAt
+    );
+
     await tx.picks.update({
       where: { id: config.id },
       data: {
         resolved: true,
         result,
-        resolvedAt: settledAt,
+        resolvedAt,
       },
     });
 
     log.info(
-      `[resolvePickConfigs] Resolved pickConfig ${config.id} → ${result}`
+      `[resolvePickConfigs] Resolved pickConfig ${config.id} → ${result} @ ${resolvedAt}`
     );
   }
 }
@@ -101,7 +151,7 @@ export async function resolvePickConfigsForCondition(
  * as COUNTERPARTY_WINS without waiting for every condition to settle.
  */
 export function computeSettlementResult(
-  picks: Array<{ conditionId: string; predictedOutcome: number }>,
+  picks: PickInput[],
   conditionMap: Map<string, ConditionOutcome>
 ): 'PREDICTOR_WINS' | 'COUNTERPARTY_WINS' | null {
   let allSettled = true;
@@ -137,4 +187,51 @@ export function computeSettlementResult(
   }
 
   return null;
+}
+
+/**
+ * The timestamp at which a pickConfig's outcome became DETERMINED — the
+ * value we want users to sort their positions by:
+ *
+ * - COUNTERPARTY_WINS (a loss): the EARLIEST settledAt among the legs that
+ *   went against the holder (non-decisive, or predicted side ≠ resolved
+ *   side). A combo is doomed the moment its first adverse leg settles, even
+ *   if other legs settle later.
+ * - PREDICTOR_WINS (a win): the LATEST settledAt across all legs. A combo is
+ *   only won once its final leg settles in the holder's favor.
+ *
+ * Derived from leg data rather than the triggering condition so it is
+ * correct regardless of the order conditions settle in or whether the config
+ * was minted before or after its conditions settled. `fallback` (the
+ * triggering condition's settledAt) is used only when leg-level settledAt
+ * values are unavailable.
+ */
+export function determineResolvedAt(
+  picks: PickInput[],
+  conditionMap: Map<string, ConditionOutcome>,
+  result: 'PREDICTOR_WINS' | 'COUNTERPARTY_WINS',
+  fallback?: number | null
+): number | null {
+  const settledAts: number[] = [];
+  const adverseAts: number[] = [];
+
+  for (const pick of picks) {
+    const cond = conditionMap.get(pick.conditionId);
+    if (!cond || !cond.settled) continue;
+
+    const at = cond.settledAt ?? null;
+    if (at != null) settledAts.push(at);
+
+    const adverse =
+      cond.nonDecisive ||
+      isPredictedYes(pick.predictedOutcome) !== cond.resolvedToYes;
+    if (adverse && at != null) adverseAts.push(at);
+  }
+
+  if (result === 'COUNTERPARTY_WINS') {
+    return adverseAts.length > 0 ? Math.min(...adverseAts) : (fallback ?? null);
+  }
+
+  // PREDICTOR_WINS
+  return settledAts.length > 0 ? Math.max(...settledAts) : (fallback ?? null);
 }

--- a/packages/api/src/workers/indexers/predictionMarketEscrowIndexer.ts
+++ b/packages/api/src/workers/indexers/predictionMarketEscrowIndexer.ts
@@ -18,6 +18,7 @@ import { isPredictedYes, normalizeOutcomeSide } from '@sapience/sdk/types';
 import { sendPositionAlert } from '../../services/discordAlert';
 
 import { createLogger } from '../../core/logger';
+import { resolvePickConfig } from './conditionSettled/resolvePickConfigs';
 
 const logger = createLogger('predictionMarketEscrowIndexer');
 
@@ -948,6 +949,11 @@ class PredictionMarketEscrowIndexer implements IIndexer {
       logger.info(
         `[PredictionMarketEscrowIndexer:${this.chainId}] Created Picks config ${pickConfigId}`
       );
+
+      // Resolve-at-mint fallback: if this config's conditions already settled
+      // before it was created, no future settlement event will fire to
+      // resolve it — settle it now from current condition state.
+      await resolvePickConfig(tx, pickConfigId);
     } else {
       // Picks already exist — accumulate collateral totals
       await tx.$executeRaw`

--- a/packages/app/src/components/positions/PositionsTable.tsx
+++ b/packages/app/src/components/positions/PositionsTable.tsx
@@ -398,7 +398,10 @@ function PositionRow({
           );
         })()}
       </TableCell>
-      {/* Resolved — when Sapience recorded the on-chain resolution */}
+      {/* Resolved — when Sapience recorded the resolution. Gated on
+          resolution status, not just resolvedAt: a position resolved before
+          resolvedAt was recorded (no backfill) is still resolved, not
+          PENDING. */}
       <TableCell className="whitespace-nowrap">
         {pickConfig?.resolvedAt ? (
           <span className="text-brand-white text-sm">
@@ -406,6 +409,8 @@ function PositionRow({
               addSuffix: true,
             })}
           </span>
+        ) : isResolved ? (
+          <span className="text-muted-foreground text-sm">Resolved</span>
         ) : (
           <span className="whitespace-nowrap tabular-nums font-mono uppercase text-muted-foreground cursor-default">
             PENDING

--- a/packages/app/src/components/positions/PositionsTable.tsx
+++ b/packages/app/src/components/positions/PositionsTable.tsx
@@ -37,6 +37,7 @@ import {
   usePositionBalances,
   usePositionBalancesByConditionId,
   type PositionBalance,
+  type PositionOrderInput,
 } from '~/hooks/graphql/usePositions';
 import PicksSummary from '~/components/shared/PicksSummary';
 import LegacyBadge from '~/components/shared/LegacyBadge';
@@ -510,6 +511,18 @@ export default function PositionsTable({
   const [filters, setFilters] = React.useState<PositionsFilterState>(
     getDefaultPositionsFilterState
   );
+  const [sort, setSort] = React.useState<SortState | null>(null);
+
+  // RESOLVED_AT sorts server-side so it orders across the whole resolved set
+  // (not just the fetched page); the other columns sort client-side within
+  // what's loaded. Declared here so it can feed the data hooks below.
+  const serverOrderBy = React.useMemo<PositionOrderInput | undefined>(() => {
+    if (sort?.key !== 'resolvedAt') return undefined;
+    return {
+      field: 'RESOLVED_AT',
+      direction: sort.dir === 'asc' ? 'ASC' : 'DESC',
+    };
+  }, [sort]);
 
   // Derive server-side `settled` filter from status selection.
   // Only 'active' → settled=false; only 'won'/'lost' → settled=true; mixed → undefined
@@ -536,6 +549,7 @@ export default function PositionsTable({
     holder: account,
     chainId,
     settled: serverSettled,
+    orderBy: serverOrderBy,
   });
 
   // Fetch position balances for a condition (all holders)
@@ -550,6 +564,7 @@ export default function PositionsTable({
   } = usePositionBalancesByConditionId({
     conditionId: !account ? conditionId : undefined,
     settled: serverSettled,
+    orderBy: serverOrderBy,
   });
 
   const positions = account ? accountPositions : conditionPositions;
@@ -648,8 +663,8 @@ export default function PositionsTable({
     return result;
   }, [positions, filters, conditionsMap]);
 
-  // Sorting
-  const [sort, setSort] = React.useState<SortState | null>(null);
+  // Sorting (sort state lifted above the data hooks so RESOLVED_AT can drive
+  // server-side ordering).
   const handleSort = React.useCallback((key: SortKey) => {
     setSort((prev) => {
       if (prev?.key === key) {
@@ -661,6 +676,10 @@ export default function PositionsTable({
 
   const sortedPositions = React.useMemo(() => {
     if (!sort) return filteredPositions;
+    // resolvedAt is ordered server-side (and paged across the whole resolved
+    // set), so preserve the order the API returned rather than re-sorting the
+    // current page in memory.
+    if (sort.key === 'resolvedAt') return filteredPositions;
     const { key, dir } = sort;
     const multiplier = dir === 'asc' ? 1 : -1;
     const getValue = (p: PositionBalance): number => {
@@ -699,10 +718,8 @@ export default function PositionsTable({
           // Missing end time sinks to the bottom regardless of direction
           return endsAt === 0 ? Number.POSITIVE_INFINITY : endsAt;
         }
-        case 'resolvedAt':
-          // When Sapience recorded the resolution. Still-pending positions
-          // (null) sort to 0 → bottom of the default DESC (recent-first) view.
-          return p.pickConfig?.resolvedAt ?? 0;
+        // 'resolvedAt' is handled server-side (early return above), so it
+        // never reaches this client-side switch.
       }
     };
     return [...filteredPositions].sort(

--- a/packages/app/src/components/positions/PositionsTable.tsx
+++ b/packages/app/src/components/positions/PositionsTable.tsx
@@ -398,6 +398,20 @@ function PositionRow({
           );
         })()}
       </TableCell>
+      {/* Resolved — when Sapience recorded the on-chain resolution */}
+      <TableCell className="whitespace-nowrap">
+        {pickConfig?.resolvedAt ? (
+          <span className="text-brand-white text-sm">
+            {formatDistanceToNow(new Date(pickConfig.resolvedAt * 1000), {
+              addSuffix: true,
+            })}
+          </span>
+        ) : (
+          <span className="whitespace-nowrap tabular-nums font-mono uppercase text-muted-foreground cursor-default">
+            PENDING
+          </span>
+        )}
+      </TableCell>
       {/* Actions */}
       <TableCell className="text-right">
         <div className="flex items-center justify-end gap-2">
@@ -414,7 +428,13 @@ function PositionRow({
   );
 }
 
-type SortKey = 'updatedAt' | 'positionSize' | 'payout' | 'pnl' | 'ends';
+type SortKey =
+  | 'updatedAt'
+  | 'positionSize'
+  | 'payout'
+  | 'pnl'
+  | 'ends'
+  | 'resolvedAt';
 type SortDir = 'asc' | 'desc';
 type SortState = { key: SortKey; dir: SortDir };
 
@@ -424,6 +444,9 @@ const DEFAULT_SORT_DIRS: Record<SortKey, SortDir> = {
   payout: 'desc',
   pnl: 'desc',
   ends: 'asc',
+  // Most recently resolved first; still-pending positions (no resolvedAt)
+  // sink to the bottom in this default view.
+  resolvedAt: 'desc',
 };
 
 function SortableHeader({
@@ -671,6 +694,10 @@ export default function PositionsTable({
           // Missing end time sinks to the bottom regardless of direction
           return endsAt === 0 ? Number.POSITIVE_INFINITY : endsAt;
         }
+        case 'resolvedAt':
+          // When Sapience recorded the resolution. Still-pending positions
+          // (null) sort to 0 → bottom of the default DESC (recent-first) view.
+          return p.pickConfig?.resolvedAt ?? 0;
       }
     };
     return [...filteredPositions].sort(
@@ -844,6 +871,14 @@ export default function PositionsTable({
                     </span>
                   }
                   sortKey="ends"
+                  sort={sort}
+                  onSort={handleSort}
+                />
+              </TableHead>
+              <TableHead className="h-auto py-3">
+                <SortableHeader
+                  label="Resolved"
+                  sortKey="resolvedAt"
                   sort={sort}
                   onSort={handleSort}
                 />

--- a/packages/app/src/hooks/graphql/usePositions.ts
+++ b/packages/app/src/hooks/graphql/usePositions.ts
@@ -370,8 +370,13 @@ export const PREDICTION_QUERY = `
 // away still reports `true` while more underlying rows exist, so always page
 // on `pageInfo` (which `useCursorPagination` does), never on node count.
 export const POSITIONS_V2_QUERY = `
-  query Positions($filter: PositionFilter, $first: Int!, $after: String) {
-    positions(filter: $filter, first: $first, after: $after) {
+  query Positions(
+    $filter: PositionFilter
+    $first: Int!
+    $after: String
+    $orderBy: PositionOrder
+  ) {
+    positions(filter: $filter, first: $first, after: $after, orderBy: $orderBy) {
       edges {
         node {
           ${POSITION_V2_FIELDS}
@@ -457,6 +462,17 @@ export function usePredictions(params: {
 const DEFAULT_POSITIONS_PAGE_SIZE = 15;
 
 /**
+ * Server-side ordering for the positions connection. RESOLVED_AT orders by
+ * `pickConfiguration.resolvedAt` across the whole resolved set (so the
+ * client can sort by resolution time across pages, not just the fetched
+ * page); the server restricts to resolved positions for that field.
+ */
+export type PositionOrderInput = {
+  field: 'CREATED_AT' | 'UPDATED_AT' | 'RESOLVED_AT';
+  direction: 'ASC' | 'DESC';
+};
+
+/**
  * Hook to get position balances (ERC20 tokens) for a user, paginated.
  */
 export function usePositionBalances(params: {
@@ -464,12 +480,14 @@ export function usePositionBalances(params: {
   chainId?: number;
   settled?: boolean;
   pageSize?: number;
+  orderBy?: PositionOrderInput;
 }) {
   const {
     holder,
     chainId,
     settled,
     pageSize = DEFAULT_POSITIONS_PAGE_SIZE,
+    orderBy,
   } = params;
 
   const filter = useMemo(() => {
@@ -489,11 +507,19 @@ export function usePositionBalances(params: {
     error,
     refetch,
   } = useCursorPagination<PositionV2Node>({
-    queryKey: ['positionBalances', holder, chainId, settled],
+    // orderBy in the key so switching/toggling sort resets pagination.
+    queryKey: [
+      'positionBalances',
+      holder,
+      chainId,
+      settled,
+      orderBy?.field ?? null,
+      orderBy?.direction ?? null,
+    ],
     query: POSITIONS_V2_QUERY,
     connectionKey: 'positions',
     pageSize,
-    variables: { filter },
+    variables: { filter, orderBy },
     enabled: Boolean(holder),
   });
 
@@ -518,11 +544,13 @@ export function usePositionBalancesByConditionId(params: {
   conditionId?: string;
   pageSize?: number;
   settled?: boolean;
+  orderBy?: PositionOrderInput;
 }) {
   const {
     conditionId,
     pageSize = DEFAULT_POSITIONS_PAGE_SIZE,
     settled,
+    orderBy,
   } = params;
 
   const filter = useMemo(() => {
@@ -541,11 +569,17 @@ export function usePositionBalancesByConditionId(params: {
     error,
     refetch,
   } = useCursorPagination<PositionV2Node>({
-    queryKey: ['positionBalancesByCondition', conditionId, settled],
+    queryKey: [
+      'positionBalancesByCondition',
+      conditionId,
+      settled,
+      orderBy?.field ?? null,
+      orderBy?.direction ?? null,
+    ],
     query: POSITIONS_V2_QUERY,
     connectionKey: 'positions',
     pageSize,
-    variables: { filter },
+    variables: { filter, orderBy },
     enabled: Boolean(conditionId),
   });
 

--- a/packages/sdk/types/graphql.v2.ts
+++ b/packages/sdk/types/graphql.v2.ts
@@ -1208,7 +1208,16 @@ export type PositionOrder = {
   field: PositionOrderField;
 };
 
-export type PositionOrderField = 'CREATED_AT' | 'UPDATED_AT';
+export type PositionOrderField =
+  | 'CREATED_AT'
+  /**
+   * When the position's pickConfiguration resolved on Sapience
+   * (`PickConfiguration.resolvedAt`). Ordering by this field restricts the
+   * connection to resolved positions (`resolvedAt` non-null) so it pages
+   * cleanly across the whole resolved set, newest-resolved first by default.
+   */
+  | 'RESOLVED_AT'
+  | 'UPDATED_AT';
 
 /**
  * Lifecycle discriminator for a synthesized position row. v1's row stream


### PR DESCRIPTION
## Summary

Direct `staging` → `main` promotion for the Sapience monorepo, so GitHub shows the real file diff instead of a synthetic/no-diff alignment branch.

## Branch state

- `origin/main...origin/staging`: `0` main-only commits, `5` staging-only commits
- Diff size: `10 files changed, 725 insertions(+), 59 deletions(-)`
- Areas touched: API GraphQL positions query/schema, condition-settled pick config indexing, app positions table/query hook, generated SDK GraphQL v2 types

## Included changes

### API / GraphQL

- Adds `resolvedAt` support for positions ordering and schema/types.
- Updates positions query behavior so `RESOLVED_AT` sorting can work across pages and keep unresolved positions ordered after resolved positions.
- Expands position resolver tests around `resolvedAt` ordering behavior.

### Indexer

- Hardens condition-settled pick config resolution and adds coverage for edge cases around extracting pick config data.
- Updates the prediction market escrow indexer path to persist/use resolved timing data.

### App

- Updates the positions table to sort/display resolved positions by actual resolution time instead of showing `PENDING` for positions that resolved without a populated previous timestamp path.
- Updates the positions GraphQL hook for the new ordering surface.

### SDK / generated files

- Updates generated GraphQL v2 schema/types for the new `resolvedAt` fields/order support.

## Included staging commits / PRs

- #1882 — `feat: sort positions by resolution time + robust resolvedAt`
- `fix(api): RESOLVED_AT orders NULLS LAST instead of filtering pending`
- `feat: across-page RESOLVED_AT ordering for positions`
- `fix(app): don't show PENDING for resolved positions without resolvedAt`
- `feat: sort positions by resolution time + robust resolvedAt`

## Validation

- Local validation not rerun for this promotion PR yet; GitHub CI / branch protection should be treated as the merge gate.
- I will review the promotion diff separately and call out blockers/non-blockers in the thread.
