### PR TITLE
fix(api): drop resolved-but-unsettled losses from deployedCollateral

### DIFF
--- a/packages/api/src/services/timeSeriesQueries.balance.integration.test.ts
+++ b/packages/api/src/services/timeSeriesQueries.balance.integration.test.ts
@@ -36,13 +36,18 @@ const HOLDER_OTHER_SIDE = '0xbbbb000000000000000000000000000000000002';
 // Predictor who redeems only PART of a winning side — claimable must decrement
 // by the redeemed amount, not drop to zero.
 const HOLDER_PARTIAL_CLAIM = '0xcccc000000000000000000000000000000000003';
+// Predictor holding one LOST position (pickConfig resolved COUNTERPARTY_WINS but
+// the prediction was never settled on-chain, settledAt = null) plus one still-
+// open position. Deployed collateral must drop the lost leg at the pickConfig's
+// resolvedAt, not wait forever on settledAt.
+const HOLDER_DEPLOY = '0xdddd000000000000000000000000000000000004';
 
 // Minimal slices of the tables queryAccountBalance touches. `position` (the V1
 // legacy table) exists only so the all_deployed UNION branch resolves; it stays
 // empty. Prediction carries both predictionId and pickConfigId so the DDL is
 // valid against the pre-fix query too (proving the test fails before the fix).
 const DDL = `
-  CREATE TABLE "Picks" (id text PRIMARY KEY, "predictorToken" text, "counterpartyToken" text);
+  CREATE TABLE "Picks" (id text PRIMARY KEY, "predictorToken" text, "counterpartyToken" text, resolved boolean, "resolvedAt" integer);
   CREATE TABLE "Prediction" (
     "predictionId" text, "pickConfigId" text, predictor text, counterparty text,
     "predictorCollateral" text, "counterpartyCollateral" text,
@@ -90,11 +95,15 @@ let dbAvailable = false;
       await client.$executeRawUnsafe(stmt);
     }
 
+    // Scenarios A/B/C are settled winners → their pickConfigs resolved day(1).
+    // pcLose resolves COUNTERPARTY_WINS day(3); pcOpen never resolves.
     await client.$executeRawUnsafe(
-      `INSERT INTO "Picks" (id, "predictorToken", "counterpartyToken") VALUES
-         ('pcA', 'ptokA', 'ctokA'),
-         ('pcB', 'ptokB', 'ctokB'),
-         ('pcC', 'ptokC', 'ctokC')`
+      `INSERT INTO "Picks" (id, "predictorToken", "counterpartyToken", resolved, "resolvedAt") VALUES
+         ('pcA', 'ptokA', 'ctokA', true, ${day(1)}),
+         ('pcB', 'ptokB', 'ctokB', true, ${day(1)}),
+         ('pcC', 'ptokC', 'ctokC', true, ${day(1)}),
+         ('pcLose', 'ptokLose', 'ctokLose', true, ${day(3)}),
+         ('pcOpen', 'ptokOpen', 'ctokOpen', false, NULL)`
     );
 
     // Scenario A — predictor with 100 claimable on a position settled day(2),
@@ -149,6 +158,25 @@ let dbAvailable = false;
     await client.$executeRawUnsafe(
       `INSERT INTO "Claim" (holder, "pickConfigId", "positionToken", "redeemedAt", "collateralPaid")
        VALUES ('${HOLDER_PARTIAL_CLAIM}', 'pcC', 'ptokC', ${day(4)}, '40')`
+    );
+
+    // Scenario D — deployed collateral with a resolved-but-unsettled loss.
+    //   pred-lose: predictor staked 20, pickConfig resolved COUNTERPARTY_WINS on
+    //     day(3), prediction NEVER settled on-chain (settledAt = null).
+    //   pred-open: predictor staked 5, pickConfig still unresolved.
+    // Deployed must read 25 while both are live, then drop to 5 from the
+    // pickConfig's resolvedAt — NOT stay at 25 forever on the null settledAt.
+    await client.$executeRawUnsafe(
+      `INSERT INTO "Prediction"
+         ("predictionId", "pickConfigId", predictor, counterparty,
+          "predictorCollateral", "counterpartyCollateral",
+          "predictorClaimable", "counterpartyClaimable",
+          "onChainCreatedAt", "settledAt")
+       VALUES
+         ('pred-lose', 'pcLose', '${HOLDER_DEPLOY}', '0xother',
+          '20', '0', '0', '0', ${day(1)}, NULL),
+         ('pred-open', 'pcOpen', '${HOLDER_DEPLOY}', '0xother',
+          '5', '0', '0', '0', ${day(1)}, NULL)`
     );
   }
 }
@@ -211,6 +239,38 @@ describe.skipIf(!dbAvailable)(
       // From day(5): 100 − 40 = 60 (the all-or-nothing bug reported 0 here).
       expect(byDay.get(5)).toBe(60);
       expect(byDay.get(7)).toBe(60);
+    });
+
+    const deployedByDay = async (holder: string) => {
+      const points = await queryAccountBalance(
+        holder,
+        TimeInterval.DAY,
+        from,
+        to,
+        client
+      );
+      return new Map(
+        points.map((p) => [
+          new Date(p.timestamp * 1000).getUTCDate(),
+          Number(p.deployedCollateral),
+        ])
+      );
+    };
+
+    it('drops a resolved-but-unsettled loss from deployed at the pickConfig resolvedAt', async () => {
+      const byDay = await deployedByDay(HOLDER_DEPLOY);
+
+      // Positions are created noon day(1); buckets are midnight, so they first
+      // count from the day(2) bucket. Both legs live (20 lost-leg + 5 open).
+      expect(byDay.get(2)).toBe(25);
+      // resolvedAt is noon day(3), still > the midnight day(3) bucket, so the
+      // lost leg is deployed through day(3).
+      expect(byDay.get(3)).toBe(25);
+      // From day(4) the pickConfig's resolvedAt has passed → the 20 stops being
+      // deployed, even though settledAt is still null. The bug keyed off
+      // settledAt and left this at 25 forever.
+      expect(byDay.get(4)).toBe(5);
+      expect(byDay.get(7)).toBe(5);
     });
   }
 );

--- a/packages/api/src/services/timeSeriesQueries.ts
+++ b/packages/api/src/services/timeSeriesQueries.ts
@@ -413,16 +413,37 @@ export async function queryAccountBalance(
     ),
     -- Materialize all positions for this account once
     all_deployed AS (
-      SELECT "onChainCreatedAt" AS created_ts, "settledAt" AS settled_ts,
-        CASE WHEN predictor = ${addr}
-             THEN CAST("predictorCollateral" AS DECIMAL)
-             WHEN counterparty = ${addr}
-             THEN CAST("counterpartyCollateral" AS DECIMAL)
+      -- A prediction's collateral stops being "deployed" once its pick
+      -- configuration RESOLVES, not when the individual prediction settles
+      -- on-chain. Losing predictions are frequently never settled (the loser
+      -- has no incentive to claim), so "settledAt" stays null forever and
+      -- keying off it over-counts those losses as deployed indefinitely.
+      -- Mirror vaultAggregator.deployedAt: deployed while the pickConfig is
+      -- unresolved, dropped at Picks.resolvedAt. A pickConfig that is resolved
+      -- but missing a resolvedAt, or a pickConfigId pointing at a missing Picks
+      -- row, is treated as no longer deployed (undeploy_ts = created_ts ⇒ the
+      -- created<=bucket<undeploy window is empty). A null pickConfigId (rare
+      -- RPC-error case) has no resolution signal, so it stays deployed.
+      SELECT p."onChainCreatedAt" AS created_ts,
+        CASE
+          WHEN p."pickConfigId" IS NULL THEN NULL
+          WHEN pk.id IS NULL THEN p."onChainCreatedAt"
+          WHEN pk.resolved = false THEN NULL
+          WHEN pk."resolvedAt" IS NOT NULL THEN pk."resolvedAt"
+          ELSE p."onChainCreatedAt"
+        END AS undeploy_ts,
+        CASE WHEN p.predictor = ${addr}
+             THEN CAST(p."predictorCollateral" AS DECIMAL)
+             WHEN p.counterparty = ${addr}
+             THEN CAST(p."counterpartyCollateral" AS DECIMAL)
              ELSE 0 END AS collateral
-      FROM "Prediction"
-      WHERE predictor = ${addr} OR counterparty = ${addr}
+      FROM "Prediction" p
+      LEFT JOIN "Picks" pk ON p."pickConfigId" = pk.id
+      WHERE p.predictor = ${addr} OR p.counterparty = ${addr}
       UNION ALL
-      SELECT "mintedAt" AS created_ts, "settledAt" AS settled_ts,
+      -- Legacy V1 positions have no pickConfig and settle as a unit, so their
+      -- deploy window still keys off settledAt.
+      SELECT "mintedAt" AS created_ts, "settledAt" AS undeploy_ts,
         CASE WHEN predictor = ${addr}
              THEN CAST(COALESCE("predictorCollateral", '0') AS DECIMAL)
              WHEN counterparty = ${addr}
@@ -469,7 +490,7 @@ export async function queryAccountBalance(
         SELECT SUM(d.collateral)
         FROM all_deployed d
         WHERE d.created_ts <= b.bucket_epoch
-          AND (d.settled_ts IS NULL OR d.settled_ts > b.bucket_epoch)
+          AND (d.undeploy_ts IS NULL OR d.undeploy_ts > b.bucket_epoch)
       ), 0)::TEXT AS deployed_collateral,
       -- Claimable remaining = gross owed on each settled-won (pickConfig, side)
       -- MINUS the collateral already redeemed on that side up to the bucket,

--- a/packages/sdk/queries/vault.ts
+++ b/packages/sdk/queries/vault.ts
@@ -148,17 +148,19 @@ export interface VaultAccountValue {
 }
 
 // Sourced from the vault entity's live `stats` snapshot — NOT the
-// `account(...)` surface. The two compute `deployedCollateral` differently:
+// `account(...)` surface. Both now compute `deployedCollateral` off the pick
+// configuration's resolution (`Picks.resolved`/`resolvedAt`), so a position
+// drops out of "deployed" the moment its pickConfig resolves — including a
+// COUNTERPARTY_WINS loss that is never settled on-chain:
 //
-//   - `Vault.stats.deployedCollateral` (this query) keys "still open" off
-//     Picks.resolved/resolvedAt, so resolved positions drop out immediately.
-//   - `Account.statsHistory.deployedCollateral` keys it off Prediction.settledAt.
-//     Losing predictions are frequently never settled on-chain, so their
-//     counterpartyCollateral stays counted as deployed forever.
+//   - `Vault.stats.deployedCollateral` (this query) — vaultAggregator.deployedAt.
+//   - `Account.statsHistory.deployedCollateral` — queryAccountBalance SQL.
 //
-// The account path therefore over-counts deployed (e.g. ~4x for a vault with a
-// backlog of unsettled losses), inflating the headline balance well above the
-// vault's true AUM. The vault entity matches the figure the PnL chart plots.
+// They previously diverged: the account path keyed off Prediction.settledAt,
+// and losing predictions are frequently never settled on-chain, so their
+// counterpartyCollateral stayed counted as deployed forever — over-counting the
+// headline balance (e.g. ~4x for a vault with a backlog of unsettled losses).
+// Both paths now match the figure the PnL chart plots.
 export const GET_VAULT_ACCOUNT_VALUE = /* GraphQL */ `
   query VaultAccountValue($address: Address!, $chainId: Int) {
     vault(address: $address, chainId: $chainId) {


### PR DESCRIPTION
## Problem

`Account.statsHistory.deployedCollateral` — and the v1 `accountBalance` query, since both share the `queryAccountBalance` SQL in `packages/api/src/services/timeSeriesQueries.ts` — decided whether collateral was "still deployed" off `Prediction.settledAt`.

`Prediction.settledAt` and `PickConfiguration.resolved` are set by **decoupled** flows: `settledAt` only on the on-chain `PredictionSettled` event, `Picks.resolved`/`result` as soon as the conditions settle (early resolution). A losing predictor has no incentive to ever settle on-chain, so `COUNTERPARTY_WINS` losses sat with `settledAt = null` and were counted as deployed **forever**, inflating the headline balance well above true AUM.

Example: kernel `0xF20e8BA6F2b84D0d48865A47E8832494f2f6F34F` showed ~$25 deployed when only ~$5 was genuinely open — the ~$20 gap was resolved-but-unsettled losses.

The codebase already documented this divergence in `packages/sdk/queries/vault.ts`, and the vault path (`vaultAggregator.deployedAt`) already does it correctly.

## Fix

Key the Prediction branch's deploy window off `Picks.resolved`/`resolvedAt` instead of `settledAt`, mirroring `vaultAggregator.deployedAt`:

- `pickConfigId` null → stays deployed (no resolution signal; rare RPC-error case)
- pickConfig unresolved → deployed
- pickConfig resolved → drops at `resolvedAt`, regardless of `settledAt`

The legacy `position` branch keeps its `settledAt` window (no pickConfig; settles as a unit). One shared SQL change fixes both `/graphql` (v1) and `/v2/graphql` (v2).

## Test

Adds a real-SQL integration scenario to `timeSeriesQueries.balance.integration.test.ts`: a resolved-but-unsettled loss (20) + an open position (5). Asserts deployed reads 25 while both are live, then drops to 5 once the pickConfig's `resolvedAt` passes. Verified red before the fix, green after. Related suites (timeSeriesQueries unit/pnl, accountStatsHistory, Vault) all pass.

## Note

A `PREDICTOR_WINS` position now leaves "deployed" at `resolvedAt` but only enters "claimable" at `settledAt` (claimable amounts aren't known until the settle event), so it's briefly in neither bucket — same as the vault path, and short-lived in practice. Attribution-on-transfer is a separate pre-existing limitation, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)