### PR TITLE
fix(market-keeper): migrate relist discovery to keyset pagination

### DIFF
--- a/packages/market-keeper/src/__tests__/relist-market.test.ts
+++ b/packages/market-keeper/src/__tests__/relist-market.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PolymarketMarket } from '../types';
+
+// market.ts pulls fetchWithRetry from ../utils and the filter pipeline from
+// ../generate/pipeline. Mock both so the test exercises ONLY the pagination
+// loop, not the network or the binary-market filters.
+vi.mock('../utils', () => ({
+  fetchWithRetry: vi.fn(),
+}));
+
+vi.mock('../generate/pipeline', () => ({
+  runPipeline: vi.fn((input: unknown[]) => ({ output: input, stats: {} })),
+  printPipelineStats: vi.fn(),
+  MARKET_FILTERS: [],
+}));
+
+import { fetchPastEndDateMarkets } from '../relist/market';
+import { fetchWithRetry } from '../utils';
+
+const mockFetch = vi.mocked(fetchWithRetry);
+
+function makeMarket(conditionId: string): PolymarketMarket {
+  return {
+    id: conditionId,
+    question: 'Will X happen?',
+    conditionId,
+    outcomes: ['Yes', 'No'],
+    volume: '50000',
+    liquidity: '5000',
+    // Past endDate so it survives the client-side `endDate < now` filter.
+    endDate: '2020-01-01T00:00:00Z',
+    description: 'Test market',
+    slug: 'test-market',
+    active: true,
+    closed: false,
+  } as PolymarketMarket;
+}
+
+// Build a /markets/keyset envelope response. `nextCursor === undefined` omits
+// the key entirely, which is how the live API signals the final page.
+function keysetPage(
+  markets: PolymarketMarket[],
+  nextCursor?: string
+): Response {
+  const body: Record<string, unknown> = { markets };
+  if (nextCursor !== undefined) body.next_cursor = nextCursor;
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('fetchPastEndDateMarkets — keyset pagination', () => {
+  it('hits /markets/keyset and never uses offset', async () => {
+    mockFetch.mockResolvedValueOnce(keysetPage([makeMarket('0x1')]));
+
+    await fetchPastEndDateMarkets();
+
+    const url = String(mockFetch.mock.calls[0][0]);
+    expect(url).toContain('/markets/keyset');
+    expect(url).not.toContain('offset=');
+  });
+
+  it('follows next_cursor via after_cursor and aggregates across pages', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        keysetPage([makeMarket('0x1'), makeMarket('0x2')], 'CUR1')
+      )
+      .mockResolvedValueOnce(keysetPage([makeMarket('0x3')])); // no next_cursor → last page
+
+    const result = await fetchPastEndDateMarkets();
+
+    expect(result.map((m) => m.conditionId)).toEqual(['0x1', '0x2', '0x3']);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    const firstUrl = String(mockFetch.mock.calls[0][0]);
+    const secondUrl = String(mockFetch.mock.calls[1][0]);
+    expect(firstUrl).not.toContain('after_cursor');
+    expect(secondUrl).toContain('after_cursor=CUR1');
+  });
+
+  it('stops when next_cursor is absent even on a full page (no 422, no offset cap)', async () => {
+    const fullPage = Array.from({ length: 100 }, (_, i) =>
+      makeMarket(`0x${i}`)
+    );
+    // Full page but NO next_cursor → authoritative end-of-results signal.
+    mockFetch.mockResolvedValueOnce(keysetPage(fullPage));
+
+    const result = await fetchPastEndDateMarkets();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result).toHaveLength(100);
+  });
+
+  it('does not loop forever if the cursor stops advancing (stuck-cursor guard)', async () => {
+    // Regression guard for Polymarket/agents#227: a server that keeps echoing
+    // the same next_cursor must not spin into an infinite fetch loop.
+    mockFetch.mockResolvedValue(keysetPage([makeMarket('0x1')], 'STUCK'));
+
+    const result = await fetchPastEndDateMarkets();
+
+    expect(mockFetch.mock.calls.length).toBeLessThanOrEqual(3);
+    expect(result.map((m) => m.conditionId)).toEqual(['0x1']);
+  });
+});

--- a/packages/market-keeper/src/relist/market.ts
+++ b/packages/market-keeper/src/relist/market.ts
@@ -11,10 +11,19 @@ import {
   MARKET_FILTERS,
 } from '../generate/pipeline';
 
-// Polymarket's /markets endpoint silently caps `limit` at 100 server-side;
-// requesting more returns 100 anyway, and the `markets.length < PAGE_SIZE`
-// short-page stop signal below would then misfire after page 1.
+// Polymarket's keyset endpoint caps `limit` at 100 server-side.
 const PAGE_SIZE = 100;
+
+// Hard backstop on pages walked. At 100 markets/page this covers 1M markets —
+// far beyond any real corpus. Its only job is to stop a runaway loop if the API
+// ever regresses to echoing a stuck cursor (see stuck-cursor guard below).
+const MAX_PAGES = 10000;
+
+/** Shape of the /markets/keyset response envelope (vs the bare array /markets returns). */
+interface KeysetPage {
+  markets: PolymarketMarket[];
+  next_cursor?: string;
+}
 
 /**
  * Fetch markets whose endDate is in the past (within the lookback window)
@@ -28,21 +37,30 @@ export async function fetchPastEndDateMarkets(): Promise<PolymarketMarket[]> {
 
   const allMarkets: PolymarketMarket[] = [];
   const seenConditionIds = new Set<string>();
+  // Cursors already requested. Polymarket deprecated offset pagination — the
+  // /markets endpoint rejects offset > 2000 with HTTP 422 ("use /markets/keyset
+  // for deeper pagination"). Keyset pagination has no offset ceiling: each page
+  // returns a `next_cursor` we feed back as `after_cursor`. Tracking seen
+  // cursors also guards against a stuck cursor looping forever (Polymarket/agents#227).
+  const seenCursors = new Set<string>();
   let pageCount = 0;
-  let offset = 0;
+  let cursor: string | undefined;
 
   console.log(
     `[Relist] Fetching past-endDate markets from ${minEndDate.toISOString()} to ${now.toISOString()}...`
   );
 
-  while (true) {
+  while (pageCount < MAX_PAGES) {
     pageCount++;
-    // Fetch active, not closed, not archived markets with past endDates
+    // Fetch active, not closed, not archived markets with past endDates.
+    // Every filter param must be re-sent on each page — the cursor is validated
+    // against a hash of the originating query.
     const url =
-      `https://gamma-api.polymarket.com/markets?limit=${PAGE_SIZE}&offset=${offset}` +
+      `https://gamma-api.polymarket.com/markets/keyset?limit=${PAGE_SIZE}` +
       `&active=true&closed=false&archived=false` +
       `&order=endDate&ascending=false` +
-      `&end_date_min=${minEndDate.toISOString()}&end_date_max=${now.toISOString()}`;
+      `&end_date_min=${minEndDate.toISOString()}&end_date_max=${now.toISOString()}` +
+      (cursor ? `&after_cursor=${encodeURIComponent(cursor)}` : '');
 
     const response = await fetchWithRetry(url, {
       headers: { Accept: 'application/json' },
@@ -60,19 +78,25 @@ export async function fetchPastEndDateMarkets(): Promise<PolymarketMarket[]> {
       );
     }
 
-    const markets: PolymarketMarket[] = await response.json();
+    const { markets, next_cursor }: KeysetPage = await response.json();
 
-    if (markets.length === 0) {
+    if (!markets || markets.length === 0) {
       console.log(`[Relist] Page ${pageCount}: No more markets`);
       break;
     }
 
+    // Surface the earliest endDate in the batch. Results are ordered endDate
+    // descending, so this value should march backward each page — a visible
+    // signal that the cursor is advancing rather than re-fetching page 1.
+    const earliestEndDate = markets.reduce(
+      (min, m) => (new Date(m.endDate) < new Date(min) ? m.endDate : min),
+      markets[0].endDate
+    );
     console.log(
-      `[Relist] Page ${pageCount}: Fetched ${markets.length} markets`
+      `[Relist] Page ${pageCount}: Fetched ${markets.length} markets (earliest endDate ${earliestEndDate})`
     );
 
     // Deduplicate and filter out archived markets (client-side safety net)
-    let newMarketsCount = 0;
     for (const m of markets) {
       if (m.archived) continue;
       // Also filter client-side for endDate < now in case end_date_max isn't supported
@@ -80,18 +104,24 @@ export async function fetchPastEndDateMarkets(): Promise<PolymarketMarket[]> {
       if (!seenConditionIds.has(m.conditionId)) {
         seenConditionIds.add(m.conditionId);
         allMarkets.push(m);
-        newMarketsCount++;
       }
     }
 
     // Stop conditions:
-    // 1. Got less than PAGE_SIZE markets (no more pages)
-    // 2. No new markets added (all duplicates or filtered)
-    if (markets.length < PAGE_SIZE || newMarketsCount === 0) {
+    // 1. No next_cursor → server signalled the final page.
+    // 2. Cursor already seen → API stopped advancing; stop instead of looping
+    //    forever on the same page.
+    if (!next_cursor || seenCursors.has(next_cursor)) {
       break;
     }
+    seenCursors.add(next_cursor);
+    cursor = next_cursor;
+  }
 
-    offset += PAGE_SIZE;
+  if (pageCount >= MAX_PAGES) {
+    console.warn(
+      `[Relist] Reached MAX_PAGES (${MAX_PAGES}); results may be truncated`
+    );
   }
 
   console.log(


### PR DESCRIPTION
## Problem

The `discovery` cron crashes in `fetchPastEndDateMarkets`. It pages Polymarket's Gamma `/markets` endpoint by **offset** (`offset += 100`). Now that the past-endDate corpus has crossed ~2000 markets, the API rejects `offset=2100` with:

```
HTTP 422 {"type":"validation error","error":"offset too large, use /markets/keyset for deeper pagination"}
```

422 is non-retryable, so the throw at `market.ts` propagates and the whole `cron-discovery` group exits 1 — on **every** run.

## Fix

Migrate the pager to the `/markets/keyset` endpoint Polymarket recommends:

- Read the `{ markets, next_cursor }` envelope (the old `/markets` returned a bare array).
- Advance with **`after_cursor=<next_cursor>`**. Note: `cursor` / `next_cursor` as request params are silently ignored server-side and return page 1 forever (the [Polymarket/agents#227](https://github.com/Polymarket/agents/issues/227) trap). All filter params are re-sent each page since the cursor is hashed against the originating query.
- Terminate when `next_cursor` is absent. No offset → no 2000 cap → no 422.
- Guard against a stuck/echoing cursor (`seenCursors`) plus a `MAX_PAGES` backstop, so a regressed API can never spin into an infinite loop.
- Log the earliest `endDate` per page so forward progress is visible at a glance.

## Tests

New `relist-market.test.ts` (TDD — red before, green after) covers: keyset URL with no offset, `after_cursor` follow + cross-page aggregation, termination on absent `next_cursor`, and the stuck-cursor guard.

## Verification

Ran live against Polymarket: walks **28 pages / 2664 markets in ~6.6s with no 422**, earliest `endDate` marching `2026-06-18` → `2026-05-20` (the 30-day lookback edge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)