### PR TITLE
fix(app): make auctions work on Robinhood/custom EVM chains

### DIFF
--- a/packages/app/src/components/layout/ConnectDialog.tsx
+++ b/packages/app/src/components/layout/ConnectDialog.tsx
@@ -89,7 +89,7 @@ export default function ConnectDialog({
   const { isConnected, address } = useAccount();
   const [isClient, setIsClient] = useState(false);
   const { clearLoggedOut } = useAuth();
-  const { startSession, sessionCreationStep } = useSession();
+  const { startSession, sessionCreationStep, accountMode } = useSession();
   const { connectionDurationHours } = useSettings();
 
   // Track if we're creating a session after wallet connection
@@ -193,6 +193,8 @@ export default function ConnectDialog({
 
   // Start session when opened with startSessionOnOpen flag (e.g. after refcode entry)
   useEffect(() => {
+    // Sessions are a smart-account feature; never create one in EOA/wallet mode.
+    if (accountMode !== 'smart-account') return;
     if (!startSessionOnOpen || !open || !isConnected || isCreatingSession)
       return;
 
@@ -216,7 +218,7 @@ export default function ConnectDialog({
     };
 
     void runSession();
-  }, [startSessionOnOpen, open, isConnected]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [startSessionOnOpen, open, isConnected, accountMode]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Auto-create session when wallet connects, then close dialog
   // Only creates session if user has a valid referral relationship.
@@ -231,6 +233,12 @@ export default function ConnectDialog({
         '[ConnectDialog] Fresh wallet connection detected, checking referral status...'
       );
       clearLoggedOut();
+
+      // EOA/wallet mode doesn't use sessions — just connect and close.
+      if (accountMode !== 'smart-account') {
+        onOpenChange(false);
+        return;
+      }
 
       const createSessionAsync = async () => {
         try {
@@ -308,6 +316,7 @@ export default function ConnectDialog({
     startSession,
     address,
     connectionDurationHours,
+    accountMode,
   ]);
 
   const handleEIP6963Connect = useCallback(

--- a/packages/app/src/lib/auction/useAuctionStart.ts
+++ b/packages/app/src/lib/auction/useAuctionStart.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useAccount, useSignTypedData } from 'wagmi';
+import { useAccount, useSignTypedData, useSwitchChain } from 'wagmi';
 import { zeroAddress as ZERO_ADDRESS, type Hex } from 'viem';
 import type { Pick } from '@sapience/sdk/types';
 import {
@@ -9,6 +9,7 @@ import {
   type SignableTypedData,
 } from '@sapience/sdk/auction/initiate';
 import { canonicalizePicks } from '@sapience/sdk/auction/escrowEncoding';
+import { predictionMarketEscrow } from '@sapience/sdk/contracts';
 import { useSettings } from '~/lib/context/SettingsContext';
 import { useSession } from '~/lib/context/SessionContext';
 import { toAuctionWsUrl } from '~/lib/ws/auctionUrl';
@@ -123,7 +124,7 @@ export function useAuctionStart(options?: UseAuctionStartOptions) {
   const inflightRef = useRef<string>('');
   // `apiBaseUrl` is the auction relayer base URL (http(s), typically includes `/auction`)
   const { apiBaseUrl } = useSettings();
-  const { address: walletAddress } = useAccount();
+  const { address: walletAddress, chainId: walletChainId } = useAccount();
   const {
     signMessage: sessionSignMessage,
     signTypedData: sessionSignTypedData,
@@ -132,6 +133,7 @@ export function useAuctionStart(options?: UseAuctionStartOptions) {
     isUsingSession,
   } = useSession();
   const { signTypedDataAsync } = useSignTypedData();
+  const { switchChainAsync } = useSwitchChain();
 
   // Stable refs for session state — read at call time, don't trigger requestQuotes recreation
   const effectiveAddressRef = useRef(effectiveAddress);
@@ -139,7 +141,12 @@ export function useAuctionStart(options?: UseAuctionStartOptions) {
   const sessionSignTypedDataRef = useRef(sessionSignTypedData);
   const isUsingSmartAccountRef = useRef(isUsingSmartAccount);
   const isUsingSessionRef = useRef(isUsingSession);
+  // Wallet's currently-selected chain — read at sign time to switch if needed
+  const walletChainIdRef = useRef(walletChainId);
 
+  useEffect(() => {
+    walletChainIdRef.current = walletChainId;
+  }, [walletChainId]);
   useEffect(() => {
     effectiveAddressRef.current = effectiveAddress;
   }, [effectiveAddress]);
@@ -431,6 +438,12 @@ export function useAuctionStart(options?: UseAuctionStartOptions) {
 
       const chainId = canonicalizedParams.chainId;
 
+      // Resolve the escrow (verifying) contract from the SDK registry and pass
+      // it explicitly so prepareAuctionRFQ never has to fall back to its own
+      // lookup. This keeps custom/non-Ethereal chains (e.g. Robinhood testnet)
+      // working as long as the SDK has an address for the chain.
+      const verifyingContract = predictionMarketEscrow[chainId]?.address;
+
       // Build the signed auction payload via SDK
       // prepareAuctionRFQ handles: pick canonicalization, deadline computation,
       // EIP-712 typed data building, signing, payload assembly, self-validation.
@@ -477,6 +490,13 @@ export function useAuctionStart(options?: UseAuctionStartOptions) {
                 message: typedData.message,
               });
             }
+            // The EIP-712 domain is bound to the auction chain. Wallets reject
+            // eth_signTypedData_v4 when the domain.chainId differs from the
+            // wallet's active network ("chainId should be same as current
+            // chainId"), so make sure the wallet is on the target chain first.
+            if (walletChainIdRef.current !== chainId) {
+              await switchChainAsync({ chainId });
+            }
             log('[auction] Signing intent with wallet');
             return signTypedDataAsync({
               domain: typedData.domain,
@@ -487,6 +507,7 @@ export function useAuctionStart(options?: UseAuctionStartOptions) {
           },
           options: {
             deadlineSeconds: 30,
+            verifyingContract,
             skipIntentSigning: skipSigning,
             predictorSponsor: canonicalizedParams.predictorSponsor,
             predictorSponsorData: canonicalizedParams.predictorSponsorData,
@@ -507,8 +528,12 @@ export function useAuctionStart(options?: UseAuctionStartOptions) {
           );
         }
       } catch (e) {
-        log(
-          `[auction] Auction preparation failed: ${e instanceof Error ? e.message : String(e)}`
+        // Surface prep failures: previously this only went to the (often
+        // disabled) auction logger, so a thrown prepareAuctionRFQ — e.g. no
+        // escrow address for the chain — produced no sign prompt and no error,
+        // making the auction look like it silently did nothing.
+        console.error(
+          `[auction] Auction preparation failed (chainId=${chainId}, escrow=${verifyingContract ?? 'none'}): ${e instanceof Error ? e.message : String(e)}`
         );
         inflightRef.current = '';
         return;
@@ -554,7 +579,7 @@ export function useAuctionStart(options?: UseAuctionStartOptions) {
       }, 10_000);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [wsUrl, walletAddress, signTypedDataAsync]
+    [wsUrl, walletAddress, signTypedDataAsync, switchChainAsync]
   );
 
   const acceptBid = useCallback(

--- a/packages/app/src/lib/session/sessionKeyManager.ts
+++ b/packages/app/src/lib/session/sessionKeyManager.ts
@@ -56,8 +56,10 @@ import {
   DEFAULT_CHAIN_ID,
   CHAIN_ID_ETHEREAL_TESTNET,
   CHAIN_ID_ARBITRUM,
+  CHAIN_ID_ROBINHOOD_TESTNET,
   etherealChain,
   etherealTestnetChain,
+  getChainConfig,
 } from '@sapience/sdk/constants';
 import { computeSmartAccountAddress } from '@sapience/sdk/session';
 import { httpWithRetry, withRetry } from '../utils/util';
@@ -192,6 +194,10 @@ function getZeroDevUrls(chainId: number): {
       bundler: process.env.NEXT_PUBLIC_ZERODEV_BUNDLER_URL_ARBITRUM,
       paymaster: process.env.NEXT_PUBLIC_ZERODEV_PAYMASTER_URL_ARBITRUM,
     },
+    [CHAIN_ID_ROBINHOOD_TESTNET]: {
+      bundler: process.env.NEXT_PUBLIC_ZERODEV_BUNDLER_URL_ROBINHOOD,
+      paymaster: process.env.NEXT_PUBLIC_ZERODEV_PAYMASTER_URL_ROBINHOOD,
+    },
   };
 
   const chainUrls = envUrls[chainId];
@@ -199,6 +205,9 @@ function getZeroDevUrls(chainId: number): {
     throw new Error(`Unsupported chain ID: ${chainId}`);
   }
 
+  // When no chain-specific override env var is set, fall back to the generic
+  // ZeroDev v3 project URL (https://rpc.zerodev.app/api/v3/{projectId}/chain/{chainId}),
+  // which works for any chain enabled on the ZeroDev project.
   return {
     bundlerUrl: chainUrls.bundler || baseUrl,
     paymasterUrl: chainUrls.paymaster || baseUrl,
@@ -622,12 +631,19 @@ export async function verifyAccountFactoryMapping(
 }
 
 /**
- * Get the Ethereal chain config based on chainId.
+ * Get the chain config used for a session on the given chainId.
+ *
+ * Must return the chain that actually matches the wallet's network: the EIP-712
+ * session-approval domain and the smart-account client are built from this, so
+ * returning the wrong chain makes the wallet reject signing with "chainId
+ * should be same as current chainId". Non-Ethereal session-capable chains (e.g.
+ * Robinhood/Meridian testnet) resolve via the SDK rather than falling back to
+ * Ethereal mainnet.
  */
 function getEtherealChain(chainId: number): Chain {
-  return chainId === CHAIN_ID_ETHEREAL_TESTNET
-    ? etherealTestnetChain
-    : etherealChain;
+  if (chainId === CHAIN_ID_ETHEREAL_TESTNET) return etherealTestnetChain;
+  if (chainId === CHAIN_ID_ETHEREAL) return etherealChain;
+  return getChainConfig(chainId);
 }
 
 // Public clients - Arbitrum is static, Ethereal is created based on chainId

--- a/packages/app/src/lib/utils/util.ts
+++ b/packages/app/src/lib/utils/util.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_CHAIN_ID,
   etherealChain,
   etherealTestnetChain,
+  getChainConfig,
 } from '@sapience/sdk/constants';
 import {
   DEFAULT_RETRY_COUNT,
@@ -79,15 +80,33 @@ export function getPublicClientForChainId(chainId: number) {
   const envKey = `NEXT_PUBLIC_RPC_${chainId}` as keyof NodeJS.ProcessEnv;
   const envUrl = process.env[envKey as string];
 
+  // Chains not in viem/chains (e.g. Robinhood/Meridian testnet, or a custom
+  // localStorage-override chain) are resolved via the SDK, which reads the
+  // built-in registry and the custom-chain override. Without this, the client
+  // below would silently fall back to mainnet's default RPC (eth.merkle.io)
+  // and send calls for this chain to the wrong network.
+  let sdkChain: ReturnType<typeof getChainConfig> | undefined;
+  try {
+    sdkChain = getChainConfig(chainId);
+  } catch {
+    sdkChain = undefined;
+  }
+
+  const resolvedChain = chainObj ?? sdkChain ?? mainnet;
   const defaultUrl =
     envUrl ||
     chainObj?.rpcUrls?.default?.http?.[0] ||
+    sdkChain?.rpcUrls?.default?.http?.[0] ||
     (chainId === 1 ? 'https://ethereum-rpc.publicnode.com' : undefined);
 
+  if (!defaultUrl) {
+    throw new Error(
+      `No RPC URL configured for chainId=${chainId}. Set NEXT_PUBLIC_RPC_${chainId} or a custom-chain override.`
+    );
+  }
+
   const client = createPublicClient({
-    chain: (chainObj ?? mainnet) as Parameters<
-      typeof createPublicClient
-    >[0]['chain'],
+    chain: resolvedChain as Parameters<typeof createPublicClient>[0]['chain'],
     transport: httpWithRetry(defaultUrl),
   });
   publicClientCache.set(chainId, client);

--- a/packages/sdk/constants/chain.ts
+++ b/packages/sdk/constants/chain.ts
@@ -9,6 +9,11 @@ export const CHAIN_ID_ROBINHOOD_TESTNET = 46630 as const;
 const BUILT_IN_TRADING_CHAIN_IDS = new Set<number>([
   CHAIN_ID_ETHEREAL,
   CHAIN_ID_ETHEREAL_TESTNET,
+  // Robinhood/Meridian testnet has the full contract deployment (escrow, vault,
+  // collateral) in the registry and ZeroDev smart-account support, so it gets
+  // the same smart-account/session treatment as the Ethereal chains rather than
+  // being forced to EOA-only like a generic custom chain.
+  CHAIN_ID_ROBINHOOD_TESTNET,
 ]);
 
 /**


### PR DESCRIPTION
## Summary

Fixes a chain of issues that prevented running auctions (and sessions) on non-Ethereal chains such as **Robinhood/Meridian testnet (46630)**. Verified working end-to-end for **wallet/EOA-mode auctions** on Robinhood.

## Changes

- **`useAuctionStart.ts`**
  - Switch the wallet to the auction's `chainId` before signing the intent. Wallets reject `eth_signTypedData_v4` when the EIP-712 `domain.chainId` differs from the active network (`"chainId should be same as current chainId"`), which silently blocked the sign prompt.
  - Pass the SDK escrow address explicitly as `verifyingContract` to `prepareAuctionRFQ`.
  - Surface previously-swallowed `prepareAuctionRFQ` failures via `console.error` (they only went to the often-disabled auction logger, so failures produced no prompt and no error).
- **`util.getPublicClientForChainId`** — resolve RPC for chains not in `viem/chains` via the SDK (`getChainConfig`) instead of silently defaulting to mainnet's public RPC (`eth.merkle.io`). Fixes on-chain bid validation being sent to the wrong network.
- **`sessionKeyManager.ts`** — allow Robinhood in the ZeroDev URL map (falls back to the generic ZeroDev v3 project URL), and fix `getEtherealChain` to resolve the real chain instead of falling back to Ethereal mainnet.
- **`constants/chain.ts`** — treat Robinhood testnet as a built-in trading chain so it gets smart-account/session handling rather than EOA-only.

## Status / follow-ups

- **EOA/wallet-mode auctions on Robinhood: working** (the chain-switch + RPC fixes).
- **Smart-account sessions on Robinhood: still blocked upstream** — the ZeroDev paymaster (`zd_sponsorUserOperation`) does not serve chain 46630, so the smart account can't be deployed/sponsored. Tracking separately; requires ZeroDev chain support or an alternative bundler/paymaster.
- Separately investigating: in EOA mode the connect flow still auto-triggers session creation — fix to follow.

## Test plan

- `pnpm --filter @sapience/sdk run build:lib` ✓
- `pnpm --filter @sapience/app run type-check` ✓
- eslint on changed files ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)