### PR TITLE
feat(market-keeper): resolve alert env label from KEEPER_ENV / Railway, not just NODE_ENV

### DIFF
--- a/packages/market-keeper/.env.example
+++ b/packages/market-keeper/.env.example
@@ -38,3 +38,8 @@ OPENROUTER_MIN_CREDITS=10
 ADMIN_MIN_POL=5
 # Set to 1 to only post per-cron summaries on failure (reduces noise).
 KEEPER_SUMMARY_ON_FAILURE_ONLY=
+# Environment label shown on alerts. Optional override — if unset, falls back to
+# RAILWAY_ENVIRONMENT_NAME (auto on Railway), then NODE_ENV, then 'development'.
+# Set this only if NODE_ENV/Railway's name isn't the label you want shown
+# (staging runs as NODE_ENV=production, so NODE_ENV can't tell them apart).
+KEEPER_ENV=

--- a/packages/market-keeper/AGENTS.md
+++ b/packages/market-keeper/AGENTS.md
@@ -64,6 +64,7 @@ All notification logic lives in `src/notify/` (compiled to dist); the source-JS 
 - `OPENROUTER_MIN_CREDITS` - LOW-alert threshold for OpenRouter USD credits (default 10)
 - `ADMIN_MIN_POL` - LOW-alert threshold for admin wallet POL (default 5)
 - `KEEPER_SUMMARY_ON_FAILURE_ONLY` - set to `1` to only post run summaries on failure
+- `KEEPER_ENV` - optional alert environment label; falls back to `RAILWAY_ENVIRONMENT_NAME`, then `NODE_ENV`, then `development` (NODE_ENV is `production` on both staging and prod, so it can't distinguish them)
 
 ## Production Safety
 

--- a/packages/market-keeper/src/notify/discord.test.ts
+++ b/packages/market-keeper/src/notify/discord.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { keeperEnv } from './discord';
+
+describe('keeperEnv', () => {
+  const KEYS = ['KEEPER_ENV', 'RAILWAY_ENVIRONMENT_NAME', 'NODE_ENV'] as const;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('prefers KEEPER_ENV over everything', () => {
+    process.env.KEEPER_ENV = 'prod-keeper';
+    process.env.RAILWAY_ENVIRONMENT_NAME = 'production';
+    process.env.NODE_ENV = 'production';
+    expect(keeperEnv()).toBe('prod-keeper');
+  });
+
+  it('falls back to RAILWAY_ENVIRONMENT_NAME (distinguishes staging from prod)', () => {
+    process.env.RAILWAY_ENVIRONMENT_NAME = 'staging';
+    process.env.NODE_ENV = 'production';
+    expect(keeperEnv()).toBe('staging');
+  });
+
+  it('falls back to NODE_ENV off Railway', () => {
+    process.env.NODE_ENV = 'test';
+    expect(keeperEnv()).toBe('test');
+  });
+
+  it("defaults to 'development' when nothing is set", () => {
+    expect(keeperEnv()).toBe('development');
+  });
+});

--- a/packages/market-keeper/src/notify/discord.ts
+++ b/packages/market-keeper/src/notify/discord.ts
@@ -13,11 +13,24 @@ const TIMEOUT_MS = 5_000;
 
 /**
  * Environment label stamped on every alert so prod/staging/dev alerts are
- * distinguishable in a shared channel. Defaults to 'development' (Node's
- * convention for an unset NODE_ENV).
+ * distinguishable in a shared channel.
+ *
+ * NODE_ENV alone is insufficient: staging runs the production build, so it's
+ * `production` on both staging and prod. Resolution order:
+ *   1. KEEPER_ENV            — explicit override (set per deploy if you want a
+ *                              specific label)
+ *   2. RAILWAY_ENVIRONMENT_NAME — auto-injected by Railway per environment
+ *                              (e.g. 'production' vs 'staging'); no config
+ *   3. NODE_ENV              — local / non-Railway fallback
+ *   4. 'development'         — nothing set
  */
 export function keeperEnv(): string {
-  return process.env.NODE_ENV || 'development';
+  return (
+    process.env.KEEPER_ENV ||
+    process.env.RAILWAY_ENVIRONMENT_NAME ||
+    process.env.NODE_ENV ||
+    'development'
+  );
 }
 
 /** Resolve + validate the configured webhook URL, or null when unusable. */


### PR DESCRIPTION
## What

Makes the keeper alert's environment label actually distinguish **staging from production**.

`NODE_ENV` is `production` on both staging and prod (staging runs the production build), so the env footer (#1893) read `production` everywhere. `keeperEnv()` now resolves a priority chain:

1. `KEEPER_ENV` — explicit override (set per deploy if you want a specific label)
2. `RAILWAY_ENVIRONMENT_NAME` — auto-injected by Railway per environment (`production` vs `staging`); **no config needed**
3. `NODE_ENV` — local / non-Railway fallback
4. `'development'` — nothing set

## Context
Follow-up to #1892 (keeper Discord alerts) and #1893 (env footer), both now merged to `staging`.

## Config
- `KEEPER_ENV` (optional) documented in `.env.example` + `AGENTS.md`. Leave unset to let Railway's environment name drive the label automatically.

## Testing
- New `discord.test.ts` covers the resolution priority (override → Railway → NODE_ENV → default).
- `pnpm --filter @sapience/market-keeper test` — passes; type-check + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
