### PR TITLE
docs: vault-bot data-layer — one ask (positions isPredictorToken filter)

### DIFF
--- a/docs/vault-bot-api-asks.md
+++ b/docs/vault-bot-api-asks.md
@@ -1,0 +1,84 @@
+# Vault-bot → Sapience API: data-layer asks
+
+Context: vault-bot is going to production and several hot paths currently **over-fetch and filter
+client-side** because the server-side filter/pagination isn't available (or we aren't using it).
+These are the API changes that would let us stop brute-forcing. Shapes below are proposals — map
+them to the actual schema as you see fit. Each ask cites the vault-bot code that forces the
+workaround today (paths are in `sapiencexyz/vault-bot`).
+
+---
+
+## Live asks (we're acting on these now)
+
+### 1. `positions` — server-side filtering + cursor pagination + total count
+
+**Today:** vault-bot pages **every position a vault has ever held** (settled + open, predictor +
+counterparty) and filters in JS. It uses a holder-only query with `take/skip`, capped at
+**5000 rows** (`PAGE_SIZE 100 × MAX_PAGES 50`, `src/shared/effects/http/paginated-positions.ts:4-5`),
+then drops predictor tokens client-side (`position-cache.ts:47`) and resolved positions in each
+consumer. Open exposure is a tiny fraction of lifetime positions, so this is mostly wasted transfer
+— and past 5000 lifetime rows, open positions can fall off the tail and we **silently under-count
+live vault exposure** (no error on truncation).
+
+Today the only way to ask for open positions is `positions(holder, result: null)` — overloading
+`null` to mean "unsettled." That's ambiguous (null reads as "no filter" / "unknown" / "open") and
+error-prone. We want an **explicit** open-state filter and the path to be the complete, efficient one:
+
+- **Add an explicit open/settled filter** instead of `result: null` — e.g. `status: OPEN | SETTLED`
+  (enum) or `settled: Boolean`. Keep `result` (`COUNTERPARTY_WINS` / `PREDICTOR_WINS`) for the
+  *settled sub-state*; "open" should not be expressed as the absence of a result. Our hottest read
+  is "all open counterparty positions for this vault," and it should say exactly that.
+- **Guarantee the open/settled and `result` filters are index-backed** (open-only / claimable
+  without a full-history scan).
+- **Add a token-type filter**, e.g. `isPredictorToken: Boolean`, so we can request counterparty-only
+  (or both) instead of fetching both and filtering client-side.
+- **Add a condition / group filter**, e.g. `conditionId_in: [String!]` (and/or `conditionGroupId_in`),
+  so we can read exposure for just the markets a quote touches instead of the whole book.
+- **Cursor pagination + total count** — `{ items, pageInfo { endCursor, hasNextPage }, totalCount }`
+  — so results are deterministically bounded (no magic 5000 cap) and pageable in parallel.
+
+### 2. `conditions` — server-side `similarMarkets` filter + batch-by-id
+
+**Today (filter):** vault-bot fetches **all** active public unsettled conditions, then filters
+`similarMarkets` for `"polymarket.com"` **in JS** (`src/shared/effects/http/sapience-queries.ts:144-146`).
+Every non-Polymarket active condition is downloaded and discarded.
+→ **Add a server-side predicate**: `similarMarkets: { contains: "polymarket.com" }` or a
+`hasPolymarketMarket: Boolean` flag on the `conditions` `where`.
+
+**Today (batch):** `getConditionById` is called **once per leg per quote**
+(`fair-price.ts`, `fixed-edge.ts:45`) and **N positions × M legs** on the MTM path
+(`inventory-pricing.ts`). A cold N-leg parlay is N separate round-trips.
+→ **Support batch lookup** returning the same fields as `condition(id:)` for
+`conditions(where: { id: { in: [...] } })` (the same field set we use today: `conditionGroupId`,
+`conditionGroup.negRisk`, `similarMarkets`, `endTime`, `public`, `question`).
+
+---
+
+## Heads-up / likely-later (not building yet — flagging so it informs design)
+
+- **`vaultExposure` aggregate** — a server-side aggregate of *open* counterparty collateral keyed by
+  the quote's touched conditions/groups (`{ byCondition { conditionId, counterpartyCollateral,
+  positionCount }, byConditionGroup { ... } }`), so we don't transfer + rescan unrelated open rows
+  for concentration/utilization. Ask #1's `conditionId_in` filter is the minimum-viable version of
+  this; the aggregate is the fuller form. Lower priority for now.
+- **Indexed latest-prediction by address** — our auction cooldown calls
+  `predictions(address, take:1, orderBy: CREATED_AT desc)` per inbound auction. If it stays in prod
+  it must be an O(log n) indexed lookup (index on `(address, createdAt desc)`), or a small
+  `latestPrediction(address)` field. We may remove this caller entirely, so don't prioritize.
+- **Per-operation cost/freshness metadata** — a response extension carrying `indexedAt` /
+  source-data timestamp (and optionally resolver cost / row count) so clients can detect stale reads
+  and fail-closed. (We saw the cooldown silently trust hours-stale index data; freshness metadata is
+  what makes that visible.) Persisted/allowlisted operations would be a nice prod-hardening too.
+
+---
+
+## Priority
+
+| Ask | Priority | Notes |
+|-----|----------|-------|
+| 1. positions: explicit open filter + token/condition filters + cursor + count | **P0** | unblocks open-only reads; removes the 5000-cap truncation risk and the `result:null` overload |
+| 2a. conditions: server-side similarMarkets filter | P1 | kills a client-side fetch-then-filter |
+| 2b. conditions: batch by `id_in` | P1 | collapses per-leg/per-position N+1 |
+| vaultExposure aggregate | later | `conditionId_in` (ask 1) is the MVP |
+| indexed latest-prediction | later | may remove the caller |
+| operation cost/freshness metadata + persisted queries | later | observability / fail-closed |

--- a/docs/vault-bot-api-asks.md
+++ b/docs/vault-bot-api-asks.md
@@ -1,84 +1,58 @@
-# Vault-bot → Sapience API: data-layer asks
+# Vault-bot → Sapience API: data-layer
 
-Context: vault-bot is going to production and several hot paths currently **over-fetch and filter
-client-side** because the server-side filter/pagination isn't available (or we aren't using it).
-These are the API changes that would let us stop brute-forcing. Shapes below are proposals — map
-them to the actual schema as you see fit. Each ask cites the vault-bot code that forces the
-workaround today (paths are in `sapiencexyz/vault-bot`).
-
----
-
-## Live asks (we're acting on these now)
-
-### 1. `positions` — server-side filtering + cursor pagination + total count
-
-**Today:** vault-bot pages **every position a vault has ever held** (settled + open, predictor +
-counterparty) and filters in JS. It uses a holder-only query with `take/skip`, capped at
-**5000 rows** (`PAGE_SIZE 100 × MAX_PAGES 50`, `src/shared/effects/http/paginated-positions.ts:4-5`),
-then drops predictor tokens client-side (`position-cache.ts:47`) and resolved positions in each
-consumer. Open exposure is a tiny fraction of lifetime positions, so this is mostly wasted transfer
-— and past 5000 lifetime rows, open positions can fall off the tail and we **silently under-count
-live vault exposure** (no error on truncation).
-
-Today the only way to ask for open positions is `positions(holder, result: null)` — overloading
-`null` to mean "unsettled." That's ambiguous (null reads as "no filter" / "unknown" / "open") and
-error-prone. We want an **explicit** open-state filter and the path to be the complete, efficient one:
-
-- **Add an explicit open/settled filter** instead of `result: null` — e.g. `status: OPEN | SETTLED`
-  (enum) or `settled: Boolean`. Keep `result` (`COUNTERPARTY_WINS` / `PREDICTOR_WINS`) for the
-  *settled sub-state*; "open" should not be expressed as the absence of a result. Our hottest read
-  is "all open counterparty positions for this vault," and it should say exactly that.
-- **Guarantee the open/settled and `result` filters are index-backed** (open-only / claimable
-  without a full-history scan).
-- **Add a token-type filter**, e.g. `isPredictorToken: Boolean`, so we can request counterparty-only
-  (or both) instead of fetching both and filtering client-side.
-- **Add a condition / group filter**, e.g. `conditionId_in: [String!]` (and/or `conditionGroupId_in`),
-  so we can read exposure for just the markets a quote touches instead of the whole book.
-- **Cursor pagination + total count** — `{ items, pageInfo { endCursor, hasNextPage }, totalCount }`
-  — so results are deterministically bounded (no magic 5000 cap) and pageable in parallel.
-
-### 2. `conditions` — server-side `similarMarkets` filter + batch-by-id
-
-**Today (filter):** vault-bot fetches **all** active public unsettled conditions, then filters
-`similarMarkets` for `"polymarket.com"` **in JS** (`src/shared/effects/http/sapience-queries.ts:144-146`).
-Every non-Polymarket active condition is downloaded and discarded.
-→ **Add a server-side predicate**: `similarMarkets: { contains: "polymarket.com" }` or a
-`hasPolymarketMarket: Boolean` flag on the `conditions` `where`.
-
-**Today (batch):** `getConditionById` is called **once per leg per quote**
-(`fair-price.ts`, `fixed-edge.ts:45`) and **N positions × M legs** on the MTM path
-(`inventory-pricing.ts`). A cold N-leg parlay is N separate round-trips.
-→ **Support batch lookup** returning the same fields as `condition(id:)` for
-`conditions(where: { id: { in: [...] } })` (the same field set we use today: `conditionGroupId`,
-`conditionGroup.negRisk`, `similarMarkets`, `endTime`, `public`, `question`).
+**TL;DR:** Almost everything vault-bot needs already exists on `positions` / `conditions`. We're
+over-fetching because we aren't *using* the existing filters, not because they're missing. The only
+genuine API gap is an **`isPredictorToken` filter on `positions`**. The rest is vault-bot-side
+migration — recorded here so the API team can confirm the relevant fields are index-backed.
 
 ---
 
-## Heads-up / likely-later (not building yet — flagging so it informs design)
+## Already supported — vault-bot will migrate to these (no API work)
 
-- **`vaultExposure` aggregate** — a server-side aggregate of *open* counterparty collateral keyed by
-  the quote's touched conditions/groups (`{ byCondition { conditionId, counterpartyCollateral,
-  positionCount }, byConditionGroup { ... } }`), so we don't transfer + rescan unrelated open rows
-  for concentration/utilization. Ask #1's `conditionId_in` filter is the minimum-viable version of
-  this; the aggregate is the fuller form. Lower priority for now.
-- **Indexed latest-prediction by address** — our auction cooldown calls
-  `predictions(address, take:1, orderBy: CREATED_AT desc)` per inbound auction. If it stays in prod
-  it must be an O(log n) indexed lookup (index on `(address, createdAt desc)`), or a small
-  `latestPrediction(address)` field. We may remove this caller entirely, so don't prioritize.
-- **Per-operation cost/freshness metadata** — a response extension carrying `indexedAt` /
-  source-data timestamp (and optionally resolver cost / row count) so clients can detect stale reads
-  and fail-closed. (We saw the cooldown silently trust hours-stale index data; freshness metadata is
-  what makes that visible.) Persisted/allowlisted operations would be a nice prod-hardening too.
+`positions(...)` already accepts (`packages/api/src/graphql/sdl/schema/schema.graphql:1583`):
+`conditionId`, `settled: Boolean`, `result: SettlementResult`, `pickConfigId`, `holderWon`,
+`endsAtMin/Max`, `collateralMin/Max`, `orderBy`/`orderDirection`, `holder`, `take`/`skip`.
+
+- **Open positions** → use `settled: false`. Replaces vault-bot's fetch-all-then-filter
+  (`paginated-positions.ts` 5000-cap + client-side `!resolved`) and retires the `result: null`
+  overload for "open."
+- **Per-market exposure** → use `conditionId`. Replaces fetching all positions and matching
+  `pickConfig.picks` client-side.
+- **Claimable** → `result: COUNTERPARTY_WINS` (already used by vault-claimer).
+
+`conditions(... where: ConditionWhereInput)` already supports `id: { in: [...] }` (`StringFilter.in`),
+`endTime`, `public`, `settled`, `conditionGroupId`, `AND`/`OR`, plus a `cursor`:
+
+- **Batch condition lookup** → `conditions(where: { id: { in: [...] } })`. Replaces the per-leg /
+  per-position `getConditionById` N+1.
+- We are **not** asking for a `similarMarkets` filter — in practice every linked condition has a
+  single `polymarket.com` URL, so it would be a no-op.
 
 ---
 
-## Priority
+## The one real ask
 
-| Ask | Priority | Notes |
-|-----|----------|-------|
-| 1. positions: explicit open filter + token/condition filters + cursor + count | **P0** | unblocks open-only reads; removes the 5000-cap truncation risk and the `result:null` overload |
-| 2a. conditions: server-side similarMarkets filter | P1 | kills a client-side fetch-then-filter |
-| 2b. conditions: batch by `id_in` | P1 | collapses per-leg/per-position N+1 |
-| vaultExposure aggregate | later | `conditionId_in` (ask 1) is the MVP |
-| indexed latest-prediction | later | may remove the caller |
-| operation cost/freshness metadata + persisted queries | later | observability / fail-closed |
+**Add `isPredictorToken: Boolean` as a filter arg on `positions(...)`.** Today it's a returned field
+(`schema.graphql:1345`) but not a filter. The vault holds **both** sides: counterparty/maker tokens
+(its market-making exposure) *and* predictor-side tokens bought via the secondary-bidder. The hot
+exposure path wants maker-side only (`isPredictorToken: false`); we filter client-side today. A
+server filter lets the open-exposure read be fully server-scoped:
+`positions(holder, settled: false, isPredictorToken: false)`.
+
+---
+
+## Please confirm (indexing)
+
+We're about to query `positions(holder, settled: false, conditionId: ...)` on the hot path. Please
+confirm these are **index-backed** — ideally composite indexes on `(holder, settled)` and
+`(holder, conditionId)` — so the filters don't degrade to scans at scale. If `isPredictorToken`
+becomes a filter, include it in the composite.
+
+---
+
+## Minor / optional
+
+`positions` paginates with `skip`/`take` (no cursor / `totalCount`); `conditions` already has a
+cursor. Cursor + `totalCount` on `positions` would let us page deterministically and drop our
+5000-row client cap entirely — but with `settled: false` + `conditionId` the result sets are small,
+so this is low priority.


### PR DESCRIPTION
Doc-only (`docs/vault-bot-api-asks.md`). **Scope shrank after checking the schema:** almost everything vault-bot needs already exists — it just isn't using it. Recording here so the team can confirm indexing and build the one real gap.

## The one real ask
- **Add `isPredictorToken: Boolean` as a filter arg on `positions(...)`** (today it's a returned field, `schema.graphql:1345`, not a filter). The vault holds both maker-side and (secondary-bought) predictor-side tokens; the hot exposure read wants maker-side only.

## Please confirm (indexing)
- We're about to query `positions(holder, settled: false, conditionId: ...)` on the hot path — confirm composite indexes on `(holder, settled)` / `(holder, conditionId)` so the existing filters don't scan at scale.

## Already supported — vault-bot will migrate, no API work
- Open positions → `settled: false` (retires our 5000-cap fetch-all + the `result: null` overload).
- Per-market exposure → `conditionId`.
- Batch condition lookup → `conditions(where: { id: { in: [...] } })` (kills the per-leg `getConditionById` N+1).
- **Dropped** the `similarMarkets` filter ask — no-op in practice (linked conditions have a single `polymarket.com` URL).

## Minor / optional
- Cursor + `totalCount` on `positions` (uses skip/take today). Low priority — filtered result sets are small.

Base is `main` per request; retarget to staging if that fits your flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)