### PR TITLE
fix: use indexed vault account value for vaults AUM

### DIFF
--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -34,6 +34,7 @@ import RestrictedJurisdictionBanner from '~/components/shared/RestrictedJurisdic
 import {
   useVaultStats,
   useProtocolAnalytics,
+  useVaultAccountValue,
 } from '~/hooks/graphql/useAnalytics';
 import RiskDisclaimer from '~/components/markets/forms/shared/RiskDisclaimer';
 import Loader from '~/components/shared/Loader';
@@ -200,8 +201,9 @@ const VaultsPageContent = () => {
   });
 
   const { isRestricted, isPermitLoading } = useRestrictedJurisdiction();
-  const { data: vaultStats, isLoading: isAnalyticsLoading } =
-    useVaultStats(VAULT_ADDRESS);
+  const { data: vaultStats } = useVaultStats(VAULT_ADDRESS);
+  const { data: vaultAccountValue, isLoading: isAnalyticsLoading } =
+    useVaultAccountValue(VAULT_ADDRESS);
 
   const [depositAmount, setDepositAmount] = useState('');
   const [withdrawAmount, setWithdrawAmount] = useState('');
@@ -575,23 +577,19 @@ const VaultsPageContent = () => {
     </Tabs>
   );
 
-  const liquidWei = vaultData?.totalLiquidValue ?? 0n;
+  const deployedWei = vaultAccountValue?.deployedCollateral
+    ? BigInt(vaultAccountValue.deployedCollateral)
+    : 0n;
 
-  const deployedWei = useMemo(() => {
-    const lastStat = vaultStats?.[vaultStats.length - 1];
-    return lastStat?.deployedCollateral
-      ? BigInt(lastStat.deployedCollateral)
-      : 0n;
-  }, [vaultStats]);
+  // Vault AUM is computed from one indexed account view: current wallet
+  // collateral balance + collateral deployed in open positions + settled/won
+  // collateral owed but not yet claimed. Keeping all three terms on the same
+  // freshness boundary avoids the old live-contract + cached-snapshot drift.
+  const tvlWei = vaultAccountValue?.totalValue
+    ? BigInt(vaultAccountValue.totalValue)
+    : 0n;
 
-  // Vault AUM = liquid USDe in the vault + collateral deployed in open positions.
-  // getTotalLiquidValue() on the contract intentionally excludes position tokens,
-  // so we add the deployed cost basis back here to show true total.
-  const tvlWei = liquidWei + deployedWei;
-
-  // The two terms come from different sources (on-chain read vs GraphQL);
-  // until both have loaded, the sum is a misleading partial figure.
-  const isBalanceReady = !!vaultData && !!vaultStats;
+  const isBalanceReady = !!vaultAccountValue;
 
   const utilizationPercent = useMemo(() => {
     if (tvlWei <= 0n) return 0;

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -201,9 +201,13 @@ const VaultsPageContent = () => {
   });
 
   const { isRestricted, isPermitLoading } = useRestrictedJurisdiction();
-  const { data: vaultStats } = useVaultStats(VAULT_ADDRESS);
-  const { data: vaultAccountValue, isLoading: isAnalyticsLoading } =
-    useVaultAccountValue(VAULT_ADDRESS);
+  // `isAnalyticsLoading` tracks the vault-stats query that feeds the PnL chart
+  // and the yield/rewards block — keep it on that source so their loaders match
+  // the data they render. The balance display gates on `vaultAccountValue`
+  // separately via `isBalanceReady` below.
+  const { data: vaultStats, isLoading: isAnalyticsLoading } =
+    useVaultStats(VAULT_ADDRESS);
+  const { data: vaultAccountValue } = useVaultAccountValue(VAULT_ADDRESS);
 
   const [depositAmount, setDepositAmount] = useState('');
   const [withdrawAmount, setWithdrawAmount] = useState('');

--- a/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
+++ b/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
@@ -10,6 +10,7 @@ const {
   mockUsePassiveLiquidityVault,
   mockUseCurrentAddress,
   mockUseVaultStats,
+  mockUseVaultAccountValue,
   mockUseProtocolAnalytics,
   mockRouterReplace,
   mockSearchParamsToString,
@@ -18,6 +19,7 @@ const {
   mockUsePassiveLiquidityVault: vi.fn(),
   mockUseCurrentAddress: vi.fn(),
   mockUseVaultStats: vi.fn(),
+  mockUseVaultAccountValue: vi.fn(),
   mockUseProtocolAnalytics: vi.fn(),
   mockRouterReplace: vi.fn(),
   mockSearchParamsToString: vi.fn(() => ''),
@@ -44,6 +46,8 @@ vi.mock('~/hooks/graphql/useAnalytics', () => ({
   useVaultStats: (vaultAddress: string | undefined) =>
     mockUseVaultStats(vaultAddress),
   useProtocolAnalytics: () => mockUseProtocolAnalytics(),
+  useVaultAccountValue: (vaultAddress: string | undefined) =>
+    mockUseVaultAccountValue(vaultAddress),
 }));
 
 vi.mock('~/lib/context/ConnectDialogContext', () => ({
@@ -283,6 +287,17 @@ function setDefaults() {
     isLoading: false,
   });
 
+  mockUseVaultAccountValue.mockReturnValue({
+    data: {
+      collateralBalance: (1000n * 10n ** 18n).toString(),
+      deployedCollateral: '0',
+      claimableCollateral: '0',
+      totalValue: (1000n * 10n ** 18n).toString(),
+      timestamp: 1,
+    },
+    isLoading: false,
+  });
+
   mockUseProtocolAnalytics.mockReturnValue({
     data: { stats: { totalValueLocked: '0' } },
     isLoading: false,
@@ -458,7 +473,17 @@ describe('VaultsPageContent vault balance display', () => {
       permitData: { permitted: true },
       permitError: null,
     });
-    // Liquid (on-chain) = 1,000; deployed (GraphQL) = 500 -> balance 1,500.
+    // Indexed collateral balance = 1,000; deployed = 500; claimable = 125 -> balance 1,625.
+    mockUseVaultAccountValue.mockReturnValue({
+      data: {
+        collateralBalance: (1000n * 10n ** 18n).toString(),
+        deployedCollateral: (500n * 10n ** 18n).toString(),
+        claimableCollateral: (125n * 10n ** 18n).toString(),
+        totalValue: (1625n * 10n ** 18n).toString(),
+        timestamp: 1,
+      },
+      isLoading: false,
+    });
     mockUseVaultStats.mockReturnValue({
       data: [{ deployedCollateral: (500n * 10n ** 18n).toString() }],
       isLoading: false,
@@ -468,7 +493,7 @@ describe('VaultsPageContent vault balance display', () => {
   it('renders the balance and progress bar once both sources have loaded', () => {
     render(<VaultsPageContent />);
 
-    expect(screen.getByText('1,500.00 USDe')).toBeInTheDocument();
+    expect(screen.getByText('1,625.00 USDe')).toBeInTheDocument();
     expect(screen.getByTestId('vault-balance-bar')).toBeInTheDocument();
     expect(screen.getByText(/deployed/)).toBeInTheDocument();
   });
@@ -477,39 +502,34 @@ describe('VaultsPageContent vault balance display', () => {
     render(<VaultsPageContent />);
 
     const fadeIn = 'animate-in fade-in duration-200';
-    expect(screen.getByText('1,500.00 USDe').className).toContain(fadeIn);
+    expect(screen.getByText('1,625.00 USDe').className).toContain(fadeIn);
     expect(
       screen.getByTestId('vault-balance-bar').parentElement?.className
     ).toContain(fadeIn);
     expect(screen.getByText(/deployed/).className).toContain(fadeIn);
   });
 
-  it('hides the balance number and progress bar until the on-chain read has loaded', () => {
+  it('uses the indexed account value rather than the live on-chain liquid read', () => {
     mockUsePassiveLiquidityVault.mockReturnValue({
       ...passiveVaultDefaults(),
-      vaultData: null,
+      vaultData: { totalLiquidValue: 9999n * 10n ** 18n, paused: false },
     });
 
     render(<VaultsPageContent />);
 
-    // Without the liquid value, the sum would misleadingly show only the
-    // deployed portion (500.00) - it must not render at all.
-    expect(screen.queryByText('500.00 USDe')).toBeNull();
-    expect(screen.queryByTestId('vault-balance-bar')).toBeNull();
-    expect(screen.queryByText(/deployed/)).toBeNull();
+    expect(screen.getByText('1,625.00 USDe')).toBeInTheDocument();
+    expect(screen.queryByText('10,499.00 USDe')).toBeNull();
   });
 
-  it('hides the balance number and progress bar until protocol stats have loaded', () => {
-    mockUseVaultStats.mockReturnValue({
+  it('hides the balance number and progress bar until indexed account value has loaded', () => {
+    mockUseVaultAccountValue.mockReturnValue({
       data: undefined,
       isLoading: true,
     });
 
     render(<VaultsPageContent />);
 
-    // Without the deployed value, the sum would misleadingly show only the
-    // liquid portion (1,000.00) - it must not render at all.
-    expect(screen.queryByText('1,000.00 USDe')).toBeNull();
+    expect(screen.queryByText('1,625.00 USDe')).toBeNull();
     expect(screen.queryByTestId('vault-balance-bar')).toBeNull();
     expect(screen.queryByText(/deployed/)).toBeNull();
   });

--- a/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
+++ b/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
@@ -14,6 +14,7 @@ const {
   mockUseProtocolAnalytics,
   mockRouterReplace,
   mockSearchParamsToString,
+  mockVaultPnlChart,
 } = vi.hoisted(() => ({
   mockUseRestrictedJurisdiction: vi.fn(),
   mockUsePassiveLiquidityVault: vi.fn(),
@@ -23,6 +24,7 @@ const {
   mockUseProtocolAnalytics: vi.fn(),
   mockRouterReplace: vi.fn(),
   mockSearchParamsToString: vi.fn(() => ''),
+  mockVaultPnlChart: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -232,7 +234,10 @@ vi.mock('~/components/shared/Loader', () => {
 });
 
 vi.mock('~/components/vaults/VaultPnlChart', () => {
-  const VaultPnlChart = () => <div />;
+  const VaultPnlChart = (props: { isLoading?: boolean }) => {
+    mockVaultPnlChart(props);
+    return <div />;
+  };
   VaultPnlChart.displayName = 'VaultPnlChart';
   return { __esModule: true, default: VaultPnlChart };
 });
@@ -532,5 +537,28 @@ describe('VaultsPageContent vault balance display', () => {
     expect(screen.queryByText('1,625.00 USDe')).toBeNull();
     expect(screen.queryByTestId('vault-balance-bar')).toBeNull();
     expect(screen.queryByText(/deployed/)).toBeNull();
+  });
+
+  it('drives the PnL chart loader from the vault-stats query, not the account value', () => {
+    // The chart renders `vaultStats`, so its loader must track that query.
+    // The account-value query (which backs the balance number) being settled
+    // must not make the chart claim it has finished loading its own series.
+    mockUseVaultStats.mockReturnValue({ data: undefined, isLoading: true });
+    mockUseVaultAccountValue.mockReturnValue({
+      data: {
+        collateralBalance: '0',
+        deployedCollateral: '0',
+        claimableCollateral: '0',
+        totalValue: '0',
+        timestamp: 1,
+      },
+      isLoading: false,
+    });
+
+    render(<VaultsPageContent />);
+
+    expect(mockVaultPnlChart).toHaveBeenCalledWith(
+      expect.objectContaining({ isLoading: true })
+    );
   });
 });

--- a/packages/app/src/hooks/graphql/useAnalytics.ts
+++ b/packages/app/src/hooks/graphql/useAnalytics.ts
@@ -3,8 +3,10 @@ import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
 import {
   fetchProtocolAnalytics,
   fetchVaultStats,
+  fetchVaultAccountValue,
   type ProtocolAnalytics,
   type VaultStat,
+  type VaultAccountValue,
 } from '@sapience/sdk/queries';
 
 const CACHE_TIME_MS = 60 * 1000;
@@ -31,6 +33,30 @@ export function useVaultStats(vaultAddress?: string) {
 }
 
 /**
+ * Coherent indexed vault account value for the /vaults amount display.
+ * Uses one GraphQL account view instead of mixing live contract reads with
+ * cached vault stats snapshots.
+ */
+export function useVaultAccountValue(vaultAddress?: string) {
+  return useQuery<VaultAccountValue>({
+    queryKey: ['vaultAccountValue', vaultAddress?.toLowerCase() ?? null],
+    queryFn: () =>
+      vaultAddress
+        ? fetchVaultAccountValue(vaultAddress, DEFAULT_CHAIN_ID)
+        : Promise.resolve({
+            collateralBalance: '0',
+            deployedCollateral: '0',
+            claimableCollateral: '0',
+            totalValue: '0',
+            timestamp: null,
+          }),
+    enabled: !!vaultAddress,
+    staleTime: CACHE_TIME_MS,
+    refetchInterval: CACHE_TIME_MS,
+  });
+}
+
+/**
  * v2 protocol analytics: live stats, the recorded snapshot series and both
  * open-interest breakdowns in a single `protocol { ... }` query.
  */
@@ -43,7 +69,7 @@ export function useProtocolAnalytics() {
   });
 }
 
-export type { ProtocolAnalytics, VaultStat };
+export type { ProtocolAnalytics, VaultStat, VaultAccountValue };
 export type {
   ProtocolAnalyticsStat,
   ProtocolCategoryOpenInterest,

--- a/packages/sdk/queries/__tests__/vault.test.ts
+++ b/packages/sdk/queries/__tests__/vault.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
-import { fetchVaultStats, GET_VAULT_STATS } from '../vault';
+import {
+  fetchVaultAccountValue,
+  fetchVaultStats,
+  GET_VAULT_ACCOUNT_VALUE,
+  GET_VAULT_STATS,
+} from '../vault';
 
 const mockGraphqlRequestV2 = vi.fn();
 vi.mock('../client/graphqlClient', () => ({
@@ -151,5 +156,75 @@ describe('fetchVaultStats', () => {
     expect(await fetchVaultStats('0xabc', 42161)).toEqual([]);
     mockGraphqlRequestV2.mockResolvedValue(null);
     expect(await fetchVaultStats('0xabc', 42161)).toEqual([]);
+  });
+});
+
+describe('GET_VAULT_ACCOUNT_VALUE document', () => {
+  test('queries account collateralBalance and account statsHistory from one v2 surface', () => {
+    expect(GET_VAULT_ACCOUNT_VALUE).toContain(
+      'account(address: $address, chainId: $chainId)'
+    );
+    expect(GET_VAULT_ACCOUNT_VALUE).toContain('collateralBalance');
+    expect(GET_VAULT_ACCOUNT_VALUE).toContain('amount');
+    expect(GET_VAULT_ACCOUNT_VALUE).toContain(
+      'statsHistory(interval: DAY, first: 366)'
+    );
+    expect(GET_VAULT_ACCOUNT_VALUE).toContain('deployedCollateral');
+    expect(GET_VAULT_ACCOUNT_VALUE).toContain('claimableCollateral');
+  });
+});
+
+describe('fetchVaultAccountValue', () => {
+  test('lowercases the address and sums indexed wallet, deployed, and claimable collateral', async () => {
+    mockGraphqlRequestV2.mockResolvedValue({
+      account: {
+        collateralBalance: { amount: '1000' },
+        statsHistory: {
+          nodes: [
+            {
+              timestamp: 1700000000,
+              deployedCollateral: '250',
+              claimableCollateral: '25',
+            },
+            {
+              timestamp: 1700000100,
+              deployedCollateral: '500',
+              claimableCollateral: '125',
+            },
+          ],
+        },
+      },
+    });
+
+    const result = await fetchVaultAccountValue('0xABCDEF', 42161);
+
+    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(GET_VAULT_ACCOUNT_VALUE, {
+      address: '0xabcdef',
+      chainId: 42161,
+    });
+    expect(result).toEqual({
+      collateralBalance: '1000',
+      deployedCollateral: '500',
+      claimableCollateral: '125',
+      totalValue: '1625',
+      timestamp: 1700000100,
+    });
+  });
+
+  test('defaults missing account stats to just the indexed wallet balance', async () => {
+    mockGraphqlRequestV2.mockResolvedValue({
+      account: {
+        collateralBalance: { amount: 1000 },
+        statsHistory: { nodes: [] },
+      },
+    });
+
+    await expect(fetchVaultAccountValue('0xabc', 42161)).resolves.toEqual({
+      collateralBalance: '1000',
+      deployedCollateral: '0',
+      claimableCollateral: '0',
+      totalValue: '1000',
+      timestamp: null,
+    });
   });
 });

--- a/packages/sdk/queries/vault.ts
+++ b/packages/sdk/queries/vault.ts
@@ -127,3 +127,79 @@ export async function fetchVaultStats(
   }
   return nodes.map(toVaultStat).sort((a, b) => a.timestamp - b.timestamp);
 }
+
+export interface VaultAccountValue {
+  /** Current indexed wUSDe balance held by the vault wallet, wei. */
+  collateralBalance: string;
+  /** Collateral deployed into open positions by the vault account, wei. */
+  deployedCollateral: string;
+  /** Settled/won collateral owed to the vault account but not redeemed, wei. */
+  claimableCollateral: string;
+  /** Sum of collateralBalance + deployedCollateral + claimableCollateral, wei. */
+  totalValue: string;
+  /** Latest account stats bucket timestamp, epoch seconds. */
+  timestamp: number | null;
+}
+
+export const GET_VAULT_ACCOUNT_VALUE = /* GraphQL */ `
+  query VaultAccountValue($address: Address!, $chainId: Int) {
+    account(address: $address, chainId: $chainId) {
+      collateralBalance {
+        amount
+      }
+      statsHistory(interval: DAY, first: 366) {
+        nodes {
+          timestamp
+          deployedCollateral
+          claimableCollateral
+        }
+      }
+    }
+  }
+`;
+
+type WireVaultAccountStat = {
+  timestamp: number;
+  deployedCollateral: string | number;
+  claimableCollateral: string | number;
+};
+
+type VaultAccountValueResponse = {
+  account: {
+    collateralBalance: { amount: string | number };
+    statsHistory: { nodes: WireVaultAccountStat[] };
+  };
+};
+
+export async function fetchVaultAccountValue(
+  address: string,
+  chainId?: number
+): Promise<VaultAccountValue> {
+  const data = await graphqlRequestV2<VaultAccountValueResponse>(
+    GET_VAULT_ACCOUNT_VALUE,
+    {
+      address: address.toLowerCase(),
+      chainId,
+    }
+  );
+  const latestStat = data.account.statsHistory.nodes.at(-1);
+  const collateralBalance = BigInt(wei(data.account.collateralBalance.amount));
+  const deployedCollateral = latestStat?.deployedCollateral
+    ? BigInt(wei(latestStat.deployedCollateral))
+    : 0n;
+  const claimableCollateral = latestStat?.claimableCollateral
+    ? BigInt(wei(latestStat.claimableCollateral))
+    : 0n;
+
+  return {
+    collateralBalance: collateralBalance.toString(),
+    deployedCollateral: deployedCollateral.toString(),
+    claimableCollateral: claimableCollateral.toString(),
+    totalValue: (
+      collateralBalance +
+      deployedCollateral +
+      claimableCollateral
+    ).toString(),
+    timestamp: latestStat?.timestamp ?? null,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds an SDK v2 account-value query for vaults that reads indexed wallet collateral balance plus latest account deployed/claimable collateral in one GraphQL account request.
- Switches `/vaults` amount/capacity math to that coherent indexed account value instead of stitching live contract liquid value with cached vault stats.
- Updates vault balance tests to cover claimable collateral and prove the live contract read no longer drives the displayed amount.

## Test Plan
- `pnpm --filter @sapience/sdk exec vitest run queries/__tests__/vault.test.ts --maxWorkers=1 --minWorkers=1`
- `pnpm --filter @sapience/app exec vitest run src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx --maxWorkers=1 --minWorkers=1`
- `pnpm --filter @sapience/sdk type-check`
- `pnpm --filter @sapience/app type-check`
- `pnpm --filter @sapience/sdk lint`
- `pnpm --filter @sapience/app lint`

## Notes
- Assumes the indexer is caught up; this intentionally chooses one indexed freshness boundary over RPC-live freshness to avoid intermittent over/under counts.
