### PR TITLE
Staging → Main

### DIFF
--- a/packages/api/schema.v2.graphql
+++ b/packages/api/schema.v2.graphql
@@ -359,8 +359,13 @@ type Vault implements Node {
   Time-series of this vault's economic snapshots, oldest-first (ascending
   `timestamp`, matching `Account.statsHistory` — chart-ready, no consumer
   re-sort). Backs the vault dashboard's TVL / PnL charts.
+
+  `first` has no default on purpose: omitting it returns the whole bounded
+  daily series in one page, so the chart loads in a single request instead of
+  a chain of sequential paginated round-trips. (A literal `first` above
+  GRAPHQL_MAX_LIST_SIZE is still rejected pre-execution.)
   """
-  statsHistory(first: Int = 30, after: String, filter: VaultStatFilter): VaultStatConnection!
+  statsHistory(first: Int, after: String, filter: VaultStatFilter): VaultStatConnection!
 }
 
 """

--- a/packages/api/schema.v2.graphql
+++ b/packages/api/schema.v2.graphql
@@ -360,10 +360,11 @@ type Vault implements Node {
   `timestamp`, matching `Account.statsHistory` — chart-ready, no consumer
   re-sort). Backs the vault dashboard's TVL / PnL charts.
 
-  `first` has no default on purpose: omitting it returns the whole bounded
-  daily series in one page, so the chart loads in a single request instead of
-  a chain of sequential paginated round-trips. (A literal `first` above
-  GRAPHQL_MAX_LIST_SIZE is still rejected pre-execution.)
+  Omitting `first` returns up to a server-side cap (MAX_STATS_POINTS) in one
+  page, so the chart loads in a single request instead of a chain of paginated
+  round-trips — while still bounding the response for an append-only series.
+  Page forward with `after` if a vault ever exceeds the cap. (A literal `first`
+  above GRAPHQL_MAX_LIST_SIZE is still rejected pre-execution.)
   """
   statsHistory(first: Int, after: String, filter: VaultStatFilter): VaultStatConnection!
 }

--- a/packages/api/schema.v2.graphql
+++ b/packages/api/schema.v2.graphql
@@ -1601,6 +1601,12 @@ input ActivityFilter {
   conditionIds: [Bytes!]
   pickConfigId: Bytes32
 
+  """
+  Restrict activity to a single position token. With `account`, predictions
+  match only the side that minted this token; trades match exact token.
+  """
+  token: Address
+
   """Restrict to a subset of activity types. `[]` is a zero-result query."""
   types: [ActivityType!]
 

--- a/packages/api/schema.v2.graphql
+++ b/packages/api/schema.v2.graphql
@@ -1690,7 +1690,7 @@ type Protocol {
   Live, current protocol-wide stats — a single `ProtocolStat` with
   `timestamp = now`. Volume / trade-count / open-interest reflect the
   in-progress period and `totalValueLocked` is read across every configured
-  vault at query time. Use `statsHistory` for the recorded daily series.
+  vault at query time. Use `statsHistory` for the recorded snapshot series.
   """
   stats: ProtocolStat!
 
@@ -1699,8 +1699,18 @@ type Protocol {
   volume / TVL / open-interest time-series charts. (Previously named
   `stats`; renamed to `statsHistory` so `stats` can be the live singular,
   matching the `Vault` access pattern.)
+
+  Snapshots are recorded at a sub-daily cadence (configurable; ~4-hourly in
+  production), so the raw series runs to thousands of rows. Pass `interval`
+  to downsample server-side into fixed-width buckets — stock fields
+  (`cumulative*`, `openInterest`, `escrowBalance`, `totalValueLocked`) take
+  the bucket's last (latest) snapshot; flow fields (`periodVolume`,
+  `periodTradeCount`) sum across the bucket; the node's `timestamp` is the
+  bucket start. With no `interval` the raw per-snapshot series is returned.
+  The default page (`first` omitted) fits the whole bucketed series in one
+  request, so the analytics dashboard no longer paginates.
   """
-  statsHistory(first: Int = 100, after: String, filter: ProtocolStatFilter): ProtocolStatConnection!
+  statsHistory(interval: TimeInterval, first: Int = 100, after: String, filter: ProtocolStatFilter): ProtocolStatConnection!
   openInterestByCategory: [CategoryOpenInterest!]!
 
   """

--- a/packages/api/schema.v2.graphql
+++ b/packages/api/schema.v2.graphql
@@ -1719,8 +1719,9 @@ type Protocol {
   the bucket's last (latest) snapshot; flow fields (`periodVolume`,
   `periodTradeCount`) sum across the bucket; the node's `timestamp` is the
   bucket start. With no `interval` the raw per-snapshot series is returned.
-  The default page (`first` omitted) fits the whole bucketed series in one
-  request, so the analytics dashboard no longer paginates.
+  Pass `first: null` to fit the whole bucketed series in one request — an
+  explicit null bypasses the default page size, so the analytics dashboard
+  no longer paginates; omitting `first` falls back to a 100-row page.
   """
   statsHistory(interval: TimeInterval, first: Int = 100, after: String, filter: ProtocolStatFilter): ProtocolStatConnection!
   openInterestByCategory: [CategoryOpenInterest!]!

--- a/packages/api/src/graphql/v2/resolvers/Activity.test.ts
+++ b/packages/api/src/graphql/v2/resolvers/Activity.test.ts
@@ -162,12 +162,12 @@ describe('activity (v2)', () => {
     const tradeCall = mockPrisma.secondaryTrade.findMany.mock.calls[0]?.[0];
     expect(predictionCall.where).toEqual(
       expect.objectContaining({
-        OR: [{ predictor: '0xabc' }, { counterparty: '0xabc' }],
+        AND: [{ OR: [{ predictor: '0xabc' }, { counterparty: '0xabc' }] }],
       })
     );
     expect(tradeCall.where).toEqual(
       expect.objectContaining({
-        OR: [{ buyer: '0xabc' }, { seller: '0xabc' }],
+        AND: [{ OR: [{ buyer: '0xabc' }, { seller: '0xabc' }] }],
       })
     );
   });

--- a/packages/api/src/graphql/v2/resolvers/Protocol.test.ts
+++ b/packages/api/src/graphql/v2/resolvers/Protocol.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const INTERVAL = 86400;
 
@@ -108,7 +108,7 @@ vi.mock('../cacheHints', () => ({
   setCacheHint: vi.fn(),
 }));
 
-import { Protocol } from './Protocol';
+import { Protocol, __clearProtocolCaches } from './Protocol';
 
 const callResolver = <TResult = unknown>(resolver: unknown) =>
   resolver as (
@@ -119,6 +119,13 @@ const callResolver = <TResult = unknown>(resolver: unknown) =>
   ) => Promise<TResult>;
 
 describe('Protocol (v2)', () => {
+  // Memoized TVL / cross-family reads persist across calls; clear them (and
+  // mock call counts) between tests so each starts from a cold cache.
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __clearProtocolCaches();
+  });
+
   it('statsHistory drops the live candle and aggregates TVL across all vaults', async () => {
     const conn = await callResolver<{
       nodes: {
@@ -171,5 +178,144 @@ describe('Protocol (v2)', () => {
     expect(stat.cumulativeTradeCount).toBe(12);
     // computeProtocolTvl: latest escrow 60 + (150 + 250) = 460
     expect(stat.totalValueLocked).toBe(460n);
+  });
+
+  it('statsHistory(interval: DAY) buckets sub-daily snapshots into one node per day', async () => {
+    // Three recorded rows: two land in the same UTC day, one in the next.
+    // Display ts = rawTs − INTERVAL; rawTs is what crossFamily keys TVL on.
+    //   display 90000  (raw 176400) -> day 86400
+    //   display 93600  (raw 180000) -> day 86400  (same bucket)
+    //   display 176400 (raw 262800) -> day 172800
+    mockV1ProtocolStats.mockResolvedValueOnce([
+      {
+        timestamp: 90000,
+        cumulativeVolume: '1000',
+        totalTradeCount: 5,
+        periodVolume: '100',
+        periodTradeCount: 2,
+        openInterest: '10',
+        escrowBalance: '50',
+      },
+      {
+        timestamp: 93600,
+        cumulativeVolume: '1500',
+        totalTradeCount: 8,
+        periodVolume: '500',
+        periodTradeCount: 3,
+        openInterest: '15',
+        escrowBalance: '55',
+      },
+      {
+        timestamp: 176400,
+        cumulativeVolume: '2000',
+        totalTradeCount: 9,
+        periodVolume: '500',
+        periodTradeCount: 1,
+        openInterest: '20',
+        escrowBalance: '60',
+      },
+      // live candle — no matching raw snapshot, dropped before bucketing.
+      {
+        timestamp: 1_700_000_000,
+        cumulativeVolume: '9999',
+        totalTradeCount: 99,
+        periodVolume: '0',
+        periodTradeCount: 0,
+        openInterest: '0',
+        escrowBalance: '0',
+      },
+    ]);
+    // crossFamily only reads vaultAvailableAssets; escrowBalance is required by
+    // the row shape but unused for the TVL-per-snapshot sum here.
+    mockGetProtocolStatsTimeSeries.mockResolvedValueOnce([
+      {
+        vaultAddress: '0xaaaa',
+        timestamp: 176400,
+        vaultAvailableAssets: '100',
+        escrowBalance: '0',
+      },
+      {
+        vaultAddress: '0xbbbb',
+        timestamp: 176400,
+        vaultAvailableAssets: '200',
+        escrowBalance: '0',
+      },
+      {
+        vaultAddress: '0xaaaa',
+        timestamp: 180000,
+        vaultAvailableAssets: '150',
+        escrowBalance: '0',
+      },
+      {
+        vaultAddress: '0xbbbb',
+        timestamp: 180000,
+        vaultAvailableAssets: '250',
+        escrowBalance: '0',
+      },
+      {
+        vaultAddress: '0xaaaa',
+        timestamp: 262800,
+        vaultAvailableAssets: '1',
+        escrowBalance: '0',
+      },
+      {
+        vaultAddress: '0xbbbb',
+        timestamp: 262800,
+        vaultAvailableAssets: '2',
+        escrowBalance: '0',
+      },
+    ]);
+
+    const conn = await callResolver<{
+      nodes: {
+        timestamp: number;
+        cumulativeVolume: string;
+        cumulativeTradeCount: number;
+        periodVolume: string;
+        periodTradeCount: number;
+        openInterest: string;
+        escrowBalance: string;
+        totalValueLocked: bigint;
+      }[];
+      totalCount: number;
+    }>(Protocol.statsHistory)(null, { interval: 'DAY' }, {}, null);
+
+    expect(conn.totalCount).toBe(2);
+    expect(conn.nodes.map((n) => n.timestamp)).toEqual([86400, 172800]);
+
+    // Bucket 86400: stock fields from the last (display 93600) row; flows summed.
+    const first = conn.nodes[0];
+    expect(first.cumulativeVolume).toBe('1500');
+    expect(first.cumulativeTradeCount).toBe(8);
+    expect(first.openInterest).toBe('15');
+    expect(first.escrowBalance).toBe('55');
+    expect(first.periodVolume).toBe('600'); // 100 + 500
+    expect(first.periodTradeCount).toBe(5); // 2 + 3
+    // TVL = escrow 55 + (150 + 250) available at raw ts 180000 = 455
+    expect(first.totalValueLocked).toBe(455n);
+
+    // Bucket 172800: a single snapshot, flows passthrough.
+    const second = conn.nodes[1];
+    expect(second.cumulativeVolume).toBe('2000');
+    expect(second.periodVolume).toBe('500');
+    expect(second.periodTradeCount).toBe(1);
+    // TVL = escrow 60 + (1 + 2) available at raw ts 262800 = 63
+    expect(second.totalValueLocked).toBe(63n);
+  });
+
+  it('memoizes the cross-family available-assets read across statsHistory calls (B)', async () => {
+    await callResolver(Protocol.statsHistory)(null, {}, {}, null);
+    await callResolver(Protocol.statsHistory)(null, {}, {}, null);
+    // crossFamilyAvailableByRawTs is the only caller of getProtocolStatsTimeSeries
+    // here; memoized, it runs once for both pages within the TTL window.
+    expect(mockGetProtocolStatsTimeSeries).toHaveBeenCalledTimes(1);
+  });
+
+  it('memoizes the live TVL read across stats calls (C)', async () => {
+    await callResolver(Protocol.stats)(null, {}, {}, null);
+    await callResolver(Protocol.stats)(null, {}, {}, null);
+    // computeProtocolTvl reads the latest snapshot once per configured vault (2);
+    // memoized, the second stats call adds none (4 without the cache).
+    expect(mockGetLatestProtocolStats).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/api/src/graphql/v2/resolvers/Protocol.ts
+++ b/packages/api/src/graphql/v2/resolvers/Protocol.ts
@@ -43,6 +43,16 @@ type V1StatRow = Record<string, unknown>;
 
 const DAY = 86400;
 
+// Fixed-width bucket sizes (seconds) for `statsHistory(interval:)`
+// downsampling. MONTH is a fixed 30-day window (not calendar) — the analytics
+// charts only request DAY, the rest are supported for completeness.
+const INTERVAL_SECONDS: Record<string, number> = {
+  HOUR: 3600,
+  DAY,
+  WEEK: 7 * DAY,
+  MONTH: 30 * DAY,
+};
+
 // Maps v1's magic `bucket` int to the v2 `(min, max]` seconds-from-now
 // window — left-exclusive, right-inclusive, matching the SQL `delta <= bound`
 // ladder in `sdl/resolvers/queries/analytics.ts` (a prediction at exactly a
@@ -149,6 +159,56 @@ const crossFamilyAvailableByRawTs = async (
   return byTs;
 };
 
+const PROTOCOL_V2_TTL_MS = 60_000;
+
+/**
+ * Minimal single-flight TTL memo keyed by chainId. Mirrors the
+ * `protocolStatsCache` pattern in the v1 analytics resolver: the cached value
+ * is the in-flight promise — so the dashboard's concurrent `stats` +
+ * `statsHistory` (and any history pagination) collapse onto one computation
+ * per window instead of each re-running the full snapshot-table read — and a
+ * rejection evicts the entry so a transient DB blip isn't pinned for the whole
+ * TTL.
+ */
+const singleFlightByChain = <T>(
+  fn: (chainId: number) => Promise<T>,
+  ttlMs: number
+) => {
+  const cache = new Map<number, { promise: Promise<T>; expiresAt: number }>();
+  const run = (chainId: number): Promise<T> => {
+    const now = Date.now();
+    const hit = cache.get(chainId);
+    if (hit && hit.expiresAt > now) return hit.promise;
+    const promise = fn(chainId).catch((err) => {
+      cache.delete(chainId);
+      throw err;
+    });
+    cache.set(chainId, { promise, expiresAt: now + ttlMs });
+    return promise;
+  };
+  run.clear = () => cache.clear();
+  return run;
+};
+
+// (B) statsHistory called `crossFamilyAvailableByRawTs` on every page — a full
+// `protocolStatsSnapshot` read each time. (C) stats called `computeProtocolTvl`
+// (a per-vault latest-snapshot fan-out) on every request. Both are memoized
+// per chainId so the dashboard pays each at most once per TTL window.
+const cachedCrossFamilyAvailableByRawTs = singleFlightByChain(
+  crossFamilyAvailableByRawTs,
+  PROTOCOL_V2_TTL_MS
+);
+const cachedComputeProtocolTvl = singleFlightByChain(
+  computeProtocolTvl,
+  PROTOCOL_V2_TTL_MS
+);
+
+/** Test hook — drop the memoized TVL / cross-family entries. */
+export const __clearProtocolCaches = (): void => {
+  cachedCrossFamilyAvailableByRawTs.clear();
+  cachedComputeProtocolTvl.clear();
+};
+
 export const protocol: NonNullable<QueryResolvers['protocol']> = () =>
   ({}) as never;
 
@@ -160,7 +220,7 @@ export const Protocol: ProtocolResolvers = {
       (v1ProtocolStats as unknown as V1Resolver)(null, {}, null) as Promise<
         V1StatRow[]
       >,
-      computeProtocolTvl(chainId),
+      cachedComputeProtocolTvl(chainId),
     ]);
     // v1 appends the in-progress (live) candle as the last row; fall back to
     // a zero-valued current snapshot when no snapshots exist at all.
@@ -179,7 +239,7 @@ export const Protocol: ProtocolResolvers = {
       (v1ProtocolStats as unknown as V1Resolver)(null, {}, null) as Promise<
         V1StatRow[]
       >,
-      crossFamilyAvailableByRawTs(chainId),
+      cachedCrossFamilyAvailableByRawTs(chainId),
     ]);
 
     // Keep only recorded snapshots within the requested window. A v1 row's
@@ -198,28 +258,77 @@ export const Protocol: ProtocolResolvers = {
       return true;
     });
 
-    const first = clampTake(args.first ?? historyRows.length, {
-      defaultTake: historyRows.length || 100,
+    // Each row already carries the TVL inputs; `rawTsOf(row)` maps its display
+    // ts back to the snapshot ts used to key the cross-family available-assets
+    // sum.
+    const tvlOf = (row: V1StatRow): bigint =>
+      BigInt((row.escrowBalance as string) ?? '0') +
+      (availableByRawTs.get(rawTsOf(row)) ?? 0n);
+
+    // Optional server-side downsampling. The snapshot series is sub-daily
+    // (~4-hourly in prod), so without bucketing the analytics dashboard pages
+    // through thousands of rows it only ever renders as daily points. With an
+    // `interval`, collapse each fixed-width window to one node: stock fields
+    // (cumulative*, OI, escrow, TVL) take the bucket's last (latest) row; flow
+    // fields (period*) sum across it; the label is the bucket start — matching
+    // the client's `floor(ts / interval) * interval` grid, so its own
+    // bucketing becomes an idempotent no-op.
+    const intervalSeconds =
+      args.interval != null ? INTERVAL_SECONDS[args.interval] : undefined;
+
+    type Node = ReturnType<typeof mapProtocolStat>;
+    let nodes: Node[];
+    if (intervalSeconds) {
+      const buckets = new Map<number, V1StatRow[]>();
+      for (const row of historyRows) {
+        const displayTs = Number(row.timestamp ?? 0);
+        const bucketStart =
+          Math.floor(displayTs / intervalSeconds) * intervalSeconds;
+        const group = buckets.get(bucketStart);
+        if (group) group.push(row);
+        else buckets.set(bucketStart, [row]);
+      }
+      // historyRows are oldest-first, so each group's last element is the
+      // latest snapshot in that bucket.
+      nodes = [...buckets.entries()]
+        .sort((a, b) => a[0] - b[0])
+        .map(([bucketStart, group]) => {
+          const last = group[group.length - 1];
+          const node = mapProtocolStat(last, tvlOf(last));
+          node.timestamp = bucketStart;
+          node.periodVolume = group
+            .reduce(
+              (sum, r) => sum + BigInt((r.periodVolume as string) ?? '0'),
+              0n
+            )
+            .toString();
+          node.periodTradeCount = group.reduce(
+            (sum, r) => sum + Number(r.periodTradeCount ?? 0),
+            0
+          );
+          return node;
+        });
+    } else {
+      nodes = historyRows.map((row) => mapProtocolStat(row, tvlOf(row)));
+    }
+
+    const first = clampTake(args.first ?? nodes.length, {
+      defaultTake: nodes.length || 100,
       maxTake: 1000,
     });
     const after = args.after ? decodeCursor(args.after) : null;
     const start = after && /^\d+$/.test(after.k) ? Number(after.k) + 1 : 0;
-    const slice = historyRows.slice(start, start + first + 1);
+    const slice = nodes.slice(start, start + first + 1);
 
     return buildConnection({
       rows: slice,
       first,
-      totalCount: historyRows.length,
-      getNode: (row) =>
-        mapProtocolStat(
-          row,
-          BigInt((row.escrowBalance as string) ?? '0') +
-            (availableByRawTs.get(rawTsOf(row)) ?? 0n)
-        ),
-      getCursor: (row, idx) =>
+      totalCount: nodes.length,
+      getNode: (node) => node,
+      getCursor: (node, idx) =>
         encodeCursor({
           k: String(start + idx),
-          id: String(row.timestamp ?? ''),
+          id: String(node.timestamp ?? ''),
         }),
     }) as never;
   },

--- a/packages/api/src/graphql/v2/resolvers/Vault.test.ts
+++ b/packages/api/src/graphql/v2/resolvers/Vault.test.ts
@@ -44,7 +44,7 @@ vi.mock('../accountSynthesis', () => ({
 
 // Vault.ts registers `Vault` in the v2 Node registry at module import.
 import type { Mock } from 'vitest';
-import { findVaultByAddress, Vault } from './Vault';
+import { findVaultByAddress, MAX_STATS_POINTS, Vault } from './Vault';
 import { vault, vaults } from './queries/vault';
 import prisma from '../../../core/db';
 import { getConfiguredVaults } from '../../../services/protocolStats';
@@ -233,5 +233,35 @@ describe('Vault (v2)', () => {
     expect(conn.pageInfo.hasNextPage).toBe(false);
     expect(conn.nodes[0].timestamp).toBe(1000);
     expect(conn.nodes.at(-1)?.timestamp).toBe(1039);
+  });
+
+  it('caps an omitted `first` at MAX_STATS_POINTS and signals more via pageInfo', async () => {
+    const PRIMARY = '0x000000000000000000000000000000000000aaaa';
+    (getConfiguredVaults as Mock).mockReturnValueOnce([
+      { kind: 'protocol', address: PRIMARY, config: { legacy: [] } },
+    ]);
+    // A series longer than the cap must NOT dump every row in one response —
+    // it returns one capped page and flags `hasNextPage` so clients paginate.
+    const rows = Array.from({ length: MAX_STATS_POINTS + 5 }, (_, i) => ({
+      timestamp: 1000 + i,
+      vaultAddress: PRIMARY,
+      vaultBalance: String(i),
+    }));
+    (prisma.protocolStatsSnapshot.findMany as Mock).mockResolvedValueOnce(rows);
+
+    const conn = await callResolver<{
+      nodes: { timestamp: number }[];
+      totalCount: number;
+      pageInfo: { hasNextPage: boolean };
+    }>(Vault.statsHistory)(
+      { chainId: 13374202, address: PRIMARY },
+      {},
+      {},
+      null
+    );
+
+    expect(conn.totalCount).toBe(MAX_STATS_POINTS + 5);
+    expect(conn.nodes).toHaveLength(MAX_STATS_POINTS);
+    expect(conn.pageInfo.hasNextPage).toBe(true);
   });
 });

--- a/packages/api/src/graphql/v2/resolvers/Vault.test.ts
+++ b/packages/api/src/graphql/v2/resolvers/Vault.test.ts
@@ -200,4 +200,38 @@ describe('Vault (v2)', () => {
     // Oldest-first ordering (ascending timestamp), matching Account.statsHistory.
     expect(conn.nodes.map((n) => n.timestamp)).toEqual([100, 200]);
   });
+
+  it('returns the full series in one page when `first` is omitted', async () => {
+    const PRIMARY = '0x000000000000000000000000000000000000aaaa';
+    (getConfiguredVaults as Mock).mockReturnValueOnce([
+      { kind: 'protocol', address: PRIMARY, config: { legacy: [] } },
+    ]);
+    // A series longer than the old default page size (30): the SDK used to
+    // paginate this in multiple round-trips. With no `first`, the resolver must
+    // hand back the whole bounded daily series in a single page so the chart
+    // loads in one request.
+    const rows = Array.from({ length: 40 }, (_, i) => ({
+      timestamp: 1000 + i,
+      vaultAddress: PRIMARY,
+      vaultBalance: String(i),
+    }));
+    (prisma.protocolStatsSnapshot.findMany as Mock).mockResolvedValueOnce(rows);
+
+    const conn = await callResolver<{
+      nodes: { timestamp: number }[];
+      totalCount: number;
+      pageInfo: { hasNextPage: boolean };
+    }>(Vault.statsHistory)(
+      { chainId: 13374202, address: PRIMARY },
+      {},
+      {},
+      null
+    );
+
+    expect(conn.totalCount).toBe(40);
+    expect(conn.nodes).toHaveLength(40);
+    expect(conn.pageInfo.hasNextPage).toBe(false);
+    expect(conn.nodes[0].timestamp).toBe(1000);
+    expect(conn.nodes.at(-1)?.timestamp).toBe(1039);
+  });
 });

--- a/packages/api/src/graphql/v2/resolvers/Vault.ts
+++ b/packages/api/src/graphql/v2/resolvers/Vault.ts
@@ -181,10 +181,6 @@ export const Vault: VaultResolvers = {
 
   statsHistory: async (parent, args) => {
     const row = parent as unknown as VaultRow;
-    const first = clampTake(args.first ?? 30, {
-      defaultTake: 30,
-      maxTake: 365,
-    });
     const after = args.after ? decodeCursor(args.after) : null;
     const skip = after && /^\d+$/.test(after.k) ? Number(after.k) + 1 : 0;
 
@@ -249,6 +245,14 @@ export const Vault: VaultResolvers = {
       (a, b) => a.timestamp - b.timestamp
     );
     const totalCount = deduped.length;
+    // No `first` => return the whole bounded daily series in one page (mirrors
+    // Account.statsHistory), so the SDK loads the chart in a single request
+    // instead of a chain of sequential paginated round-trips. An explicit
+    // `first` still pages and is capped (also by the global list-size limit).
+    const first =
+      args.first == null
+        ? totalCount
+        : clampTake(args.first, { defaultTake: 30, maxTake: 365 });
     const pageRows = deduped.slice(skip, skip + first + 1);
 
     return buildConnection({

--- a/packages/api/src/graphql/v2/resolvers/Vault.ts
+++ b/packages/api/src/graphql/v2/resolvers/Vault.ts
@@ -35,6 +35,14 @@ export type VaultRow = {
   chainId: number;
 };
 
+// Upper bound on rows returned by `statsHistory` in a single page when the
+// caller omits `first`. The vault snapshot table is append-only (grows ~1/day),
+// so an unbounded "return everything" page would balloon the public response
+// over time. This cap keeps the common case a single request (current series
+// is well under it) while bounding the worst case; a vault that ever exceeds
+// the cap pages forward via the offset `after` cursor (see SDK fetchVaultStats).
+export const MAX_STATS_POINTS = 2000;
+
 const vaultDomainId = (chainId: number, address: string) =>
   `${chainId}:${address.toLowerCase()}`;
 
@@ -181,6 +189,15 @@ export const Vault: VaultResolvers = {
 
   statsHistory: async (parent, args) => {
     const row = parent as unknown as VaultRow;
+    // Omitting `first` returns up to MAX_STATS_POINTS in one page (mirrors
+    // Account.statsHistory) — large enough that the daily series loads in a
+    // single request, but finite so a public query can't pull an ever-growing
+    // table unbounded. An explicit `first` still pages and is additionally
+    // capped pre-execution by GRAPHQL_MAX_LIST_SIZE.
+    const first = clampTake(args.first ?? MAX_STATS_POINTS, {
+      defaultTake: MAX_STATS_POINTS,
+      maxTake: MAX_STATS_POINTS,
+    });
     const after = args.after ? decodeCursor(args.after) : null;
     const skip = after && /^\d+$/.test(after.k) ? Number(after.k) + 1 : 0;
 
@@ -245,14 +262,6 @@ export const Vault: VaultResolvers = {
       (a, b) => a.timestamp - b.timestamp
     );
     const totalCount = deduped.length;
-    // No `first` => return the whole bounded daily series in one page (mirrors
-    // Account.statsHistory), so the SDK loads the chart in a single request
-    // instead of a chain of sequential paginated round-trips. An explicit
-    // `first` still pages and is capped (also by the global list-size limit).
-    const first =
-      args.first == null
-        ? totalCount
-        : clampTake(args.first, { defaultTake: 30, maxTake: 365 });
     const pageRows = deduped.slice(skip, skip + first + 1);
 
     return buildConnection({

--- a/packages/api/src/graphql/v2/resolvers/queries/activity.test.ts
+++ b/packages/api/src/graphql/v2/resolvers/queries/activity.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockPrisma = vi.hoisted(() => ({
+  prediction: { findMany: vi.fn(), count: vi.fn() },
+  secondaryTrade: { findMany: vi.fn(), count: vi.fn() },
+}));
+
+vi.mock('../../../../core/db', () => ({ default: mockPrisma }));
+
+import { activity } from './activity';
+
+type ActivityFn = (
+  parent: unknown,
+  args: Record<string, unknown>,
+  ctx: unknown,
+  info: unknown
+) => Promise<{
+  edges: unknown[];
+  totalCount: unknown;
+  pageInfo: {
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+    startCursor: string | null;
+    endCursor: string | null;
+  };
+}>;
+
+const activityFn = activity as unknown as ActivityFn;
+
+const ALICE = '0xalice000000000000000000000000000000000001';
+const TOKEN_PRED = '0xpred000000000000000000000000000000000001';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.prediction.findMany.mockResolvedValue([]);
+  mockPrisma.secondaryTrade.findMany.mockResolvedValue([]);
+  mockPrisma.prediction.count.mockResolvedValue(0);
+  mockPrisma.secondaryTrade.count.mockResolvedValue(0);
+});
+
+describe('activity query token filtering', () => {
+  it('scopes account activity to the exact position token side', async () => {
+    await activityFn(
+      null,
+      {
+        first: 20,
+        filter: {
+          account: ALICE.toUpperCase(),
+          token: TOKEN_PRED.toUpperCase(),
+        },
+      },
+      null,
+      null
+    );
+
+    expect(mockPrisma.prediction.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          AND: [
+            {
+              OR: [
+                {
+                  predictor: ALICE,
+                  pickConfiguration: { predictorToken: TOKEN_PRED },
+                },
+                {
+                  counterparty: ALICE,
+                  pickConfiguration: { counterpartyToken: TOKEN_PRED },
+                },
+              ],
+            },
+          ],
+        },
+      })
+    );
+
+    expect(mockPrisma.secondaryTrade.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          AND: [
+            { OR: [{ buyer: ALICE }, { seller: ALICE }] },
+            { token: TOKEN_PRED },
+          ],
+        },
+      })
+    );
+  });
+});

--- a/packages/api/src/graphql/v2/resolvers/queries/activity.ts
+++ b/packages/api/src/graphql/v2/resolvers/queries/activity.ts
@@ -130,10 +130,10 @@ export const activity: NonNullable<QueryResolvers['activity']> = async (
     });
   }
 
-  if (args.filter?.pickConfigId)
-    predictionClauses.push({
-      pickConfigId: args.filter.pickConfigId.toLowerCase(),
-    });
+  // A single pickConfigId constraint. When `conditionIds` resolved a set of
+  // pick configs, that set already narrows to (and intersects with) any
+  // explicit `pickConfigId`, so emit only the intersection — pushing the
+  // standalone clause too would just duplicate it inside the AND.
   if (conditionPickConfigIds) {
     const ids = args.filter?.pickConfigId
       ? conditionPickConfigIds.filter(
@@ -142,6 +142,10 @@ export const activity: NonNullable<QueryResolvers['activity']> = async (
       : conditionPickConfigIds;
     predictionClauses.push({
       pickConfigId: ids.length === 1 ? ids[0] : { in: ids },
+    });
+  } else if (args.filter?.pickConfigId) {
+    predictionClauses.push({
+      pickConfigId: args.filter.pickConfigId.toLowerCase(),
     });
   }
   if (args.filter?.timestamp) {

--- a/packages/api/src/graphql/v2/resolvers/queries/activity.ts
+++ b/packages/api/src/graphql/v2/resolvers/queries/activity.ts
@@ -96,21 +96,53 @@ export const activity: NonNullable<QueryResolvers['activity']> = async (
     conditionTokens = tokens;
   }
 
-  // Prediction-side where
-  const predictionWhere: Prisma.PredictionWhereInput = {};
-  if (args.filter?.account) {
-    const addr = args.filter.account.toLowerCase();
-    predictionWhere.OR = [{ predictor: addr }, { counterparty: addr }];
+  const account = args.filter?.account?.toLowerCase();
+  const token = args.filter?.token?.toLowerCase();
+
+  // Prediction-side where. When account + token are both provided, match the
+  // exact side the account minted; `account AND (predictorToken OR
+  // counterpartyToken)` would incorrectly include the opposite-side token on
+  // the same prediction.
+  const predictionClauses: Prisma.PredictionWhereInput[] = [];
+  if (account && token) {
+    predictionClauses.push({
+      OR: [
+        {
+          predictor: account,
+          pickConfiguration: { predictorToken: token },
+        },
+        {
+          counterparty: account,
+          pickConfiguration: { counterpartyToken: token },
+        },
+      ],
+    });
+  } else if (account) {
+    predictionClauses.push({
+      OR: [{ predictor: account }, { counterparty: account }],
+    });
+  } else if (token) {
+    predictionClauses.push({
+      OR: [
+        { pickConfiguration: { predictorToken: token } },
+        { pickConfiguration: { counterpartyToken: token } },
+      ],
+    });
   }
+
   if (args.filter?.pickConfigId)
-    predictionWhere.pickConfigId = args.filter.pickConfigId.toLowerCase();
+    predictionClauses.push({
+      pickConfigId: args.filter.pickConfigId.toLowerCase(),
+    });
   if (conditionPickConfigIds) {
     const ids = args.filter?.pickConfigId
       ? conditionPickConfigIds.filter(
           (id) => id === args.filter!.pickConfigId!.toLowerCase()
         )
       : conditionPickConfigIds;
-    predictionWhere.pickConfigId = ids.length === 1 ? ids[0] : { in: ids };
+    predictionClauses.push({
+      pickConfigId: ids.length === 1 ? ids[0] : { in: ids },
+    });
   }
   if (args.filter?.timestamp) {
     const r: Prisma.DateTimeFilter = {};
@@ -118,24 +150,36 @@ export const activity: NonNullable<QueryResolvers['activity']> = async (
       r.gte = new Date(args.filter.timestamp.gte * 1000);
     if (args.filter.timestamp.lte != null)
       r.lte = new Date(args.filter.timestamp.lte * 1000);
-    predictionWhere.createdAt = r;
+    predictionClauses.push({ createdAt: r });
   }
+  const predictionWhere: Prisma.PredictionWhereInput = predictionClauses.length
+    ? { AND: predictionClauses }
+    : {};
 
-  // Trade-side where
-  const tradeWhere: Prisma.SecondaryTradeWhereInput = {};
-  if (args.filter?.account) {
-    const addr = args.filter.account.toLowerCase();
-    tradeWhere.OR = [{ buyer: addr }, { seller: addr }];
+  // Trade-side where. Token filtering is exact because SecondaryTrade.token is
+  // the ERC-20 position token that changed hands.
+  const tradeClauses: Prisma.SecondaryTradeWhereInput[] = [];
+  if (account) {
+    tradeClauses.push({ OR: [{ buyer: account }, { seller: account }] });
   }
-  if (conditionTokens != null) {
-    tradeWhere.token = { in: conditionTokens };
+  if (token && conditionTokens != null) {
+    tradeClauses.push(
+      conditionTokens.includes(token) ? { token } : { token: { in: [] } }
+    );
+  } else if (token) {
+    tradeClauses.push({ token });
+  } else if (conditionTokens != null) {
+    tradeClauses.push({ token: { in: conditionTokens } });
   }
   if (args.filter?.timestamp) {
     const r: Prisma.IntFilter = {};
     if (args.filter.timestamp.gte != null) r.gte = args.filter.timestamp.gte;
     if (args.filter.timestamp.lte != null) r.lte = args.filter.timestamp.lte;
-    tradeWhere.executedAt = r;
+    tradeClauses.push({ executedAt: r });
   }
+  const tradeWhere: Prisma.SecondaryTradeWhereInput = tradeClauses.length
+    ? { AND: tradeClauses }
+    : {};
 
   // Cursor — applied to both sides as `ts < cursor.ts OR (ts == cursor.ts AND ...)`
   const cursor = parseCursor(args.after);

--- a/packages/api/src/graphql/v2/schema/schema.graphql
+++ b/packages/api/src/graphql/v2/schema/schema.graphql
@@ -1852,8 +1852,9 @@ type Protocol {
   the bucket's last (latest) snapshot; flow fields (`periodVolume`,
   `periodTradeCount`) sum across the bucket; the node's `timestamp` is the
   bucket start. With no `interval` the raw per-snapshot series is returned.
-  The default page (`first` omitted) fits the whole bucketed series in one
-  request, so the analytics dashboard no longer paginates.
+  Pass `first: null` to fit the whole bucketed series in one request — an
+  explicit null bypasses the default page size, so the analytics dashboard
+  no longer paginates; omitting `first` falls back to a 100-row page.
   """
   statsHistory(
     interval: TimeInterval

--- a/packages/api/src/graphql/v2/schema/schema.graphql
+++ b/packages/api/src/graphql/v2/schema/schema.graphql
@@ -406,10 +406,11 @@ type Vault implements Node {
   `timestamp`, matching `Account.statsHistory` — chart-ready, no consumer
   re-sort). Backs the vault dashboard's TVL / PnL charts.
 
-  `first` has no default on purpose: omitting it returns the whole bounded
-  daily series in one page, so the chart loads in a single request instead of
-  a chain of sequential paginated round-trips. (A literal `first` above
-  GRAPHQL_MAX_LIST_SIZE is still rejected pre-execution.)
+  Omitting `first` returns up to a server-side cap (MAX_STATS_POINTS) in one
+  page, so the chart loads in a single request instead of a chain of paginated
+  round-trips — while still bounding the response for an append-only series.
+  Page forward with `after` if a vault ever exceeds the cap. (A literal `first`
+  above GRAPHQL_MAX_LIST_SIZE is still rejected pre-execution.)
   """
   statsHistory(
     first: Int

--- a/packages/api/src/graphql/v2/schema/schema.graphql
+++ b/packages/api/src/graphql/v2/schema/schema.graphql
@@ -1824,7 +1824,7 @@ type Protocol {
   Live, current protocol-wide stats — a single `ProtocolStat` with
   `timestamp = now`. Volume / trade-count / open-interest reflect the
   in-progress period and `totalValueLocked` is read across every configured
-  vault at query time. Use `statsHistory` for the recorded daily series.
+  vault at query time. Use `statsHistory` for the recorded snapshot series.
   """
   stats: ProtocolStat!
 
@@ -1833,8 +1833,19 @@ type Protocol {
   volume / TVL / open-interest time-series charts. (Previously named
   `stats`; renamed to `statsHistory` so `stats` can be the live singular,
   matching the `Vault` access pattern.)
+
+  Snapshots are recorded at a sub-daily cadence (configurable; ~4-hourly in
+  production), so the raw series runs to thousands of rows. Pass `interval`
+  to downsample server-side into fixed-width buckets — stock fields
+  (`cumulative*`, `openInterest`, `escrowBalance`, `totalValueLocked`) take
+  the bucket's last (latest) snapshot; flow fields (`periodVolume`,
+  `periodTradeCount`) sum across the bucket; the node's `timestamp` is the
+  bucket start. With no `interval` the raw per-snapshot series is returned.
+  The default page (`first` omitted) fits the whole bucketed series in one
+  request, so the analytics dashboard no longer paginates.
   """
   statsHistory(
+    interval: TimeInterval
     first: Int = 100
     after: String
     filter: ProtocolStatFilter

--- a/packages/api/src/graphql/v2/schema/schema.graphql
+++ b/packages/api/src/graphql/v2/schema/schema.graphql
@@ -405,9 +405,14 @@ type Vault implements Node {
   Time-series of this vault's economic snapshots, oldest-first (ascending
   `timestamp`, matching `Account.statsHistory` — chart-ready, no consumer
   re-sort). Backs the vault dashboard's TVL / PnL charts.
+
+  `first` has no default on purpose: omitting it returns the whole bounded
+  daily series in one page, so the chart loads in a single request instead of
+  a chain of sequential paginated round-trips. (A literal `first` above
+  GRAPHQL_MAX_LIST_SIZE is still rejected pre-execution.)
   """
   statsHistory(
-    first: Int = 30
+    first: Int
     after: String
     filter: VaultStatFilter
   ): VaultStatConnection!

--- a/packages/api/src/graphql/v2/schema/schema.graphql
+++ b/packages/api/src/graphql/v2/schema/schema.graphql
@@ -1722,6 +1722,11 @@ input ActivityFilter {
   conditionIds: [Bytes!]
   pickConfigId: Bytes32
   """
+  Restrict activity to a single position token. With `account`, predictions
+  match only the side that minted this token; trades match exact token.
+  """
+  token: Address
+  """
   Restrict to a subset of activity types. `[]` is a zero-result query.
   """
   types: [ActivityType!]

--- a/packages/app/src/components/positions/ActivityTable.tsx
+++ b/packages/app/src/components/positions/ActivityTable.tsx
@@ -576,6 +576,7 @@ export default function ActivityTable({
   pageSize,
   hiddenColumns,
   filterPickConfigId,
+  filterToken,
   hideFilters,
   fill = false,
 }: {
@@ -595,6 +596,8 @@ export default function ActivityTable({
    * in the first page of the unscoped feed.
    */
   filterPickConfigId?: string;
+  /** Scope the feed to a single position token. */
+  filterToken?: Address;
   /** Hide the filter toolbar (search/status/value-range/date-range). */
   hideFilters?: boolean;
   /** Grow the empty/loading panel via `flex-1` to fill the parent.
@@ -629,6 +632,7 @@ export default function ActivityTable({
     pageSize: effectivePageSize,
     activityType: filters.activityType,
     pickConfigId: filterPickConfigId,
+    token: filterToken,
     conditionId: !account ? conditionId : undefined,
   });
 

--- a/packages/app/src/components/positions/PositionDialog.tsx
+++ b/packages/app/src/components/positions/PositionDialog.tsx
@@ -136,6 +136,7 @@ export default function PositionDialog({
                 <ActivityTable
                   account={position.holder as Address}
                   filterPickConfigId={position.pickConfigId}
+                  filterToken={position.tokenAddress as Address}
                   hiddenColumns={['position', 'status', 'share']}
                   hideFilters
                 />

--- a/packages/app/src/components/positions/PositionDialog.tsx
+++ b/packages/app/src/components/positions/PositionDialog.tsx
@@ -135,7 +135,6 @@ export default function PositionDialog({
               <div className="border-t border-border/60 max-h-56 overflow-y-auto">
                 <ActivityTable
                   account={position.holder as Address}
-                  filterPickConfigId={position.pickConfigId}
                   filterToken={position.tokenAddress as Address}
                   hiddenColumns={['position', 'status', 'share']}
                   hideFilters

--- a/packages/app/src/components/positions/__tests__/PositionDialog.test.tsx
+++ b/packages/app/src/components/positions/__tests__/PositionDialog.test.tsx
@@ -48,10 +48,11 @@ vi.mock('~/components/shared/AddressDisplay', () => ({
 // hood); exercise its data path in its own tests, not here.
 vi.mock('~/components/positions/ActivityTable', () => ({
   __esModule: true,
-  default: (props: { filterPickConfigId?: string }) => (
+  default: (props: { filterPickConfigId?: string; filterToken?: string }) => (
     <div
       data-testid="activity-table"
       data-pickconfigid={props.filterPickConfigId ?? ''}
+      data-token={props.filterToken ?? ''}
     />
   ),
 }));
@@ -217,12 +218,15 @@ describe('PositionDialog', () => {
     expect(toggle).toHaveAttribute('aria-expanded', 'false');
     expect(screen.queryByTestId('activity-table')).not.toBeInTheDocument();
 
-    // Expand it; the embedded ActivityTable mounts, scoped to this pickConfig.
+    // Expand it; the embedded ActivityTable mounts, scoped to this token balance.
     fireEvent.click(toggle);
     expect(toggle).toHaveAttribute('aria-expanded', 'true');
     const embedded = screen.getByTestId('activity-table');
     expect(embedded.getAttribute('data-pickconfigid')).toBe(
       counterpartyPosition.pickConfigId
+    );
+    expect(embedded.getAttribute('data-token')).toBe(
+      counterpartyPosition.tokenAddress
     );
   });
 

--- a/packages/app/src/components/positions/__tests__/PositionDialog.test.tsx
+++ b/packages/app/src/components/positions/__tests__/PositionDialog.test.tsx
@@ -222,9 +222,9 @@ describe('PositionDialog', () => {
     fireEvent.click(toggle);
     expect(toggle).toHaveAttribute('aria-expanded', 'true');
     const embedded = screen.getByTestId('activity-table');
-    expect(embedded.getAttribute('data-pickconfigid')).toBe(
-      counterpartyPosition.pickConfigId
-    );
+    // Scoped by token alone — the position token already pins the pick config
+    // and side, so `filterPickConfigId` is intentionally not passed.
+    expect(embedded.getAttribute('data-pickconfigid')).toBe('');
     expect(embedded.getAttribute('data-token')).toBe(
       counterpartyPosition.tokenAddress
     );

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -33,7 +33,7 @@ import { useRestrictedJurisdiction } from '~/hooks/useRestrictedJurisdiction';
 import RestrictedJurisdictionBanner from '~/components/shared/RestrictedJurisdictionBanner';
 import {
   useVaultStats,
-  useProtocolAnalytics,
+  useProtocolStats,
   useVaultAccountValue,
 } from '~/hooks/graphql/useAnalytics';
 import RiskDisclaimer from '~/components/markets/forms/shared/RiskDisclaimer';
@@ -139,41 +139,11 @@ const VaultsPageContent = () => {
   const selectedVaultValue = selectedVault?.address ?? '';
   const collateralSymbol = COLLATERAL_SYMBOLS[VAULT_CHAIN_ID] || 'testUSDe';
 
-  // Separate reads for each vault so the Vault Rewards
-  // calc can sum across all vaults regardless of which tab is selected. Hooks
-  // must be called unconditionally, so missing addresses are handled inside
-  // the hook via the `enabled` flag.
-  const coreAddr = predictionMarketVault[VAULT_CHAIN_ID]?.address;
-  const optionsAddr = pythPredictionMarketVault[VAULT_CHAIN_ID]?.address;
-  const edgeAddr = predictionMarketVaultStrategyB[VAULT_CHAIN_ID]?.address;
-  const singlesAddr = singleLegVault[VAULT_CHAIN_ID]?.address;
-
-  const coreVault = usePassiveLiquidityVault({
-    vaultAddress: coreAddr,
-    chainId: VAULT_CHAIN_ID,
-  });
-  const optionsVault = usePassiveLiquidityVault({
-    vaultAddress: optionsAddr,
-    chainId: VAULT_CHAIN_ID,
-  });
-  const edgeVault = usePassiveLiquidityVault({
-    vaultAddress: edgeAddr,
-    chainId: VAULT_CHAIN_ID,
-  });
-  const singlesVault = usePassiveLiquidityVault({
-    vaultAddress: singlesAddr,
-    chainId: VAULT_CHAIN_ID,
-  });
-
-  const { data: coreStats } = useVaultStats(coreAddr);
-  const { data: optionsStats } = useVaultStats(optionsAddr);
-  const { data: edgeStats } = useVaultStats(edgeAddr);
-  const { data: singlesStats } = useVaultStats(singlesAddr);
-
-  // Protocol-wide TVL (escrow collateral + undeployed assets across every
-  // vault family), server-computed on v2. Replaces v1's client-side
-  // reconstruction from per-vault `escrowBalance + vaultAvailableAssets`.
-  const { data: protocolAnalytics } = useProtocolAnalytics();
+  // Latest protocol-wide TVL for the rewards card. Keep this independent of
+  // the selected vault tab so switching tabs doesn't preload every vault's
+  // chart/account series just to calculate rewards.
+  const { data: protocolStats, isLoading: isProtocolStatsLoading } =
+    useProtocolStats();
 
   const {
     vaultData,
@@ -663,40 +633,15 @@ const VaultsPageContent = () => {
   const utilizationDisplay = `${utilizationPercent.toFixed(2)}%`;
 
   const yieldMetrics = useMemo(() => {
-    // Rewards are paid from the protocol-wide Ethena yield and are shared
-    // among every vault's LPs. Calc must be identical regardless of which
-    // tab is selected — sum TVL across all deployed vaults.
-    const vaultEntries = [
-      [coreVault.vaultData, coreStats] as const,
-      [optionsVault.vaultData, optionsStats] as const,
-      [edgeVault.vaultData, edgeStats] as const,
-      [singlesVault.vaultData, singlesStats] as const,
-    ];
-    const totalVaultTvlWei = vaultEntries.reduce((sum, [v, stats]) => {
-      const liquid = v?.totalLiquidValue ?? 0n;
-      const lastStat = stats?.[stats.length - 1];
-      const deployed = lastStat?.deployedCollateral
-        ? BigInt(lastStat.deployedCollateral)
-        : 0n;
-      return sum + liquid + deployed;
-    }, 0n);
-
-    // Protocol TVL = escrow collateral + undeployed assets across every vault
-    // family, server-computed on v2 (`protocol.stats.totalValueLocked`). v1
-    // reconstructed this client-side from per-vault `escrowBalance +
-    // vaultAvailableAssets`; the v2 figure is authoritative and avoids the
-    // selected-vault dependence that zeroed out when switching tabs.
-    const protocolTvlWei = protocolAnalytics?.stats?.totalValueLocked
-      ? BigInt(protocolAnalytics.stats.totalValueLocked)
+    // Rewards are paid from the protocol-wide Ethena yield and are shared among
+    // vault LPs. `protocol.stats.totalValueLocked` is already the latest
+    // server-computed total across configured vault families, so the rewards
+    // card no longer needs to fan out across every vault tab.
+    const totalTvlWei = protocolStats?.totalValueLocked
+      ? BigInt(protocolStats.totalValueLocked)
       : 0n;
-    const protocolTvlNum = Number(formatAssetAmount(protocolTvlWei));
-    const totalVaultTvlNum = Number(formatAssetAmount(totalVaultTvlWei));
-
-    const effectiveApy =
-      totalVaultTvlNum > 0
-        ? (protocolTvlNum / totalVaultTvlNum) * ETHENA_BASE_APY
-        : 0;
-    const annualYieldToVaults = totalVaultTvlNum * (effectiveApy / 100);
+    const totalTvlNum = Number(formatAssetAmount(totalTvlWei));
+    const annualYieldToVaults = totalTvlNum * (ETHENA_BASE_APY / 100);
     const weeklyYield = (annualYieldToVaults / 365) * 7;
 
     const fmt = (n: number) =>
@@ -708,23 +653,12 @@ const VaultsPageContent = () => {
         : '0.00';
 
     return {
-      protocolTvl: fmt(protocolTvlNum),
+      protocolTvl: fmt(totalTvlNum),
       annualYield: fmt(annualYieldToVaults),
       weeklyYield: fmt(weeklyYield),
-      effectiveApy: effectiveApy.toFixed(2),
+      effectiveApy: ETHENA_BASE_APY.toFixed(2),
     };
-  }, [
-    coreVault.vaultData,
-    optionsVault.vaultData,
-    edgeVault.vaultData,
-    singlesVault.vaultData,
-    coreStats,
-    optionsStats,
-    edgeStats,
-    singlesStats,
-    protocolAnalytics,
-    formatAssetAmount,
-  ]);
+  }, [protocolStats, formatAssetAmount]);
 
   return (
     <div className="relative">
@@ -983,7 +917,7 @@ const VaultsPageContent = () => {
                               the vault's participation in prediction markets.
                             </p>
                           </div>
-                          {isAnalyticsLoading || !vaultData ? (
+                          {isProtocolStatsLoading ? (
                             <div className="flex justify-center py-4">
                               <Loader className="w-6 h-6" />
                             </div>

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -34,6 +34,7 @@ import RestrictedJurisdictionBanner from '~/components/shared/RestrictedJurisdic
 import {
   useVaultStats,
   useProtocolAnalytics,
+  useVaultAccountValue,
 } from '~/hooks/graphql/useAnalytics';
 import RiskDisclaimer from '~/components/markets/forms/shared/RiskDisclaimer';
 import Loader from '~/components/shared/Loader';
@@ -200,8 +201,9 @@ const VaultsPageContent = () => {
   });
 
   const { isRestricted, isPermitLoading } = useRestrictedJurisdiction();
-  const { data: vaultStats, isLoading: isAnalyticsLoading } =
-    useVaultStats(VAULT_ADDRESS);
+  const { data: vaultStats } = useVaultStats(VAULT_ADDRESS);
+  const { data: vaultAccountValue, isLoading: isAnalyticsLoading } =
+    useVaultAccountValue(VAULT_ADDRESS);
 
   const [depositAmount, setDepositAmount] = useState('');
   const [withdrawAmount, setWithdrawAmount] = useState('');
@@ -575,23 +577,19 @@ const VaultsPageContent = () => {
     </Tabs>
   );
 
-  const liquidWei = vaultData?.totalLiquidValue ?? 0n;
+  const deployedWei = vaultAccountValue?.deployedCollateral
+    ? BigInt(vaultAccountValue.deployedCollateral)
+    : 0n;
 
-  const deployedWei = useMemo(() => {
-    const lastStat = vaultStats?.[vaultStats.length - 1];
-    return lastStat?.deployedCollateral
-      ? BigInt(lastStat.deployedCollateral)
-      : 0n;
-  }, [vaultStats]);
+  // Vault AUM is computed from one indexed account view: current wallet
+  // collateral balance + collateral deployed in open positions + settled/won
+  // collateral owed but not yet claimed. Keeping all three terms on the same
+  // freshness boundary avoids the old live-contract + cached-snapshot drift.
+  const tvlWei = vaultAccountValue?.totalValue
+    ? BigInt(vaultAccountValue.totalValue)
+    : 0n;
 
-  // Vault AUM = liquid USDe in the vault + collateral deployed in open positions.
-  // getTotalLiquidValue() on the contract intentionally excludes position tokens,
-  // so we add the deployed cost basis back here to show true total.
-  const tvlWei = liquidWei + deployedWei;
-
-  // The two terms come from different sources (on-chain read vs GraphQL);
-  // until both have loaded, the sum is a misleading partial figure.
-  const isBalanceReady = !!vaultData && !!vaultStats;
+  const isBalanceReady = !!vaultAccountValue;
 
   const utilizationPercent = useMemo(() => {
     if (tvlWei <= 0n) return 0;

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -406,7 +406,11 @@ const VaultsPageContent = () => {
               !!(pendingRequest && !pendingRequest.processed) ||
               isPermitLoading ||
               isRestricted ||
-              (!!depositAmount && exceedsVaultCapacity) ||
+              // Block deposits until the indexed AUM has loaded: while it is
+              // still loading `tvlWei` reads 0, so `exceedsVaultCapacity`
+              // understates the true total and a near-cap vault could let an
+              // over-cap deposit through the client check.
+              (!!depositAmount && (!isBalanceReady || exceedsVaultCapacity)) ||
               (isConnected && !isWhitelisted)
             }
             onClick={async () => {

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -201,9 +201,13 @@ const VaultsPageContent = () => {
   });
 
   const { isRestricted, isPermitLoading } = useRestrictedJurisdiction();
-  const { data: vaultStats } = useVaultStats(VAULT_ADDRESS);
-  const { data: vaultAccountValue, isLoading: isAnalyticsLoading } =
-    useVaultAccountValue(VAULT_ADDRESS);
+  // `isAnalyticsLoading` tracks the vault-stats query that feeds the PnL chart
+  // and the yield/rewards block — keep it on that source so their loaders match
+  // the data they render. The balance display gates on `vaultAccountValue`
+  // separately via `isBalanceReady` below.
+  const { data: vaultStats, isLoading: isAnalyticsLoading } =
+    useVaultStats(VAULT_ADDRESS);
+  const { data: vaultAccountValue } = useVaultAccountValue(VAULT_ADDRESS);
 
   const [depositAmount, setDepositAmount] = useState('');
   const [withdrawAmount, setWithdrawAmount] = useState('');

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -80,6 +80,10 @@ const VaultsPageContent = () => {
           | undefined,
         'Edge Vault',
       ],
+      [
+        singleLegVault[VAULT_CHAIN_ID]?.address as `0x${string}` | undefined,
+        'Singles Vault',
+      ],
     ];
     return entries
       .filter((entry): entry is [`0x${string}`, string] => Boolean(entry[0]))
@@ -93,10 +97,6 @@ const VaultsPageContent = () => {
           | `0x${string}`
           | undefined,
         'Options Vault',
-      ],
-      [
-        singleLegVault[VAULT_CHAIN_ID]?.address as `0x${string}` | undefined,
-        'Singles Vault',
       ],
     ];
     const hiddenVaultOptions = hiddenEntries
@@ -138,13 +138,14 @@ const VaultsPageContent = () => {
   const selectedVaultValue = selectedVault?.address ?? '';
   const collateralSymbol = COLLATERAL_SYMBOLS[VAULT_CHAIN_ID] || 'testUSDe';
 
-  // Separate reads for each of the (up to) three vaults so the Vault Rewards
+  // Separate reads for each vault so the Vault Rewards
   // calc can sum across all vaults regardless of which tab is selected. Hooks
   // must be called unconditionally, so missing addresses are handled inside
   // the hook via the `enabled` flag.
   const coreAddr = predictionMarketVault[VAULT_CHAIN_ID]?.address;
   const optionsAddr = pythPredictionMarketVault[VAULT_CHAIN_ID]?.address;
   const edgeAddr = predictionMarketVaultStrategyB[VAULT_CHAIN_ID]?.address;
+  const singlesAddr = singleLegVault[VAULT_CHAIN_ID]?.address;
 
   const coreVault = usePassiveLiquidityVault({
     vaultAddress: coreAddr,
@@ -158,10 +159,15 @@ const VaultsPageContent = () => {
     vaultAddress: edgeAddr,
     chainId: VAULT_CHAIN_ID,
   });
+  const singlesVault = usePassiveLiquidityVault({
+    vaultAddress: singlesAddr,
+    chainId: VAULT_CHAIN_ID,
+  });
 
   const { data: coreStats } = useVaultStats(coreAddr);
   const { data: optionsStats } = useVaultStats(optionsAddr);
   const { data: edgeStats } = useVaultStats(edgeAddr);
+  const { data: singlesStats } = useVaultStats(singlesAddr);
 
   // Protocol-wide TVL (escrow collateral + undeployed assets across every
   // vault family), server-computed on v2. Replaces v1's client-side
@@ -658,6 +664,7 @@ const VaultsPageContent = () => {
       [coreVault.vaultData, coreStats] as const,
       [optionsVault.vaultData, optionsStats] as const,
       [edgeVault.vaultData, edgeStats] as const,
+      [singlesVault.vaultData, singlesStats] as const,
     ];
     const totalVaultTvlWei = vaultEntries.reduce((sum, [v, stats]) => {
       const liquid = v?.totalLiquidValue ?? 0n;
@@ -704,9 +711,11 @@ const VaultsPageContent = () => {
     coreVault.vaultData,
     optionsVault.vaultData,
     edgeVault.vaultData,
+    singlesVault.vaultData,
     coreStats,
     optionsStats,
     edgeStats,
+    singlesStats,
     protocolAnalytics,
     formatAssetAmount,
   ]);

--- a/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
+++ b/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
@@ -346,7 +346,7 @@ describe('VaultsPageContent geofence', () => {
     expect(depositBtn).not.toBeDisabled();
   });
 
-  it('hides the options and singles vaults from tabs', () => {
+  it('shows the singles vault tab while keeping options hidden', () => {
     mockUseRestrictedJurisdiction.mockReturnValue({
       isRestricted: false,
       isPermitLoading: false,
@@ -366,11 +366,11 @@ describe('VaultsPageContent geofence', () => {
       screen.queryByRole('button', { name: 'Options Vault' })
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole('button', { name: 'Singles Vault' })
-    ).not.toBeInTheDocument();
+      screen.getByRole('button', { name: 'Singles Vault' })
+    ).toBeInTheDocument();
   });
 
-  it('accepts a hidden known/indexed vault address from the URL without rewriting it', () => {
+  it('accepts the singles vault address from the URL without rewriting it', () => {
     const singleLegVault = '0xSingleLegVault';
     mockSearchParamsToString.mockReturnValue(`address=${singleLegVault}`);
     mockUseRestrictedJurisdiction.mockReturnValue({
@@ -382,7 +382,9 @@ describe('VaultsPageContent geofence', () => {
 
     render(<VaultsPageContent />);
 
-    expect(screen.getByText('Singles Vault')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Singles Vault' })
+    ).toBeInTheDocument();
     expect(mockRouterReplace).not.toHaveBeenCalled();
     expect(
       mockUsePassiveLiquidityVault.mock.calls.some(

--- a/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
+++ b/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
@@ -10,6 +10,7 @@ const {
   mockUsePassiveLiquidityVault,
   mockUseCurrentAddress,
   mockUseVaultStats,
+  mockUseVaultAccountValue,
   mockUseProtocolAnalytics,
   mockRouterReplace,
   mockSearchParamsToString,
@@ -18,6 +19,7 @@ const {
   mockUsePassiveLiquidityVault: vi.fn(),
   mockUseCurrentAddress: vi.fn(),
   mockUseVaultStats: vi.fn(),
+  mockUseVaultAccountValue: vi.fn(),
   mockUseProtocolAnalytics: vi.fn(),
   mockRouterReplace: vi.fn(),
   mockSearchParamsToString: vi.fn(() => ''),
@@ -44,6 +46,8 @@ vi.mock('~/hooks/graphql/useAnalytics', () => ({
   useVaultStats: (vaultAddress: string | undefined) =>
     mockUseVaultStats(vaultAddress),
   useProtocolAnalytics: () => mockUseProtocolAnalytics(),
+  useVaultAccountValue: (vaultAddress: string | undefined) =>
+    mockUseVaultAccountValue(vaultAddress),
 }));
 
 vi.mock('~/lib/context/ConnectDialogContext', () => ({
@@ -283,6 +287,17 @@ function setDefaults() {
     isLoading: false,
   });
 
+  mockUseVaultAccountValue.mockReturnValue({
+    data: {
+      collateralBalance: (1000n * 10n ** 18n).toString(),
+      deployedCollateral: '0',
+      claimableCollateral: '0',
+      totalValue: (1000n * 10n ** 18n).toString(),
+      timestamp: 1,
+    },
+    isLoading: false,
+  });
+
   mockUseProtocolAnalytics.mockReturnValue({
     data: { stats: { totalValueLocked: '0' } },
     isLoading: false,
@@ -458,7 +473,17 @@ describe('VaultsPageContent vault balance display', () => {
       permitData: { permitted: true },
       permitError: null,
     });
-    // Liquid (on-chain) = 1,000; deployed (GraphQL) = 500 -> balance 1,500.
+    // Indexed collateral balance = 1,000; deployed = 500; claimable = 125 -> balance 1,625.
+    mockUseVaultAccountValue.mockReturnValue({
+      data: {
+        collateralBalance: (1000n * 10n ** 18n).toString(),
+        deployedCollateral: (500n * 10n ** 18n).toString(),
+        claimableCollateral: (125n * 10n ** 18n).toString(),
+        totalValue: (1625n * 10n ** 18n).toString(),
+        timestamp: 1,
+      },
+      isLoading: false,
+    });
     mockUseVaultStats.mockReturnValue({
       data: [{ deployedCollateral: (500n * 10n ** 18n).toString() }],
       isLoading: false,
@@ -468,7 +493,7 @@ describe('VaultsPageContent vault balance display', () => {
   it('renders the balance and progress bar once both sources have loaded', () => {
     render(<VaultsPageContent />);
 
-    expect(screen.getByText('1,500.00 USDe')).toBeInTheDocument();
+    expect(screen.getByText('1,625.00 USDe')).toBeInTheDocument();
     expect(screen.getByTestId('vault-balance-bar')).toBeInTheDocument();
     expect(screen.getByText(/deployed/)).toBeInTheDocument();
   });
@@ -477,39 +502,34 @@ describe('VaultsPageContent vault balance display', () => {
     render(<VaultsPageContent />);
 
     const fadeIn = 'animate-in fade-in duration-200';
-    expect(screen.getByText('1,500.00 USDe').className).toContain(fadeIn);
+    expect(screen.getByText('1,625.00 USDe').className).toContain(fadeIn);
     expect(
       screen.getByTestId('vault-balance-bar').parentElement?.className
     ).toContain(fadeIn);
     expect(screen.getByText(/deployed/).className).toContain(fadeIn);
   });
 
-  it('hides the balance number and progress bar until the on-chain read has loaded', () => {
+  it('uses the indexed account value rather than the live on-chain liquid read', () => {
     mockUsePassiveLiquidityVault.mockReturnValue({
       ...passiveVaultDefaults(),
-      vaultData: null,
+      vaultData: { totalLiquidValue: 9999n * 10n ** 18n, paused: false },
     });
 
     render(<VaultsPageContent />);
 
-    // Without the liquid value, the sum would misleadingly show only the
-    // deployed portion (500.00) - it must not render at all.
-    expect(screen.queryByText('500.00 USDe')).toBeNull();
-    expect(screen.queryByTestId('vault-balance-bar')).toBeNull();
-    expect(screen.queryByText(/deployed/)).toBeNull();
+    expect(screen.getByText('1,625.00 USDe')).toBeInTheDocument();
+    expect(screen.queryByText('10,499.00 USDe')).toBeNull();
   });
 
-  it('hides the balance number and progress bar until protocol stats have loaded', () => {
-    mockUseVaultStats.mockReturnValue({
+  it('hides the balance number and progress bar until indexed account value has loaded', () => {
+    mockUseVaultAccountValue.mockReturnValue({
       data: undefined,
       isLoading: true,
     });
 
     render(<VaultsPageContent />);
 
-    // Without the deployed value, the sum would misleadingly show only the
-    // liquid portion (1,000.00) - it must not render at all.
-    expect(screen.queryByText('1,000.00 USDe')).toBeNull();
+    expect(screen.queryByText('1,625.00 USDe')).toBeNull();
     expect(screen.queryByTestId('vault-balance-bar')).toBeNull();
     expect(screen.queryByText(/deployed/)).toBeNull();
   });

--- a/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
+++ b/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
@@ -11,7 +11,7 @@ const {
   mockUseCurrentAddress,
   mockUseVaultStats,
   mockUseVaultAccountValue,
-  mockUseProtocolAnalytics,
+  mockUseProtocolStats,
   mockRouterReplace,
   mockSearchParamsToString,
   mockVaultPnlChart,
@@ -21,7 +21,7 @@ const {
   mockUseCurrentAddress: vi.fn(),
   mockUseVaultStats: vi.fn(),
   mockUseVaultAccountValue: vi.fn(),
-  mockUseProtocolAnalytics: vi.fn(),
+  mockUseProtocolStats: vi.fn(),
   mockRouterReplace: vi.fn(),
   mockSearchParamsToString: vi.fn(() => ''),
   mockVaultPnlChart: vi.fn(),
@@ -47,7 +47,7 @@ vi.mock('~/hooks/blockchain/useCurrentAddress', () => ({
 vi.mock('~/hooks/graphql/useAnalytics', () => ({
   useVaultStats: (vaultAddress: string | undefined) =>
     mockUseVaultStats(vaultAddress),
-  useProtocolAnalytics: () => mockUseProtocolAnalytics(),
+  useProtocolStats: () => mockUseProtocolStats(),
   useVaultAccountValue: (vaultAddress: string | undefined) =>
     mockUseVaultAccountValue(vaultAddress),
 }));
@@ -303,8 +303,8 @@ function setDefaults() {
     isLoading: false,
   });
 
-  mockUseProtocolAnalytics.mockReturnValue({
-    data: { stats: { totalValueLocked: '0' } },
+  mockUseProtocolStats.mockReturnValue({
+    data: { totalValueLocked: '0' },
     isLoading: false,
   });
 }
@@ -413,6 +413,28 @@ describe('VaultsPageContent geofence', () => {
       )
     ).toBe(true);
     expect(mockUseVaultStats).toHaveBeenCalledWith(singleLegVault);
+  });
+
+  it('loads stats and contract data only for the selected vault plus protocol rewards stats', () => {
+    mockUseRestrictedJurisdiction.mockReturnValue({
+      isRestricted: false,
+      isPermitLoading: false,
+      permitData: { permitted: true },
+      permitError: null,
+    });
+
+    render(<VaultsPageContent />);
+
+    expect(mockUseVaultStats).toHaveBeenCalledTimes(1);
+    expect(mockUseVaultStats).toHaveBeenCalledWith('0xVault');
+    expect(mockUseVaultAccountValue).toHaveBeenCalledTimes(1);
+    expect(mockUseVaultAccountValue).toHaveBeenCalledWith('0xVault');
+    expect(mockUsePassiveLiquidityVault).toHaveBeenCalledTimes(1);
+    expect(mockUsePassiveLiquidityVault).toHaveBeenCalledWith({
+      vaultAddress: '0xVault',
+      chainId: 42161,
+    });
+    expect(mockUseProtocolStats).toHaveBeenCalledTimes(1);
   });
 
   it('accepts the hidden options vault address from the URL without showing its tab', () => {

--- a/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
+++ b/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
@@ -14,6 +14,7 @@ const {
   mockUseProtocolAnalytics,
   mockRouterReplace,
   mockSearchParamsToString,
+  mockVaultPnlChart,
 } = vi.hoisted(() => ({
   mockUseRestrictedJurisdiction: vi.fn(),
   mockUsePassiveLiquidityVault: vi.fn(),
@@ -23,6 +24,7 @@ const {
   mockUseProtocolAnalytics: vi.fn(),
   mockRouterReplace: vi.fn(),
   mockSearchParamsToString: vi.fn(() => ''),
+  mockVaultPnlChart: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -232,7 +234,10 @@ vi.mock('~/components/shared/Loader', () => {
 });
 
 vi.mock('~/components/vaults/VaultPnlChart', () => {
-  const VaultPnlChart = () => <div />;
+  const VaultPnlChart = (props: { isLoading?: boolean }) => {
+    mockVaultPnlChart(props);
+    return <div />;
+  };
   VaultPnlChart.displayName = 'VaultPnlChart';
   return { __esModule: true, default: VaultPnlChart };
 });
@@ -532,5 +537,28 @@ describe('VaultsPageContent vault balance display', () => {
     expect(screen.queryByText('1,625.00 USDe')).toBeNull();
     expect(screen.queryByTestId('vault-balance-bar')).toBeNull();
     expect(screen.queryByText(/deployed/)).toBeNull();
+  });
+
+  it('drives the PnL chart loader from the vault-stats query, not the account value', () => {
+    // The chart renders `vaultStats`, so its loader must track that query.
+    // The account-value query (which backs the balance number) being settled
+    // must not make the chart claim it has finished loading its own series.
+    mockUseVaultStats.mockReturnValue({ data: undefined, isLoading: true });
+    mockUseVaultAccountValue.mockReturnValue({
+      data: {
+        collateralBalance: '0',
+        deployedCollateral: '0',
+        claimableCollateral: '0',
+        totalValue: '0',
+        timestamp: 1,
+      },
+      isLoading: false,
+    });
+
+    render(<VaultsPageContent />);
+
+    expect(mockVaultPnlChart).toHaveBeenCalledWith(
+      expect.objectContaining({ isLoading: true })
+    );
   });
 });

--- a/packages/app/src/hooks/graphql/__tests__/useAccountActivity.test.ts
+++ b/packages/app/src/hooks/graphql/__tests__/useAccountActivity.test.ts
@@ -189,6 +189,7 @@ describe('useAccountActivity', () => {
       account: null,
       conditionIds: null,
       pickConfigId: null,
+      token: null,
       types: null,
       first: 20,
       after: null,
@@ -288,6 +289,7 @@ describe('useAccountActivity', () => {
           account:
             '0xABCDEF0000000000000000000000000000000001' as `0x${string}`,
           pickConfigId: '0xpc1',
+          token: '0xpredictortoken' as `0x${string}`,
           conditionId: '0xc1',
           activityType: 'trade',
         }),
@@ -302,6 +304,7 @@ describe('useAccountActivity', () => {
     expect(variables).toMatchObject({
       account: '0xABCDEF0000000000000000000000000000000001',
       pickConfigId: '0xpc1',
+      token: '0xpredictortoken',
       conditionIds: ['0xc1'],
       types: ['TRADE'],
     });

--- a/packages/app/src/hooks/graphql/useAccountActivity.ts
+++ b/packages/app/src/hooks/graphql/useAccountActivity.ts
@@ -47,6 +47,7 @@ export const ACCOUNT_ACTIVITY_QUERY = `
     $account: Address
     $conditionIds: [Bytes!]
     $pickConfigId: Bytes32
+    $token: Address
     $types: [ActivityType!]
     $first: Int!
     $after: String
@@ -58,6 +59,7 @@ export const ACCOUNT_ACTIVITY_QUERY = `
         account: $account
         conditionIds: $conditionIds
         pickConfigId: $pickConfigId
+        token: $token
         types: $types
       }
     ) {
@@ -195,6 +197,7 @@ export function useAccountActivity({
   pageSize = DEFAULT_PAGE_SIZE,
   activityType,
   pickConfigId,
+  token,
   conditionId,
   enabled: enabledOverride,
 }: {
@@ -206,6 +209,11 @@ export function useAccountActivity({
    * pickConfigId and trades by the pickConfig's predictor/counterparty tokens.
    */
   pickConfigId?: string;
+  /**
+   * Scope the feed to a single position token. With `account`, predictions
+   * only match the side that minted that token; trades match exact token.
+   */
+  token?: Address;
   /**
    * Scope the feed to a condition. Matches every pick configuration whose
    * picks reference this conditionId.
@@ -242,6 +250,7 @@ export function useAccountActivity({
       account ?? 'global',
       typeFilter,
       pickConfigId ?? null,
+      token ?? null,
       conditionId ?? null,
       pageSize,
     ],
@@ -263,6 +272,7 @@ export function useAccountActivity({
         account: account ?? null,
         conditionIds: conditionId ? [conditionId] : null,
         pickConfigId: pickConfigId ?? null,
+        token: token ?? null,
         types,
         first: pageSize,
         after: pageParam ?? null,

--- a/packages/app/src/hooks/graphql/useAnalytics.ts
+++ b/packages/app/src/hooks/graphql/useAnalytics.ts
@@ -3,8 +3,10 @@ import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
 import {
   fetchProtocolAnalytics,
   fetchVaultStats,
+  fetchVaultAccountValue,
   type ProtocolAnalytics,
   type VaultStat,
+  type VaultAccountValue,
 } from '@sapience/sdk/queries';
 
 const CACHE_TIME_MS = 60 * 1000;
@@ -31,6 +33,30 @@ export function useVaultStats(vaultAddress?: string) {
 }
 
 /**
+ * Coherent indexed vault account value for the /vaults amount display.
+ * Uses one GraphQL account view instead of mixing live contract reads with
+ * cached vault stats snapshots.
+ */
+export function useVaultAccountValue(vaultAddress?: string) {
+  return useQuery<VaultAccountValue>({
+    queryKey: ['vaultAccountValue', vaultAddress?.toLowerCase() ?? null],
+    queryFn: () =>
+      vaultAddress
+        ? fetchVaultAccountValue(vaultAddress, DEFAULT_CHAIN_ID)
+        : Promise.resolve({
+            collateralBalance: '0',
+            deployedCollateral: '0',
+            claimableCollateral: '0',
+            totalValue: '0',
+            timestamp: null,
+          }),
+    enabled: !!vaultAddress,
+    staleTime: CACHE_TIME_MS,
+    refetchInterval: CACHE_TIME_MS,
+  });
+}
+
+/**
  * v2 protocol analytics: live stats, the recorded snapshot series and both
  * open-interest breakdowns in a single `protocol { ... }` query.
  */
@@ -43,7 +69,7 @@ export function useProtocolAnalytics() {
   });
 }
 
-export type { ProtocolAnalytics, VaultStat };
+export type { ProtocolAnalytics, VaultStat, VaultAccountValue };
 export type {
   ProtocolAnalyticsStat,
   ProtocolCategoryOpenInterest,

--- a/packages/app/src/hooks/graphql/useAnalytics.ts
+++ b/packages/app/src/hooks/graphql/useAnalytics.ts
@@ -2,9 +2,11 @@ import { useQuery } from '@tanstack/react-query';
 import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
 import {
   fetchProtocolAnalytics,
+  fetchProtocolStats,
   fetchVaultStats,
   fetchVaultAccountValue,
   type ProtocolAnalytics,
+  type ProtocolAnalyticsStat,
   type VaultStat,
   type VaultAccountValue,
 } from '@sapience/sdk/queries';
@@ -51,6 +53,19 @@ export function useVaultAccountValue(vaultAddress?: string) {
             timestamp: null,
           }),
     enabled: !!vaultAddress,
+    staleTime: CACHE_TIME_MS,
+    refetchInterval: CACHE_TIME_MS,
+  });
+}
+
+/**
+ * Latest v2 protocol stats only. Use this when callers need the live aggregate
+ * numbers without the heavier history/open-interest analytics payload.
+ */
+export function useProtocolStats() {
+  return useQuery<ProtocolAnalyticsStat>({
+    queryKey: ['protocolStats'],
+    queryFn: () => fetchProtocolStats(),
     staleTime: CACHE_TIME_MS,
     refetchInterval: CACHE_TIME_MS,
   });

--- a/packages/market-keeper/.env.example
+++ b/packages/market-keeper/.env.example
@@ -27,3 +27,14 @@ LLM_ENDTIME_SEARCH_ENABLED=true
 OPENROUTER_API_KEY=
 LLM_ENDTIME_MODEL=perplexity/sonar
 NODE_ENV=development
+
+# --- Keeper Discord alerts ---
+# Webhook for keeper alerts: balance heartbeat + per-cron run summaries.
+# Leave empty to disable all keeper Discord notifications.
+DISCORD_KEEPER_WEBHOOK=
+# Alert when OpenRouter credits fall below this many USD (default 10).
+OPENROUTER_MIN_CREDITS=10
+# Alert when the admin wallet's POL balance falls below this many POL (default 5).
+ADMIN_MIN_POL=5
+# Set to 1 to only post per-cron summaries on failure (reduces noise).
+KEEPER_SUMMARY_ON_FAILURE_ONLY=

--- a/packages/market-keeper/.env.example
+++ b/packages/market-keeper/.env.example
@@ -38,3 +38,8 @@ OPENROUTER_MIN_CREDITS=10
 ADMIN_MIN_POL=5
 # Set to 1 to only post per-cron summaries on failure (reduces noise).
 KEEPER_SUMMARY_ON_FAILURE_ONLY=
+# Environment label shown on alerts. Optional override — if unset, falls back to
+# RAILWAY_ENVIRONMENT_NAME (auto on Railway), then NODE_ENV, then 'development'.
+# Set this only if NODE_ENV/Railway's name isn't the label you want shown
+# (staging runs as NODE_ENV=production, so NODE_ENV can't tell them apart).
+KEEPER_ENV=

--- a/packages/market-keeper/AGENTS.md
+++ b/packages/market-keeper/AGENTS.md
@@ -64,6 +64,7 @@ All notification logic lives in `src/notify/` (compiled to dist); the source-JS 
 - `OPENROUTER_MIN_CREDITS` - LOW-alert threshold for OpenRouter USD credits (default 10)
 - `ADMIN_MIN_POL` - LOW-alert threshold for admin wallet POL (default 5)
 - `KEEPER_SUMMARY_ON_FAILURE_ONLY` - set to `1` to only post run summaries on failure
+- `KEEPER_ENV` - optional alert environment label; falls back to `RAILWAY_ENVIRONMENT_NAME`, then `NODE_ENV`, then `development` (NODE_ENV is `production` on both staging and prod, so it can't distinguish them)
 
 ## Production Safety
 

--- a/packages/market-keeper/AGENTS.md
+++ b/packages/market-keeper/AGENTS.md
@@ -43,6 +43,15 @@ pnpm --filter @sapience/market-keeper start
 
 The `start` script orchestrates `refresh-metadata → generate → relist → prices-and-1d-7d-volume → refresh-volume → cleanup-polymarket → settle-polymarket/manual → settle-pyth`; `scripts/start.js` is the source of truth for ordering. Settlement script selection is chain-dependent — mainnet (`5064014`) runs `settle-polymarket`, testnet runs `settle-manual`.
 
+## Discord alerts
+
+Set `DISCORD_KEEPER_WEBHOOK` (in the keeper's env, not just the API's) to enable two notification flows; with it unset both are silent no-ops.
+
+- **Per-cron run summaries.** The cron runner (`scripts/lib/groups.js`) posts one embed per group run (discovery / metadata-tags / market-data / settlement) with each subservice's ✅/❌ status, duration, and counts. Counts come from subservices appending a JSON line via `emitStepSummary()` (`src/notify/summary.ts`) to the `KEEPER_SUMMARY_FILE` the runner provisions per run. Set `KEEPER_SUMMARY_ON_FAILURE_ONLY=1` to suppress success summaries.
+- **Balance heartbeat.** `pnpm start:status` (`scripts/keeper-status.ts`, run as its own cron, e.g. hourly) reports OpenRouter credits + admin-wallet POL, escalating to a LOW alert below `OPENROUTER_MIN_CREDITS` / `ADMIN_MIN_POL`.
+
+All notification logic lives in `src/notify/` (compiled to dist); the source-JS runner reaches it only through the single `dist/src/notify/report` entry point.
+
 ## Environment Variables
 
 - `ADMIN_PRIVATE_KEY` - Private key for API auth and settlements
@@ -51,6 +60,10 @@ The `start` script orchestrates `refresh-metadata → generate → relist → pr
 - `LLM_ENABLED` - Enable LLM enrichment (optional)
 - `OPENROUTER_API_KEY` - OpenRouter key if LLM enabled
 - `LLM_MODEL` - Model to use (default: openai/gpt-4o-mini)
+- `DISCORD_KEEPER_WEBHOOK` - Discord webhook for keeper alerts (heartbeat + run summaries); unset = disabled
+- `OPENROUTER_MIN_CREDITS` - LOW-alert threshold for OpenRouter USD credits (default 10)
+- `ADMIN_MIN_POL` - LOW-alert threshold for admin wallet POL (default 5)
+- `KEEPER_SUMMARY_ON_FAILURE_ONLY` - set to `1` to only post run summaries on failure
 
 ## Production Safety
 

--- a/packages/market-keeper/package.json
+++ b/packages/market-keeper/package.json
@@ -46,6 +46,8 @@
     "start:metadata-tags": "node scripts/cron-metadata-tags.js",
     "start:market-data": "node scripts/cron-market-data.js",
     "start:settlement": "node scripts/cron-settlement.js",
+    "start:status": "node scripts/cron-status.js",
+    "keeper-status": "tsx scripts/keeper-status.ts",
     "lint": "eslint src --quiet",
     "lint:fix": "eslint src --fix --quiet && pnpm format",
     "format": "prettier --write src scripts",

--- a/packages/market-keeper/scripts/cron-discovery.js
+++ b/packages/market-keeper/scripts/cron-discovery.js
@@ -4,4 +4,9 @@
  * generate → relist. Create-only — touches no existing tags, so it carries no
  * tag-write race and can run more often than the heavy metadata-tags sweep.
  */
-require('./lib/groups').runGroup('discovery');
+require('./lib/groups')
+  .runGroup('discovery')
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/market-keeper/scripts/cron-market-data.js
+++ b/packages/market-keeper/scripts/cron-market-data.js
@@ -4,4 +4,9 @@
  * Writes only price/volume fields (disjoint from tags), so it's safe to run
  * frequently and independently of the other crons.
  */
-require('./lib/groups').runGroup('market-data');
+require('./lib/groups')
+  .runGroup('market-data')
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/market-keeper/scripts/cron-metadata-tags.js
+++ b/packages/market-keeper/scripts/cron-metadata-tags.js
@@ -5,4 +5,9 @@
  * sequential group — never run them as separate overlapping crons or a
  * stale-read tag write can clobber the other's.
  */
-require('./lib/groups').runGroup('metadata-tags');
+require('./lib/groups')
+  .runGroup('metadata-tags')
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/market-keeper/scripts/cron-settlement.js
+++ b/packages/market-keeper/scripts/cron-settlement.js
@@ -4,4 +4,9 @@
  * Writes settlement state only; independent of the metadata/tag/market-data
  * crons, so a failure here can't block them.
  */
-require('./lib/groups').runGroup('settlement');
+require('./lib/groups')
+  .runGroup('settlement')
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/market-keeper/scripts/cron-status.js
+++ b/packages/market-keeper/scripts/cron-status.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+/**
+ * Status cron: balance heartbeat (OpenRouter credits + admin POL) to Discord.
+ * Standalone — reads only, writes nothing, so it can run on its own cadence
+ * (e.g. hourly) independent of the data/settlement crons.
+ */
+const { execSync } = require('child_process');
+
+execSync('node dist/scripts/keeper-status.js', { stdio: 'inherit' });

--- a/packages/market-keeper/scripts/keeper-status.ts
+++ b/packages/market-keeper/scripts/keeper-status.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Keeper heartbeat: reads the balances the keeper depends on and posts them to
+ * the Discord webhook (DISCORD_KEEPER_WEBHOOK), escalating to a LOW alert when
+ * a balance falls below its threshold.
+ *
+ *   - OpenRouter credits   (OPENROUTER_API_KEY)
+ *   - Admin wallet POL     (POLYGON_RPC_URL + ADMIN_PRIVATE_KEY)
+ *
+ * Intended to run as its own Railway cron (e.g. hourly): `pnpm start:status`.
+ *
+ * Thresholds (USD credits / POL):
+ *   OPENROUTER_MIN_CREDITS   default 10
+ *   ADMIN_MIN_POL            default 5
+ */
+import 'dotenv/config';
+import {
+  fetchOpenRouterBalance,
+  fetchPolBalance,
+  classifyBalances,
+} from '../src/notify/balances.js';
+import { buildHeartbeatEmbed } from '../src/notify/embeds.js';
+import { postKeeperEmbeds } from '../src/notify/discord.js';
+import { log, logError, logSeparator } from '../src/utils/log.js';
+import type { BalanceReport } from '../src/notify/types.js';
+
+const DEFAULT_OPENROUTER_MIN_CREDITS = 10;
+const DEFAULT_ADMIN_MIN_POL = 5;
+
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+function numEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === '') return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+async function main(): Promise<void> {
+  const report: BalanceReport = {};
+
+  const openrouterKey = process.env.OPENROUTER_API_KEY;
+  if (openrouterKey) {
+    try {
+      report.openrouter = await fetchOpenRouterBalance(openrouterKey);
+    } catch (e) {
+      report.openrouterError = errMsg(e);
+      logError(
+        '[keeper-status] OpenRouter balance failed:',
+        report.openrouterError
+      );
+    }
+  } else {
+    report.openrouterError = 'OPENROUTER_API_KEY not set';
+  }
+
+  const rpcUrl = process.env.POLYGON_RPC_URL;
+  const adminKey = process.env.ADMIN_PRIVATE_KEY;
+  if (rpcUrl && adminKey) {
+    try {
+      report.pol = await fetchPolBalance(rpcUrl, adminKey);
+    } catch (e) {
+      report.polError = errMsg(e);
+      logError('[keeper-status] POL balance failed:', report.polError);
+    }
+  } else {
+    report.polError = 'POLYGON_RPC_URL or ADMIN_PRIVATE_KEY not set';
+  }
+
+  const thresholds = {
+    openrouterMinCredits: numEnv(
+      'OPENROUTER_MIN_CREDITS',
+      DEFAULT_OPENROUTER_MIN_CREDITS
+    ),
+    adminMinPol: numEnv('ADMIN_MIN_POL', DEFAULT_ADMIN_MIN_POL),
+  };
+  const cls = classifyBalances(report, thresholds);
+
+  log(
+    `[keeper-status] OpenRouter remaining: ${
+      report.openrouter
+        ? `$${report.openrouter.remaining.toFixed(2)}`
+        : report.openrouterError
+    }`
+  );
+  log(
+    `[keeper-status] Admin POL: ${
+      report.pol ? report.pol.pol.toFixed(3) : report.polError
+    }`
+  );
+  if (cls.anyLow) {
+    logError(
+      `[keeper-status] LOW BALANCE: openrouterLow=${cls.openrouterLow} polLow=${cls.polLow}`
+    );
+  }
+
+  await postKeeperEmbeds([buildHeartbeatEmbed(report, cls)]);
+}
+
+logSeparator('keeper-status', 'START');
+main()
+  .catch((e) => {
+    logError('[keeper-status] fatal:', errMsg(e));
+    process.exit(1);
+  })
+  .finally(() => logSeparator('keeper-status', 'END'));

--- a/packages/market-keeper/scripts/keeper-status.ts
+++ b/packages/market-keeper/scripts/keeper-status.ts
@@ -20,7 +20,7 @@ import {
   classifyBalances,
 } from '../src/notify/balances.js';
 import { buildHeartbeatEmbed } from '../src/notify/embeds.js';
-import { postKeeperEmbeds } from '../src/notify/discord.js';
+import { postKeeperEmbeds, keeperEnv } from '../src/notify/discord.js';
 import { log, logError, logSeparator } from '../src/utils/log.js';
 import type { BalanceReport } from '../src/notify/types.js';
 
@@ -96,7 +96,7 @@ async function main(): Promise<void> {
     );
   }
 
-  await postKeeperEmbeds([buildHeartbeatEmbed(report, cls)]);
+  await postKeeperEmbeds([buildHeartbeatEmbed(report, cls, keeperEnv())]);
 }
 
 logSeparator('keeper-status', 'START');

--- a/packages/market-keeper/scripts/lib/groups.js
+++ b/packages/market-keeper/scripts/lib/groups.js
@@ -20,8 +20,23 @@
  * non-zero, so Railway's on_failure restart policy retries it. Cross-concern
  * isolation comes from running each group as its OWN Railway cron, not from
  * swallowing errors here — a broken settle cron can't block the tag cron.
+ *
+ * Reporting: each step process appends a structured summary to the file named
+ * by KEEPER_SUMMARY_FILE (see src/notify/summary.ts). After the group runs we
+ * read those summaries back and POST one aggregated embed to the keeper Discord
+ * webhook (DISCORD_KEEPER_WEBHOOK). This is the only place the source-JS
+ * orchestration layer reaches into compiled code, via the single
+ * dist/src/notify/report entry point.
  */
+// Load .env so the runner itself (which posts the Discord summary) sees
+// DISCORD_KEEPER_WEBHOOK locally. dotenv does not override already-set vars, so
+// Railway-injected env still wins in production. The subservices load their own
+// dotenv when they run; this is only for the orchestrator's own env reads.
+require('dotenv/config');
 const { execSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 
 // Chain-dependent settlement entrypoint, matching the original start.js branch.
 const settleCmd =
@@ -53,14 +68,100 @@ const GROUPS = {
 // metadata + tags → market data → settle.
 const ORDER = ['discovery', 'metadata-tags', 'market-data', 'settlement'];
 
-/** Run one group's steps sequentially, fail-fast (throws on first failure). */
-function runGroup(name) {
+// Lazily-required so a missing/stale dist build degrades to "no Discord report"
+// instead of crashing the runner. Returns null if dist isn't built yet.
+function loadReporter() {
+  try {
+    return require('../../dist/src/notify/report');
+  } catch (err) {
+    console.error(
+      '[keeper] Discord reporter unavailable (dist not built?):',
+      err && err.message ? err.message : err
+    );
+    return null;
+  }
+}
+
+/**
+ * Run one group's steps sequentially, fail-fast. Captures each step's
+ * pass/fail, duration, and emitted summary, posts an aggregated Discord
+ * report, then re-throws on failure to preserve the non-zero exit code.
+ */
+async function runGroup(name) {
   const steps = GROUPS[name];
   if (!steps) throw new Error(`Unknown keeper cron group: ${name}`);
+
+  const reporter = loadReporter();
+  const summaryFile = path.join(
+    os.tmpdir(),
+    `keeper-summary-${name}-${process.pid}-${Date.now()}.jsonl`
+  );
+  try {
+    fs.writeFileSync(summaryFile, '');
+  } catch {
+    // if we can't create the file, steps just won't emit; carry on
+  }
+
+  const runs = [];
+  let failure = null;
+  let consumed = 0;
+
   for (const [label, cmd] of steps) {
     console.log(`[keeper:${name}] ▶ ${label}`);
-    execSync(cmd, { stdio: 'inherit' });
+    const start = Date.now();
+    let status = 'ok';
+    let error;
+    try {
+      execSync(cmd, {
+        stdio: 'inherit',
+        env: { ...process.env, KEEPER_SUMMARY_FILE: summaryFile },
+      });
+    } catch (err) {
+      status = 'failed';
+      error = err && err.message ? err.message : String(err);
+      failure = err;
+    }
+    const durationMs = Date.now() - start;
+
+    let summaries = [];
+    if (reporter) {
+      const all = reporter.readStepSummaries(summaryFile);
+      summaries = all.slice(consumed);
+      consumed = all.length;
+    }
+    runs.push({ label, status, durationMs, summaries, error });
+
+    if (failure) break;
   }
+
+  // Mark steps that never ran (aborted by fail-fast) as skipped.
+  if (failure) {
+    const ranLabels = new Set(runs.map((r) => r.label));
+    for (const [label] of steps) {
+      if (!ranLabels.has(label)) {
+        runs.push({ label, status: 'skipped', durationMs: 0, summaries: [] });
+      }
+    }
+  }
+
+  if (reporter) {
+    try {
+      await reporter.postGroupReport({ group: name, runs });
+    } catch (err) {
+      console.error(
+        '[keeper] Failed to post Discord summary:',
+        err && err.message ? err.message : err
+      );
+    }
+  }
+
+  try {
+    fs.unlinkSync(summaryFile);
+  } catch {
+    // ignore cleanup failure
+  }
+
+  if (failure) throw failure; // preserve fail-fast / non-zero exit
 }
 
 module.exports = { GROUPS, ORDER, runGroup };

--- a/packages/market-keeper/scripts/settle-manual.ts
+++ b/packages/market-keeper/scripts/settle-manual.ts
@@ -50,6 +50,7 @@ import { privateKeyToAccount } from 'viem/accounts';
 import { polygon } from 'viem/chains';
 import { fetchWithRetry } from '../src/utils/fetch.js';
 import { logSeparator } from '../src/utils/log.js';
+import { emitStepSummary } from '../src/notify/summary.js';
 import {
   manualConditionResolver,
   conditionalTokensReader,
@@ -782,6 +783,18 @@ async function main() {
     console.log(`  Settled (tx sent):   ${totals.settled}`);
     console.log(`  Not resolved:        ${totals.notResolved}`);
     console.log(`  Errors:              ${totals.errors}`);
+
+    emitStepSummary({
+      step: 'settle-manual',
+      dryRun: options.dryRun,
+      metrics: {
+        total: totals.total,
+        alreadySettled: totals.alreadySettled,
+        settled: totals.settled,
+        notResolved: totals.notResolved,
+        errors: totals.errors,
+      },
+    });
   } catch (error) {
     console.error('Error:', error);
     process.exit(1);

--- a/packages/market-keeper/scripts/settle-polymarket.ts
+++ b/packages/market-keeper/scripts/settle-polymarket.ts
@@ -54,6 +54,7 @@ import {
 } from '../src/polygon/client.js';
 import { fetchWithRetry } from '../src/utils/fetch.js';
 import { confirmProductionAccess } from '../src/utils/index.js';
+import { emitStepSummary } from '../src/notify/summary.js';
 
 // ============ Constants ============
 
@@ -703,6 +704,19 @@ async function main() {
     console.log(`  Settled (tx sent):   ${totals.settled}`);
     console.log(`  Skipped:             ${totals.skipped}`);
     console.log(`  Errors:              ${totals.errors}`);
+
+    emitStepSummary({
+      step: 'settle-polymarket',
+      dryRun: options.dryRun,
+      metrics: {
+        total: totals.total,
+        alreadyResolved: totals.alreadyResolved,
+        canResolve: totals.canResolve,
+        settled: totals.settled,
+        skipped: totals.skipped,
+        errors: totals.errors,
+      },
+    });
   } catch (error) {
     console.error('Error:', error);
     process.exit(1);

--- a/packages/market-keeper/scripts/settle-pyth.ts
+++ b/packages/market-keeper/scripts/settle-pyth.ts
@@ -56,6 +56,7 @@ import { getChainConfig } from '@sapience/sdk/constants';
 import { fetchWithRetry } from '../src/utils/fetch.js';
 import { confirmProductionAccess } from '../src/utils/index.js';
 import { logSeparator } from '../src/utils/log.js';
+import { emitStepSummary } from '../src/notify/summary.js';
 import {
   decodeFeedIdFromPriceId,
   extractEvmBlobFromJson,
@@ -745,6 +746,12 @@ async function main() {
   console.log(`Submitted:   ${submitted}`);
   console.log(`Skipped:     ${skipped}`);
   console.log(`Errors:      ${errors}`);
+
+  emitStepSummary({
+    step: 'settle-pyth',
+    dryRun: options.dryRun,
+    metrics: { attempted, submitted, skipped, errors },
+  });
 }
 
 // Run

--- a/packages/market-keeper/scripts/start.js
+++ b/packages/market-keeper/scripts/start.js
@@ -14,4 +14,9 @@
  */
 const { ORDER, runGroup } = require('./lib/groups');
 
-for (const name of ORDER) runGroup(name);
+(async () => {
+  for (const name of ORDER) await runGroup(name);
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/market-keeper/src/__tests__/decide-endtime.test.ts
+++ b/packages/market-keeper/src/__tests__/decide-endtime.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { decideEndTime, toUnixTimestamp } from '../generate/api';
+import { gameEndTime } from '../generate/extractors/sports/game';
 import type { SapienceCondition } from '../types';
 
 function makeCondition(
@@ -48,6 +49,25 @@ describe('decideEndTime', () => {
       const { ts, source } = decideEndTime(c);
       expect(ts).toBe(expected);
       expect(source).toBe('game');
+    });
+
+    it('declines the game rung when there is no recognized sports league (S&P index market with a Polymarket gameStartTime)', () => {
+      // Polymarket stamps some non-sports markets (e.g. S&P 500 index price
+      // markets) with a gameStartTime but no sports league. The game rung must
+      // decline so the cascade falls through to category/LLM/regex/PM instead
+      // of inventing a default "game duration" endTime. Regression for the SPY
+      // "Will S&P 500 hit (LOW) $740" market that logged source: game.
+      const c = makeCondition({
+        question: 'Will S&P 500 (SPY) hit (LOW) $740 Week of June 15?',
+        gameStartTime: '2026-06-14 21:00:00+00',
+        league: undefined,
+        endDate: '2026-06-19T16:00:00Z',
+        isTemplated: true,
+      });
+      const { ts, source } = decideEndTime(c);
+      expect(source).not.toBe('game');
+      expect(source).toBe('pm-fallback');
+      expect(ts).toBe(toUnixTimestamp('2026-06-19T16:00:00Z') + 86_400);
     });
 
     it('categoryEndTime wins over LLM, regex, and PM endDate', () => {
@@ -151,6 +171,22 @@ describe('decideEndTime', () => {
       expect(decideEndTime(c).ts).toBe(pmTs + 86_400);
       expect(decideEndTime(c).ts).not.toBe(pmTs); // not raw
       expect(decideEndTime(c).ts).not.toBe(pmTs + 14400); // not legacy 4h
+    });
+  });
+
+  // The game rung is sports-only: it fires off a recognized league's
+  // calibrated duration, and declines (returns null) when Polymarket attaches
+  // a gameStartTime to a non-sports market (no league).
+  describe('gameEndTime league gating', () => {
+    it('returns the calibrated end for a recognized sports league', () => {
+      expect(gameEndTime('2099-04-01 00:00:00+00', 'nba')).toBe(
+        toUnixTimestamp('2099-04-01T03:29:00Z') // +209m
+      );
+    });
+
+    it('declines a gameStartTime without a recognized league', () => {
+      expect(gameEndTime('2026-06-14 21:00:00+00', undefined)).toBeNull();
+      expect(gameEndTime('2026-06-14 21:00:00+00', null)).toBeNull();
     });
   });
 

--- a/packages/market-keeper/src/__tests__/relist-market.test.ts
+++ b/packages/market-keeper/src/__tests__/relist-market.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PolymarketMarket } from '../types';
+
+// market.ts pulls fetchWithRetry from ../utils and the filter pipeline from
+// ../generate/pipeline. Mock both so the test exercises ONLY the pagination
+// loop, not the network or the binary-market filters.
+vi.mock('../utils', () => ({
+  fetchWithRetry: vi.fn(),
+}));
+
+vi.mock('../generate/pipeline', () => ({
+  runPipeline: vi.fn((input: unknown[]) => ({ output: input, stats: {} })),
+  printPipelineStats: vi.fn(),
+  MARKET_FILTERS: [],
+}));
+
+import { fetchPastEndDateMarkets } from '../relist/market';
+import { fetchWithRetry } from '../utils';
+
+const mockFetch = vi.mocked(fetchWithRetry);
+
+function makeMarket(conditionId: string): PolymarketMarket {
+  return {
+    id: conditionId,
+    question: 'Will X happen?',
+    conditionId,
+    outcomes: ['Yes', 'No'],
+    volume: '50000',
+    liquidity: '5000',
+    // Past endDate so it survives the client-side `endDate < now` filter.
+    endDate: '2020-01-01T00:00:00Z',
+    description: 'Test market',
+    slug: 'test-market',
+    active: true,
+    closed: false,
+  } as PolymarketMarket;
+}
+
+// Build a /markets/keyset envelope response. `nextCursor === undefined` omits
+// the key entirely, which is how the live API signals the final page.
+function keysetPage(
+  markets: PolymarketMarket[],
+  nextCursor?: string
+): Response {
+  const body: Record<string, unknown> = { markets };
+  if (nextCursor !== undefined) body.next_cursor = nextCursor;
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('fetchPastEndDateMarkets — keyset pagination', () => {
+  it('hits /markets/keyset and never uses offset', async () => {
+    mockFetch.mockResolvedValueOnce(keysetPage([makeMarket('0x1')]));
+
+    await fetchPastEndDateMarkets();
+
+    const url = String(mockFetch.mock.calls[0][0]);
+    expect(url).toContain('/markets/keyset');
+    expect(url).not.toContain('offset=');
+  });
+
+  it('follows next_cursor via after_cursor and aggregates across pages', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        keysetPage([makeMarket('0x1'), makeMarket('0x2')], 'CUR1')
+      )
+      .mockResolvedValueOnce(keysetPage([makeMarket('0x3')])); // no next_cursor → last page
+
+    const result = await fetchPastEndDateMarkets();
+
+    expect(result.map((m) => m.conditionId)).toEqual(['0x1', '0x2', '0x3']);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    const firstUrl = String(mockFetch.mock.calls[0][0]);
+    const secondUrl = String(mockFetch.mock.calls[1][0]);
+    expect(firstUrl).not.toContain('after_cursor');
+    expect(secondUrl).toContain('after_cursor=CUR1');
+  });
+
+  it('stops when next_cursor is absent even on a full page (no 422, no offset cap)', async () => {
+    const fullPage = Array.from({ length: 100 }, (_, i) =>
+      makeMarket(`0x${i}`)
+    );
+    // Full page but NO next_cursor → authoritative end-of-results signal.
+    mockFetch.mockResolvedValueOnce(keysetPage(fullPage));
+
+    const result = await fetchPastEndDateMarkets();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result).toHaveLength(100);
+  });
+
+  it('does not loop forever if the cursor stops advancing (stuck-cursor guard)', async () => {
+    // Regression guard for Polymarket/agents#227: a server that keeps echoing
+    // the same next_cursor must not spin into an infinite fetch loop.
+    mockFetch.mockResolvedValue(keysetPage([makeMarket('0x1')], 'STUCK'));
+
+    const result = await fetchPastEndDateMarkets();
+
+    expect(mockFetch.mock.calls.length).toBeLessThanOrEqual(3);
+    expect(result.map((m) => m.conditionId)).toEqual(['0x1']);
+  });
+});

--- a/packages/market-keeper/src/cleanup/index.ts
+++ b/packages/market-keeper/src/cleanup/index.ts
@@ -20,6 +20,7 @@ import {
 } from '../polygon/client';
 import { batchCheckGammaResolution } from '../polymarket-api';
 import { validatePrivateKey, confirmProductionAccess, log } from '../utils';
+import { emitStepSummary } from '../notify/summary';
 import {
   fetchNoEngagementConditions,
   privateConditions,
@@ -284,4 +285,16 @@ export async function main(): Promise<void> {
   log(`Skipped (active on Gamma):   ${results.skippedActive}`);
   log(`Skipped (not resolved):      ${results.skippedUnresolved}`);
   log(`Errors:                      ${results.errors}`);
+
+  emitStepSummary({
+    step: 'cleanup-polymarket',
+    dryRun: options.dryRun,
+    metrics: {
+      total: results.total,
+      resolved: results.resolved,
+      privated: results.privated,
+      skipped: results.skippedActive + results.skippedUnresolved,
+      errors: results.errors,
+    },
+  });
 }

--- a/packages/market-keeper/src/generate/api.ts
+++ b/packages/market-keeper/src/generate/api.ts
@@ -664,6 +664,18 @@ export async function submitGroupMetadataUpdates(
   console.log(`[Metadata] ${updated} groups updated, ${failed} failed`);
 }
 
+/** Outcome counts from a submitToAPI run, surfaced for run reporting. */
+export interface SubmitResult {
+  /** Conditions submitted (after filters). */
+  conditions: number;
+  created: number;
+  skipped: number;
+  failed: number;
+  uniqueGroups: number;
+  cryptoGroupsSkipped: number;
+  cryptoConditionsSkipped: number;
+}
+
 /**
  * Submit all condition groups and conditions to the API
  */
@@ -671,7 +683,7 @@ export async function submitToAPI(
   apiUrl: string,
   privateKey: `0x${string}`,
   data: SapienceOutput
-): Promise<void> {
+): Promise<SubmitResult> {
   console.log(`Submitting to API: ${apiUrl}`);
 
   // Apply API filters pipeline
@@ -709,7 +721,15 @@ export async function submitToAPI(
 
   if (allConditions.length === 0) {
     console.log('[API] No conditions to submit');
-    return;
+    return {
+      conditions: 0,
+      created: 0,
+      skipped: 0,
+      failed: 0,
+      uniqueGroups: 0,
+      cryptoGroupsSkipped,
+      cryptoConditionsSkipped,
+    };
   }
 
   // Build batch payloads
@@ -860,4 +880,14 @@ export async function submitToAPI(
       `Crypto skipped: ${cryptoGroupsSkipped} groups, ${cryptoConditionsSkipped} conditions`
     );
   }
+
+  return {
+    conditions: payloads.length,
+    created: totalCreated,
+    skipped: totalSkipped,
+    failed: totalFailed,
+    uniqueGroups,
+    cryptoGroupsSkipped,
+    cryptoConditionsSkipped,
+  };
 }

--- a/packages/market-keeper/src/generate/extractors/sports/game.ts
+++ b/packages/market-keeper/src/generate/extractors/sports/game.ts
@@ -35,8 +35,6 @@ export const LEAGUE_DURATION_MIN: Record<string, number> = {
 /** League tags (also the fetch list). */
 export const SPORT_LEAGUES = Object.keys(LEAGUE_DURATION_MIN);
 
-const DEFAULT_MIN = 210;
-
 /** Normalize "2026-06-10 19:45:00+00" (or ISO) to epoch ms, or null. */
 function parseGameStart(gst: string): number | null {
   const iso = gst.replace(' ', 'T').replace(/\+00$/, 'Z');
@@ -46,17 +44,22 @@ function parseGameStart(gst: string): number | null {
 
 /**
  * Resolution time (unix SECONDS) for a game market = gameStartTime + the
- * per-league median duration. Returns null when there's no gameStartTime (e.g.
- * unscheduled match, or a futures/championship market) so callers fall back.
+ * per-league median duration.
+ *
+ * Sports-only: returns null when there's no gameStartTime (e.g. unscheduled
+ * match, or a futures/championship market) AND when there's no recognized
+ * sports league — Polymarket attaches a gameStartTime to some non-sports
+ * markets (e.g. S&P 500 index price markets), and the game rung must decline
+ * those so the cascade falls through instead of inventing a default duration.
  */
 export function gameEndTime(
   gameStartTime: string | null | undefined,
   league: string | null | undefined
 ): number | null {
   if (!gameStartTime) return null;
+  const mins = league ? LEAGUE_DURATION_MIN[league] : undefined;
+  if (mins == null) return null;
   const start = parseGameStart(gameStartTime);
   if (start == null) return null;
-  const mins =
-    (league ? LEAGUE_DURATION_MIN[league] : undefined) ?? DEFAULT_MIN;
   return toSec(start + mins * 60_000);
 }

--- a/packages/market-keeper/src/generate/index.ts
+++ b/packages/market-keeper/src/generate/index.ts
@@ -8,6 +8,7 @@ import { validatePrivateKey, confirmProductionAccess } from '../utils';
 import { fetchEndingSoonestMarkets } from './market';
 import { groupMarkets, exportJSON } from './grouping';
 import { printDryRun, submitToAPI } from './api';
+import { emitStepSummary } from '../notify/summary';
 
 // ============ CLI Arguments ============
 
@@ -94,12 +95,39 @@ export async function main() {
     // Dry run mode - just print what would be submitted
     if (options.dryRun) {
       printDryRun(sapienceData);
+      emitStepSummary({
+        step: 'generate',
+        dryRun: true,
+        metrics: {
+          conditions: sapienceData.metadata.totalConditions,
+          groups: sapienceData.metadata.totalGroups,
+        },
+      });
       return;
     }
 
     // Submit to API if credentials are available
     if (hasAPICredentials && apiUrl && privateKey) {
-      await submitToAPI(apiUrl, privateKey, sapienceData);
+      const result = await submitToAPI(apiUrl, privateKey, sapienceData);
+      emitStepSummary({
+        step: 'generate',
+        metrics: {
+          conditions: result.conditions,
+          created: result.created,
+          skipped: result.skipped,
+          failed: result.failed,
+          groups: result.uniqueGroups,
+        },
+      });
+    } else {
+      emitStepSummary({
+        step: 'generate',
+        note: 'no API credentials',
+        metrics: {
+          conditions: sapienceData.metadata.totalConditions,
+          groups: sapienceData.metadata.totalGroups,
+        },
+      });
     }
   } catch (error) {
     console.error('Error:', error);

--- a/packages/market-keeper/src/notify/balances.test.ts
+++ b/packages/market-keeper/src/notify/balances.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { classifyBalances } from './balances';
+import type { BalanceReport, BalanceThresholds } from './types';
+
+const thresholds: BalanceThresholds = {
+  openrouterMinCredits: 10,
+  adminMinPol: 5,
+};
+
+describe('classifyBalances', () => {
+  it('flags OpenRouter low when remaining is below threshold', () => {
+    const report: BalanceReport = {
+      openrouter: { remaining: 1.62, totalCredits: 360, totalUsage: 358.38 },
+      pol: { address: '0xabc', pol: 12 },
+    };
+    const cls = classifyBalances(report, thresholds);
+    expect(cls.openrouterLow).toBe(true);
+    expect(cls.polLow).toBe(false);
+    expect(cls.anyLow).toBe(true);
+  });
+
+  it('flags POL low when balance is below threshold', () => {
+    const report: BalanceReport = {
+      openrouter: { remaining: 100, totalCredits: 200, totalUsage: 100 },
+      pol: { address: '0xabc', pol: 0.4 },
+    };
+    const cls = classifyBalances(report, thresholds);
+    expect(cls.openrouterLow).toBe(false);
+    expect(cls.polLow).toBe(true);
+    expect(cls.anyLow).toBe(true);
+  });
+
+  it('reports all-ok when both are above threshold', () => {
+    const report: BalanceReport = {
+      openrouter: { remaining: 50, totalCredits: 100, totalUsage: 50 },
+      pol: { address: '0xabc', pol: 20 },
+    };
+    expect(classifyBalances(report, thresholds)).toEqual({
+      openrouterLow: false,
+      polLow: false,
+      anyLow: false,
+    });
+  });
+
+  it('treats a missing balance (fetch error) as not-low', () => {
+    const report: BalanceReport = {
+      openrouterError: 'HTTP 500',
+      polError: 'rpc down',
+    };
+    expect(classifyBalances(report, thresholds)).toEqual({
+      openrouterLow: false,
+      polLow: false,
+      anyLow: false,
+    });
+  });
+
+  it('uses strict less-than at the threshold boundary', () => {
+    const report: BalanceReport = {
+      openrouter: { remaining: 10, totalCredits: 10, totalUsage: 0 },
+      pol: { address: '0xabc', pol: 5 },
+    };
+    const cls = classifyBalances(report, thresholds);
+    expect(cls.openrouterLow).toBe(false);
+    expect(cls.polLow).toBe(false);
+  });
+});

--- a/packages/market-keeper/src/notify/balances.ts
+++ b/packages/market-keeper/src/notify/balances.ts
@@ -1,0 +1,118 @@
+/**
+ * Balance lookups + threshold classification for the keeper heartbeat.
+ *
+ *  - OpenRouter credits via the public credits/key endpoints
+ *  - Admin wallet POL balance on Polygon (the wallet that pays LayerZero/POL
+ *    fees for resolution requests), derived from ADMIN_PRIVATE_KEY
+ */
+import {
+  createPublicClient,
+  http,
+  formatEther,
+  type Hex,
+  type PublicClient,
+} from 'viem';
+import { polygon } from 'viem/chains';
+import { privateKeyToAccount } from 'viem/accounts';
+import type {
+  OpenRouterBalance,
+  PolBalance,
+  BalanceReport,
+  BalanceThresholds,
+  BalanceClassification,
+} from './types';
+
+const OPENROUTER_CREDITS_URL = 'https://openrouter.ai/api/v1/credits';
+const OPENROUTER_KEY_URL = 'https://openrouter.ai/api/v1/key';
+const FETCH_TIMEOUT_MS = 10_000;
+
+function numberOrUndefined(v: unknown): number | undefined {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/**
+ * Fetch OpenRouter credit balance.
+ *
+ * `/api/v1/credits` returns `{ data: { total_credits, total_usage } }`; the
+ * remaining balance is `total_credits - total_usage`. We additionally pull
+ * burn-rate context (daily/weekly/monthly usage) from `/api/v1/key` on a
+ * best-effort basis — a failure there does not fail the call.
+ */
+export async function fetchOpenRouterBalance(
+  apiKey: string
+): Promise<OpenRouterBalance> {
+  const headers = { Authorization: `Bearer ${apiKey}` };
+
+  const creditsRes = await fetch(OPENROUTER_CREDITS_URL, {
+    headers,
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!creditsRes.ok) {
+    throw new Error(`OpenRouter /credits HTTP ${creditsRes.status}`);
+  }
+  const creditsJson = (await creditsRes.json()) as {
+    data?: { total_credits?: number; total_usage?: number };
+  };
+  const totalCredits = Number(creditsJson?.data?.total_credits ?? 0);
+  const totalUsage = Number(creditsJson?.data?.total_usage ?? 0);
+
+  const balance: OpenRouterBalance = {
+    totalCredits,
+    totalUsage,
+    remaining: totalCredits - totalUsage,
+  };
+
+  try {
+    const keyRes = await fetch(OPENROUTER_KEY_URL, {
+      headers,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (keyRes.ok) {
+      const keyJson = (await keyRes.json()) as {
+        data?: {
+          usage_daily?: number;
+          usage_weekly?: number;
+          usage_monthly?: number;
+        };
+      };
+      const d = keyJson?.data ?? {};
+      balance.usageDaily = numberOrUndefined(d.usage_daily);
+      balance.usageWeekly = numberOrUndefined(d.usage_weekly);
+      balance.usageMonthly = numberOrUndefined(d.usage_monthly);
+    }
+  } catch {
+    // burn-rate enrichment is optional
+  }
+
+  return balance;
+}
+
+/** Read the admin wallet's native POL balance on Polygon. */
+export async function fetchPolBalance(
+  rpcUrl: string,
+  privateKey: string
+): Promise<PolBalance> {
+  const formattedKey = privateKey.startsWith('0x')
+    ? privateKey
+    : `0x${privateKey}`;
+  const account = privateKeyToAccount(formattedKey as Hex);
+  const client: PublicClient = createPublicClient({
+    chain: polygon,
+    transport: http(rpcUrl),
+  });
+  const wei = await client.getBalance({ address: account.address });
+  return { address: account.address, pol: Number(formatEther(wei)) };
+}
+
+/** Pure threshold check: which tracked balances are below their minimum. */
+export function classifyBalances(
+  report: BalanceReport,
+  thresholds: BalanceThresholds
+): BalanceClassification {
+  const openrouterLow = report.openrouter
+    ? report.openrouter.remaining < thresholds.openrouterMinCredits
+    : false;
+  const polLow = report.pol ? report.pol.pol < thresholds.adminMinPol : false;
+  return { openrouterLow, polLow, anyLow: openrouterLow || polLow };
+}

--- a/packages/market-keeper/src/notify/discord.test.ts
+++ b/packages/market-keeper/src/notify/discord.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { keeperEnv } from './discord';
+
+describe('keeperEnv', () => {
+  const KEYS = ['KEEPER_ENV', 'RAILWAY_ENVIRONMENT_NAME', 'NODE_ENV'] as const;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('prefers KEEPER_ENV over everything', () => {
+    process.env.KEEPER_ENV = 'prod-keeper';
+    process.env.RAILWAY_ENVIRONMENT_NAME = 'production';
+    process.env.NODE_ENV = 'production';
+    expect(keeperEnv()).toBe('prod-keeper');
+  });
+
+  it('falls back to RAILWAY_ENVIRONMENT_NAME (distinguishes staging from prod)', () => {
+    process.env.RAILWAY_ENVIRONMENT_NAME = 'staging';
+    process.env.NODE_ENV = 'production';
+    expect(keeperEnv()).toBe('staging');
+  });
+
+  it('falls back to NODE_ENV off Railway', () => {
+    process.env.NODE_ENV = 'test';
+    expect(keeperEnv()).toBe('test');
+  });
+
+  it("defaults to 'development' when nothing is set", () => {
+    expect(keeperEnv()).toBe('development');
+  });
+});

--- a/packages/market-keeper/src/notify/discord.ts
+++ b/packages/market-keeper/src/notify/discord.ts
@@ -11,6 +11,15 @@ import { log, logError } from '../utils/log';
 const WEBHOOK_PREFIX = 'https://discord.com/api/webhooks/';
 const TIMEOUT_MS = 5_000;
 
+/**
+ * Environment label stamped on every alert so prod/staging/dev alerts are
+ * distinguishable in a shared channel. Defaults to 'development' (Node's
+ * convention for an unset NODE_ENV).
+ */
+export function keeperEnv(): string {
+  return process.env.NODE_ENV || 'development';
+}
+
 /** Resolve + validate the configured webhook URL, or null when unusable. */
 export function getKeeperWebhook(): string | null {
   const url = (process.env.DISCORD_KEEPER_WEBHOOK || '').trim();

--- a/packages/market-keeper/src/notify/discord.ts
+++ b/packages/market-keeper/src/notify/discord.ts
@@ -1,0 +1,55 @@
+/**
+ * Send embeds to the keeper Discord webhook (DISCORD_KEEPER_WEBHOOK).
+ *
+ * Unlike the indexer's fire-and-forget alerts, these calls are awaited: the
+ * keeper subservices/runner are short-lived processes that exit immediately
+ * after posting, so we must let the request finish (≤5s) before the process
+ * dies. The call still never throws.
+ */
+import { log, logError } from '../utils/log';
+
+const WEBHOOK_PREFIX = 'https://discord.com/api/webhooks/';
+const TIMEOUT_MS = 5_000;
+
+/** Resolve + validate the configured webhook URL, or null when unusable. */
+export function getKeeperWebhook(): string | null {
+  const url = (process.env.DISCORD_KEEPER_WEBHOOK || '').trim();
+  if (!url) return null;
+  if (!url.startsWith(WEBHOOK_PREFIX)) {
+    logError(
+      `[keeperDiscord] Ignoring invalid DISCORD_KEEPER_WEBHOOK (must start with ${WEBHOOK_PREFIX})`
+    );
+    return null;
+  }
+  return url;
+}
+
+/** POST embeds to the keeper webhook. Awaits delivery (≤5s). Never throws. */
+export async function postKeeperEmbeds(embeds: object[]): Promise<void> {
+  const url = getKeeperWebhook();
+  if (!url) {
+    log('[keeperDiscord] DISCORD_KEEPER_WEBHOOK not set — skipping post');
+    return;
+  }
+  if (embeds.length === 0) return;
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ embeds }),
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      logError(
+        `[keeperDiscord] Webhook HTTP ${res.status}: ${body.slice(0, 200)}`
+      );
+    }
+  } catch (err) {
+    logError(
+      '[keeperDiscord] Webhook failed:',
+      err instanceof Error ? err.message : err
+    );
+  }
+}

--- a/packages/market-keeper/src/notify/discord.ts
+++ b/packages/market-keeper/src/notify/discord.ts
@@ -13,11 +13,24 @@ const TIMEOUT_MS = 5_000;
 
 /**
  * Environment label stamped on every alert so prod/staging/dev alerts are
- * distinguishable in a shared channel. Defaults to 'development' (Node's
- * convention for an unset NODE_ENV).
+ * distinguishable in a shared channel.
+ *
+ * NODE_ENV alone is insufficient: staging runs the production build, so it's
+ * `production` on both staging and prod. Resolution order:
+ *   1. KEEPER_ENV            — explicit override (set per deploy if you want a
+ *                              specific label)
+ *   2. RAILWAY_ENVIRONMENT_NAME — auto-injected by Railway per environment
+ *                              (e.g. 'production' vs 'staging'); no config
+ *   3. NODE_ENV              — local / non-Railway fallback
+ *   4. 'development'         — nothing set
  */
 export function keeperEnv(): string {
-  return process.env.NODE_ENV || 'development';
+  return (
+    process.env.KEEPER_ENV ||
+    process.env.RAILWAY_ENVIRONMENT_NAME ||
+    process.env.NODE_ENV ||
+    'development'
+  );
 }
 
 /** Resolve + validate the configured webhook URL, or null when unusable. */

--- a/packages/market-keeper/src/notify/embeds.test.ts
+++ b/packages/market-keeper/src/notify/embeds.test.ts
@@ -26,9 +26,13 @@ describe('buildGroupEmbed', () => {
         summaries: [{ step: 'relist', metrics: { new: 2 } }],
       },
     ];
-    const embed = buildGroupEmbed('discovery', runs) as Record<string, unknown>;
+    const embed = buildGroupEmbed('discovery', runs, 'production') as Record<
+      string,
+      unknown
+    >;
     expect(embed.title).toBe('✅ Keeper · discovery');
     expect(embed.color).toBe(0x22c55e);
+    expect((embed.footer as { text: string }).text).toBe('env: production');
     const desc = embed.description as string;
     expect(desc).toContain('✅ **generate**');
     expect(desc).toContain('created=4');
@@ -54,11 +58,12 @@ describe('buildGroupEmbed', () => {
       },
       { label: 'settle-pyth', status: 'skipped', durationMs: 0, summaries: [] },
     ];
-    const embed = buildGroupEmbed('settlement', runs) as Record<
+    const embed = buildGroupEmbed('settlement', runs, 'staging') as Record<
       string,
       unknown
     >;
     expect(embed.title).toBe('❌ Keeper · settlement');
+    expect((embed.footer as { text: string }).text).toBe('env: staging');
     expect(embed.color).toBe(0xef4444);
     const desc = embed.description as string;
     expect(desc).toContain('❌ **settle**');
@@ -75,8 +80,11 @@ describe('buildGroupEmbed', () => {
         summaries: [{ step: 'relist', metrics: { new: 0 }, dryRun: true }],
       },
     ];
-    const desc = (buildGroupEmbed('discovery', runs) as { description: string })
-      .description;
+    const desc = (
+      buildGroupEmbed('discovery', runs, 'production') as {
+        description: string;
+      }
+    ).description;
     expect(desc).toContain('_[dry-run]_');
   });
 });
@@ -98,9 +106,13 @@ describe('buildHeartbeatEmbed', () => {
       },
       pol: { address: '0xADMIN', pol: 12.345 },
     };
-    const embed = buildHeartbeatEmbed(report, ok) as Record<string, unknown>;
+    const embed = buildHeartbeatEmbed(report, ok, 'production') as Record<
+      string,
+      unknown
+    >;
     expect(embed.title).toBe('💓 Keeper heartbeat');
     expect(embed.color).toBe(0x3b82f6);
+    expect((embed.footer as { text: string }).text).toBe('env: production');
     const fields = embed.fields as Array<{ name: string; value: string }>;
     expect(fields[0].value).toContain('$50.00 remaining');
     expect(fields[0].value).toContain('~$7.11/day');
@@ -118,7 +130,10 @@ describe('buildHeartbeatEmbed', () => {
       polLow: true,
       anyLow: true,
     };
-    const embed = buildHeartbeatEmbed(report, cls) as Record<string, unknown>;
+    const embed = buildHeartbeatEmbed(report, cls, 'production') as Record<
+      string,
+      unknown
+    >;
     expect(embed.title).toBe('⚠️ Keeper balances LOW');
     expect(embed.color).toBe(0xf59e0b);
     const fields = embed.fields as Array<{ name: string; value: string }>;
@@ -131,7 +146,10 @@ describe('buildHeartbeatEmbed', () => {
       openrouterError: 'HTTP 401',
       polError: 'rpc down',
     };
-    const embed = buildHeartbeatEmbed(report, ok) as Record<string, unknown>;
+    const embed = buildHeartbeatEmbed(report, ok, 'production') as Record<
+      string,
+      unknown
+    >;
     expect(embed.color).toBe(0xef4444);
     const fields = embed.fields as Array<{ value: string }>;
     expect(fields[0].value).toContain('HTTP 401');

--- a/packages/market-keeper/src/notify/embeds.test.ts
+++ b/packages/market-keeper/src/notify/embeds.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { buildGroupEmbed, buildHeartbeatEmbed, formatDuration } from './embeds';
+import type { StepRun, BalanceReport, BalanceClassification } from './types';
+
+describe('formatDuration', () => {
+  it('formats sub-second, seconds, and minutes', () => {
+    expect(formatDuration(450)).toBe('450ms');
+    expect(formatDuration(2500)).toBe('2.5s');
+    expect(formatDuration(125000)).toBe('2m5s');
+  });
+});
+
+describe('buildGroupEmbed', () => {
+  it('builds a green success embed with per-step metrics', () => {
+    const runs: StepRun[] = [
+      {
+        label: 'generate',
+        status: 'ok',
+        durationMs: 3200,
+        summaries: [{ step: 'generate', metrics: { created: 4, skipped: 1 } }],
+      },
+      {
+        label: 'relist',
+        status: 'ok',
+        durationMs: 1500,
+        summaries: [{ step: 'relist', metrics: { new: 2 } }],
+      },
+    ];
+    const embed = buildGroupEmbed('discovery', runs) as Record<string, unknown>;
+    expect(embed.title).toBe('✅ Keeper · discovery');
+    expect(embed.color).toBe(0x22c55e);
+    const desc = embed.description as string;
+    expect(desc).toContain('✅ **generate**');
+    expect(desc).toContain('created=4');
+    expect(desc).toContain('skipped=1');
+    expect(desc).toContain('✅ **relist**');
+    expect(desc).toContain('new=2');
+  });
+
+  it('builds a red embed on failure and marks later steps skipped', () => {
+    const runs: StepRun[] = [
+      {
+        label: 'cleanup-polymarket',
+        status: 'ok',
+        durationMs: 1000,
+        summaries: [],
+      },
+      {
+        label: 'settle',
+        status: 'failed',
+        durationMs: 800,
+        summaries: [],
+        error: 'POLYGON_RPC_URL timeout',
+      },
+      { label: 'settle-pyth', status: 'skipped', durationMs: 0, summaries: [] },
+    ];
+    const embed = buildGroupEmbed('settlement', runs) as Record<
+      string,
+      unknown
+    >;
+    expect(embed.title).toBe('❌ Keeper · settlement');
+    expect(embed.color).toBe(0xef4444);
+    const desc = embed.description as string;
+    expect(desc).toContain('❌ **settle**');
+    expect(desc).toContain('POLYGON_RPC_URL timeout');
+    expect(desc).toContain('⏭️ **settle-pyth**');
+  });
+
+  it('tags dry-run steps', () => {
+    const runs: StepRun[] = [
+      {
+        label: 'relist',
+        status: 'ok',
+        durationMs: 500,
+        summaries: [{ step: 'relist', metrics: { new: 0 }, dryRun: true }],
+      },
+    ];
+    const desc = (buildGroupEmbed('discovery', runs) as { description: string })
+      .description;
+    expect(desc).toContain('_[dry-run]_');
+  });
+});
+
+describe('buildHeartbeatEmbed', () => {
+  const ok: BalanceClassification = {
+    openrouterLow: false,
+    polLow: false,
+    anyLow: false,
+  };
+
+  it('renders a blue heartbeat with balances when all ok', () => {
+    const report: BalanceReport = {
+      openrouter: {
+        remaining: 50,
+        totalCredits: 100,
+        totalUsage: 50,
+        usageDaily: 7.11,
+      },
+      pol: { address: '0xADMIN', pol: 12.345 },
+    };
+    const embed = buildHeartbeatEmbed(report, ok) as Record<string, unknown>;
+    expect(embed.title).toBe('💓 Keeper heartbeat');
+    expect(embed.color).toBe(0x3b82f6);
+    const fields = embed.fields as Array<{ name: string; value: string }>;
+    expect(fields[0].value).toContain('$50.00 remaining');
+    expect(fields[0].value).toContain('~$7.11/day');
+    expect(fields[1].value).toContain('12.345 POL');
+    expect(fields[1].value).toContain('0xADMIN');
+  });
+
+  it('renders an amber LOW alert with warning markers', () => {
+    const report: BalanceReport = {
+      openrouter: { remaining: 1.62, totalCredits: 360, totalUsage: 358.38 },
+      pol: { address: '0xADMIN', pol: 0.5 },
+    };
+    const cls: BalanceClassification = {
+      openrouterLow: true,
+      polLow: true,
+      anyLow: true,
+    };
+    const embed = buildHeartbeatEmbed(report, cls) as Record<string, unknown>;
+    expect(embed.title).toBe('⚠️ Keeper balances LOW');
+    expect(embed.color).toBe(0xf59e0b);
+    const fields = embed.fields as Array<{ name: string; value: string }>;
+    expect(fields[0].name).toContain('⚠️');
+    expect(fields[1].name).toContain('⚠️');
+  });
+
+  it('surfaces fetch errors as a red embed', () => {
+    const report: BalanceReport = {
+      openrouterError: 'HTTP 401',
+      polError: 'rpc down',
+    };
+    const embed = buildHeartbeatEmbed(report, ok) as Record<string, unknown>;
+    expect(embed.color).toBe(0xef4444);
+    const fields = embed.fields as Array<{ value: string }>;
+    expect(fields[0].value).toContain('HTTP 401');
+    expect(fields[1].value).toContain('rpc down');
+  });
+});

--- a/packages/market-keeper/src/notify/embeds.ts
+++ b/packages/market-keeper/src/notify/embeds.ts
@@ -46,7 +46,11 @@ function formatMetrics(summaries: StepSummary[]): string {
 }
 
 /** Build a single embed summarizing one cron group's run. */
-export function buildGroupEmbed(group: string, runs: StepRun[]): object {
+export function buildGroupEmbed(
+  group: string,
+  runs: StepRun[],
+  env: string
+): object {
   const failed = runs.some((r) => r.status === 'failed');
 
   const lines = runs.map((r) => {
@@ -64,6 +68,7 @@ export function buildGroupEmbed(group: string, runs: StepRun[]): object {
     title: `${failed ? '❌' : '✅'} Keeper · ${group}`,
     color: failed ? COLOR_FAIL : COLOR_OK,
     description: lines.join('\n') || '_no steps_',
+    footer: { text: `env: ${env}` },
     timestamp: new Date().toISOString(),
   };
 }
@@ -71,7 +76,8 @@ export function buildGroupEmbed(group: string, runs: StepRun[]): object {
 /** Build the balance heartbeat embed (also serves as the low-balance alert). */
 export function buildHeartbeatEmbed(
   report: BalanceReport,
-  cls: BalanceClassification
+  cls: BalanceClassification,
+  env: string
 ): object {
   const fields: Array<{ name: string; value: string; inline: boolean }> = [];
 
@@ -112,6 +118,7 @@ export function buildHeartbeatEmbed(
     title: cls.anyLow ? '⚠️ Keeper balances LOW' : '💓 Keeper heartbeat',
     color: cls.anyLow ? COLOR_WARN : anyError ? COLOR_FAIL : COLOR_INFO,
     fields,
+    footer: { text: `env: ${env}` },
     timestamp: new Date().toISOString(),
   };
 }

--- a/packages/market-keeper/src/notify/embeds.ts
+++ b/packages/market-keeper/src/notify/embeds.ts
@@ -1,0 +1,117 @@
+/**
+ * Pure Discord embed builders for keeper notifications. No I/O here so these
+ * stay trivially unit-testable; the network send lives in ./discord.
+ */
+import type {
+  StepRun,
+  StepSummary,
+  BalanceReport,
+  BalanceClassification,
+} from './types';
+
+const COLOR_OK = 0x22c55e; // green
+const COLOR_FAIL = 0xef4444; // red
+const COLOR_INFO = 0x3b82f6; // blue
+const COLOR_WARN = 0xf59e0b; // amber
+
+const STATUS_ICON: Record<string, string> = {
+  ok: '✅',
+  failed: '❌',
+  skipped: '⏭️',
+};
+
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  const rem = Math.round(s % 60);
+  return `${m}m${rem}s`;
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, max - 1)}…`;
+}
+
+/** Render a step's emitted metrics as `key=value` pieces joined with spaces. */
+function formatMetrics(summaries: StepSummary[]): string {
+  const parts: string[] = [];
+  for (const s of summaries) {
+    if (!s.metrics) continue;
+    for (const [k, v] of Object.entries(s.metrics)) {
+      parts.push(`${k}=${v}`);
+    }
+  }
+  return parts.join(' ');
+}
+
+/** Build a single embed summarizing one cron group's run. */
+export function buildGroupEmbed(group: string, runs: StepRun[]): object {
+  const failed = runs.some((r) => r.status === 'failed');
+
+  const lines = runs.map((r) => {
+    const icon = STATUS_ICON[r.status] ?? '•';
+    const dur =
+      r.status === 'skipped' ? '' : ` (${formatDuration(r.durationMs)})`;
+    const dry = r.summaries.some((s) => s.dryRun) ? ' _[dry-run]_' : '';
+    const metrics = formatMetrics(r.summaries);
+    const metricsPart = metrics ? ` — ${metrics}` : '';
+    const errPart = r.error ? ` — ${truncate(r.error, 140)}` : '';
+    return `${icon} **${r.label}**${dur}${dry}${metricsPart}${errPart}`;
+  });
+
+  return {
+    title: `${failed ? '❌' : '✅'} Keeper · ${group}`,
+    color: failed ? COLOR_FAIL : COLOR_OK,
+    description: lines.join('\n') || '_no steps_',
+    timestamp: new Date().toISOString(),
+  };
+}
+
+/** Build the balance heartbeat embed (also serves as the low-balance alert). */
+export function buildHeartbeatEmbed(
+  report: BalanceReport,
+  cls: BalanceClassification
+): object {
+  const fields: Array<{ name: string; value: string; inline: boolean }> = [];
+
+  if (report.openrouter) {
+    const o = report.openrouter;
+    const burn =
+      o.usageDaily != null ? ` • ~$${o.usageDaily.toFixed(2)}/day` : '';
+    fields.push({
+      name: `${cls.openrouterLow ? '⚠️ ' : ''}OpenRouter credits`,
+      value: `$${o.remaining.toFixed(2)} remaining${burn}`,
+      inline: true,
+    });
+  } else if (report.openrouterError) {
+    fields.push({
+      name: '⚠️ OpenRouter credits',
+      value: `error: ${truncate(report.openrouterError, 120)}`,
+      inline: true,
+    });
+  }
+
+  if (report.pol) {
+    fields.push({
+      name: `${cls.polLow ? '⚠️ ' : ''}Admin POL`,
+      value: `${report.pol.pol.toFixed(3)} POL\n\`${report.pol.address}\``,
+      inline: true,
+    });
+  } else if (report.polError) {
+    fields.push({
+      name: '⚠️ Admin POL',
+      value: `error: ${truncate(report.polError, 120)}`,
+      inline: true,
+    });
+  }
+
+  const anyError = Boolean(report.openrouterError || report.polError);
+
+  return {
+    title: cls.anyLow ? '⚠️ Keeper balances LOW' : '💓 Keeper heartbeat',
+    color: cls.anyLow ? COLOR_WARN : anyError ? COLOR_FAIL : COLOR_INFO,
+    fields,
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/packages/market-keeper/src/notify/report.ts
+++ b/packages/market-keeper/src/notify/report.ts
@@ -1,0 +1,31 @@
+/**
+ * Single entry point the (plain-JS) cron runner requires from dist:
+ *   const { readStepSummaries, postGroupReport } =
+ *     require('../../dist/src/notify/report');
+ *
+ * Keeping the runner's dependency on compiled code to this one module means the
+ * orchestration layer (scripts/lib/groups.js) stays a thin source-JS file while
+ * all the testable logic lives in TypeScript under src/notify.
+ */
+import { readStepSummaries } from './summary';
+import { buildGroupEmbed } from './embeds';
+import { postKeeperEmbeds } from './discord';
+import type { StepRun } from './types';
+
+export { readStepSummaries };
+
+/**
+ * Build and post one cron group's run summary.
+ *
+ * Set KEEPER_SUMMARY_ON_FAILURE_ONLY=1 to suppress success summaries (cuts
+ * noise on frequent crons); failures are always reported.
+ */
+export async function postGroupReport(input: {
+  group: string;
+  runs: StepRun[];
+}): Promise<void> {
+  const failed = input.runs.some((r) => r.status === 'failed');
+  if (!failed && process.env.KEEPER_SUMMARY_ON_FAILURE_ONLY === '1') return;
+  const embed = buildGroupEmbed(input.group, input.runs);
+  await postKeeperEmbeds([embed]);
+}

--- a/packages/market-keeper/src/notify/report.ts
+++ b/packages/market-keeper/src/notify/report.ts
@@ -9,7 +9,7 @@
  */
 import { readStepSummaries } from './summary';
 import { buildGroupEmbed } from './embeds';
-import { postKeeperEmbeds } from './discord';
+import { postKeeperEmbeds, keeperEnv } from './discord';
 import type { StepRun } from './types';
 
 export { readStepSummaries };
@@ -26,6 +26,6 @@ export async function postGroupReport(input: {
 }): Promise<void> {
   const failed = input.runs.some((r) => r.status === 'failed');
   if (!failed && process.env.KEEPER_SUMMARY_ON_FAILURE_ONLY === '1') return;
-  const embed = buildGroupEmbed(input.group, input.runs);
+  const embed = buildGroupEmbed(input.group, input.runs, keeperEnv());
   await postKeeperEmbeds([embed]);
 }

--- a/packages/market-keeper/src/notify/summary.test.ts
+++ b/packages/market-keeper/src/notify/summary.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  emitStepSummary,
+  readStepSummaries,
+  parseStepSummaries,
+  SUMMARY_FILE_ENV,
+} from './summary';
+
+describe('parseStepSummaries', () => {
+  it('parses well-formed JSONL', () => {
+    const raw =
+      '{"step":"relist","metrics":{"created":3}}\n{"step":"generate","metrics":{"created":1}}\n';
+    const out = parseStepSummaries(raw);
+    expect(out).toHaveLength(2);
+    expect(out[0].step).toBe('relist');
+    expect(out[0].metrics?.created).toBe(3);
+    expect(out[1].step).toBe('generate');
+  });
+
+  it('skips blank and malformed lines', () => {
+    const raw = '\n{"step":"a"}\nnot-json\n{"missing":"step"}\n  \n';
+    const out = parseStepSummaries(raw);
+    expect(out).toHaveLength(1);
+    expect(out[0].step).toBe('a');
+  });
+
+  it('returns [] for empty input', () => {
+    expect(parseStepSummaries('')).toEqual([]);
+  });
+});
+
+describe('emitStepSummary / readStepSummaries round-trip', () => {
+  let file: string;
+  const original = process.env[SUMMARY_FILE_ENV];
+
+  beforeEach(() => {
+    file = path.join(
+      os.tmpdir(),
+      `keeper-summary-test-${process.pid}-${Math.random().toString(36).slice(2)}.jsonl`
+    );
+    process.env[SUMMARY_FILE_ENV] = file;
+  });
+
+  afterEach(() => {
+    if (original === undefined) delete process.env[SUMMARY_FILE_ENV];
+    else process.env[SUMMARY_FILE_ENV] = original;
+    try {
+      fs.unlinkSync(file);
+    } catch {
+      // ignore
+    }
+  });
+
+  it('appends emitted summaries and reads them back in order', () => {
+    emitStepSummary({ step: 'relist', metrics: { created: 2, skipped: 1 } });
+    emitStepSummary({
+      step: 'settle-pyth',
+      metrics: { settled: 5 },
+      dryRun: true,
+    });
+
+    const out = readStepSummaries(file);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toMatchObject({ step: 'relist', metrics: { created: 2 } });
+    expect(out[1]).toMatchObject({ step: 'settle-pyth', dryRun: true });
+  });
+
+  it('is a no-op (and does not throw) when the env var is unset', () => {
+    delete process.env[SUMMARY_FILE_ENV];
+    expect(() =>
+      emitStepSummary({ step: 'x', metrics: { n: 1 } })
+    ).not.toThrow();
+    expect(fs.existsSync(file)).toBe(false);
+  });
+});
+
+describe('readStepSummaries', () => {
+  it('returns [] when the file does not exist', () => {
+    expect(readStepSummaries('/no/such/keeper-summary.jsonl')).toEqual([]);
+  });
+});

--- a/packages/market-keeper/src/notify/summary.ts
+++ b/packages/market-keeper/src/notify/summary.ts
@@ -1,0 +1,63 @@
+/**
+ * Cross-process result reporting for keeper subservices.
+ *
+ * Each subservice runs as its own `node dist/scripts/X.js` process, so it can't
+ * hand a return value back to the cron runner in memory. Instead it appends a
+ * JSON line to the file named by KEEPER_SUMMARY_FILE; the runner
+ * (scripts/lib/groups.js) provisions that file, sets the env var, and reads the
+ * lines back to build the per-group Discord summary.
+ */
+import * as fs from 'fs';
+import type { StepSummary } from './types';
+
+export const SUMMARY_FILE_ENV = 'KEEPER_SUMMARY_FILE';
+
+/**
+ * Append one structured step summary as a JSON line to KEEPER_SUMMARY_FILE.
+ *
+ * No-op when the env var is unset (e.g. running a subservice directly, outside
+ * the cron runner). MUST NEVER THROW — these calls sit at the end of production
+ * settlement/generation paths and a reporting failure must not break the work.
+ */
+export function emitStepSummary(summary: StepSummary): void {
+  try {
+    const file = process.env[SUMMARY_FILE_ENV];
+    if (!file) return;
+    fs.appendFileSync(file, `${JSON.stringify(summary)}\n`);
+  } catch {
+    // best-effort: never let reporting break the subservice
+  }
+}
+
+/** Read a JSONL summary file into StepSummary[]; tolerant of malformed lines. */
+export function readStepSummaries(file: string): StepSummary[] {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch {
+    return [];
+  }
+  return parseStepSummaries(raw);
+}
+
+/** Parse JSONL content into StepSummary[], skipping blank/malformed lines. */
+export function parseStepSummaries(raw: string): StepSummary[] {
+  const out: StepSummary[] = [];
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const obj = JSON.parse(trimmed) as unknown;
+      if (
+        obj &&
+        typeof obj === 'object' &&
+        typeof (obj as StepSummary).step === 'string'
+      ) {
+        out.push(obj as StepSummary);
+      }
+    } catch {
+      // skip malformed line
+    }
+  }
+  return out;
+}

--- a/packages/market-keeper/src/notify/types.ts
+++ b/packages/market-keeper/src/notify/types.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared types for keeper Discord notifications.
+ *
+ * Two flows feed the DISCORD_KEEPER_WEBHOOK:
+ *  - per-cron-group run summaries (built by the cron runner in
+ *    scripts/lib/groups.js from the StepRun records below)
+ *  - a balance heartbeat (scripts/keeper-status.ts) over BalanceReport
+ */
+
+export type StepStatus = 'ok' | 'failed' | 'skipped';
+
+/**
+ * One subservice's structured result, emitted to the file named by
+ * KEEPER_SUMMARY_FILE so the (separate-process) cron runner can read it back.
+ */
+export interface StepSummary {
+  /** Canonical subservice name, e.g. 'relist', 'settle-pyth'. */
+  step: string;
+  /** Counts/keyed metrics, e.g. { created: 3, skipped: 2, errors: 0 }. */
+  metrics?: Record<string, number | string>;
+  /** True when the run was a dry run (no writes). */
+  dryRun?: boolean;
+  /** Optional one-line note. */
+  note?: string;
+}
+
+/** A step as observed by the cron runner: emitted summary + process outcome. */
+export interface StepRun {
+  /** Runner's label for the step, e.g. 'settle'. */
+  label: string;
+  status: StepStatus;
+  /** Wall-clock duration in ms. */
+  durationMs: number;
+  /** Structured summaries the step emitted (usually 0 or 1). */
+  summaries: StepSummary[];
+  /** Error message if the step failed. */
+  error?: string;
+}
+
+export interface OpenRouterBalance {
+  /** USD credits remaining = total_credits - total_usage. */
+  remaining: number;
+  totalCredits: number;
+  totalUsage: number;
+  /** Best-effort burn-rate context from /api/v1/key. */
+  usageDaily?: number;
+  usageWeekly?: number;
+  usageMonthly?: number;
+}
+
+export interface PolBalance {
+  address: string;
+  /** POL, human-readable. */
+  pol: number;
+}
+
+export interface BalanceReport {
+  openrouter?: OpenRouterBalance;
+  openrouterError?: string;
+  pol?: PolBalance;
+  polError?: string;
+}
+
+export interface BalanceThresholds {
+  /** Minimum acceptable OpenRouter USD credits. */
+  openrouterMinCredits: number;
+  /** Minimum acceptable admin POL balance. */
+  adminMinPol: number;
+}
+
+export interface BalanceClassification {
+  openrouterLow: boolean;
+  polLow: boolean;
+  /** True if any tracked balance is below threshold. */
+  anyLow: boolean;
+}

--- a/packages/market-keeper/src/prices-and-1d-7d-volume/index.ts
+++ b/packages/market-keeper/src/prices-and-1d-7d-volume/index.ts
@@ -21,6 +21,7 @@ import {
 import { parseYesPrice } from '../utils/price';
 import { submitPriceUpdates, submitVolumeUpdates } from '../generate/api';
 import { fetchActiveConditionIds } from '../sapience/active-conditions';
+import { emitStepSummary } from '../notify/summary';
 
 // ============ CLI Arguments ============
 
@@ -219,6 +220,15 @@ export async function main() {
         }
       }
       log('\n========== END DRY RUN ==========\n');
+      emitStepSummary({
+        step: 'prices-and-1d-7d-volume',
+        dryRun: true,
+        metrics: {
+          scanned: conditionIds.length,
+          priceUpdates: priceUpdates.length,
+          volumeUpdates: volumeUpdates.length,
+        },
+      });
       return;
     }
 
@@ -230,6 +240,15 @@ export async function main() {
         await submitVolumeUpdates(apiUrl, privateKey, volumeUpdates);
       }
     }
+
+    emitStepSummary({
+      step: 'prices-and-1d-7d-volume',
+      metrics: {
+        scanned: conditionIds.length,
+        priceUpdates: priceUpdates.length,
+        volumeUpdates: volumeUpdates.length,
+      },
+    });
   } catch (error) {
     logError('Error:', error);
     process.exit(1);

--- a/packages/market-keeper/src/refresh-imminent-tag/index.ts
+++ b/packages/market-keeper/src/refresh-imminent-tag/index.ts
@@ -20,6 +20,7 @@ import {
   logError,
 } from '../utils';
 import { submitMetadataUpdates } from '../generate/api';
+import { emitStepSummary } from '../notify/summary';
 import { fetchAllUnsettledConditions } from './fetch';
 import {
   conditionMentionsImminentDate,
@@ -205,6 +206,16 @@ export async function main(): Promise<void> {
     log(
       `[TodayTag] Total wall-clock: ${((Date.now() - runStart) / 1000).toFixed(1)}s`
     );
+    emitStepSummary({
+      step: 'refresh-imminent-tag',
+      dryRun: true,
+      metrics: {
+        scanned: conditions.length,
+        matched: matchedCount,
+        added: additions.length,
+        removed: removals.length,
+      },
+    });
     return;
   }
 
@@ -213,6 +224,15 @@ export async function main(): Promise<void> {
     log(
       `[TodayTag] Total wall-clock: ${((Date.now() - runStart) / 1000).toFixed(1)}s`
     );
+    emitStepSummary({
+      step: 'refresh-imminent-tag',
+      metrics: {
+        scanned: conditions.length,
+        matched: matchedCount,
+        added: 0,
+        removed: 0,
+      },
+    });
     return;
   }
 
@@ -232,4 +252,13 @@ export async function main(): Promise<void> {
   log(
     `[TodayTag] Total wall-clock: ${((Date.now() - runStart) / 1000).toFixed(1)}s`
   );
+  emitStepSummary({
+    step: 'refresh-imminent-tag',
+    metrics: {
+      scanned: conditions.length,
+      matched: matchedCount,
+      added: additions.length,
+      removed: removals.length,
+    },
+  });
 }

--- a/packages/market-keeper/src/refresh-metadata/index.ts
+++ b/packages/market-keeper/src/refresh-metadata/index.ts
@@ -32,6 +32,7 @@ import {
   fetchMarketsByConditionIds,
   fetchEventTagsByIds,
 } from './fetch';
+import { emitStepSummary } from '../notify/summary';
 
 interface RefreshMetadataCLIOptions {
   dryRun: boolean;
@@ -244,6 +245,15 @@ export async function main() {
       printDryRun(metadataUpdates, groupMetadataUpdates);
       const totalSec = ((performance.now() - totalStart) / 1000).toFixed(1);
       log(`[RefreshMetadata] Total runtime: ${totalSec}s`);
+      emitStepSummary({
+        step: 'refresh-metadata',
+        dryRun: true,
+        metrics: {
+          scanned: existing.size,
+          conditionUpdates: metadataUpdates.length,
+          groupUpdates: groupMetadataUpdates.length,
+        },
+      });
       return;
     }
 
@@ -266,6 +276,14 @@ export async function main() {
 
     const totalSec = ((performance.now() - totalStart) / 1000).toFixed(1);
     log(`[RefreshMetadata] Total runtime: ${totalSec}s`);
+    emitStepSummary({
+      step: 'refresh-metadata',
+      metrics: {
+        scanned: existing.size,
+        conditionUpdates: metadataUpdates.length,
+        groupUpdates: groupMetadataUpdates.length,
+      },
+    });
   } catch (error) {
     logError('Error:', error);
     process.exit(1);

--- a/packages/market-keeper/src/refresh-volume/index.ts
+++ b/packages/market-keeper/src/refresh-volume/index.ts
@@ -17,6 +17,7 @@ import {
 } from '../utils';
 import { submitVolumeUpdates } from '../generate/api';
 import { fetchActiveConditionIds } from '../sapience/active-conditions';
+import { emitStepSummary } from '../notify/summary';
 
 // ============ Constants ============
 
@@ -471,6 +472,15 @@ export async function main() {
       const totalSec = ((performance.now() - totalStart) / 1000).toFixed(1);
       log(`\nTotal runtime: ${totalSec}s`);
       log('\n========== END DRY RUN ==========\n');
+      emitStepSummary({
+        step: 'refresh-volume',
+        dryRun: true,
+        metrics: {
+          scanned: conditionIds.length,
+          updates: successfulVolumes.length,
+          failed: totalFetchFailures,
+        },
+      });
       return;
     }
 
@@ -491,6 +501,14 @@ export async function main() {
 
     const totalSec = ((performance.now() - totalStart) / 1000).toFixed(1);
     log(`[RefreshVolume] Total runtime: ${totalSec}s`);
+    emitStepSummary({
+      step: 'refresh-volume',
+      metrics: {
+        scanned: conditionIds.length,
+        updates: successfulVolumes.length,
+        failed: totalFetchFailures,
+      },
+    });
   } catch (error) {
     logError('Error:', error);
     process.exit(1);

--- a/packages/market-keeper/src/relist/index.ts
+++ b/packages/market-keeper/src/relist/index.ts
@@ -18,6 +18,7 @@ import {
 import { fetchPastEndDateMarkets } from './market';
 import { groupMarkets, exportJSON } from '../generate/grouping';
 import { printDryRun, submitToAPI } from '../generate/api';
+import { emitStepSummary } from '../notify/summary';
 import { checkExistingConditions } from '../generate/pipeline';
 
 // ============ CLI Arguments ============
@@ -86,6 +87,11 @@ export async function main() {
 
     if (markets.length === 0) {
       log('[Relist] No past-endDate markets found that are still traded');
+      emitStepSummary({
+        step: 'relist',
+        note: 'no past-endDate markets',
+        metrics: { candidates: 0, new: 0 },
+      });
       return;
     }
 
@@ -115,6 +121,14 @@ export async function main() {
 
     if (newMarkets.length === 0) {
       log('[Relist] No new markets to create');
+      emitStepSummary({
+        step: 'relist',
+        metrics: {
+          candidates: markets.length,
+          alreadyListed: existingConditions.size,
+          new: 0,
+        },
+      });
       return;
     }
 
@@ -134,12 +148,41 @@ export async function main() {
 
     if (options.dryRun) {
       printDryRun(sapienceData);
+      emitStepSummary({
+        step: 'relist',
+        dryRun: true,
+        metrics: {
+          candidates: markets.length,
+          alreadyListed: existingConditions.size,
+          new: sapienceData.metadata.totalConditions,
+        },
+      });
       return;
     }
 
     // 6. Submit new conditions to API
     if (hasAPICredentials && apiUrl && privateKey) {
-      await submitToAPI(apiUrl, privateKey, sapienceData);
+      const result = await submitToAPI(apiUrl, privateKey, sapienceData);
+      emitStepSummary({
+        step: 'relist',
+        metrics: {
+          candidates: markets.length,
+          alreadyListed: existingConditions.size,
+          created: result.created,
+          skipped: result.skipped,
+          failed: result.failed,
+        },
+      });
+    } else {
+      emitStepSummary({
+        step: 'relist',
+        note: 'no API credentials',
+        metrics: {
+          candidates: markets.length,
+          alreadyListed: existingConditions.size,
+          new: sapienceData.metadata.totalConditions,
+        },
+      });
     }
   } catch (error) {
     logError('Error:', error);

--- a/packages/market-keeper/src/relist/market.ts
+++ b/packages/market-keeper/src/relist/market.ts
@@ -11,10 +11,19 @@ import {
   MARKET_FILTERS,
 } from '../generate/pipeline';
 
-// Polymarket's /markets endpoint silently caps `limit` at 100 server-side;
-// requesting more returns 100 anyway, and the `markets.length < PAGE_SIZE`
-// short-page stop signal below would then misfire after page 1.
+// Polymarket's keyset endpoint caps `limit` at 100 server-side.
 const PAGE_SIZE = 100;
+
+// Hard backstop on pages walked. At 100 markets/page this covers 1M markets —
+// far beyond any real corpus. Its only job is to stop a runaway loop if the API
+// ever regresses to echoing a stuck cursor (see stuck-cursor guard below).
+const MAX_PAGES = 10000;
+
+/** Shape of the /markets/keyset response envelope (vs the bare array /markets returns). */
+interface KeysetPage {
+  markets: PolymarketMarket[];
+  next_cursor?: string;
+}
 
 /**
  * Fetch markets whose endDate is in the past (within the lookback window)
@@ -28,21 +37,30 @@ export async function fetchPastEndDateMarkets(): Promise<PolymarketMarket[]> {
 
   const allMarkets: PolymarketMarket[] = [];
   const seenConditionIds = new Set<string>();
+  // Cursors already requested. Polymarket deprecated offset pagination — the
+  // /markets endpoint rejects offset > 2000 with HTTP 422 ("use /markets/keyset
+  // for deeper pagination"). Keyset pagination has no offset ceiling: each page
+  // returns a `next_cursor` we feed back as `after_cursor`. Tracking seen
+  // cursors also guards against a stuck cursor looping forever (Polymarket/agents#227).
+  const seenCursors = new Set<string>();
   let pageCount = 0;
-  let offset = 0;
+  let cursor: string | undefined;
 
   console.log(
     `[Relist] Fetching past-endDate markets from ${minEndDate.toISOString()} to ${now.toISOString()}...`
   );
 
-  while (true) {
+  while (pageCount < MAX_PAGES) {
     pageCount++;
-    // Fetch active, not closed, not archived markets with past endDates
+    // Fetch active, not closed, not archived markets with past endDates.
+    // Every filter param must be re-sent on each page — the cursor is validated
+    // against a hash of the originating query.
     const url =
-      `https://gamma-api.polymarket.com/markets?limit=${PAGE_SIZE}&offset=${offset}` +
+      `https://gamma-api.polymarket.com/markets/keyset?limit=${PAGE_SIZE}` +
       `&active=true&closed=false&archived=false` +
       `&order=endDate&ascending=false` +
-      `&end_date_min=${minEndDate.toISOString()}&end_date_max=${now.toISOString()}`;
+      `&end_date_min=${minEndDate.toISOString()}&end_date_max=${now.toISOString()}` +
+      (cursor ? `&after_cursor=${encodeURIComponent(cursor)}` : '');
 
     const response = await fetchWithRetry(url, {
       headers: { Accept: 'application/json' },
@@ -60,19 +78,25 @@ export async function fetchPastEndDateMarkets(): Promise<PolymarketMarket[]> {
       );
     }
 
-    const markets: PolymarketMarket[] = await response.json();
+    const { markets, next_cursor }: KeysetPage = await response.json();
 
-    if (markets.length === 0) {
+    if (!markets || markets.length === 0) {
       console.log(`[Relist] Page ${pageCount}: No more markets`);
       break;
     }
 
+    // Surface the earliest endDate in the batch. Results are ordered endDate
+    // descending, so this value should march backward each page — a visible
+    // signal that the cursor is advancing rather than re-fetching page 1.
+    const earliestEndDate = markets.reduce(
+      (min, m) => (new Date(m.endDate) < new Date(min) ? m.endDate : min),
+      markets[0].endDate
+    );
     console.log(
-      `[Relist] Page ${pageCount}: Fetched ${markets.length} markets`
+      `[Relist] Page ${pageCount}: Fetched ${markets.length} markets (earliest endDate ${earliestEndDate})`
     );
 
     // Deduplicate and filter out archived markets (client-side safety net)
-    let newMarketsCount = 0;
     for (const m of markets) {
       if (m.archived) continue;
       // Also filter client-side for endDate < now in case end_date_max isn't supported
@@ -80,18 +104,24 @@ export async function fetchPastEndDateMarkets(): Promise<PolymarketMarket[]> {
       if (!seenConditionIds.has(m.conditionId)) {
         seenConditionIds.add(m.conditionId);
         allMarkets.push(m);
-        newMarketsCount++;
       }
     }
 
     // Stop conditions:
-    // 1. Got less than PAGE_SIZE markets (no more pages)
-    // 2. No new markets added (all duplicates or filtered)
-    if (markets.length < PAGE_SIZE || newMarketsCount === 0) {
+    // 1. No next_cursor → server signalled the final page.
+    // 2. Cursor already seen → API stopped advancing; stop instead of looping
+    //    forever on the same page.
+    if (!next_cursor || seenCursors.has(next_cursor)) {
       break;
     }
+    seenCursors.add(next_cursor);
+    cursor = next_cursor;
+  }
 
-    offset += PAGE_SIZE;
+  if (pageCount >= MAX_PAGES) {
+    console.warn(
+      `[Relist] Reached MAX_PAGES (${MAX_PAGES}); results may be truncated`
+    );
   }
 
   console.log(

--- a/packages/sdk/queries/__tests__/protocol.test.ts
+++ b/packages/sdk/queries/__tests__/protocol.test.ts
@@ -65,8 +65,9 @@ describe('GET_PROTOCOL_ANALYTICS document', () => {
     expect(GET_PROTOCOL_ANALYTICS).toContain('protocol');
     expect(GET_PROTOCOL_ANALYTICS).toContain('stats');
     expect(GET_PROTOCOL_ANALYTICS).toContain(
-      'statsHistory(first: $first, after: $after)'
+      'statsHistory(interval: $interval, first: $first, after: $after)'
     );
+    expect(GET_PROTOCOL_ANALYTICS).toContain('$interval: TimeInterval');
     expect(GET_PROTOCOL_ANALYTICS).toContain('hasNextPage');
     expect(GET_PROTOCOL_ANALYTICS).toContain('openInterestByCategory');
     expect(GET_PROTOCOL_ANALYTICS).toContain('openInterestByTimeToResolution');
@@ -94,12 +95,13 @@ describe('GET_PROTOCOL_ANALYTICS document', () => {
 });
 
 describe('fetchProtocolAnalytics', () => {
-  test('requests the first history page within the list-size cap (100)', async () => {
+  test('requests the daily-bucketed series in one page (interval DAY, first null)', async () => {
     mockGraphqlRequestV2.mockResolvedValue(fullResponse());
     await fetchProtocolAnalytics();
     expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
     expect(mockGraphqlRequestV2).toHaveBeenCalledWith(GET_PROTOCOL_ANALYTICS, {
-      first: 100,
+      interval: 'DAY',
+      first: null,
       after: null,
     });
   });
@@ -122,17 +124,17 @@ describe('fetchProtocolAnalytics', () => {
     const result = await fetchProtocolAnalytics();
 
     expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(2);
-    // First call: the combined analytics query, first page.
+    // First call: the combined analytics query, daily-bucketed first page.
     expect(mockGraphqlRequestV2).toHaveBeenNthCalledWith(
       1,
       GET_PROTOCOL_ANALYTICS,
-      { first: 100, after: null }
+      { interval: 'DAY', first: null, after: null }
     );
     // Second call: the lighter history-only page query, threading the cursor.
     expect(mockGraphqlRequestV2).toHaveBeenNthCalledWith(
       2,
       GET_PROTOCOL_STATS_HISTORY_PAGE,
-      { first: 100, after: 'cursor-1' }
+      { interval: 'DAY', first: null, after: 'cursor-1' }
     );
     expect(result.statsHistory.map((s) => s.timestamp)).toEqual([
       1700000100, 1700000200, 1700000300,

--- a/packages/sdk/queries/__tests__/vault.test.ts
+++ b/packages/sdk/queries/__tests__/vault.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
-import { fetchVaultStats, GET_VAULT_STATS } from '../vault';
+import {
+  fetchVaultAccountValue,
+  fetchVaultStats,
+  GET_VAULT_ACCOUNT_VALUE,
+  GET_VAULT_STATS,
+} from '../vault';
 
 const mockGraphqlRequestV2 = vi.fn();
 vi.mock('../client/graphqlClient', () => ({
@@ -151,5 +156,75 @@ describe('fetchVaultStats', () => {
     expect(await fetchVaultStats('0xabc', 42161)).toEqual([]);
     mockGraphqlRequestV2.mockResolvedValue(null);
     expect(await fetchVaultStats('0xabc', 42161)).toEqual([]);
+  });
+});
+
+describe('GET_VAULT_ACCOUNT_VALUE document', () => {
+  test('queries account collateralBalance and account statsHistory from one v2 surface', () => {
+    expect(GET_VAULT_ACCOUNT_VALUE).toContain(
+      'account(address: $address, chainId: $chainId)'
+    );
+    expect(GET_VAULT_ACCOUNT_VALUE).toContain('collateralBalance');
+    expect(GET_VAULT_ACCOUNT_VALUE).toContain('amount');
+    expect(GET_VAULT_ACCOUNT_VALUE).toContain(
+      'statsHistory(interval: DAY, first: 366)'
+    );
+    expect(GET_VAULT_ACCOUNT_VALUE).toContain('deployedCollateral');
+    expect(GET_VAULT_ACCOUNT_VALUE).toContain('claimableCollateral');
+  });
+});
+
+describe('fetchVaultAccountValue', () => {
+  test('lowercases the address and sums indexed wallet, deployed, and claimable collateral', async () => {
+    mockGraphqlRequestV2.mockResolvedValue({
+      account: {
+        collateralBalance: { amount: '1000' },
+        statsHistory: {
+          nodes: [
+            {
+              timestamp: 1700000000,
+              deployedCollateral: '250',
+              claimableCollateral: '25',
+            },
+            {
+              timestamp: 1700000100,
+              deployedCollateral: '500',
+              claimableCollateral: '125',
+            },
+          ],
+        },
+      },
+    });
+
+    const result = await fetchVaultAccountValue('0xABCDEF', 42161);
+
+    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(GET_VAULT_ACCOUNT_VALUE, {
+      address: '0xabcdef',
+      chainId: 42161,
+    });
+    expect(result).toEqual({
+      collateralBalance: '1000',
+      deployedCollateral: '500',
+      claimableCollateral: '125',
+      totalValue: '1625',
+      timestamp: 1700000100,
+    });
+  });
+
+  test('defaults missing account stats to just the indexed wallet balance', async () => {
+    mockGraphqlRequestV2.mockResolvedValue({
+      account: {
+        collateralBalance: { amount: 1000 },
+        statsHistory: { nodes: [] },
+      },
+    });
+
+    await expect(fetchVaultAccountValue('0xabc', 42161)).resolves.toEqual({
+      collateralBalance: '1000',
+      deployedCollateral: '0',
+      claimableCollateral: '0',
+      totalValue: '1000',
+      timestamp: null,
+    });
   });
 });

--- a/packages/sdk/queries/__tests__/vault.test.ts
+++ b/packages/sdk/queries/__tests__/vault.test.ts
@@ -25,8 +25,14 @@ const node = (timestamp: number, overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
-const responseWith = (nodes: ReturnType<typeof node>[]) => ({
-  vault: { statsHistory: { nodes } },
+const responseWith = (
+  nodes: ReturnType<typeof node>[],
+  pageInfo: { hasNextPage: boolean; endCursor: string | null } = {
+    hasNextPage: false,
+    endCursor: null,
+  }
+) => ({
+  vault: { statsHistory: { nodes, pageInfo } },
 });
 
 describe('GET_VAULT_STATS document', () => {
@@ -34,12 +40,14 @@ describe('GET_VAULT_STATS document', () => {
     expect(GET_VAULT_STATS).toContain(
       'vault(address: $address, chainId: $chainId)'
     );
-    // No explicit `first`: a literal above GRAPHQL_MAX_LIST_SIZE (100) is
-    // rejected pre-execution with PAGINATION_LIMIT_EXCEEDED, so we rely on the
-    // resolver returning the full bounded series in one page (mirrors
-    // GET_VAULT_ACCOUNT_VALUE). The series fits one request, so we don't page.
-    expect(GET_VAULT_STATS).toContain('statsHistory {');
-    expect(GET_VAULT_STATS).not.toContain('first:');
+    // `first` is a nullable variable: omitting it lets the resolver return up
+    // to its MAX_STATS_POINTS cap in one page, while `pageInfo`/`after` keep a
+    // pagination fallback for any vault that exceeds the cap.
+    expect(GET_VAULT_STATS).toContain(
+      'statsHistory(first: $first, after: $after)'
+    );
+    expect(GET_VAULT_STATS).toContain('hasNextPage');
+    expect(GET_VAULT_STATS).toContain('endCursor');
     expect(GET_VAULT_STATS).toContain('timestamp');
     expect(GET_VAULT_STATS).toContain('balance');
     expect(GET_VAULT_STATS).toContain('deployedCollateral');
@@ -54,29 +62,69 @@ describe('GET_VAULT_STATS document', () => {
 });
 
 describe('fetchVaultStats', () => {
-  test('fetches the whole series in a single request (address lowercased)', async () => {
+  test('single request (no pageSize) sends a null `first`, address lowercased', async () => {
     mockGraphqlRequestV2.mockResolvedValue(responseWith([node(1700000100)]));
     await fetchVaultStats('0xABCDEF', 42161);
     expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
     expect(mockGraphqlRequestV2).toHaveBeenCalledWith(GET_VAULT_STATS, {
       address: '0xabcdef',
       chainId: 42161,
+      first: null,
+      after: null,
     });
   });
 
-  test('does not paginate — one request returns the full bounded series', async () => {
+  test('one request returns the bounded series when the server signals no next page', async () => {
     mockGraphqlRequestV2.mockResolvedValue(
       responseWith([node(1700000300), node(1700000200), node(1700000100)])
     );
 
     const result = await fetchVaultStats('0xabc', 42161);
 
-    // Single round-trip: the resolver hands back the entire daily series.
+    // Single round-trip: the resolver's cap covers the whole series.
     expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
     // All snapshots accumulated, sorted oldest-first.
     expect(result.map((s) => s.timestamp)).toEqual([
       1700000100, 1700000200, 1700000300,
     ]);
+  });
+
+  test('pages on `pageInfo` when a vault exceeds the server cap', async () => {
+    mockGraphqlRequestV2
+      .mockResolvedValueOnce(
+        responseWith([node(1700000300), node(1700000200)], {
+          hasNextPage: true,
+          endCursor: 'cursor-1',
+        })
+      )
+      .mockResolvedValueOnce(
+        responseWith([node(1700000100)], {
+          hasNextPage: false,
+          endCursor: null,
+        })
+      );
+
+    const result = await fetchVaultStats('0xabc', 42161);
+
+    expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(2);
+    // Second page threads the first page's endCursor as `after`.
+    expect(mockGraphqlRequestV2.mock.calls[1][1]).toMatchObject({
+      after: 'cursor-1',
+    });
+    expect(result.map((s) => s.timestamp)).toEqual([
+      1700000100, 1700000200, 1700000300,
+    ]);
+  });
+
+  test('forwards an explicit pageSize as the per-page `first`', async () => {
+    mockGraphqlRequestV2.mockResolvedValue(responseWith([node(1700000100)]));
+    await fetchVaultStats('0xabc', 42161, 100);
+    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(GET_VAULT_STATS, {
+      address: '0xabc',
+      chainId: 42161,
+      first: 100,
+      after: null,
+    });
   });
 
   test('maps wire nodes to the adapted vault stat shape', async () => {

--- a/packages/sdk/queries/__tests__/vault.test.ts
+++ b/packages/sdk/queries/__tests__/vault.test.ts
@@ -25,14 +25,8 @@ const node = (timestamp: number, overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
-const responseWith = (
-  nodes: ReturnType<typeof node>[],
-  pageInfo: { hasNextPage: boolean; endCursor: string | null } = {
-    hasNextPage: false,
-    endCursor: null,
-  }
-) => ({
-  vault: { statsHistory: { nodes, pageInfo } },
+const responseWith = (nodes: ReturnType<typeof node>[]) => ({
+  vault: { statsHistory: { nodes } },
 });
 
 describe('GET_VAULT_STATS document', () => {
@@ -40,11 +34,12 @@ describe('GET_VAULT_STATS document', () => {
     expect(GET_VAULT_STATS).toContain(
       'vault(address: $address, chainId: $chainId)'
     );
-    expect(GET_VAULT_STATS).toContain(
-      'statsHistory(first: $first, after: $after)'
-    );
-    expect(GET_VAULT_STATS).toContain('hasNextPage');
-    expect(GET_VAULT_STATS).toContain('endCursor');
+    // No explicit `first`: a literal above GRAPHQL_MAX_LIST_SIZE (100) is
+    // rejected pre-execution with PAGINATION_LIMIT_EXCEEDED, so we rely on the
+    // resolver returning the full bounded series in one page (mirrors
+    // GET_VAULT_ACCOUNT_VALUE). The series fits one request, so we don't page.
+    expect(GET_VAULT_STATS).toContain('statsHistory {');
+    expect(GET_VAULT_STATS).not.toContain('first:');
     expect(GET_VAULT_STATS).toContain('timestamp');
     expect(GET_VAULT_STATS).toContain('balance');
     expect(GET_VAULT_STATS).toContain('deployedCollateral');
@@ -59,40 +54,26 @@ describe('GET_VAULT_STATS document', () => {
 });
 
 describe('fetchVaultStats', () => {
-  test('passes the address (lowercased), chainId and first page args', async () => {
+  test('fetches the whole series in a single request (address lowercased)', async () => {
     mockGraphqlRequestV2.mockResolvedValue(responseWith([node(1700000100)]));
     await fetchVaultStats('0xABCDEF', 42161);
+    expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
     expect(mockGraphqlRequestV2).toHaveBeenCalledWith(GET_VAULT_STATS, {
       address: '0xabcdef',
       chainId: 42161,
-      first: 100,
-      after: null,
     });
   });
 
-  test('pages through statsHistory until the connection is exhausted', async () => {
-    mockGraphqlRequestV2
-      .mockResolvedValueOnce(
-        responseWith([node(1700000300), node(1700000200)], {
-          hasNextPage: true,
-          endCursor: 'cursor-1',
-        })
-      )
-      .mockResolvedValueOnce(
-        responseWith([node(1700000100)], {
-          hasNextPage: false,
-          endCursor: null,
-        })
-      );
+  test('does not paginate — one request returns the full bounded series', async () => {
+    mockGraphqlRequestV2.mockResolvedValue(
+      responseWith([node(1700000300), node(1700000200), node(1700000100)])
+    );
 
     const result = await fetchVaultStats('0xabc', 42161);
 
-    expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(2);
-    // Second page threads the first page's endCursor as `after`.
-    expect(mockGraphqlRequestV2.mock.calls[1][1]).toMatchObject({
-      after: 'cursor-1',
-    });
-    // All three snapshots accumulated, sorted oldest-first.
+    // Single round-trip: the resolver hands back the entire daily series.
+    expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
+    // All snapshots accumulated, sorted oldest-first.
     expect(result.map((s) => s.timestamp)).toEqual([
       1700000100, 1700000200, 1700000300,
     ]);

--- a/packages/sdk/queries/__tests__/vault.test.ts
+++ b/packages/sdk/queries/__tests__/vault.test.ts
@@ -166,9 +166,11 @@ describe('GET_VAULT_ACCOUNT_VALUE document', () => {
     );
     expect(GET_VAULT_ACCOUNT_VALUE).toContain('collateralBalance');
     expect(GET_VAULT_ACCOUNT_VALUE).toContain('amount');
-    expect(GET_VAULT_ACCOUNT_VALUE).toContain(
-      'statsHistory(interval: DAY, first: 366)'
-    );
+    expect(GET_VAULT_ACCOUNT_VALUE).toContain('statsHistory(interval: DAY)');
+    // No explicit `first`: a literal above GRAPHQL_MAX_LIST_SIZE (100) is
+    // rejected pre-execution with PAGINATION_LIMIT_EXCEEDED, so we rely on the
+    // resolver's MAX_STATS_POINTS default for the full rolling-year window.
+    expect(GET_VAULT_ACCOUNT_VALUE).not.toContain('first:');
     expect(GET_VAULT_ACCOUNT_VALUE).toContain('deployedCollateral');
     expect(GET_VAULT_ACCOUNT_VALUE).toContain('claimableCollateral');
   });

--- a/packages/sdk/queries/protocol.ts
+++ b/packages/sdk/queries/protocol.ts
@@ -79,18 +79,25 @@ const PROTOCOL_STAT_FIELDS = /* GraphQL */ `
 // `Protocol.statsHistory` exposes no orderBy argument — the connection is
 // defined oldest-first in the SDL; the mapper still sorts defensively.
 //
-// `statsHistory` pages on `pageInfo`: `first` must stay <= the API's
-// GRAPHQL_MAX_LIST_SIZE (100) or the request is rejected pre-execution with
-// PAGINATION_LIMIT_EXCEEDED. The first page is fetched alongside the singular
-// stats/open-interest fields; `GET_PROTOCOL_STATS_HISTORY_PAGE` fetches the
-// remaining history pages on their own.
+// We request `interval: DAY` so the server downsamples the (sub-daily, ~4-hourly
+// in prod) snapshot series to one node per day — exactly what the charts render
+// — instead of returning thousands of raw rows. `first` is left null so the
+// server returns the whole bucketed series in one page (it ignores the
+// GRAPHQL_MAX_LIST_SIZE 100 cap only because no explicit `first` value is sent);
+// the daily series fits comfortably under the resolver's internal page cap.
+// `GET_PROTOCOL_STATS_HISTORY_PAGE` remains as a forward-pagination safety net
+// for the rare case the series ever exceeds one page.
 export const GET_PROTOCOL_ANALYTICS = /* GraphQL */ `
-  query ProtocolAnalytics($first: Int!, $after: String) {
+  query ProtocolAnalytics(
+    $interval: TimeInterval
+    $first: Int
+    $after: String
+  ) {
     protocol {
       stats {
         ...ProtocolStatFields
       }
-      statsHistory(first: $first, after: $after) {
+      statsHistory(interval: $interval, first: $first, after: $after) {
         nodes {
           ...ProtocolStatFields
         }
@@ -119,9 +126,13 @@ export const GET_PROTOCOL_ANALYTICS = /* GraphQL */ `
 `;
 
 export const GET_PROTOCOL_STATS_HISTORY_PAGE = /* GraphQL */ `
-  query ProtocolStatsHistoryPage($first: Int!, $after: String) {
+  query ProtocolStatsHistoryPage(
+    $interval: TimeInterval
+    $first: Int
+    $after: String
+  ) {
     protocol {
-      statsHistory(first: $first, after: $after) {
+      statsHistory(interval: $interval, first: $first, after: $after) {
         nodes {
           ...ProtocolStatFields
         }
@@ -228,16 +239,20 @@ function toProtocolAnalytics(
   };
 }
 
-// Snapshot pages are capped at the API's GRAPHQL_MAX_LIST_SIZE (100). The
-// daily series is bounded, so a handful of pages covers all history; MAX_PAGES
-// guards against a non-progressing cursor.
-const HISTORY_PAGE_SIZE = 100;
+// Daily bucketing keeps the series to ~one node per day, so the whole history
+// comes back in the first page. `first: null` lets the server return the full
+// bucketed series without tripping the GRAPHQL_MAX_LIST_SIZE (100) pre-execution
+// cap (which only inspects explicit `first` values). The pagination loop below
+// is a safety net — normally it never iterates — with MAX_PAGES guarding against
+// a non-progressing cursor.
+const HISTORY_INTERVAL = 'DAY';
+const HISTORY_PAGE_SIZE = null;
 const MAX_HISTORY_PAGES = 50;
 
 export async function fetchProtocolAnalytics(): Promise<ProtocolAnalytics> {
   const data = await graphqlRequestV2<ProtocolAnalyticsV2Response>(
     GET_PROTOCOL_ANALYTICS,
-    { first: HISTORY_PAGE_SIZE, after: null }
+    { interval: HISTORY_INTERVAL, first: HISTORY_PAGE_SIZE, after: null }
   );
 
   const historyNodes: WireStat[] = [
@@ -250,6 +265,7 @@ export async function fetchProtocolAnalytics(): Promise<ProtocolAnalytics> {
     const next = await graphqlRequestV2<{
       protocol: { statsHistory: StatsHistoryPage } | null;
     }>(GET_PROTOCOL_STATS_HISTORY_PAGE, {
+      interval: HISTORY_INTERVAL,
       first: HISTORY_PAGE_SIZE,
       after: pageInfo.endCursor,
     });

--- a/packages/sdk/queries/protocol.ts
+++ b/packages/sdk/queries/protocol.ts
@@ -125,6 +125,18 @@ export const GET_PROTOCOL_ANALYTICS = /* GraphQL */ `
   ${PROTOCOL_STAT_FIELDS}
 `;
 
+export const GET_PROTOCOL_STATS = /* GraphQL */ `
+  query ProtocolStats {
+    protocol {
+      stats {
+        ...ProtocolStatFields
+      }
+    }
+  }
+
+  ${PROTOCOL_STAT_FIELDS}
+`;
+
 export const GET_PROTOCOL_STATS_HISTORY_PAGE = /* GraphQL */ `
   query ProtocolStatsHistoryPage(
     $interval: TimeInterval
@@ -248,6 +260,19 @@ function toProtocolAnalytics(
 const HISTORY_INTERVAL = 'DAY';
 const HISTORY_PAGE_SIZE = null;
 const MAX_HISTORY_PAGES = 50;
+
+export async function fetchProtocolStats(): Promise<ProtocolAnalyticsStat> {
+  const data = await graphqlRequestV2<{
+    protocol: { stats: WireStat } | null;
+  }>(GET_PROTOCOL_STATS);
+  const stats = data?.protocol?.stats;
+  if (!stats) {
+    throw new Error(
+      'Failed to fetch protocol stats: Invalid response structure'
+    );
+  }
+  return toStat(stats);
+}
 
 export async function fetchProtocolAnalytics(): Promise<ProtocolAnalytics> {
   const data = await graphqlRequestV2<ProtocolAnalyticsV2Response>(

--- a/packages/sdk/queries/vault.ts
+++ b/packages/sdk/queries/vault.ts
@@ -24,17 +24,25 @@ export interface VaultStat {
 }
 
 // `statsHistory` returns ascending (oldest-first) timestamps; the final
-// `.sort()` below is a defensive no-op that keeps the result ordered.
+// `.sort()` below is a defensive no-op that also keeps a merged multi-page
+// result ordered.
 //
-// No explicit `first`: a literal above GRAPHQL_MAX_LIST_SIZE (100) is rejected
-// pre-execution with PAGINATION_LIMIT_EXCEEDED, so we omit it and rely on the
-// resolver returning the full bounded daily series in a single page (mirrors
-// GET_VAULT_ACCOUNT_VALUE). The series fits one request, so we never page —
-// avoiding a per-vault chain of sequential round-trips on chart load.
+// `first` is left to the variable (nullable): omitting it lets the resolver
+// return up to its MAX_STATS_POINTS cap in one page, so the common case is a
+// single request. The query still selects `pageInfo` and threads `after` so
+// fetchVaultStats can page forward if a vault ever exceeds that cap — the
+// series stays complete without re-introducing a fixed chain of round-trips.
+// A literal `first` above GRAPHQL_MAX_LIST_SIZE (100) is rejected
+// pre-execution, so an explicit `pageSize` must stay <= 100.
 export const GET_VAULT_STATS = /* GraphQL */ `
-  query VaultStats($address: Address!, $chainId: Int) {
+  query VaultStats(
+    $address: Address!
+    $chainId: Int
+    $first: Int
+    $after: String
+  ) {
     vault(address: $address, chainId: $chainId) {
-      statsHistory {
+      statsHistory(first: $first, after: $after) {
         nodes {
           timestamp
           balance
@@ -42,6 +50,10 @@ export const GET_VAULT_STATS = /* GraphQL */ `
           undeployedCollateral
           cumulativePnl
           claimableCollateral
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
         }
       }
     }
@@ -61,6 +73,7 @@ type VaultStatsResponse = {
   vault: {
     statsHistory: {
       nodes: WireVaultStat[];
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
     };
   } | null;
 };
@@ -81,26 +94,43 @@ function toVaultStat(node: WireVaultStat): VaultStat {
 }
 
 /**
- * Fetch a vault's full snapshot series, oldest-first, in a single request.
- * The resolver returns the complete bounded daily series when `first` is
- * omitted (mirrors `fetchVaultAccountValue`), so the chart loads without the
- * per-vault chain of sequential paginated round-trips it used to make.
- * Returns an empty array when the address is not a configured vault (the v2
- * `vault` field resolves null).
+ * Fetch a vault's full snapshot series, oldest-first.
+ *
+ * The resolver returns up to its MAX_STATS_POINTS cap per page, so for a
+ * normal vault this completes in a single request. The loop pages on
+ * `pageInfo` only if a vault's series ever exceeds the cap, so the chart never
+ * silently loses history. Returns an empty array when the address is not a
+ * configured vault (the v2 `vault` field resolves null).
+ *
+ * `pageSize` (optional) forces an explicit per-page `first` — it must stay
+ * <= the API's GRAPHQL_MAX_LIST_SIZE (100), since a larger literal is rejected
+ * pre-execution. Omit it to use the resolver's single-page cap.
  */
 export async function fetchVaultStats(
   address: string,
-  chainId?: number
+  chainId?: number,
+  pageSize?: number
 ): Promise<VaultStat[]> {
-  const data: VaultStatsResponse = await graphqlRequestV2<VaultStatsResponse>(
-    GET_VAULT_STATS,
-    {
-      address: address.toLowerCase(),
-      chainId,
-    }
-  );
-  const nodes = data?.vault?.statsHistory?.nodes;
-  if (!Array.isArray(nodes)) return [];
+  const nodes: WireVaultStat[] = [];
+  let after: string | null = null;
+  // Bound the loop defensively against a non-progressing cursor; the daily
+  // series can't realistically exceed a few thousand snapshots.
+  for (let page = 0; page < 50; page += 1) {
+    const data: VaultStatsResponse = await graphqlRequestV2<VaultStatsResponse>(
+      GET_VAULT_STATS,
+      {
+        address: address.toLowerCase(),
+        chainId,
+        first: pageSize ?? null,
+        after,
+      }
+    );
+    const history = data?.vault?.statsHistory;
+    if (!history || !Array.isArray(history.nodes)) break;
+    nodes.push(...history.nodes);
+    if (!history.pageInfo?.hasNextPage || !history.pageInfo.endCursor) break;
+    after = history.pageInfo.endCursor;
+  }
   return nodes.map(toVaultStat).sort((a, b) => a.timestamp - b.timestamp);
 }
 

--- a/packages/sdk/queries/vault.ts
+++ b/packages/sdk/queries/vault.ts
@@ -24,22 +24,17 @@ export interface VaultStat {
 }
 
 // `statsHistory` returns ascending (oldest-first) timestamps; the final
-// `.sort()` below is a defensive no-op that also keeps the merged multi-page
-// result ordered.
+// `.sort()` below is a defensive no-op that keeps the result ordered.
 //
-// The resolver caps `first` per page (daily snapshots, bounded series), so we
-// page on `pageInfo` until exhausted rather than over-fetching a single page —
-// otherwise a vault older than the cap would silently lose the earliest chart
-// history.
+// No explicit `first`: a literal above GRAPHQL_MAX_LIST_SIZE (100) is rejected
+// pre-execution with PAGINATION_LIMIT_EXCEEDED, so we omit it and rely on the
+// resolver returning the full bounded daily series in a single page (mirrors
+// GET_VAULT_ACCOUNT_VALUE). The series fits one request, so we never page —
+// avoiding a per-vault chain of sequential round-trips on chart load.
 export const GET_VAULT_STATS = /* GraphQL */ `
-  query VaultStats(
-    $address: Address!
-    $chainId: Int
-    $first: Int!
-    $after: String
-  ) {
+  query VaultStats($address: Address!, $chainId: Int) {
     vault(address: $address, chainId: $chainId) {
-      statsHistory(first: $first, after: $after) {
+      statsHistory {
         nodes {
           timestamp
           balance
@@ -47,10 +42,6 @@ export const GET_VAULT_STATS = /* GraphQL */ `
           undeployedCollateral
           cumulativePnl
           claimableCollateral
-        }
-        pageInfo {
-          hasNextPage
-          endCursor
         }
       }
     }
@@ -70,7 +61,6 @@ type VaultStatsResponse = {
   vault: {
     statsHistory: {
       nodes: WireVaultStat[];
-      pageInfo: { hasNextPage: boolean; endCursor: string | null };
     };
   } | null;
 };
@@ -91,40 +81,26 @@ function toVaultStat(node: WireVaultStat): VaultStat {
 }
 
 /**
- * Fetch a vault's full snapshot series, oldest-first. Pages through
- * `statsHistory` until the connection is exhausted (the resolver caps page
- * size), so the chart gets the complete history regardless of vault age.
+ * Fetch a vault's full snapshot series, oldest-first, in a single request.
+ * The resolver returns the complete bounded daily series when `first` is
+ * omitted (mirrors `fetchVaultAccountValue`), so the chart loads without the
+ * per-vault chain of sequential paginated round-trips it used to make.
  * Returns an empty array when the address is not a configured vault (the v2
  * `vault` field resolves null).
  */
 export async function fetchVaultStats(
   address: string,
-  chainId?: number,
-  // Must stay <= the API's GRAPHQL_MAX_LIST_SIZE (100); a larger `first` is
-  // rejected pre-execution with PAGINATION_LIMIT_EXCEEDED. The loop below pages
-  // on `pageInfo`, so a 100-row page still yields the full series.
-  pageSize = 100
+  chainId?: number
 ): Promise<VaultStat[]> {
-  const nodes: WireVaultStat[] = [];
-  let after: string | null = null;
-  // Bound the loop defensively against a non-progressing cursor; a daily
-  // series can't realistically exceed a few thousand snapshots.
-  for (let page = 0; page < 50; page += 1) {
-    const data: VaultStatsResponse = await graphqlRequestV2<VaultStatsResponse>(
-      GET_VAULT_STATS,
-      {
-        address: address.toLowerCase(),
-        chainId,
-        first: pageSize,
-        after,
-      }
-    );
-    const history = data?.vault?.statsHistory;
-    if (!history || !Array.isArray(history.nodes)) break;
-    nodes.push(...history.nodes);
-    if (!history.pageInfo?.hasNextPage || !history.pageInfo.endCursor) break;
-    after = history.pageInfo.endCursor;
-  }
+  const data: VaultStatsResponse = await graphqlRequestV2<VaultStatsResponse>(
+    GET_VAULT_STATS,
+    {
+      address: address.toLowerCase(),
+      chainId,
+    }
+  );
+  const nodes = data?.vault?.statsHistory?.nodes;
+  if (!Array.isArray(nodes)) return [];
   return nodes.map(toVaultStat).sort((a, b) => a.timestamp - b.timestamp);
 }
 

--- a/packages/sdk/queries/vault.ts
+++ b/packages/sdk/queries/vault.ts
@@ -141,13 +141,19 @@ export interface VaultAccountValue {
   timestamp: number | null;
 }
 
+// `statsHistory` is intentionally called without `first`: the API's
+// pre-execution validation rejects any literal `first` above
+// GRAPHQL_MAX_LIST_SIZE (100) with PAGINATION_LIMIT_EXCEEDED, and the daily
+// series needs the full rolling-year window. With no `first` the resolver
+// defaults to its MAX_STATS_POINTS (366) cap — the whole [now-365d, now] grid,
+// oldest-first — so `.at(-1)` is always the latest (today's) bucket.
 export const GET_VAULT_ACCOUNT_VALUE = /* GraphQL */ `
   query VaultAccountValue($address: Address!, $chainId: Int) {
     account(address: $address, chainId: $chainId) {
       collateralBalance {
         amount
       }
-      statsHistory(interval: DAY, first: 366) {
+      statsHistory(interval: DAY) {
         nodes {
           timestamp
           deployedCollateral

--- a/packages/sdk/queries/vault.ts
+++ b/packages/sdk/queries/vault.ts
@@ -127,3 +127,79 @@ export async function fetchVaultStats(
   }
   return nodes.map(toVaultStat).sort((a, b) => a.timestamp - b.timestamp);
 }
+
+export interface VaultAccountValue {
+  /** Current indexed wUSDe balance held by the vault wallet, wei. */
+  collateralBalance: string;
+  /** Collateral deployed into open positions by the vault account, wei. */
+  deployedCollateral: string;
+  /** Settled/won collateral owed to the vault account but not redeemed, wei. */
+  claimableCollateral: string;
+  /** Sum of collateralBalance + deployedCollateral + claimableCollateral, wei. */
+  totalValue: string;
+  /** Latest account stats bucket timestamp, epoch seconds. */
+  timestamp: number | null;
+}
+
+export const GET_VAULT_ACCOUNT_VALUE = /* GraphQL */ `
+  query VaultAccountValue($address: Address!, $chainId: Int) {
+    account(address: $address, chainId: $chainId) {
+      collateralBalance {
+        amount
+      }
+      statsHistory(interval: DAY, first: 366) {
+        nodes {
+          timestamp
+          deployedCollateral
+          claimableCollateral
+        }
+      }
+    }
+  }
+`;
+
+type WireVaultAccountStat = {
+  timestamp: number;
+  deployedCollateral: string | number;
+  claimableCollateral: string | number;
+};
+
+type VaultAccountValueResponse = {
+  account: {
+    collateralBalance: { amount: string | number };
+    statsHistory: { nodes: WireVaultAccountStat[] };
+  };
+};
+
+export async function fetchVaultAccountValue(
+  address: string,
+  chainId?: number
+): Promise<VaultAccountValue> {
+  const data = await graphqlRequestV2<VaultAccountValueResponse>(
+    GET_VAULT_ACCOUNT_VALUE,
+    {
+      address: address.toLowerCase(),
+      chainId,
+    }
+  );
+  const latestStat = data.account.statsHistory.nodes.at(-1);
+  const collateralBalance = BigInt(wei(data.account.collateralBalance.amount));
+  const deployedCollateral = latestStat?.deployedCollateral
+    ? BigInt(wei(latestStat.deployedCollateral))
+    : 0n;
+  const claimableCollateral = latestStat?.claimableCollateral
+    ? BigInt(wei(latestStat.claimableCollateral))
+    : 0n;
+
+  return {
+    collateralBalance: collateralBalance.toString(),
+    deployedCollateral: deployedCollateral.toString(),
+    claimableCollateral: claimableCollateral.toString(),
+    totalValue: (
+      collateralBalance +
+      deployedCollateral +
+      claimableCollateral
+    ).toString(),
+    timestamp: latestStat?.timestamp ?? null,
+  };
+}

--- a/packages/sdk/types/graphql.v2.ts
+++ b/packages/sdk/types/graphql.v2.ts
@@ -2153,10 +2153,11 @@ export type Vault = Node & {
    * `timestamp`, matching `Account.statsHistory` — chart-ready, no consumer
    * re-sort). Backs the vault dashboard's TVL / PnL charts.
    *
-   * `first` has no default on purpose: omitting it returns the whole bounded
-   * daily series in one page, so the chart loads in a single request instead of
-   * a chain of sequential paginated round-trips. (A literal `first` above
-   * GRAPHQL_MAX_LIST_SIZE is still rejected pre-execution.)
+   * Omitting `first` returns up to a server-side cap (MAX_STATS_POINTS) in one
+   * page, so the chart loads in a single request instead of a chain of paginated
+   * round-trips — while still bounding the response for an append-only series.
+   * Page forward with `after` if a vault ever exceeds the cap. (A literal `first`
+   * above GRAPHQL_MAX_LIST_SIZE is still rejected pre-execution.)
    */
   statsHistory: VaultStatConnection;
 };

--- a/packages/sdk/types/graphql.v2.ts
+++ b/packages/sdk/types/graphql.v2.ts
@@ -331,6 +331,11 @@ export type ActivityFilter = {
   pickConfigId?: InputMaybe<Scalars['Bytes32']['input']>;
   /** Filter by activity timestamp in epoch seconds. */
   timestamp?: InputMaybe<IntRangeFilter>;
+  /**
+   * Restrict activity to a single position token. With `account`, predictions
+   * match only the side that minted this token; trades match exact token.
+   */
+  token?: InputMaybe<Scalars['Address']['input']>;
   /** Restrict to a subset of activity types. `[]` is a zero-result query. */
   types?: InputMaybe<Array<ActivityType>>;
 };

--- a/packages/sdk/types/graphql.v2.ts
+++ b/packages/sdk/types/graphql.v2.ts
@@ -2152,6 +2152,11 @@ export type Vault = Node & {
    * Time-series of this vault's economic snapshots, oldest-first (ascending
    * `timestamp`, matching `Account.statsHistory` — chart-ready, no consumer
    * re-sort). Backs the vault dashboard's TVL / PnL charts.
+   *
+   * `first` has no default on purpose: omitting it returns the whole bounded
+   * daily series in one page, so the chart loads in a single request instead of
+   * a chain of sequential paginated round-trips. (A literal `first` above
+   * GRAPHQL_MAX_LIST_SIZE is still rejected pre-execution.)
    */
   statsHistory: VaultStatConnection;
 };

--- a/packages/sdk/types/graphql.v2.ts
+++ b/packages/sdk/types/graphql.v2.ts
@@ -1347,7 +1347,7 @@ export type Protocol = {
    * Live, current protocol-wide stats — a single `ProtocolStat` with
    * `timestamp = now`. Volume / trade-count / open-interest reflect the
    * in-progress period and `totalValueLocked` is read across every configured
-   * vault at query time. Use `statsHistory` for the recorded daily series.
+   * vault at query time. Use `statsHistory` for the recorded snapshot series.
    */
   stats: ProtocolStat;
   /**
@@ -1355,6 +1355,16 @@ export type Protocol = {
    * volume / TVL / open-interest time-series charts. (Previously named
    * `stats`; renamed to `statsHistory` so `stats` can be the live singular,
    * matching the `Vault` access pattern.)
+   *
+   * Snapshots are recorded at a sub-daily cadence (configurable; ~4-hourly in
+   * production), so the raw series runs to thousands of rows. Pass `interval`
+   * to downsample server-side into fixed-width buckets — stock fields
+   * (`cumulative*`, `openInterest`, `escrowBalance`, `totalValueLocked`) take
+   * the bucket's last (latest) snapshot; flow fields (`periodVolume`,
+   * `periodTradeCount`) sum across the bucket; the node's `timestamp` is the
+   * bucket start. With no `interval` the raw per-snapshot series is returned.
+   * The default page (`first` omitted) fits the whole bucketed series in one
+   * request, so the analytics dashboard no longer paginates.
    */
   statsHistory: ProtocolStatConnection;
 };
@@ -1368,6 +1378,7 @@ export type ProtocolStatsHistoryArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   filter?: InputMaybe<ProtocolStatFilter>;
   first?: InputMaybe<Scalars['Int']['input']>;
+  interval?: InputMaybe<TimeInterval>;
 };
 
 /**


### PR DESCRIPTION
## Summary

Promotes the current `staging` branch to `main`. Net diff spans the API, app (frontend), and SDK packages. The substantive changes (by squash-merged PR):

- **#1884 — fix(market-keeper): migrate relist discovery to keyset pagination.** Replaces offset pagination in relist discovery with keyset pagination.
- **#1886 — perf(api): speed up `/analytics`.** Daily-bucket `Protocol.statsHistory` + memoize TVL / cross-family reads (downsampling).
- **#1888 — Add Singles Vault to vault tabs.**
- **#1889 — Scope position related activity by token.** Activity in the position dialog is now scoped by token alone.
- **#1890 — fix: use indexed vault account value for vaults AUM.** Vaults AUM uses the indexed vault account value; PnL chart loader tracks the vault-stats query rather than account value.

## Diff overview

```
20 files changed, 807 insertions(+), 106 deletions(-)
```

Touched areas: `packages/api` (Protocol/Activity resolvers + schema), `packages/app` (vaults page, position dialog, activity table, analytics hook), `packages/sdk` (protocol/vault queries + generated v2 types).

## Review

A thorough review of this diff follows in the PR comments.