### PR TITLE
feat(market-keeper): Discord alerts for balances + per-cron run summaries

### DIFF
--- a/packages/market-keeper/.env.example
+++ b/packages/market-keeper/.env.example
@@ -27,3 +27,14 @@ LLM_ENDTIME_SEARCH_ENABLED=true
 OPENROUTER_API_KEY=
 LLM_ENDTIME_MODEL=perplexity/sonar
 NODE_ENV=development
+
+# --- Keeper Discord alerts ---
+# Webhook for keeper alerts: balance heartbeat + per-cron run summaries.
+# Leave empty to disable all keeper Discord notifications.
+DISCORD_KEEPER_WEBHOOK=
+# Alert when OpenRouter credits fall below this many USD (default 10).
+OPENROUTER_MIN_CREDITS=10
+# Alert when the admin wallet's POL balance falls below this many POL (default 5).
+ADMIN_MIN_POL=5
+# Set to 1 to only post per-cron summaries on failure (reduces noise).
+KEEPER_SUMMARY_ON_FAILURE_ONLY=

--- a/packages/market-keeper/AGENTS.md
+++ b/packages/market-keeper/AGENTS.md
@@ -43,6 +43,15 @@ pnpm --filter @sapience/market-keeper start
 
 The `start` script orchestrates `refresh-metadata → generate → relist → prices-and-1d-7d-volume → refresh-volume → cleanup-polymarket → settle-polymarket/manual → settle-pyth`; `scripts/start.js` is the source of truth for ordering. Settlement script selection is chain-dependent — mainnet (`5064014`) runs `settle-polymarket`, testnet runs `settle-manual`.
 
+## Discord alerts
+
+Set `DISCORD_KEEPER_WEBHOOK` (in the keeper's env, not just the API's) to enable two notification flows; with it unset both are silent no-ops.
+
+- **Per-cron run summaries.** The cron runner (`scripts/lib/groups.js`) posts one embed per group run (discovery / metadata-tags / market-data / settlement) with each subservice's ✅/❌ status, duration, and counts. Counts come from subservices appending a JSON line via `emitStepSummary()` (`src/notify/summary.ts`) to the `KEEPER_SUMMARY_FILE` the runner provisions per run. Set `KEEPER_SUMMARY_ON_FAILURE_ONLY=1` to suppress success summaries.
+- **Balance heartbeat.** `pnpm start:status` (`scripts/keeper-status.ts`, run as its own cron, e.g. hourly) reports OpenRouter credits + admin-wallet POL, escalating to a LOW alert below `OPENROUTER_MIN_CREDITS` / `ADMIN_MIN_POL`.
+
+All notification logic lives in `src/notify/` (compiled to dist); the source-JS runner reaches it only through the single `dist/src/notify/report` entry point.
+
 ## Environment Variables
 
 - `ADMIN_PRIVATE_KEY` - Private key for API auth and settlements
@@ -51,6 +60,10 @@ The `start` script orchestrates `refresh-metadata → generate → relist → pr
 - `LLM_ENABLED` - Enable LLM enrichment (optional)
 - `OPENROUTER_API_KEY` - OpenRouter key if LLM enabled
 - `LLM_MODEL` - Model to use (default: openai/gpt-4o-mini)
+- `DISCORD_KEEPER_WEBHOOK` - Discord webhook for keeper alerts (heartbeat + run summaries); unset = disabled
+- `OPENROUTER_MIN_CREDITS` - LOW-alert threshold for OpenRouter USD credits (default 10)
+- `ADMIN_MIN_POL` - LOW-alert threshold for admin wallet POL (default 5)
+- `KEEPER_SUMMARY_ON_FAILURE_ONLY` - set to `1` to only post run summaries on failure
 
 ## Production Safety
 

--- a/packages/market-keeper/package.json
+++ b/packages/market-keeper/package.json
@@ -46,6 +46,8 @@
     "start:metadata-tags": "node scripts/cron-metadata-tags.js",
     "start:market-data": "node scripts/cron-market-data.js",
     "start:settlement": "node scripts/cron-settlement.js",
+    "start:status": "node scripts/cron-status.js",
+    "keeper-status": "tsx scripts/keeper-status.ts",
     "lint": "eslint src --quiet",
     "lint:fix": "eslint src --fix --quiet && pnpm format",
     "format": "prettier --write src scripts",

--- a/packages/market-keeper/scripts/cron-discovery.js
+++ b/packages/market-keeper/scripts/cron-discovery.js
@@ -4,4 +4,9 @@
  * generate → relist. Create-only — touches no existing tags, so it carries no
  * tag-write race and can run more often than the heavy metadata-tags sweep.
  */
-require('./lib/groups').runGroup('discovery');
+require('./lib/groups')
+  .runGroup('discovery')
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/market-keeper/scripts/cron-market-data.js
+++ b/packages/market-keeper/scripts/cron-market-data.js
@@ -4,4 +4,9 @@
  * Writes only price/volume fields (disjoint from tags), so it's safe to run
  * frequently and independently of the other crons.
  */
-require('./lib/groups').runGroup('market-data');
+require('./lib/groups')
+  .runGroup('market-data')
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/market-keeper/scripts/cron-metadata-tags.js
+++ b/packages/market-keeper/scripts/cron-metadata-tags.js
@@ -5,4 +5,9 @@
  * sequential group — never run them as separate overlapping crons or a
  * stale-read tag write can clobber the other's.
  */
-require('./lib/groups').runGroup('metadata-tags');
+require('./lib/groups')
+  .runGroup('metadata-tags')
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/market-keeper/scripts/cron-settlement.js
+++ b/packages/market-keeper/scripts/cron-settlement.js
@@ -4,4 +4,9 @@
  * Writes settlement state only; independent of the metadata/tag/market-data
  * crons, so a failure here can't block them.
  */
-require('./lib/groups').runGroup('settlement');
+require('./lib/groups')
+  .runGroup('settlement')
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/market-keeper/scripts/cron-status.js
+++ b/packages/market-keeper/scripts/cron-status.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+/**
+ * Status cron: balance heartbeat (OpenRouter credits + admin POL) to Discord.
+ * Standalone — reads only, writes nothing, so it can run on its own cadence
+ * (e.g. hourly) independent of the data/settlement crons.
+ */
+const { execSync } = require('child_process');
+
+execSync('node dist/scripts/keeper-status.js', { stdio: 'inherit' });

--- a/packages/market-keeper/scripts/keeper-status.ts
+++ b/packages/market-keeper/scripts/keeper-status.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Keeper heartbeat: reads the balances the keeper depends on and posts them to
+ * the Discord webhook (DISCORD_KEEPER_WEBHOOK), escalating to a LOW alert when
+ * a balance falls below its threshold.
+ *
+ *   - OpenRouter credits   (OPENROUTER_API_KEY)
+ *   - Admin wallet POL     (POLYGON_RPC_URL + ADMIN_PRIVATE_KEY)
+ *
+ * Intended to run as its own Railway cron (e.g. hourly): `pnpm start:status`.
+ *
+ * Thresholds (USD credits / POL):
+ *   OPENROUTER_MIN_CREDITS   default 10
+ *   ADMIN_MIN_POL            default 5
+ */
+import 'dotenv/config';
+import {
+  fetchOpenRouterBalance,
+  fetchPolBalance,
+  classifyBalances,
+} from '../src/notify/balances.js';
+import { buildHeartbeatEmbed } from '../src/notify/embeds.js';
+import { postKeeperEmbeds } from '../src/notify/discord.js';
+import { log, logError, logSeparator } from '../src/utils/log.js';
+import type { BalanceReport } from '../src/notify/types.js';
+
+const DEFAULT_OPENROUTER_MIN_CREDITS = 10;
+const DEFAULT_ADMIN_MIN_POL = 5;
+
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+function numEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === '') return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+async function main(): Promise<void> {
+  const report: BalanceReport = {};
+
+  const openrouterKey = process.env.OPENROUTER_API_KEY;
+  if (openrouterKey) {
+    try {
+      report.openrouter = await fetchOpenRouterBalance(openrouterKey);
+    } catch (e) {
+      report.openrouterError = errMsg(e);
+      logError(
+        '[keeper-status] OpenRouter balance failed:',
+        report.openrouterError
+      );
+    }
+  } else {
+    report.openrouterError = 'OPENROUTER_API_KEY not set';
+  }
+
+  const rpcUrl = process.env.POLYGON_RPC_URL;
+  const adminKey = process.env.ADMIN_PRIVATE_KEY;
+  if (rpcUrl && adminKey) {
+    try {
+      report.pol = await fetchPolBalance(rpcUrl, adminKey);
+    } catch (e) {
+      report.polError = errMsg(e);
+      logError('[keeper-status] POL balance failed:', report.polError);
+    }
+  } else {
+    report.polError = 'POLYGON_RPC_URL or ADMIN_PRIVATE_KEY not set';
+  }
+
+  const thresholds = {
+    openrouterMinCredits: numEnv(
+      'OPENROUTER_MIN_CREDITS',
+      DEFAULT_OPENROUTER_MIN_CREDITS
+    ),
+    adminMinPol: numEnv('ADMIN_MIN_POL', DEFAULT_ADMIN_MIN_POL),
+  };
+  const cls = classifyBalances(report, thresholds);
+
+  log(
+    `[keeper-status] OpenRouter remaining: ${
+      report.openrouter
+        ? `$${report.openrouter.remaining.toFixed(2)}`
+        : report.openrouterError
+    }`
+  );
+  log(
+    `[keeper-status] Admin POL: ${
+      report.pol ? report.pol.pol.toFixed(3) : report.polError
+    }`
+  );
+  if (cls.anyLow) {
+    logError(
+      `[keeper-status] LOW BALANCE: openrouterLow=${cls.openrouterLow} polLow=${cls.polLow}`
+    );
+  }
+
+  await postKeeperEmbeds([buildHeartbeatEmbed(report, cls)]);
+}
+
+logSeparator('keeper-status', 'START');
+main()
+  .catch((e) => {
+    logError('[keeper-status] fatal:', errMsg(e));
+    process.exit(1);
+  })
+  .finally(() => logSeparator('keeper-status', 'END'));

--- a/packages/market-keeper/scripts/lib/groups.js
+++ b/packages/market-keeper/scripts/lib/groups.js
@@ -20,8 +20,23 @@
  * non-zero, so Railway's on_failure restart policy retries it. Cross-concern
  * isolation comes from running each group as its OWN Railway cron, not from
  * swallowing errors here — a broken settle cron can't block the tag cron.
+ *
+ * Reporting: each step process appends a structured summary to the file named
+ * by KEEPER_SUMMARY_FILE (see src/notify/summary.ts). After the group runs we
+ * read those summaries back and POST one aggregated embed to the keeper Discord
+ * webhook (DISCORD_KEEPER_WEBHOOK). This is the only place the source-JS
+ * orchestration layer reaches into compiled code, via the single
+ * dist/src/notify/report entry point.
  */
+// Load .env so the runner itself (which posts the Discord summary) sees
+// DISCORD_KEEPER_WEBHOOK locally. dotenv does not override already-set vars, so
+// Railway-injected env still wins in production. The subservices load their own
+// dotenv when they run; this is only for the orchestrator's own env reads.
+require('dotenv/config');
 const { execSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 
 // Chain-dependent settlement entrypoint, matching the original start.js branch.
 const settleCmd =
@@ -53,14 +68,100 @@ const GROUPS = {
 // metadata + tags → market data → settle.
 const ORDER = ['discovery', 'metadata-tags', 'market-data', 'settlement'];
 
-/** Run one group's steps sequentially, fail-fast (throws on first failure). */
-function runGroup(name) {
+// Lazily-required so a missing/stale dist build degrades to "no Discord report"
+// instead of crashing the runner. Returns null if dist isn't built yet.
+function loadReporter() {
+  try {
+    return require('../../dist/src/notify/report');
+  } catch (err) {
+    console.error(
+      '[keeper] Discord reporter unavailable (dist not built?):',
+      err && err.message ? err.message : err
+    );
+    return null;
+  }
+}
+
+/**
+ * Run one group's steps sequentially, fail-fast. Captures each step's
+ * pass/fail, duration, and emitted summary, posts an aggregated Discord
+ * report, then re-throws on failure to preserve the non-zero exit code.
+ */
+async function runGroup(name) {
   const steps = GROUPS[name];
   if (!steps) throw new Error(`Unknown keeper cron group: ${name}`);
+
+  const reporter = loadReporter();
+  const summaryFile = path.join(
+    os.tmpdir(),
+    `keeper-summary-${name}-${process.pid}-${Date.now()}.jsonl`
+  );
+  try {
+    fs.writeFileSync(summaryFile, '');
+  } catch {
+    // if we can't create the file, steps just won't emit; carry on
+  }
+
+  const runs = [];
+  let failure = null;
+  let consumed = 0;
+
   for (const [label, cmd] of steps) {
     console.log(`[keeper:${name}] ▶ ${label}`);
-    execSync(cmd, { stdio: 'inherit' });
+    const start = Date.now();
+    let status = 'ok';
+    let error;
+    try {
+      execSync(cmd, {
+        stdio: 'inherit',
+        env: { ...process.env, KEEPER_SUMMARY_FILE: summaryFile },
+      });
+    } catch (err) {
+      status = 'failed';
+      error = err && err.message ? err.message : String(err);
+      failure = err;
+    }
+    const durationMs = Date.now() - start;
+
+    let summaries = [];
+    if (reporter) {
+      const all = reporter.readStepSummaries(summaryFile);
+      summaries = all.slice(consumed);
+      consumed = all.length;
+    }
+    runs.push({ label, status, durationMs, summaries, error });
+
+    if (failure) break;
   }
+
+  // Mark steps that never ran (aborted by fail-fast) as skipped.
+  if (failure) {
+    const ranLabels = new Set(runs.map((r) => r.label));
+    for (const [label] of steps) {
+      if (!ranLabels.has(label)) {
+        runs.push({ label, status: 'skipped', durationMs: 0, summaries: [] });
+      }
+    }
+  }
+
+  if (reporter) {
+    try {
+      await reporter.postGroupReport({ group: name, runs });
+    } catch (err) {
+      console.error(
+        '[keeper] Failed to post Discord summary:',
+        err && err.message ? err.message : err
+      );
+    }
+  }
+
+  try {
+    fs.unlinkSync(summaryFile);
+  } catch {
+    // ignore cleanup failure
+  }
+
+  if (failure) throw failure; // preserve fail-fast / non-zero exit
 }
 
 module.exports = { GROUPS, ORDER, runGroup };

--- a/packages/market-keeper/scripts/settle-manual.ts
+++ b/packages/market-keeper/scripts/settle-manual.ts
@@ -50,6 +50,7 @@ import { privateKeyToAccount } from 'viem/accounts';
 import { polygon } from 'viem/chains';
 import { fetchWithRetry } from '../src/utils/fetch.js';
 import { logSeparator } from '../src/utils/log.js';
+import { emitStepSummary } from '../src/notify/summary.js';
 import {
   manualConditionResolver,
   conditionalTokensReader,
@@ -782,6 +783,18 @@ async function main() {
     console.log(`  Settled (tx sent):   ${totals.settled}`);
     console.log(`  Not resolved:        ${totals.notResolved}`);
     console.log(`  Errors:              ${totals.errors}`);
+
+    emitStepSummary({
+      step: 'settle-manual',
+      dryRun: options.dryRun,
+      metrics: {
+        total: totals.total,
+        alreadySettled: totals.alreadySettled,
+        settled: totals.settled,
+        notResolved: totals.notResolved,
+        errors: totals.errors,
+      },
+    });
   } catch (error) {
     console.error('Error:', error);
     process.exit(1);

--- a/packages/market-keeper/scripts/settle-polymarket.ts
+++ b/packages/market-keeper/scripts/settle-polymarket.ts
@@ -54,6 +54,7 @@ import {
 } from '../src/polygon/client.js';
 import { fetchWithRetry } from '../src/utils/fetch.js';
 import { confirmProductionAccess } from '../src/utils/index.js';
+import { emitStepSummary } from '../src/notify/summary.js';
 
 // ============ Constants ============
 
@@ -703,6 +704,19 @@ async function main() {
     console.log(`  Settled (tx sent):   ${totals.settled}`);
     console.log(`  Skipped:             ${totals.skipped}`);
     console.log(`  Errors:              ${totals.errors}`);
+
+    emitStepSummary({
+      step: 'settle-polymarket',
+      dryRun: options.dryRun,
+      metrics: {
+        total: totals.total,
+        alreadyResolved: totals.alreadyResolved,
+        canResolve: totals.canResolve,
+        settled: totals.settled,
+        skipped: totals.skipped,
+        errors: totals.errors,
+      },
+    });
   } catch (error) {
     console.error('Error:', error);
     process.exit(1);

--- a/packages/market-keeper/scripts/settle-pyth.ts
+++ b/packages/market-keeper/scripts/settle-pyth.ts
@@ -56,6 +56,7 @@ import { getChainConfig } from '@sapience/sdk/constants';
 import { fetchWithRetry } from '../src/utils/fetch.js';
 import { confirmProductionAccess } from '../src/utils/index.js';
 import { logSeparator } from '../src/utils/log.js';
+import { emitStepSummary } from '../src/notify/summary.js';
 import {
   decodeFeedIdFromPriceId,
   extractEvmBlobFromJson,
@@ -745,6 +746,12 @@ async function main() {
   console.log(`Submitted:   ${submitted}`);
   console.log(`Skipped:     ${skipped}`);
   console.log(`Errors:      ${errors}`);
+
+  emitStepSummary({
+    step: 'settle-pyth',
+    dryRun: options.dryRun,
+    metrics: { attempted, submitted, skipped, errors },
+  });
 }
 
 // Run

--- a/packages/market-keeper/scripts/start.js
+++ b/packages/market-keeper/scripts/start.js
@@ -14,4 +14,9 @@
  */
 const { ORDER, runGroup } = require('./lib/groups');
 
-for (const name of ORDER) runGroup(name);
+(async () => {
+  for (const name of ORDER) await runGroup(name);
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/market-keeper/src/__tests__/decide-endtime.test.ts
+++ b/packages/market-keeper/src/__tests__/decide-endtime.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { decideEndTime, toUnixTimestamp } from '../generate/api';
+import { gameEndTime } from '../generate/extractors/sports/game';
 import type { SapienceCondition } from '../types';
 
 function makeCondition(
@@ -48,6 +49,25 @@ describe('decideEndTime', () => {
       const { ts, source } = decideEndTime(c);
       expect(ts).toBe(expected);
       expect(source).toBe('game');
+    });
+
+    it('declines the game rung when there is no recognized sports league (S&P index market with a Polymarket gameStartTime)', () => {
+      // Polymarket stamps some non-sports markets (e.g. S&P 500 index price
+      // markets) with a gameStartTime but no sports league. The game rung must
+      // decline so the cascade falls through to category/LLM/regex/PM instead
+      // of inventing a default "game duration" endTime. Regression for the SPY
+      // "Will S&P 500 hit (LOW) $740" market that logged source: game.
+      const c = makeCondition({
+        question: 'Will S&P 500 (SPY) hit (LOW) $740 Week of June 15?',
+        gameStartTime: '2026-06-14 21:00:00+00',
+        league: undefined,
+        endDate: '2026-06-19T16:00:00Z',
+        isTemplated: true,
+      });
+      const { ts, source } = decideEndTime(c);
+      expect(source).not.toBe('game');
+      expect(source).toBe('pm-fallback');
+      expect(ts).toBe(toUnixTimestamp('2026-06-19T16:00:00Z') + 86_400);
     });
 
     it('categoryEndTime wins over LLM, regex, and PM endDate', () => {
@@ -151,6 +171,22 @@ describe('decideEndTime', () => {
       expect(decideEndTime(c).ts).toBe(pmTs + 86_400);
       expect(decideEndTime(c).ts).not.toBe(pmTs); // not raw
       expect(decideEndTime(c).ts).not.toBe(pmTs + 14400); // not legacy 4h
+    });
+  });
+
+  // The game rung is sports-only: it fires off a recognized league's
+  // calibrated duration, and declines (returns null) when Polymarket attaches
+  // a gameStartTime to a non-sports market (no league).
+  describe('gameEndTime league gating', () => {
+    it('returns the calibrated end for a recognized sports league', () => {
+      expect(gameEndTime('2099-04-01 00:00:00+00', 'nba')).toBe(
+        toUnixTimestamp('2099-04-01T03:29:00Z') // +209m
+      );
+    });
+
+    it('declines a gameStartTime without a recognized league', () => {
+      expect(gameEndTime('2026-06-14 21:00:00+00', undefined)).toBeNull();
+      expect(gameEndTime('2026-06-14 21:00:00+00', null)).toBeNull();
     });
   });
 

--- a/packages/market-keeper/src/cleanup/index.ts
+++ b/packages/market-keeper/src/cleanup/index.ts
@@ -20,6 +20,7 @@ import {
 } from '../polygon/client';
 import { batchCheckGammaResolution } from '../polymarket-api';
 import { validatePrivateKey, confirmProductionAccess, log } from '../utils';
+import { emitStepSummary } from '../notify/summary';
 import {
   fetchNoEngagementConditions,
   privateConditions,
@@ -284,4 +285,16 @@ export async function main(): Promise<void> {
   log(`Skipped (active on Gamma):   ${results.skippedActive}`);
   log(`Skipped (not resolved):      ${results.skippedUnresolved}`);
   log(`Errors:                      ${results.errors}`);
+
+  emitStepSummary({
+    step: 'cleanup-polymarket',
+    dryRun: options.dryRun,
+    metrics: {
+      total: results.total,
+      resolved: results.resolved,
+      privated: results.privated,
+      skipped: results.skippedActive + results.skippedUnresolved,
+      errors: results.errors,
+    },
+  });
 }

--- a/packages/market-keeper/src/generate/api.ts
+++ b/packages/market-keeper/src/generate/api.ts
@@ -664,6 +664,18 @@ export async function submitGroupMetadataUpdates(
   console.log(`[Metadata] ${updated} groups updated, ${failed} failed`);
 }
 
+/** Outcome counts from a submitToAPI run, surfaced for run reporting. */
+export interface SubmitResult {
+  /** Conditions submitted (after filters). */
+  conditions: number;
+  created: number;
+  skipped: number;
+  failed: number;
+  uniqueGroups: number;
+  cryptoGroupsSkipped: number;
+  cryptoConditionsSkipped: number;
+}
+
 /**
  * Submit all condition groups and conditions to the API
  */
@@ -671,7 +683,7 @@ export async function submitToAPI(
   apiUrl: string,
   privateKey: `0x${string}`,
   data: SapienceOutput
-): Promise<void> {
+): Promise<SubmitResult> {
   console.log(`Submitting to API: ${apiUrl}`);
 
   // Apply API filters pipeline
@@ -709,7 +721,15 @@ export async function submitToAPI(
 
   if (allConditions.length === 0) {
     console.log('[API] No conditions to submit');
-    return;
+    return {
+      conditions: 0,
+      created: 0,
+      skipped: 0,
+      failed: 0,
+      uniqueGroups: 0,
+      cryptoGroupsSkipped,
+      cryptoConditionsSkipped,
+    };
   }
 
   // Build batch payloads
@@ -860,4 +880,14 @@ export async function submitToAPI(
       `Crypto skipped: ${cryptoGroupsSkipped} groups, ${cryptoConditionsSkipped} conditions`
     );
   }
+
+  return {
+    conditions: payloads.length,
+    created: totalCreated,
+    skipped: totalSkipped,
+    failed: totalFailed,
+    uniqueGroups,
+    cryptoGroupsSkipped,
+    cryptoConditionsSkipped,
+  };
 }

--- a/packages/market-keeper/src/generate/extractors/sports/game.ts
+++ b/packages/market-keeper/src/generate/extractors/sports/game.ts
@@ -35,8 +35,6 @@ export const LEAGUE_DURATION_MIN: Record<string, number> = {
 /** League tags (also the fetch list). */
 export const SPORT_LEAGUES = Object.keys(LEAGUE_DURATION_MIN);
 
-const DEFAULT_MIN = 210;
-
 /** Normalize "2026-06-10 19:45:00+00" (or ISO) to epoch ms, or null. */
 function parseGameStart(gst: string): number | null {
   const iso = gst.replace(' ', 'T').replace(/\+00$/, 'Z');
@@ -46,17 +44,22 @@ function parseGameStart(gst: string): number | null {
 
 /**
  * Resolution time (unix SECONDS) for a game market = gameStartTime + the
- * per-league median duration. Returns null when there's no gameStartTime (e.g.
- * unscheduled match, or a futures/championship market) so callers fall back.
+ * per-league median duration.
+ *
+ * Sports-only: returns null when there's no gameStartTime (e.g. unscheduled
+ * match, or a futures/championship market) AND when there's no recognized
+ * sports league — Polymarket attaches a gameStartTime to some non-sports
+ * markets (e.g. S&P 500 index price markets), and the game rung must decline
+ * those so the cascade falls through instead of inventing a default duration.
  */
 export function gameEndTime(
   gameStartTime: string | null | undefined,
   league: string | null | undefined
 ): number | null {
   if (!gameStartTime) return null;
+  const mins = league ? LEAGUE_DURATION_MIN[league] : undefined;
+  if (mins == null) return null;
   const start = parseGameStart(gameStartTime);
   if (start == null) return null;
-  const mins =
-    (league ? LEAGUE_DURATION_MIN[league] : undefined) ?? DEFAULT_MIN;
   return toSec(start + mins * 60_000);
 }

--- a/packages/market-keeper/src/generate/index.ts
+++ b/packages/market-keeper/src/generate/index.ts
@@ -8,6 +8,7 @@ import { validatePrivateKey, confirmProductionAccess } from '../utils';
 import { fetchEndingSoonestMarkets } from './market';
 import { groupMarkets, exportJSON } from './grouping';
 import { printDryRun, submitToAPI } from './api';
+import { emitStepSummary } from '../notify/summary';
 
 // ============ CLI Arguments ============
 
@@ -94,12 +95,39 @@ export async function main() {
     // Dry run mode - just print what would be submitted
     if (options.dryRun) {
       printDryRun(sapienceData);
+      emitStepSummary({
+        step: 'generate',
+        dryRun: true,
+        metrics: {
+          conditions: sapienceData.metadata.totalConditions,
+          groups: sapienceData.metadata.totalGroups,
+        },
+      });
       return;
     }
 
     // Submit to API if credentials are available
     if (hasAPICredentials && apiUrl && privateKey) {
-      await submitToAPI(apiUrl, privateKey, sapienceData);
+      const result = await submitToAPI(apiUrl, privateKey, sapienceData);
+      emitStepSummary({
+        step: 'generate',
+        metrics: {
+          conditions: result.conditions,
+          created: result.created,
+          skipped: result.skipped,
+          failed: result.failed,
+          groups: result.uniqueGroups,
+        },
+      });
+    } else {
+      emitStepSummary({
+        step: 'generate',
+        note: 'no API credentials',
+        metrics: {
+          conditions: sapienceData.metadata.totalConditions,
+          groups: sapienceData.metadata.totalGroups,
+        },
+      });
     }
   } catch (error) {
     console.error('Error:', error);

--- a/packages/market-keeper/src/notify/balances.test.ts
+++ b/packages/market-keeper/src/notify/balances.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { classifyBalances } from './balances';
+import type { BalanceReport, BalanceThresholds } from './types';
+
+const thresholds: BalanceThresholds = {
+  openrouterMinCredits: 10,
+  adminMinPol: 5,
+};
+
+describe('classifyBalances', () => {
+  it('flags OpenRouter low when remaining is below threshold', () => {
+    const report: BalanceReport = {
+      openrouter: { remaining: 1.62, totalCredits: 360, totalUsage: 358.38 },
+      pol: { address: '0xabc', pol: 12 },
+    };
+    const cls = classifyBalances(report, thresholds);
+    expect(cls.openrouterLow).toBe(true);
+    expect(cls.polLow).toBe(false);
+    expect(cls.anyLow).toBe(true);
+  });
+
+  it('flags POL low when balance is below threshold', () => {
+    const report: BalanceReport = {
+      openrouter: { remaining: 100, totalCredits: 200, totalUsage: 100 },
+      pol: { address: '0xabc', pol: 0.4 },
+    };
+    const cls = classifyBalances(report, thresholds);
+    expect(cls.openrouterLow).toBe(false);
+    expect(cls.polLow).toBe(true);
+    expect(cls.anyLow).toBe(true);
+  });
+
+  it('reports all-ok when both are above threshold', () => {
+    const report: BalanceReport = {
+      openrouter: { remaining: 50, totalCredits: 100, totalUsage: 50 },
+      pol: { address: '0xabc', pol: 20 },
+    };
+    expect(classifyBalances(report, thresholds)).toEqual({
+      openrouterLow: false,
+      polLow: false,
+      anyLow: false,
+    });
+  });
+
+  it('treats a missing balance (fetch error) as not-low', () => {
+    const report: BalanceReport = {
+      openrouterError: 'HTTP 500',
+      polError: 'rpc down',
+    };
+    expect(classifyBalances(report, thresholds)).toEqual({
+      openrouterLow: false,
+      polLow: false,
+      anyLow: false,
+    });
+  });
+
+  it('uses strict less-than at the threshold boundary', () => {
+    const report: BalanceReport = {
+      openrouter: { remaining: 10, totalCredits: 10, totalUsage: 0 },
+      pol: { address: '0xabc', pol: 5 },
+    };
+    const cls = classifyBalances(report, thresholds);
+    expect(cls.openrouterLow).toBe(false);
+    expect(cls.polLow).toBe(false);
+  });
+});

--- a/packages/market-keeper/src/notify/balances.ts
+++ b/packages/market-keeper/src/notify/balances.ts
@@ -1,0 +1,118 @@
+/**
+ * Balance lookups + threshold classification for the keeper heartbeat.
+ *
+ *  - OpenRouter credits via the public credits/key endpoints
+ *  - Admin wallet POL balance on Polygon (the wallet that pays LayerZero/POL
+ *    fees for resolution requests), derived from ADMIN_PRIVATE_KEY
+ */
+import {
+  createPublicClient,
+  http,
+  formatEther,
+  type Hex,
+  type PublicClient,
+} from 'viem';
+import { polygon } from 'viem/chains';
+import { privateKeyToAccount } from 'viem/accounts';
+import type {
+  OpenRouterBalance,
+  PolBalance,
+  BalanceReport,
+  BalanceThresholds,
+  BalanceClassification,
+} from './types';
+
+const OPENROUTER_CREDITS_URL = 'https://openrouter.ai/api/v1/credits';
+const OPENROUTER_KEY_URL = 'https://openrouter.ai/api/v1/key';
+const FETCH_TIMEOUT_MS = 10_000;
+
+function numberOrUndefined(v: unknown): number | undefined {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/**
+ * Fetch OpenRouter credit balance.
+ *
+ * `/api/v1/credits` returns `{ data: { total_credits, total_usage } }`; the
+ * remaining balance is `total_credits - total_usage`. We additionally pull
+ * burn-rate context (daily/weekly/monthly usage) from `/api/v1/key` on a
+ * best-effort basis — a failure there does not fail the call.
+ */
+export async function fetchOpenRouterBalance(
+  apiKey: string
+): Promise<OpenRouterBalance> {
+  const headers = { Authorization: `Bearer ${apiKey}` };
+
+  const creditsRes = await fetch(OPENROUTER_CREDITS_URL, {
+    headers,
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!creditsRes.ok) {
+    throw new Error(`OpenRouter /credits HTTP ${creditsRes.status}`);
+  }
+  const creditsJson = (await creditsRes.json()) as {
+    data?: { total_credits?: number; total_usage?: number };
+  };
+  const totalCredits = Number(creditsJson?.data?.total_credits ?? 0);
+  const totalUsage = Number(creditsJson?.data?.total_usage ?? 0);
+
+  const balance: OpenRouterBalance = {
+    totalCredits,
+    totalUsage,
+    remaining: totalCredits - totalUsage,
+  };
+
+  try {
+    const keyRes = await fetch(OPENROUTER_KEY_URL, {
+      headers,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (keyRes.ok) {
+      const keyJson = (await keyRes.json()) as {
+        data?: {
+          usage_daily?: number;
+          usage_weekly?: number;
+          usage_monthly?: number;
+        };
+      };
+      const d = keyJson?.data ?? {};
+      balance.usageDaily = numberOrUndefined(d.usage_daily);
+      balance.usageWeekly = numberOrUndefined(d.usage_weekly);
+      balance.usageMonthly = numberOrUndefined(d.usage_monthly);
+    }
+  } catch {
+    // burn-rate enrichment is optional
+  }
+
+  return balance;
+}
+
+/** Read the admin wallet's native POL balance on Polygon. */
+export async function fetchPolBalance(
+  rpcUrl: string,
+  privateKey: string
+): Promise<PolBalance> {
+  const formattedKey = privateKey.startsWith('0x')
+    ? privateKey
+    : `0x${privateKey}`;
+  const account = privateKeyToAccount(formattedKey as Hex);
+  const client: PublicClient = createPublicClient({
+    chain: polygon,
+    transport: http(rpcUrl),
+  });
+  const wei = await client.getBalance({ address: account.address });
+  return { address: account.address, pol: Number(formatEther(wei)) };
+}
+
+/** Pure threshold check: which tracked balances are below their minimum. */
+export function classifyBalances(
+  report: BalanceReport,
+  thresholds: BalanceThresholds
+): BalanceClassification {
+  const openrouterLow = report.openrouter
+    ? report.openrouter.remaining < thresholds.openrouterMinCredits
+    : false;
+  const polLow = report.pol ? report.pol.pol < thresholds.adminMinPol : false;
+  return { openrouterLow, polLow, anyLow: openrouterLow || polLow };
+}

--- a/packages/market-keeper/src/notify/discord.ts
+++ b/packages/market-keeper/src/notify/discord.ts
@@ -1,0 +1,55 @@
+/**
+ * Send embeds to the keeper Discord webhook (DISCORD_KEEPER_WEBHOOK).
+ *
+ * Unlike the indexer's fire-and-forget alerts, these calls are awaited: the
+ * keeper subservices/runner are short-lived processes that exit immediately
+ * after posting, so we must let the request finish (≤5s) before the process
+ * dies. The call still never throws.
+ */
+import { log, logError } from '../utils/log';
+
+const WEBHOOK_PREFIX = 'https://discord.com/api/webhooks/';
+const TIMEOUT_MS = 5_000;
+
+/** Resolve + validate the configured webhook URL, or null when unusable. */
+export function getKeeperWebhook(): string | null {
+  const url = (process.env.DISCORD_KEEPER_WEBHOOK || '').trim();
+  if (!url) return null;
+  if (!url.startsWith(WEBHOOK_PREFIX)) {
+    logError(
+      `[keeperDiscord] Ignoring invalid DISCORD_KEEPER_WEBHOOK (must start with ${WEBHOOK_PREFIX})`
+    );
+    return null;
+  }
+  return url;
+}
+
+/** POST embeds to the keeper webhook. Awaits delivery (≤5s). Never throws. */
+export async function postKeeperEmbeds(embeds: object[]): Promise<void> {
+  const url = getKeeperWebhook();
+  if (!url) {
+    log('[keeperDiscord] DISCORD_KEEPER_WEBHOOK not set — skipping post');
+    return;
+  }
+  if (embeds.length === 0) return;
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ embeds }),
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      logError(
+        `[keeperDiscord] Webhook HTTP ${res.status}: ${body.slice(0, 200)}`
+      );
+    }
+  } catch (err) {
+    logError(
+      '[keeperDiscord] Webhook failed:',
+      err instanceof Error ? err.message : err
+    );
+  }
+}

--- a/packages/market-keeper/src/notify/embeds.test.ts
+++ b/packages/market-keeper/src/notify/embeds.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { buildGroupEmbed, buildHeartbeatEmbed, formatDuration } from './embeds';
+import type { StepRun, BalanceReport, BalanceClassification } from './types';
+
+describe('formatDuration', () => {
+  it('formats sub-second, seconds, and minutes', () => {
+    expect(formatDuration(450)).toBe('450ms');
+    expect(formatDuration(2500)).toBe('2.5s');
+    expect(formatDuration(125000)).toBe('2m5s');
+  });
+});
+
+describe('buildGroupEmbed', () => {
+  it('builds a green success embed with per-step metrics', () => {
+    const runs: StepRun[] = [
+      {
+        label: 'generate',
+        status: 'ok',
+        durationMs: 3200,
+        summaries: [{ step: 'generate', metrics: { created: 4, skipped: 1 } }],
+      },
+      {
+        label: 'relist',
+        status: 'ok',
+        durationMs: 1500,
+        summaries: [{ step: 'relist', metrics: { new: 2 } }],
+      },
+    ];
+    const embed = buildGroupEmbed('discovery', runs) as Record<string, unknown>;
+    expect(embed.title).toBe('✅ Keeper · discovery');
+    expect(embed.color).toBe(0x22c55e);
+    const desc = embed.description as string;
+    expect(desc).toContain('✅ **generate**');
+    expect(desc).toContain('created=4');
+    expect(desc).toContain('skipped=1');
+    expect(desc).toContain('✅ **relist**');
+    expect(desc).toContain('new=2');
+  });
+
+  it('builds a red embed on failure and marks later steps skipped', () => {
+    const runs: StepRun[] = [
+      {
+        label: 'cleanup-polymarket',
+        status: 'ok',
+        durationMs: 1000,
+        summaries: [],
+      },
+      {
+        label: 'settle',
+        status: 'failed',
+        durationMs: 800,
+        summaries: [],
+        error: 'POLYGON_RPC_URL timeout',
+      },
+      { label: 'settle-pyth', status: 'skipped', durationMs: 0, summaries: [] },
+    ];
+    const embed = buildGroupEmbed('settlement', runs) as Record<
+      string,
+      unknown
+    >;
+    expect(embed.title).toBe('❌ Keeper · settlement');
+    expect(embed.color).toBe(0xef4444);
+    const desc = embed.description as string;
+    expect(desc).toContain('❌ **settle**');
+    expect(desc).toContain('POLYGON_RPC_URL timeout');
+    expect(desc).toContain('⏭️ **settle-pyth**');
+  });
+
+  it('tags dry-run steps', () => {
+    const runs: StepRun[] = [
+      {
+        label: 'relist',
+        status: 'ok',
+        durationMs: 500,
+        summaries: [{ step: 'relist', metrics: { new: 0 }, dryRun: true }],
+      },
+    ];
+    const desc = (buildGroupEmbed('discovery', runs) as { description: string })
+      .description;
+    expect(desc).toContain('_[dry-run]_');
+  });
+});
+
+describe('buildHeartbeatEmbed', () => {
+  const ok: BalanceClassification = {
+    openrouterLow: false,
+    polLow: false,
+    anyLow: false,
+  };
+
+  it('renders a blue heartbeat with balances when all ok', () => {
+    const report: BalanceReport = {
+      openrouter: {
+        remaining: 50,
+        totalCredits: 100,
+        totalUsage: 50,
+        usageDaily: 7.11,
+      },
+      pol: { address: '0xADMIN', pol: 12.345 },
+    };
+    const embed = buildHeartbeatEmbed(report, ok) as Record<string, unknown>;
+    expect(embed.title).toBe('💓 Keeper heartbeat');
+    expect(embed.color).toBe(0x3b82f6);
+    const fields = embed.fields as Array<{ name: string; value: string }>;
+    expect(fields[0].value).toContain('$50.00 remaining');
+    expect(fields[0].value).toContain('~$7.11/day');
+    expect(fields[1].value).toContain('12.345 POL');
+    expect(fields[1].value).toContain('0xADMIN');
+  });
+
+  it('renders an amber LOW alert with warning markers', () => {
+    const report: BalanceReport = {
+      openrouter: { remaining: 1.62, totalCredits: 360, totalUsage: 358.38 },
+      pol: { address: '0xADMIN', pol: 0.5 },
+    };
+    const cls: BalanceClassification = {
+      openrouterLow: true,
+      polLow: true,
+      anyLow: true,
+    };
+    const embed = buildHeartbeatEmbed(report, cls) as Record<string, unknown>;
+    expect(embed.title).toBe('⚠️ Keeper balances LOW');
+    expect(embed.color).toBe(0xf59e0b);
+    const fields = embed.fields as Array<{ name: string; value: string }>;
+    expect(fields[0].name).toContain('⚠️');
+    expect(fields[1].name).toContain('⚠️');
+  });
+
+  it('surfaces fetch errors as a red embed', () => {
+    const report: BalanceReport = {
+      openrouterError: 'HTTP 401',
+      polError: 'rpc down',
+    };
+    const embed = buildHeartbeatEmbed(report, ok) as Record<string, unknown>;
+    expect(embed.color).toBe(0xef4444);
+    const fields = embed.fields as Array<{ value: string }>;
+    expect(fields[0].value).toContain('HTTP 401');
+    expect(fields[1].value).toContain('rpc down');
+  });
+});

--- a/packages/market-keeper/src/notify/embeds.ts
+++ b/packages/market-keeper/src/notify/embeds.ts
@@ -1,0 +1,117 @@
+/**
+ * Pure Discord embed builders for keeper notifications. No I/O here so these
+ * stay trivially unit-testable; the network send lives in ./discord.
+ */
+import type {
+  StepRun,
+  StepSummary,
+  BalanceReport,
+  BalanceClassification,
+} from './types';
+
+const COLOR_OK = 0x22c55e; // green
+const COLOR_FAIL = 0xef4444; // red
+const COLOR_INFO = 0x3b82f6; // blue
+const COLOR_WARN = 0xf59e0b; // amber
+
+const STATUS_ICON: Record<string, string> = {
+  ok: '✅',
+  failed: '❌',
+  skipped: '⏭️',
+};
+
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  const rem = Math.round(s % 60);
+  return `${m}m${rem}s`;
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, max - 1)}…`;
+}
+
+/** Render a step's emitted metrics as `key=value` pieces joined with spaces. */
+function formatMetrics(summaries: StepSummary[]): string {
+  const parts: string[] = [];
+  for (const s of summaries) {
+    if (!s.metrics) continue;
+    for (const [k, v] of Object.entries(s.metrics)) {
+      parts.push(`${k}=${v}`);
+    }
+  }
+  return parts.join(' ');
+}
+
+/** Build a single embed summarizing one cron group's run. */
+export function buildGroupEmbed(group: string, runs: StepRun[]): object {
+  const failed = runs.some((r) => r.status === 'failed');
+
+  const lines = runs.map((r) => {
+    const icon = STATUS_ICON[r.status] ?? '•';
+    const dur =
+      r.status === 'skipped' ? '' : ` (${formatDuration(r.durationMs)})`;
+    const dry = r.summaries.some((s) => s.dryRun) ? ' _[dry-run]_' : '';
+    const metrics = formatMetrics(r.summaries);
+    const metricsPart = metrics ? ` — ${metrics}` : '';
+    const errPart = r.error ? ` — ${truncate(r.error, 140)}` : '';
+    return `${icon} **${r.label}**${dur}${dry}${metricsPart}${errPart}`;
+  });
+
+  return {
+    title: `${failed ? '❌' : '✅'} Keeper · ${group}`,
+    color: failed ? COLOR_FAIL : COLOR_OK,
+    description: lines.join('\n') || '_no steps_',
+    timestamp: new Date().toISOString(),
+  };
+}
+
+/** Build the balance heartbeat embed (also serves as the low-balance alert). */
+export function buildHeartbeatEmbed(
+  report: BalanceReport,
+  cls: BalanceClassification
+): object {
+  const fields: Array<{ name: string; value: string; inline: boolean }> = [];
+
+  if (report.openrouter) {
+    const o = report.openrouter;
+    const burn =
+      o.usageDaily != null ? ` • ~$${o.usageDaily.toFixed(2)}/day` : '';
+    fields.push({
+      name: `${cls.openrouterLow ? '⚠️ ' : ''}OpenRouter credits`,
+      value: `$${o.remaining.toFixed(2)} remaining${burn}`,
+      inline: true,
+    });
+  } else if (report.openrouterError) {
+    fields.push({
+      name: '⚠️ OpenRouter credits',
+      value: `error: ${truncate(report.openrouterError, 120)}`,
+      inline: true,
+    });
+  }
+
+  if (report.pol) {
+    fields.push({
+      name: `${cls.polLow ? '⚠️ ' : ''}Admin POL`,
+      value: `${report.pol.pol.toFixed(3)} POL\n\`${report.pol.address}\``,
+      inline: true,
+    });
+  } else if (report.polError) {
+    fields.push({
+      name: '⚠️ Admin POL',
+      value: `error: ${truncate(report.polError, 120)}`,
+      inline: true,
+    });
+  }
+
+  const anyError = Boolean(report.openrouterError || report.polError);
+
+  return {
+    title: cls.anyLow ? '⚠️ Keeper balances LOW' : '💓 Keeper heartbeat',
+    color: cls.anyLow ? COLOR_WARN : anyError ? COLOR_FAIL : COLOR_INFO,
+    fields,
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/packages/market-keeper/src/notify/report.ts
+++ b/packages/market-keeper/src/notify/report.ts
@@ -1,0 +1,31 @@
+/**
+ * Single entry point the (plain-JS) cron runner requires from dist:
+ *   const { readStepSummaries, postGroupReport } =
+ *     require('../../dist/src/notify/report');
+ *
+ * Keeping the runner's dependency on compiled code to this one module means the
+ * orchestration layer (scripts/lib/groups.js) stays a thin source-JS file while
+ * all the testable logic lives in TypeScript under src/notify.
+ */
+import { readStepSummaries } from './summary';
+import { buildGroupEmbed } from './embeds';
+import { postKeeperEmbeds } from './discord';
+import type { StepRun } from './types';
+
+export { readStepSummaries };
+
+/**
+ * Build and post one cron group's run summary.
+ *
+ * Set KEEPER_SUMMARY_ON_FAILURE_ONLY=1 to suppress success summaries (cuts
+ * noise on frequent crons); failures are always reported.
+ */
+export async function postGroupReport(input: {
+  group: string;
+  runs: StepRun[];
+}): Promise<void> {
+  const failed = input.runs.some((r) => r.status === 'failed');
+  if (!failed && process.env.KEEPER_SUMMARY_ON_FAILURE_ONLY === '1') return;
+  const embed = buildGroupEmbed(input.group, input.runs);
+  await postKeeperEmbeds([embed]);
+}

--- a/packages/market-keeper/src/notify/summary.test.ts
+++ b/packages/market-keeper/src/notify/summary.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  emitStepSummary,
+  readStepSummaries,
+  parseStepSummaries,
+  SUMMARY_FILE_ENV,
+} from './summary';
+
+describe('parseStepSummaries', () => {
+  it('parses well-formed JSONL', () => {
+    const raw =
+      '{"step":"relist","metrics":{"created":3}}\n{"step":"generate","metrics":{"created":1}}\n';
+    const out = parseStepSummaries(raw);
+    expect(out).toHaveLength(2);
+    expect(out[0].step).toBe('relist');
+    expect(out[0].metrics?.created).toBe(3);
+    expect(out[1].step).toBe('generate');
+  });
+
+  it('skips blank and malformed lines', () => {
+    const raw = '\n{"step":"a"}\nnot-json\n{"missing":"step"}\n  \n';
+    const out = parseStepSummaries(raw);
+    expect(out).toHaveLength(1);
+    expect(out[0].step).toBe('a');
+  });
+
+  it('returns [] for empty input', () => {
+    expect(parseStepSummaries('')).toEqual([]);
+  });
+});
+
+describe('emitStepSummary / readStepSummaries round-trip', () => {
+  let file: string;
+  const original = process.env[SUMMARY_FILE_ENV];
+
+  beforeEach(() => {
+    file = path.join(
+      os.tmpdir(),
+      `keeper-summary-test-${process.pid}-${Math.random().toString(36).slice(2)}.jsonl`
+    );
+    process.env[SUMMARY_FILE_ENV] = file;
+  });
+
+  afterEach(() => {
+    if (original === undefined) delete process.env[SUMMARY_FILE_ENV];
+    else process.env[SUMMARY_FILE_ENV] = original;
+    try {
+      fs.unlinkSync(file);
+    } catch {
+      // ignore
+    }
+  });
+
+  it('appends emitted summaries and reads them back in order', () => {
+    emitStepSummary({ step: 'relist', metrics: { created: 2, skipped: 1 } });
+    emitStepSummary({
+      step: 'settle-pyth',
+      metrics: { settled: 5 },
+      dryRun: true,
+    });
+
+    const out = readStepSummaries(file);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toMatchObject({ step: 'relist', metrics: { created: 2 } });
+    expect(out[1]).toMatchObject({ step: 'settle-pyth', dryRun: true });
+  });
+
+  it('is a no-op (and does not throw) when the env var is unset', () => {
+    delete process.env[SUMMARY_FILE_ENV];
+    expect(() =>
+      emitStepSummary({ step: 'x', metrics: { n: 1 } })
+    ).not.toThrow();
+    expect(fs.existsSync(file)).toBe(false);
+  });
+});
+
+describe('readStepSummaries', () => {
+  it('returns [] when the file does not exist', () => {
+    expect(readStepSummaries('/no/such/keeper-summary.jsonl')).toEqual([]);
+  });
+});

--- a/packages/market-keeper/src/notify/summary.ts
+++ b/packages/market-keeper/src/notify/summary.ts
@@ -1,0 +1,63 @@
+/**
+ * Cross-process result reporting for keeper subservices.
+ *
+ * Each subservice runs as its own `node dist/scripts/X.js` process, so it can't
+ * hand a return value back to the cron runner in memory. Instead it appends a
+ * JSON line to the file named by KEEPER_SUMMARY_FILE; the runner
+ * (scripts/lib/groups.js) provisions that file, sets the env var, and reads the
+ * lines back to build the per-group Discord summary.
+ */
+import * as fs from 'fs';
+import type { StepSummary } from './types';
+
+export const SUMMARY_FILE_ENV = 'KEEPER_SUMMARY_FILE';
+
+/**
+ * Append one structured step summary as a JSON line to KEEPER_SUMMARY_FILE.
+ *
+ * No-op when the env var is unset (e.g. running a subservice directly, outside
+ * the cron runner). MUST NEVER THROW — these calls sit at the end of production
+ * settlement/generation paths and a reporting failure must not break the work.
+ */
+export function emitStepSummary(summary: StepSummary): void {
+  try {
+    const file = process.env[SUMMARY_FILE_ENV];
+    if (!file) return;
+    fs.appendFileSync(file, `${JSON.stringify(summary)}\n`);
+  } catch {
+    // best-effort: never let reporting break the subservice
+  }
+}
+
+/** Read a JSONL summary file into StepSummary[]; tolerant of malformed lines. */
+export function readStepSummaries(file: string): StepSummary[] {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch {
+    return [];
+  }
+  return parseStepSummaries(raw);
+}
+
+/** Parse JSONL content into StepSummary[], skipping blank/malformed lines. */
+export function parseStepSummaries(raw: string): StepSummary[] {
+  const out: StepSummary[] = [];
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const obj = JSON.parse(trimmed) as unknown;
+      if (
+        obj &&
+        typeof obj === 'object' &&
+        typeof (obj as StepSummary).step === 'string'
+      ) {
+        out.push(obj as StepSummary);
+      }
+    } catch {
+      // skip malformed line
+    }
+  }
+  return out;
+}

--- a/packages/market-keeper/src/notify/types.ts
+++ b/packages/market-keeper/src/notify/types.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared types for keeper Discord notifications.
+ *
+ * Two flows feed the DISCORD_KEEPER_WEBHOOK:
+ *  - per-cron-group run summaries (built by the cron runner in
+ *    scripts/lib/groups.js from the StepRun records below)
+ *  - a balance heartbeat (scripts/keeper-status.ts) over BalanceReport
+ */
+
+export type StepStatus = 'ok' | 'failed' | 'skipped';
+
+/**
+ * One subservice's structured result, emitted to the file named by
+ * KEEPER_SUMMARY_FILE so the (separate-process) cron runner can read it back.
+ */
+export interface StepSummary {
+  /** Canonical subservice name, e.g. 'relist', 'settle-pyth'. */
+  step: string;
+  /** Counts/keyed metrics, e.g. { created: 3, skipped: 2, errors: 0 }. */
+  metrics?: Record<string, number | string>;
+  /** True when the run was a dry run (no writes). */
+  dryRun?: boolean;
+  /** Optional one-line note. */
+  note?: string;
+}
+
+/** A step as observed by the cron runner: emitted summary + process outcome. */
+export interface StepRun {
+  /** Runner's label for the step, e.g. 'settle'. */
+  label: string;
+  status: StepStatus;
+  /** Wall-clock duration in ms. */
+  durationMs: number;
+  /** Structured summaries the step emitted (usually 0 or 1). */
+  summaries: StepSummary[];
+  /** Error message if the step failed. */
+  error?: string;
+}
+
+export interface OpenRouterBalance {
+  /** USD credits remaining = total_credits - total_usage. */
+  remaining: number;
+  totalCredits: number;
+  totalUsage: number;
+  /** Best-effort burn-rate context from /api/v1/key. */
+  usageDaily?: number;
+  usageWeekly?: number;
+  usageMonthly?: number;
+}
+
+export interface PolBalance {
+  address: string;
+  /** POL, human-readable. */
+  pol: number;
+}
+
+export interface BalanceReport {
+  openrouter?: OpenRouterBalance;
+  openrouterError?: string;
+  pol?: PolBalance;
+  polError?: string;
+}
+
+export interface BalanceThresholds {
+  /** Minimum acceptable OpenRouter USD credits. */
+  openrouterMinCredits: number;
+  /** Minimum acceptable admin POL balance. */
+  adminMinPol: number;
+}
+
+export interface BalanceClassification {
+  openrouterLow: boolean;
+  polLow: boolean;
+  /** True if any tracked balance is below threshold. */
+  anyLow: boolean;
+}

--- a/packages/market-keeper/src/prices-and-1d-7d-volume/index.ts
+++ b/packages/market-keeper/src/prices-and-1d-7d-volume/index.ts
@@ -21,6 +21,7 @@ import {
 import { parseYesPrice } from '../utils/price';
 import { submitPriceUpdates, submitVolumeUpdates } from '../generate/api';
 import { fetchActiveConditionIds } from '../sapience/active-conditions';
+import { emitStepSummary } from '../notify/summary';
 
 // ============ CLI Arguments ============
 
@@ -219,6 +220,15 @@ export async function main() {
         }
       }
       log('\n========== END DRY RUN ==========\n');
+      emitStepSummary({
+        step: 'prices-and-1d-7d-volume',
+        dryRun: true,
+        metrics: {
+          scanned: conditionIds.length,
+          priceUpdates: priceUpdates.length,
+          volumeUpdates: volumeUpdates.length,
+        },
+      });
       return;
     }
 
@@ -230,6 +240,15 @@ export async function main() {
         await submitVolumeUpdates(apiUrl, privateKey, volumeUpdates);
       }
     }
+
+    emitStepSummary({
+      step: 'prices-and-1d-7d-volume',
+      metrics: {
+        scanned: conditionIds.length,
+        priceUpdates: priceUpdates.length,
+        volumeUpdates: volumeUpdates.length,
+      },
+    });
   } catch (error) {
     logError('Error:', error);
     process.exit(1);

--- a/packages/market-keeper/src/refresh-imminent-tag/index.ts
+++ b/packages/market-keeper/src/refresh-imminent-tag/index.ts
@@ -20,6 +20,7 @@ import {
   logError,
 } from '../utils';
 import { submitMetadataUpdates } from '../generate/api';
+import { emitStepSummary } from '../notify/summary';
 import { fetchAllUnsettledConditions } from './fetch';
 import {
   conditionMentionsImminentDate,
@@ -205,6 +206,16 @@ export async function main(): Promise<void> {
     log(
       `[TodayTag] Total wall-clock: ${((Date.now() - runStart) / 1000).toFixed(1)}s`
     );
+    emitStepSummary({
+      step: 'refresh-imminent-tag',
+      dryRun: true,
+      metrics: {
+        scanned: conditions.length,
+        matched: matchedCount,
+        added: additions.length,
+        removed: removals.length,
+      },
+    });
     return;
   }
 
@@ -213,6 +224,15 @@ export async function main(): Promise<void> {
     log(
       `[TodayTag] Total wall-clock: ${((Date.now() - runStart) / 1000).toFixed(1)}s`
     );
+    emitStepSummary({
+      step: 'refresh-imminent-tag',
+      metrics: {
+        scanned: conditions.length,
+        matched: matchedCount,
+        added: 0,
+        removed: 0,
+      },
+    });
     return;
   }
 
@@ -232,4 +252,13 @@ export async function main(): Promise<void> {
   log(
     `[TodayTag] Total wall-clock: ${((Date.now() - runStart) / 1000).toFixed(1)}s`
   );
+  emitStepSummary({
+    step: 'refresh-imminent-tag',
+    metrics: {
+      scanned: conditions.length,
+      matched: matchedCount,
+      added: additions.length,
+      removed: removals.length,
+    },
+  });
 }

--- a/packages/market-keeper/src/refresh-metadata/index.ts
+++ b/packages/market-keeper/src/refresh-metadata/index.ts
@@ -32,6 +32,7 @@ import {
   fetchMarketsByConditionIds,
   fetchEventTagsByIds,
 } from './fetch';
+import { emitStepSummary } from '../notify/summary';
 
 interface RefreshMetadataCLIOptions {
   dryRun: boolean;
@@ -244,6 +245,15 @@ export async function main() {
       printDryRun(metadataUpdates, groupMetadataUpdates);
       const totalSec = ((performance.now() - totalStart) / 1000).toFixed(1);
       log(`[RefreshMetadata] Total runtime: ${totalSec}s`);
+      emitStepSummary({
+        step: 'refresh-metadata',
+        dryRun: true,
+        metrics: {
+          scanned: existing.size,
+          conditionUpdates: metadataUpdates.length,
+          groupUpdates: groupMetadataUpdates.length,
+        },
+      });
       return;
     }
 
@@ -266,6 +276,14 @@ export async function main() {
 
     const totalSec = ((performance.now() - totalStart) / 1000).toFixed(1);
     log(`[RefreshMetadata] Total runtime: ${totalSec}s`);
+    emitStepSummary({
+      step: 'refresh-metadata',
+      metrics: {
+        scanned: existing.size,
+        conditionUpdates: metadataUpdates.length,
+        groupUpdates: groupMetadataUpdates.length,
+      },
+    });
   } catch (error) {
     logError('Error:', error);
     process.exit(1);

--- a/packages/market-keeper/src/refresh-volume/index.ts
+++ b/packages/market-keeper/src/refresh-volume/index.ts
@@ -17,6 +17,7 @@ import {
 } from '../utils';
 import { submitVolumeUpdates } from '../generate/api';
 import { fetchActiveConditionIds } from '../sapience/active-conditions';
+import { emitStepSummary } from '../notify/summary';
 
 // ============ Constants ============
 
@@ -471,6 +472,15 @@ export async function main() {
       const totalSec = ((performance.now() - totalStart) / 1000).toFixed(1);
       log(`\nTotal runtime: ${totalSec}s`);
       log('\n========== END DRY RUN ==========\n');
+      emitStepSummary({
+        step: 'refresh-volume',
+        dryRun: true,
+        metrics: {
+          scanned: conditionIds.length,
+          updates: successfulVolumes.length,
+          failed: totalFetchFailures,
+        },
+      });
       return;
     }
 
@@ -491,6 +501,14 @@ export async function main() {
 
     const totalSec = ((performance.now() - totalStart) / 1000).toFixed(1);
     log(`[RefreshVolume] Total runtime: ${totalSec}s`);
+    emitStepSummary({
+      step: 'refresh-volume',
+      metrics: {
+        scanned: conditionIds.length,
+        updates: successfulVolumes.length,
+        failed: totalFetchFailures,
+      },
+    });
   } catch (error) {
     logError('Error:', error);
     process.exit(1);

--- a/packages/market-keeper/src/relist/index.ts
+++ b/packages/market-keeper/src/relist/index.ts
@@ -18,6 +18,7 @@ import {
 import { fetchPastEndDateMarkets } from './market';
 import { groupMarkets, exportJSON } from '../generate/grouping';
 import { printDryRun, submitToAPI } from '../generate/api';
+import { emitStepSummary } from '../notify/summary';
 import { checkExistingConditions } from '../generate/pipeline';
 
 // ============ CLI Arguments ============
@@ -86,6 +87,11 @@ export async function main() {
 
     if (markets.length === 0) {
       log('[Relist] No past-endDate markets found that are still traded');
+      emitStepSummary({
+        step: 'relist',
+        note: 'no past-endDate markets',
+        metrics: { candidates: 0, new: 0 },
+      });
       return;
     }
 
@@ -115,6 +121,14 @@ export async function main() {
 
     if (newMarkets.length === 0) {
       log('[Relist] No new markets to create');
+      emitStepSummary({
+        step: 'relist',
+        metrics: {
+          candidates: markets.length,
+          alreadyListed: existingConditions.size,
+          new: 0,
+        },
+      });
       return;
     }
 
@@ -134,12 +148,41 @@ export async function main() {
 
     if (options.dryRun) {
       printDryRun(sapienceData);
+      emitStepSummary({
+        step: 'relist',
+        dryRun: true,
+        metrics: {
+          candidates: markets.length,
+          alreadyListed: existingConditions.size,
+          new: sapienceData.metadata.totalConditions,
+        },
+      });
       return;
     }
 
     // 6. Submit new conditions to API
     if (hasAPICredentials && apiUrl && privateKey) {
-      await submitToAPI(apiUrl, privateKey, sapienceData);
+      const result = await submitToAPI(apiUrl, privateKey, sapienceData);
+      emitStepSummary({
+        step: 'relist',
+        metrics: {
+          candidates: markets.length,
+          alreadyListed: existingConditions.size,
+          created: result.created,
+          skipped: result.skipped,
+          failed: result.failed,
+        },
+      });
+    } else {
+      emitStepSummary({
+        step: 'relist',
+        note: 'no API credentials',
+        metrics: {
+          candidates: markets.length,
+          alreadyListed: existingConditions.size,
+          new: sapienceData.metadata.totalConditions,
+        },
+      });
     }
   } catch (error) {
     logError('Error:', error);


### PR DESCRIPTION
## What

Wires `DISCORD_KEEPER_WEBHOOK` so the keeper reports to Discord, plus a small endtime-cascade fix.

### Keeper Discord alerts
Two notification flows (both silent no-ops when `DISCORD_KEEPER_WEBHOOK` is unset):

- **Balance heartbeat** — `scripts/keeper-status.ts` (run as its own cron via `pnpm start:status`) reports OpenRouter credits + the admin wallet's POL balance, escalating to a LOW alert below `OPENROUTER_MIN_CREDITS` (default 10) / `ADMIN_MIN_POL` (default 5).
- **Per-cron run summaries** — the cron runner (`scripts/lib/groups.js`) posts one embed per group (discovery / metadata-tags / market-data / settlement) with each subservice's ✅/❌ status, duration, and counts. Counts come from each subservice appending a JSON line via `emitStepSummary()` to the `KEEPER_SUMMARY_FILE` the runner provisions; the runner reads them back and posts.

All notification logic lives in `src/notify/` (unit-tested); the source-JS runner reaches it through the single `dist/src/notify/report` entry point. `runGroup` is now async (so the post completes before the short-lived process exits) and loads `.env`, while preserving fail-fast / non-zero exit.

### Endtime fix (rider)
`gameEndTime()` now declines (returns `null`) when there's no recognized sports league, so a non-sports Polymarket `gameStartTime` (e.g. S&P 500 index markets) falls through to `pm-fallback` instead of inventing a default game duration. Includes the regression spec in `decide-endtime.test.ts`.

## Config
- `DISCORD_KEEPER_WEBHOOK` — webhook for keeper alerts (unset = disabled)
- `OPENROUTER_MIN_CREDITS` (default 10), `ADMIN_MIN_POL` (default 5) — LOW-alert thresholds
- `KEEPER_SUMMARY_ON_FAILURE_ONLY=1` — only post run summaries on failure

## Notes
- The webhook must be present in the keeper's own environment (Railway service), not just the API's.
- Subservices instrumented with `emitStepSummary`: generate, relist, refresh-metadata, refresh-imminent-tag, prices-and-1d-7d-volume, refresh-volume, cleanup, settle-manual/polymarket, settle-pyth.

## Testing
- `pnpm --filter @sapience/market-keeper test` — 530/530 pass (incl. 18 new `src/notify/` tests); type-check + lint clean.
- Heartbeat + summary paths verified end-to-end against a real webhook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
