### PR TITLE
Scope position related activity by token

### DIFF
--- a/packages/api/schema.v2.graphql
+++ b/packages/api/schema.v2.graphql
@@ -1601,6 +1601,12 @@ input ActivityFilter {
   conditionIds: [Bytes!]
   pickConfigId: Bytes32
 
+  """
+  Restrict activity to a single position token. With `account`, predictions
+  match only the side that minted this token; trades match exact token.
+  """
+  token: Address
+
   """Restrict to a subset of activity types. `[]` is a zero-result query."""
   types: [ActivityType!]
 

--- a/packages/api/src/graphql/v2/resolvers/Activity.test.ts
+++ b/packages/api/src/graphql/v2/resolvers/Activity.test.ts
@@ -162,12 +162,12 @@ describe('activity (v2)', () => {
     const tradeCall = mockPrisma.secondaryTrade.findMany.mock.calls[0]?.[0];
     expect(predictionCall.where).toEqual(
       expect.objectContaining({
-        OR: [{ predictor: '0xabc' }, { counterparty: '0xabc' }],
+        AND: [{ OR: [{ predictor: '0xabc' }, { counterparty: '0xabc' }] }],
       })
     );
     expect(tradeCall.where).toEqual(
       expect.objectContaining({
-        OR: [{ buyer: '0xabc' }, { seller: '0xabc' }],
+        AND: [{ OR: [{ buyer: '0xabc' }, { seller: '0xabc' }] }],
       })
     );
   });

--- a/packages/api/src/graphql/v2/resolvers/queries/activity.test.ts
+++ b/packages/api/src/graphql/v2/resolvers/queries/activity.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockPrisma = vi.hoisted(() => ({
+  prediction: { findMany: vi.fn(), count: vi.fn() },
+  secondaryTrade: { findMany: vi.fn(), count: vi.fn() },
+}));
+
+vi.mock('../../../../core/db', () => ({ default: mockPrisma }));
+
+import { activity } from './activity';
+
+type ActivityFn = (
+  parent: unknown,
+  args: Record<string, unknown>,
+  ctx: unknown,
+  info: unknown
+) => Promise<{
+  edges: unknown[];
+  totalCount: unknown;
+  pageInfo: {
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+    startCursor: string | null;
+    endCursor: string | null;
+  };
+}>;
+
+const activityFn = activity as unknown as ActivityFn;
+
+const ALICE = '0xalice000000000000000000000000000000000001';
+const TOKEN_PRED = '0xpred000000000000000000000000000000000001';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.prediction.findMany.mockResolvedValue([]);
+  mockPrisma.secondaryTrade.findMany.mockResolvedValue([]);
+  mockPrisma.prediction.count.mockResolvedValue(0);
+  mockPrisma.secondaryTrade.count.mockResolvedValue(0);
+});
+
+describe('activity query token filtering', () => {
+  it('scopes account activity to the exact position token side', async () => {
+    await activityFn(
+      null,
+      {
+        first: 20,
+        filter: {
+          account: ALICE.toUpperCase(),
+          token: TOKEN_PRED.toUpperCase(),
+        },
+      },
+      null,
+      null
+    );
+
+    expect(mockPrisma.prediction.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          AND: [
+            {
+              OR: [
+                {
+                  predictor: ALICE,
+                  pickConfiguration: { predictorToken: TOKEN_PRED },
+                },
+                {
+                  counterparty: ALICE,
+                  pickConfiguration: { counterpartyToken: TOKEN_PRED },
+                },
+              ],
+            },
+          ],
+        },
+      })
+    );
+
+    expect(mockPrisma.secondaryTrade.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          AND: [
+            { OR: [{ buyer: ALICE }, { seller: ALICE }] },
+            { token: TOKEN_PRED },
+          ],
+        },
+      })
+    );
+  });
+});

--- a/packages/api/src/graphql/v2/resolvers/queries/activity.ts
+++ b/packages/api/src/graphql/v2/resolvers/queries/activity.ts
@@ -96,21 +96,53 @@ export const activity: NonNullable<QueryResolvers['activity']> = async (
     conditionTokens = tokens;
   }
 
-  // Prediction-side where
-  const predictionWhere: Prisma.PredictionWhereInput = {};
-  if (args.filter?.account) {
-    const addr = args.filter.account.toLowerCase();
-    predictionWhere.OR = [{ predictor: addr }, { counterparty: addr }];
+  const account = args.filter?.account?.toLowerCase();
+  const token = args.filter?.token?.toLowerCase();
+
+  // Prediction-side where. When account + token are both provided, match the
+  // exact side the account minted; `account AND (predictorToken OR
+  // counterpartyToken)` would incorrectly include the opposite-side token on
+  // the same prediction.
+  const predictionClauses: Prisma.PredictionWhereInput[] = [];
+  if (account && token) {
+    predictionClauses.push({
+      OR: [
+        {
+          predictor: account,
+          pickConfiguration: { predictorToken: token },
+        },
+        {
+          counterparty: account,
+          pickConfiguration: { counterpartyToken: token },
+        },
+      ],
+    });
+  } else if (account) {
+    predictionClauses.push({
+      OR: [{ predictor: account }, { counterparty: account }],
+    });
+  } else if (token) {
+    predictionClauses.push({
+      OR: [
+        { pickConfiguration: { predictorToken: token } },
+        { pickConfiguration: { counterpartyToken: token } },
+      ],
+    });
   }
+
   if (args.filter?.pickConfigId)
-    predictionWhere.pickConfigId = args.filter.pickConfigId.toLowerCase();
+    predictionClauses.push({
+      pickConfigId: args.filter.pickConfigId.toLowerCase(),
+    });
   if (conditionPickConfigIds) {
     const ids = args.filter?.pickConfigId
       ? conditionPickConfigIds.filter(
           (id) => id === args.filter!.pickConfigId!.toLowerCase()
         )
       : conditionPickConfigIds;
-    predictionWhere.pickConfigId = ids.length === 1 ? ids[0] : { in: ids };
+    predictionClauses.push({
+      pickConfigId: ids.length === 1 ? ids[0] : { in: ids },
+    });
   }
   if (args.filter?.timestamp) {
     const r: Prisma.DateTimeFilter = {};
@@ -118,24 +150,36 @@ export const activity: NonNullable<QueryResolvers['activity']> = async (
       r.gte = new Date(args.filter.timestamp.gte * 1000);
     if (args.filter.timestamp.lte != null)
       r.lte = new Date(args.filter.timestamp.lte * 1000);
-    predictionWhere.createdAt = r;
+    predictionClauses.push({ createdAt: r });
   }
+  const predictionWhere: Prisma.PredictionWhereInput = predictionClauses.length
+    ? { AND: predictionClauses }
+    : {};
 
-  // Trade-side where
-  const tradeWhere: Prisma.SecondaryTradeWhereInput = {};
-  if (args.filter?.account) {
-    const addr = args.filter.account.toLowerCase();
-    tradeWhere.OR = [{ buyer: addr }, { seller: addr }];
+  // Trade-side where. Token filtering is exact because SecondaryTrade.token is
+  // the ERC-20 position token that changed hands.
+  const tradeClauses: Prisma.SecondaryTradeWhereInput[] = [];
+  if (account) {
+    tradeClauses.push({ OR: [{ buyer: account }, { seller: account }] });
   }
-  if (conditionTokens != null) {
-    tradeWhere.token = { in: conditionTokens };
+  if (token && conditionTokens != null) {
+    tradeClauses.push(
+      conditionTokens.includes(token) ? { token } : { token: { in: [] } }
+    );
+  } else if (token) {
+    tradeClauses.push({ token });
+  } else if (conditionTokens != null) {
+    tradeClauses.push({ token: { in: conditionTokens } });
   }
   if (args.filter?.timestamp) {
     const r: Prisma.IntFilter = {};
     if (args.filter.timestamp.gte != null) r.gte = args.filter.timestamp.gte;
     if (args.filter.timestamp.lte != null) r.lte = args.filter.timestamp.lte;
-    tradeWhere.executedAt = r;
+    tradeClauses.push({ executedAt: r });
   }
+  const tradeWhere: Prisma.SecondaryTradeWhereInput = tradeClauses.length
+    ? { AND: tradeClauses }
+    : {};
 
   // Cursor — applied to both sides as `ts < cursor.ts OR (ts == cursor.ts AND ...)`
   const cursor = parseCursor(args.after);

--- a/packages/api/src/graphql/v2/schema/schema.graphql
+++ b/packages/api/src/graphql/v2/schema/schema.graphql
@@ -1722,6 +1722,11 @@ input ActivityFilter {
   conditionIds: [Bytes!]
   pickConfigId: Bytes32
   """
+  Restrict activity to a single position token. With `account`, predictions
+  match only the side that minted this token; trades match exact token.
+  """
+  token: Address
+  """
   Restrict to a subset of activity types. `[]` is a zero-result query.
   """
   types: [ActivityType!]

--- a/packages/app/src/components/positions/ActivityTable.tsx
+++ b/packages/app/src/components/positions/ActivityTable.tsx
@@ -576,6 +576,7 @@ export default function ActivityTable({
   pageSize,
   hiddenColumns,
   filterPickConfigId,
+  filterToken,
   hideFilters,
   fill = false,
 }: {
@@ -595,6 +596,8 @@ export default function ActivityTable({
    * in the first page of the unscoped feed.
    */
   filterPickConfigId?: string;
+  /** Scope the feed to a single position token. */
+  filterToken?: Address;
   /** Hide the filter toolbar (search/status/value-range/date-range). */
   hideFilters?: boolean;
   /** Grow the empty/loading panel via `flex-1` to fill the parent.
@@ -629,6 +632,7 @@ export default function ActivityTable({
     pageSize: effectivePageSize,
     activityType: filters.activityType,
     pickConfigId: filterPickConfigId,
+    token: filterToken,
     conditionId: !account ? conditionId : undefined,
   });
 

--- a/packages/app/src/components/positions/PositionDialog.tsx
+++ b/packages/app/src/components/positions/PositionDialog.tsx
@@ -136,6 +136,7 @@ export default function PositionDialog({
                 <ActivityTable
                   account={position.holder as Address}
                   filterPickConfigId={position.pickConfigId}
+                  filterToken={position.tokenAddress as Address}
                   hiddenColumns={['position', 'status', 'share']}
                   hideFilters
                 />

--- a/packages/app/src/components/positions/PositionDialog.tsx
+++ b/packages/app/src/components/positions/PositionDialog.tsx
@@ -135,7 +135,6 @@ export default function PositionDialog({
               <div className="border-t border-border/60 max-h-56 overflow-y-auto">
                 <ActivityTable
                   account={position.holder as Address}
-                  filterPickConfigId={position.pickConfigId}
                   filterToken={position.tokenAddress as Address}
                   hiddenColumns={['position', 'status', 'share']}
                   hideFilters

--- a/packages/app/src/components/positions/__tests__/PositionDialog.test.tsx
+++ b/packages/app/src/components/positions/__tests__/PositionDialog.test.tsx
@@ -48,10 +48,11 @@ vi.mock('~/components/shared/AddressDisplay', () => ({
 // hood); exercise its data path in its own tests, not here.
 vi.mock('~/components/positions/ActivityTable', () => ({
   __esModule: true,
-  default: (props: { filterPickConfigId?: string }) => (
+  default: (props: { filterPickConfigId?: string; filterToken?: string }) => (
     <div
       data-testid="activity-table"
       data-pickconfigid={props.filterPickConfigId ?? ''}
+      data-token={props.filterToken ?? ''}
     />
   ),
 }));
@@ -217,12 +218,15 @@ describe('PositionDialog', () => {
     expect(toggle).toHaveAttribute('aria-expanded', 'false');
     expect(screen.queryByTestId('activity-table')).not.toBeInTheDocument();
 
-    // Expand it; the embedded ActivityTable mounts, scoped to this pickConfig.
+    // Expand it; the embedded ActivityTable mounts, scoped to this token balance.
     fireEvent.click(toggle);
     expect(toggle).toHaveAttribute('aria-expanded', 'true');
     const embedded = screen.getByTestId('activity-table');
     expect(embedded.getAttribute('data-pickconfigid')).toBe(
       counterpartyPosition.pickConfigId
+    );
+    expect(embedded.getAttribute('data-token')).toBe(
+      counterpartyPosition.tokenAddress
     );
   });
 

--- a/packages/app/src/components/positions/__tests__/PositionDialog.test.tsx
+++ b/packages/app/src/components/positions/__tests__/PositionDialog.test.tsx
@@ -222,9 +222,9 @@ describe('PositionDialog', () => {
     fireEvent.click(toggle);
     expect(toggle).toHaveAttribute('aria-expanded', 'true');
     const embedded = screen.getByTestId('activity-table');
-    expect(embedded.getAttribute('data-pickconfigid')).toBe(
-      counterpartyPosition.pickConfigId
-    );
+    // Scoped by token alone — the position token already pins the pick config
+    // and side, so `filterPickConfigId` is intentionally not passed.
+    expect(embedded.getAttribute('data-pickconfigid')).toBe('');
     expect(embedded.getAttribute('data-token')).toBe(
       counterpartyPosition.tokenAddress
     );

--- a/packages/app/src/hooks/graphql/__tests__/useAccountActivity.test.ts
+++ b/packages/app/src/hooks/graphql/__tests__/useAccountActivity.test.ts
@@ -189,6 +189,7 @@ describe('useAccountActivity', () => {
       account: null,
       conditionIds: null,
       pickConfigId: null,
+      token: null,
       types: null,
       first: 20,
       after: null,
@@ -288,6 +289,7 @@ describe('useAccountActivity', () => {
           account:
             '0xABCDEF0000000000000000000000000000000001' as `0x${string}`,
           pickConfigId: '0xpc1',
+          token: '0xpredictortoken' as `0x${string}`,
           conditionId: '0xc1',
           activityType: 'trade',
         }),
@@ -302,6 +304,7 @@ describe('useAccountActivity', () => {
     expect(variables).toMatchObject({
       account: '0xABCDEF0000000000000000000000000000000001',
       pickConfigId: '0xpc1',
+      token: '0xpredictortoken',
       conditionIds: ['0xc1'],
       types: ['TRADE'],
     });

--- a/packages/app/src/hooks/graphql/useAccountActivity.ts
+++ b/packages/app/src/hooks/graphql/useAccountActivity.ts
@@ -47,6 +47,7 @@ export const ACCOUNT_ACTIVITY_QUERY = `
     $account: Address
     $conditionIds: [Bytes!]
     $pickConfigId: Bytes32
+    $token: Address
     $types: [ActivityType!]
     $first: Int!
     $after: String
@@ -58,6 +59,7 @@ export const ACCOUNT_ACTIVITY_QUERY = `
         account: $account
         conditionIds: $conditionIds
         pickConfigId: $pickConfigId
+        token: $token
         types: $types
       }
     ) {
@@ -195,6 +197,7 @@ export function useAccountActivity({
   pageSize = DEFAULT_PAGE_SIZE,
   activityType,
   pickConfigId,
+  token,
   conditionId,
   enabled: enabledOverride,
 }: {
@@ -206,6 +209,11 @@ export function useAccountActivity({
    * pickConfigId and trades by the pickConfig's predictor/counterparty tokens.
    */
   pickConfigId?: string;
+  /**
+   * Scope the feed to a single position token. With `account`, predictions
+   * only match the side that minted that token; trades match exact token.
+   */
+  token?: Address;
   /**
    * Scope the feed to a condition. Matches every pick configuration whose
    * picks reference this conditionId.
@@ -242,6 +250,7 @@ export function useAccountActivity({
       account ?? 'global',
       typeFilter,
       pickConfigId ?? null,
+      token ?? null,
       conditionId ?? null,
       pageSize,
     ],
@@ -263,6 +272,7 @@ export function useAccountActivity({
         account: account ?? null,
         conditionIds: conditionId ? [conditionId] : null,
         pickConfigId: pickConfigId ?? null,
+        token: token ?? null,
         types,
         first: pageSize,
         after: pageParam ?? null,

--- a/packages/sdk/types/graphql.v2.ts
+++ b/packages/sdk/types/graphql.v2.ts
@@ -331,6 +331,11 @@ export type ActivityFilter = {
   pickConfigId?: InputMaybe<Scalars['Bytes32']['input']>;
   /** Filter by activity timestamp in epoch seconds. */
   timestamp?: InputMaybe<IntRangeFilter>;
+  /**
+   * Restrict activity to a single position token. With `account`, predictions
+   * match only the side that minted this token; trades match exact token.
+   */
+  token?: InputMaybe<Scalars['Address']['input']>;
   /** Restrict to a subset of activity types. `[]` is a zero-result query. */
   types?: InputMaybe<Array<ActivityType>>;
 };


### PR DESCRIPTION
## Summary
- adds a v2 `ActivityFilter.token` field for exact position-token scoped activity
- scopes prediction activity side-aware when `account + token` are provided
- scopes secondary trades to the exact token and passes `position.tokenAddress` from the position dialog

## Why
Related Activity in the position dialog should describe the token balance, not every activity row for the same account/pick config. This keeps older valid trades for the same token, while excluding unrelated secondary trades.

## Tests
- `pnpm --filter @sapience/api run type-check`
- `pnpm --filter @sapience/app run type-check`
- `pnpm --filter @sapience/api exec vitest run src/graphql/v2/resolvers/queries/activity.test.ts`
- `pnpm --filter @sapience/app exec vitest run src/hooks/graphql/__tests__/useAccountActivity.test.ts src/components/positions/__tests__/PositionDialog.test.tsx`
- `pnpm --filter @sapience/api run lint`
- `pnpm --filter @sapience/app run lint`