### PR TITLE
feat(market-keeper): stamp NODE_ENV on keeper Discord alerts

### DIFF
--- a/packages/market-keeper/scripts/keeper-status.ts
+++ b/packages/market-keeper/scripts/keeper-status.ts
@@ -20,7 +20,7 @@ import {
   classifyBalances,
 } from '../src/notify/balances.js';
 import { buildHeartbeatEmbed } from '../src/notify/embeds.js';
-import { postKeeperEmbeds } from '../src/notify/discord.js';
+import { postKeeperEmbeds, keeperEnv } from '../src/notify/discord.js';
 import { log, logError, logSeparator } from '../src/utils/log.js';
 import type { BalanceReport } from '../src/notify/types.js';
 
@@ -96,7 +96,7 @@ async function main(): Promise<void> {
     );
   }
 
-  await postKeeperEmbeds([buildHeartbeatEmbed(report, cls)]);
+  await postKeeperEmbeds([buildHeartbeatEmbed(report, cls, keeperEnv())]);
 }
 
 logSeparator('keeper-status', 'START');

--- a/packages/market-keeper/src/notify/discord.ts
+++ b/packages/market-keeper/src/notify/discord.ts
@@ -11,6 +11,15 @@ import { log, logError } from '../utils/log';
 const WEBHOOK_PREFIX = 'https://discord.com/api/webhooks/';
 const TIMEOUT_MS = 5_000;
 
+/**
+ * Environment label stamped on every alert so prod/staging/dev alerts are
+ * distinguishable in a shared channel. Defaults to 'development' (Node's
+ * convention for an unset NODE_ENV).
+ */
+export function keeperEnv(): string {
+  return process.env.NODE_ENV || 'development';
+}
+
 /** Resolve + validate the configured webhook URL, or null when unusable. */
 export function getKeeperWebhook(): string | null {
   const url = (process.env.DISCORD_KEEPER_WEBHOOK || '').trim();

--- a/packages/market-keeper/src/notify/embeds.test.ts
+++ b/packages/market-keeper/src/notify/embeds.test.ts
@@ -26,9 +26,13 @@ describe('buildGroupEmbed', () => {
         summaries: [{ step: 'relist', metrics: { new: 2 } }],
       },
     ];
-    const embed = buildGroupEmbed('discovery', runs) as Record<string, unknown>;
+    const embed = buildGroupEmbed('discovery', runs, 'production') as Record<
+      string,
+      unknown
+    >;
     expect(embed.title).toBe('✅ Keeper · discovery');
     expect(embed.color).toBe(0x22c55e);
+    expect((embed.footer as { text: string }).text).toBe('env: production');
     const desc = embed.description as string;
     expect(desc).toContain('✅ **generate**');
     expect(desc).toContain('created=4');
@@ -54,11 +58,12 @@ describe('buildGroupEmbed', () => {
       },
       { label: 'settle-pyth', status: 'skipped', durationMs: 0, summaries: [] },
     ];
-    const embed = buildGroupEmbed('settlement', runs) as Record<
+    const embed = buildGroupEmbed('settlement', runs, 'staging') as Record<
       string,
       unknown
     >;
     expect(embed.title).toBe('❌ Keeper · settlement');
+    expect((embed.footer as { text: string }).text).toBe('env: staging');
     expect(embed.color).toBe(0xef4444);
     const desc = embed.description as string;
     expect(desc).toContain('❌ **settle**');
@@ -75,8 +80,11 @@ describe('buildGroupEmbed', () => {
         summaries: [{ step: 'relist', metrics: { new: 0 }, dryRun: true }],
       },
     ];
-    const desc = (buildGroupEmbed('discovery', runs) as { description: string })
-      .description;
+    const desc = (
+      buildGroupEmbed('discovery', runs, 'production') as {
+        description: string;
+      }
+    ).description;
     expect(desc).toContain('_[dry-run]_');
   });
 });
@@ -98,9 +106,13 @@ describe('buildHeartbeatEmbed', () => {
       },
       pol: { address: '0xADMIN', pol: 12.345 },
     };
-    const embed = buildHeartbeatEmbed(report, ok) as Record<string, unknown>;
+    const embed = buildHeartbeatEmbed(report, ok, 'production') as Record<
+      string,
+      unknown
+    >;
     expect(embed.title).toBe('💓 Keeper heartbeat');
     expect(embed.color).toBe(0x3b82f6);
+    expect((embed.footer as { text: string }).text).toBe('env: production');
     const fields = embed.fields as Array<{ name: string; value: string }>;
     expect(fields[0].value).toContain('$50.00 remaining');
     expect(fields[0].value).toContain('~$7.11/day');
@@ -118,7 +130,10 @@ describe('buildHeartbeatEmbed', () => {
       polLow: true,
       anyLow: true,
     };
-    const embed = buildHeartbeatEmbed(report, cls) as Record<string, unknown>;
+    const embed = buildHeartbeatEmbed(report, cls, 'production') as Record<
+      string,
+      unknown
+    >;
     expect(embed.title).toBe('⚠️ Keeper balances LOW');
     expect(embed.color).toBe(0xf59e0b);
     const fields = embed.fields as Array<{ name: string; value: string }>;
@@ -131,7 +146,10 @@ describe('buildHeartbeatEmbed', () => {
       openrouterError: 'HTTP 401',
       polError: 'rpc down',
     };
-    const embed = buildHeartbeatEmbed(report, ok) as Record<string, unknown>;
+    const embed = buildHeartbeatEmbed(report, ok, 'production') as Record<
+      string,
+      unknown
+    >;
     expect(embed.color).toBe(0xef4444);
     const fields = embed.fields as Array<{ value: string }>;
     expect(fields[0].value).toContain('HTTP 401');

--- a/packages/market-keeper/src/notify/embeds.ts
+++ b/packages/market-keeper/src/notify/embeds.ts
@@ -46,7 +46,11 @@ function formatMetrics(summaries: StepSummary[]): string {
 }
 
 /** Build a single embed summarizing one cron group's run. */
-export function buildGroupEmbed(group: string, runs: StepRun[]): object {
+export function buildGroupEmbed(
+  group: string,
+  runs: StepRun[],
+  env: string
+): object {
   const failed = runs.some((r) => r.status === 'failed');
 
   const lines = runs.map((r) => {
@@ -64,6 +68,7 @@ export function buildGroupEmbed(group: string, runs: StepRun[]): object {
     title: `${failed ? '❌' : '✅'} Keeper · ${group}`,
     color: failed ? COLOR_FAIL : COLOR_OK,
     description: lines.join('\n') || '_no steps_',
+    footer: { text: `env: ${env}` },
     timestamp: new Date().toISOString(),
   };
 }
@@ -71,7 +76,8 @@ export function buildGroupEmbed(group: string, runs: StepRun[]): object {
 /** Build the balance heartbeat embed (also serves as the low-balance alert). */
 export function buildHeartbeatEmbed(
   report: BalanceReport,
-  cls: BalanceClassification
+  cls: BalanceClassification,
+  env: string
 ): object {
   const fields: Array<{ name: string; value: string; inline: boolean }> = [];
 
@@ -112,6 +118,7 @@ export function buildHeartbeatEmbed(
     title: cls.anyLow ? '⚠️ Keeper balances LOW' : '💓 Keeper heartbeat',
     color: cls.anyLow ? COLOR_WARN : anyError ? COLOR_FAIL : COLOR_INFO,
     fields,
+    footer: { text: `env: ${env}` },
     timestamp: new Date().toISOString(),
   };
 }

--- a/packages/market-keeper/src/notify/report.ts
+++ b/packages/market-keeper/src/notify/report.ts
@@ -9,7 +9,7 @@
  */
 import { readStepSummaries } from './summary';
 import { buildGroupEmbed } from './embeds';
-import { postKeeperEmbeds } from './discord';
+import { postKeeperEmbeds, keeperEnv } from './discord';
 import type { StepRun } from './types';
 
 export { readStepSummaries };
@@ -26,6 +26,6 @@ export async function postGroupReport(input: {
 }): Promise<void> {
   const failed = input.runs.some((r) => r.status === 'failed');
   if (!failed && process.env.KEEPER_SUMMARY_ON_FAILURE_ONLY === '1') return;
-  const embed = buildGroupEmbed(input.group, input.runs);
+  const embed = buildGroupEmbed(input.group, input.runs, keeperEnv());
   await postKeeperEmbeds([embed]);
 }


### PR DESCRIPTION
## What

Stamps the keeper's `NODE_ENV` onto the Discord alerts so prod / staging / dev alerts are distinguishable in a shared channel.

Both embeds — the per-cron run summary and the balance heartbeat — now carry an `env: <NODE_ENV>` footer.

## How
- The (pure) embed builders `buildGroupEmbed` / `buildHeartbeatEmbed` take an `env` argument and render it as the embed footer.
- A shared `keeperEnv()` helper (in `notify/discord.ts`) resolves `process.env.NODE_ENV`, defaulting to `development` when unset (Node convention). The two callers — `report.ts` (per-cron summaries) and `keeper-status.ts` (heartbeat) — pass it in, keeping the builders I/O-free.

## Context
Follow-up to #1892 (keeper Discord alerts), which is now merged to `staging`.

## Testing
- `pnpm --filter @sapience/market-keeper test` — 530/530 pass; type-check + lint clean.
- Embed tests assert the footer renders the passed env (`production` / `staging`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
