### PR TITLE
fix(vaults): correct inflated vault balance (deployed over-counting)

### DIFF
--- a/packages/sdk/queries/__tests__/vault.test.ts
+++ b/packages/sdk/queries/__tests__/vault.test.ts
@@ -189,40 +189,32 @@ describe('fetchVaultStats', () => {
 });
 
 describe('GET_VAULT_ACCOUNT_VALUE document', () => {
-  test('queries account collateralBalance and account statsHistory from one v2 surface', () => {
+  test('reads the live vault `stats` snapshot, not the account surface', () => {
+    // Must source from the vault entity: its `deployedCollateral` is keyed off
+    // Picks.resolved/resolvedAt, so resolved-but-unsettled (losing) positions
+    // drop out. The `account(...)` surface keys deployed off Prediction.settledAt
+    // — losing predictions are never settled on-chain, so they stay counted as
+    // deployed forever and inflate the balance. Regression guard for that.
     expect(GET_VAULT_ACCOUNT_VALUE).toContain(
-      'account(address: $address, chainId: $chainId)'
+      'vault(address: $address, chainId: $chainId)'
     );
-    expect(GET_VAULT_ACCOUNT_VALUE).toContain('collateralBalance');
-    expect(GET_VAULT_ACCOUNT_VALUE).toContain('amount');
-    expect(GET_VAULT_ACCOUNT_VALUE).toContain('statsHistory(interval: DAY)');
-    // No explicit `first`: a literal above GRAPHQL_MAX_LIST_SIZE (100) is
-    // rejected pre-execution with PAGINATION_LIMIT_EXCEEDED, so we rely on the
-    // resolver's MAX_STATS_POINTS default for the full rolling-year window.
-    expect(GET_VAULT_ACCOUNT_VALUE).not.toContain('first:');
+    expect(GET_VAULT_ACCOUNT_VALUE).not.toContain('account(');
+    expect(GET_VAULT_ACCOUNT_VALUE).toContain('stats {');
+    expect(GET_VAULT_ACCOUNT_VALUE).toContain('balance');
     expect(GET_VAULT_ACCOUNT_VALUE).toContain('deployedCollateral');
     expect(GET_VAULT_ACCOUNT_VALUE).toContain('claimableCollateral');
   });
 });
 
 describe('fetchVaultAccountValue', () => {
-  test('lowercases the address and sums indexed wallet, deployed, and claimable collateral', async () => {
+  test('lowercases the address and sums vault balance, deployed, and claimable collateral', async () => {
     mockGraphqlRequestV2.mockResolvedValue({
-      account: {
-        collateralBalance: { amount: '1000' },
-        statsHistory: {
-          nodes: [
-            {
-              timestamp: 1700000000,
-              deployedCollateral: '250',
-              claimableCollateral: '25',
-            },
-            {
-              timestamp: 1700000100,
-              deployedCollateral: '500',
-              claimableCollateral: '125',
-            },
-          ],
+      vault: {
+        stats: {
+          timestamp: 1700000100,
+          balance: '1000',
+          deployedCollateral: '500',
+          claimableCollateral: '125',
         },
       },
     });
@@ -242,19 +234,28 @@ describe('fetchVaultAccountValue', () => {
     });
   });
 
-  test('defaults missing account stats to just the indexed wallet balance', async () => {
+  test('defaults to zeros when the vault has no stats snapshot yet', async () => {
     mockGraphqlRequestV2.mockResolvedValue({
-      account: {
-        collateralBalance: { amount: 1000 },
-        statsHistory: { nodes: [] },
-      },
+      vault: { stats: null },
     });
 
     await expect(fetchVaultAccountValue('0xabc', 42161)).resolves.toEqual({
-      collateralBalance: '1000',
+      collateralBalance: '0',
       deployedCollateral: '0',
       claimableCollateral: '0',
-      totalValue: '1000',
+      totalValue: '0',
+      timestamp: null,
+    });
+  });
+
+  test('defaults to zeros when the address is not a configured vault', async () => {
+    mockGraphqlRequestV2.mockResolvedValue({ vault: null });
+
+    await expect(fetchVaultAccountValue('0xabc', 42161)).resolves.toEqual({
+      collateralBalance: '0',
+      deployedCollateral: '0',
+      claimableCollateral: '0',
+      totalValue: '0',
       timestamp: null,
     });
   });

--- a/packages/sdk/queries/vault.ts
+++ b/packages/sdk/queries/vault.ts
@@ -135,52 +135,54 @@ export async function fetchVaultStats(
 }
 
 export interface VaultAccountValue {
-  /** Current indexed wUSDe balance held by the vault wallet, wei. */
+  /** Raw wUSDe held by the vault contract (`balanceOf`), excludes deployed, wei. */
   collateralBalance: string;
-  /** Collateral deployed into open positions by the vault account, wei. */
+  /** Collateral deployed into escrow backing the vault's open positions, wei. */
   deployedCollateral: string;
-  /** Settled/won collateral owed to the vault account but not redeemed, wei. */
+  /** Settled/won collateral owed to the vault but not yet redeemed, wei. */
   claimableCollateral: string;
   /** Sum of collateralBalance + deployedCollateral + claimableCollateral, wei. */
   totalValue: string;
-  /** Latest account stats bucket timestamp, epoch seconds. */
+  /** Latest vault stats snapshot timestamp, epoch seconds. */
   timestamp: number | null;
 }
 
-// `statsHistory` is intentionally called without `first`: the API's
-// pre-execution validation rejects any literal `first` above
-// GRAPHQL_MAX_LIST_SIZE (100) with PAGINATION_LIMIT_EXCEEDED, and the daily
-// series needs the full rolling-year window. With no `first` the resolver
-// defaults to its MAX_STATS_POINTS (366) cap — the whole [now-365d, now] grid,
-// oldest-first — so `.at(-1)` is always the latest (today's) bucket.
+// Sourced from the vault entity's live `stats` snapshot — NOT the
+// `account(...)` surface. The two compute `deployedCollateral` differently:
+//
+//   - `Vault.stats.deployedCollateral` (this query) keys "still open" off
+//     Picks.resolved/resolvedAt, so resolved positions drop out immediately.
+//   - `Account.statsHistory.deployedCollateral` keys it off Prediction.settledAt.
+//     Losing predictions are frequently never settled on-chain, so their
+//     counterpartyCollateral stays counted as deployed forever.
+//
+// The account path therefore over-counts deployed (e.g. ~4x for a vault with a
+// backlog of unsettled losses), inflating the headline balance well above the
+// vault's true AUM. The vault entity matches the figure the PnL chart plots.
 export const GET_VAULT_ACCOUNT_VALUE = /* GraphQL */ `
   query VaultAccountValue($address: Address!, $chainId: Int) {
-    account(address: $address, chainId: $chainId) {
-      collateralBalance {
-        amount
-      }
-      statsHistory(interval: DAY) {
-        nodes {
-          timestamp
-          deployedCollateral
-          claimableCollateral
-        }
+    vault(address: $address, chainId: $chainId) {
+      stats {
+        timestamp
+        balance
+        deployedCollateral
+        claimableCollateral
       }
     }
   }
 `;
 
-type WireVaultAccountStat = {
+type WireVaultLiveStat = {
   timestamp: number;
+  balance: string | number;
   deployedCollateral: string | number;
   claimableCollateral: string | number;
 };
 
 type VaultAccountValueResponse = {
-  account: {
-    collateralBalance: { amount: string | number };
-    statsHistory: { nodes: WireVaultAccountStat[] };
-  };
+  vault: {
+    stats: WireVaultLiveStat | null;
+  } | null;
 };
 
 export async function fetchVaultAccountValue(
@@ -194,13 +196,15 @@ export async function fetchVaultAccountValue(
       chainId,
     }
   );
-  const latestStat = data.account.statsHistory.nodes.at(-1);
-  const collateralBalance = BigInt(wei(data.account.collateralBalance.amount));
-  const deployedCollateral = latestStat?.deployedCollateral
-    ? BigInt(wei(latestStat.deployedCollateral))
+  // `stats` is null until the stats writer has recorded a snapshot, and `vault`
+  // is null when the address is not a configured vault.
+  const stats = data.vault?.stats;
+  const collateralBalance = stats?.balance ? BigInt(wei(stats.balance)) : 0n;
+  const deployedCollateral = stats?.deployedCollateral
+    ? BigInt(wei(stats.deployedCollateral))
     : 0n;
-  const claimableCollateral = latestStat?.claimableCollateral
-    ? BigInt(wei(latestStat.claimableCollateral))
+  const claimableCollateral = stats?.claimableCollateral
+    ? BigInt(wei(stats.claimableCollateral))
     : 0n;
 
   return {
@@ -212,6 +216,6 @@ export async function fetchVaultAccountValue(
       deployedCollateral +
       claimableCollateral
     ).toString(),
-    timestamp: latestStat?.timestamp ?? null,
+    timestamp: stats?.timestamp ?? null,
   };
 }


### PR DESCRIPTION
## Problem

The `/vaults` headline **VAULT BALANCE** has been inflated since #1890 ("use indexed vault account value for vaults AUM"):

- **Core**: showed **40,942.68** (was ~$35k before the merge)
- **Edge**: showed **4,659.07** — but only ~$2k was ever deposited and the PnL chart shows ~$900 profit (true ≈ $2.9k)

## Root cause

`fetchVaultAccountValue` summed `collateralBalance + deployedCollateral + claimableCollateral` from the **`account(...)`** surface. The two surfaces compute `deployedCollateral` differently:

- `Account.statsHistory.deployedCollateral` (`timeSeriesQueries.queryAccountBalance`) keys "still open" off **`Prediction.settledAt`**. Losing predictions are frequently never settled on-chain, so their counterparty collateral stays counted as deployed **forever**.
- `Vault.stats.deployedCollateral` (`fetchVaultDeployed`) keys it off **`Picks.resolved/resolvedAt`** — resolved positions drop out immediately. This is the figure the PnL chart already plots.

So the account path piled phantom "deployed" on top of the (correct) liquid balance.

## Verification (chain 5064014)

On-chain reads confirm the **liquid** term was already correct — only **deployed** was wrong:

| | balanceOf == availableAssets == account.collateralBalance | account deployed (wrong) | vault deployed (correct) | cumulativePnl |
|---|---|---|---|---|
| Core | 33,141.59 | 7,310.49 | 2,105.83 | 1,869.42 |
| Edge | 2,339.57 | 2,308.18 | 522.73 | 952.77 |

Resulting balance:
- **Core: 40,942.68 → ~35,362** (≈ pre-merge $35k) ✓
- **Edge: 4,659.07 → ~2,957** (= $2k deposit + ~$952 PnL) ✓

## Fix

Repoint `GET_VAULT_ACCOUNT_VALUE` / `fetchVaultAccountValue` to the vault entity's live `stats` snapshot (`balance + deployedCollateral + claimableCollateral`). The hook's return shape is unchanged, so the `VaultsPageContent` component (which already renders deployed as a subset of total) needs no change.

## Tests

- Updated `packages/sdk/queries/__tests__/vault.test.ts` to assert the query reads `vault { stats }` (regression guard against the `account(...)` source) and to cover null-vault / null-stats fallbacks.
- SDK: 728 passed. App: 766 passed (`VaultsPageContent` suite included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)