### PR TITLE
fix(market-keeper): migrate Discovery market fetch to /markets/keyset

### DIFF
--- a/packages/market-keeper/src/__tests__/fetch-ending-soonest-keyset.test.ts
+++ b/packages/market-keeper/src/__tests__/fetch-ending-soonest-keyset.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PolymarketMarket } from '../types';
+
+type FetchCall = { url: string; init?: RequestInit };
+const fetchCalls: FetchCall[] = [];
+const fetchQueue: Array<() => Response> = [];
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+vi.mock('../utils/fetch', () => ({
+  fetchWithRetry: vi.fn(async (url: string, init?: RequestInit) => {
+    fetchCalls.push({ url, init });
+    const next = fetchQueue.shift();
+    if (!next) throw new Error(`No queued response for ${url}`);
+    return next();
+  }),
+}));
+
+import { fetchEndingSoonMarketsViaKeyset } from '../generate/market';
+
+beforeEach(() => {
+  fetchCalls.length = 0;
+  fetchQueue.length = 0;
+  vi.clearAllMocks();
+});
+
+// endDate well inside the window so nothing is filtered by the boundary guard.
+const IN_WINDOW = '2026-07-01T00:00:00.000Z';
+
+function mkt(id: string, endDate: string = IN_WINDOW): PolymarketMarket {
+  return {
+    id,
+    conditionId: `cond-${id}`,
+    question: `Q ${id}`,
+    outcomes: ['Yes', 'No'],
+    volume: '0',
+    liquidity: '0',
+    endDate,
+    description: '',
+    slug: `slug-${id}`,
+    active: true,
+    closed: false,
+  };
+}
+
+function keysetPage(markets: PolymarketMarket[], next_cursor?: string) {
+  return jsonResponse({ markets, ...(next_cursor ? { next_cursor } : {}) });
+}
+
+const MIN = new Date('2026-06-27T15:00:00.000Z');
+const MAX = new Date('2026-09-25T15:00:00.000Z');
+
+describe('fetchEndingSoonMarketsViaKeyset', () => {
+  it('hits /markets/keyset and never sends an offset param', async () => {
+    fetchQueue.push(() => keysetPage([mkt('a')]));
+
+    await fetchEndingSoonMarketsViaKeyset(MIN, MAX);
+
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0].url).toContain(
+      'https://gamma-api.polymarket.com/markets/keyset'
+    );
+    for (const call of fetchCalls) {
+      expect(call.url).not.toContain('offset=');
+    }
+  });
+
+  it('bounds the window with end_date_min and end_date_max', async () => {
+    fetchQueue.push(() => keysetPage([mkt('a')]));
+
+    await fetchEndingSoonMarketsViaKeyset(MIN, MAX);
+
+    const url = fetchCalls[0].url;
+    expect(url).toContain(
+      `end_date_min=${encodeURIComponent(MIN.toISOString())}`
+    );
+    expect(url).toContain(
+      `end_date_max=${encodeURIComponent(MAX.toISOString())}`
+    );
+    expect(url).toContain('active=true');
+    expect(url).toContain('closed=false');
+  });
+
+  it('follows next_cursor across pages and passes it as after_cursor', async () => {
+    fetchQueue.push(() => keysetPage([mkt('a')], 'cursor-1'));
+    fetchQueue.push(() => keysetPage([mkt('b')], 'cursor-2'));
+    fetchQueue.push(() => keysetPage([mkt('c')])); // last page: no next_cursor
+
+    const result = await fetchEndingSoonMarketsViaKeyset(MIN, MAX);
+
+    expect(fetchCalls).toHaveLength(3);
+    expect(fetchCalls[0].url).not.toContain('after_cursor');
+    expect(fetchCalls[1].url).toContain('after_cursor=cursor-1');
+    expect(fetchCalls[2].url).toContain('after_cursor=cursor-2');
+    expect(result.map((m) => m.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('paginates a large same-endDate cluster via cursor (regression: HTTP 422 offset cap)', async () => {
+    // Reproduces the crash: hundreds of markets sharing one endDate. The old
+    // offset fallback drove offset past Gamma's cap → 422. Keyset must walk the
+    // whole cluster purely by cursor.
+    const sameEnd = '2026-07-06T10:00:00.000Z';
+    const pages = 5;
+    for (let p = 0; p < pages; p++) {
+      const batch = Array.from({ length: 100 }, (_, i) =>
+        mkt(`p${p}-i${i}`, sameEnd)
+      );
+      const isLast = p === pages - 1;
+      fetchQueue.push(() => keysetPage(batch, isLast ? undefined : `c${p}`));
+    }
+
+    const result = await fetchEndingSoonMarketsViaKeyset(MIN, MAX);
+
+    expect(fetchCalls).toHaveLength(pages);
+    expect(result).toHaveLength(pages * 100);
+    for (const call of fetchCalls) {
+      expect(call.url).not.toContain('offset=');
+    }
+  });
+
+  it('deduplicates markets by conditionId across pages', async () => {
+    fetchQueue.push(() => keysetPage([mkt('a'), mkt('b')], 'c1'));
+    fetchQueue.push(() => keysetPage([mkt('b'), mkt('c')])); // b repeats
+
+    const result = await fetchEndingSoonMarketsViaKeyset(MIN, MAX);
+
+    expect(result.map((m) => m.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('drops markets at or beyond maxEndDate (boundary guard)', async () => {
+    const atMax = MAX.toISOString();
+    const beyond = '2026-12-01T00:00:00.000Z';
+    fetchQueue.push(() =>
+      keysetPage([mkt('in', IN_WINDOW), mkt('edge', atMax), mkt('out', beyond)])
+    );
+
+    const result = await fetchEndingSoonMarketsViaKeyset(MIN, MAX);
+
+    expect(result.map((m) => m.id)).toEqual(['in']);
+  });
+
+  it('stops if a page returns only already-seen markets even with a persistent next_cursor (guards cursor-ignored bug)', async () => {
+    const batch = [mkt('a'), mkt('b')];
+    // Server keeps handing back the same page + a non-null cursor (the reported
+    // keyset cursor-ignored bug). Must not loop forever.
+    fetchQueue.push(() => keysetPage(batch, 'stuck'));
+    fetchQueue.push(() => keysetPage(batch, 'stuck'));
+    fetchQueue.push(() => keysetPage(batch, 'stuck'));
+
+    const result = await fetchEndingSoonMarketsViaKeyset(MIN, MAX);
+
+    expect(fetchCalls.length).toBeLessThanOrEqual(2);
+    expect(result.map((m) => m.id)).toEqual(['a', 'b']);
+  });
+
+  it('throws and surfaces the status on a non-ok response', async () => {
+    fetchQueue.push(() =>
+      jsonResponse({ type: 'validation error', error: 'boom' }, 422)
+    );
+
+    await expect(fetchEndingSoonMarketsViaKeyset(MIN, MAX)).rejects.toThrow(
+      /422/
+    );
+  });
+});

--- a/packages/market-keeper/src/__tests__/fetch-ending-soonest-keyset.test.ts
+++ b/packages/market-keeper/src/__tests__/fetch-ending-soonest-keyset.test.ts
@@ -21,7 +21,10 @@ vi.mock('../utils/fetch', () => ({
   }),
 }));
 
-import { fetchEndingSoonMarketsViaKeyset } from '../generate/market';
+import {
+  fetchEndingSoonMarketsViaKeyset,
+  fetchMarketsByEventTags,
+} from '../generate/market';
 
 beforeEach(() => {
   fetchCalls.length = 0;
@@ -86,6 +89,16 @@ describe('fetchEndingSoonMarketsViaKeyset', () => {
     expect(url).toContain('closed=false');
   });
 
+  it('orders ending-soonest (order=endDate&ascending=true) so the cursor walks the window front-to-back', async () => {
+    fetchQueue.push(() => keysetPage([mkt('a')]));
+
+    await fetchEndingSoonMarketsViaKeyset(MIN, MAX);
+
+    const url = fetchCalls[0].url;
+    expect(url).toContain('order=endDate');
+    expect(url).toContain('ascending=true');
+  });
+
   it('follows next_cursor across pages and passes it as after_cursor', async () => {
     fetchQueue.push(() => keysetPage([mkt('a')], 'cursor-1'));
     fetchQueue.push(() => keysetPage([mkt('b')], 'cursor-2'));
@@ -144,10 +157,10 @@ describe('fetchEndingSoonMarketsViaKeyset', () => {
     expect(result.map((m) => m.id)).toEqual(['in']);
   });
 
-  it('stops if a page returns only already-seen markets even with a persistent next_cursor (guards cursor-ignored bug)', async () => {
+  it('stops on an unchanged cursor (guards the keyset cursor-ignored bug)', async () => {
     const batch = [mkt('a'), mkt('b')];
-    // Server keeps handing back the same page + a non-null cursor (the reported
-    // keyset cursor-ignored bug). Must not loop forever.
+    // Server keeps handing back the same non-null cursor it was given (the
+    // reported keyset cursor-ignored bug). Must not loop forever.
     fetchQueue.push(() => keysetPage(batch, 'stuck'));
     fetchQueue.push(() => keysetPage(batch, 'stuck'));
     fetchQueue.push(() => keysetPage(batch, 'stuck'));
@@ -158,6 +171,20 @@ describe('fetchEndingSoonMarketsViaKeyset', () => {
     expect(result.map((m) => m.id)).toEqual(['a', 'b']);
   });
 
+  it('does NOT stop on a zero-new page while the cursor is still advancing', async () => {
+    // A page can add zero markets because everything was filtered/deduped, not
+    // because the cursor is stuck. As long as the cursor advances we must keep
+    // walking, or we truncate the window early.
+    const beyond = '2026-12-01T00:00:00.000Z'; // filtered out by the window guard
+    fetchQueue.push(() => keysetPage([mkt('out', beyond)], 'cursor-1')); // 0 new, cursor advances
+    fetchQueue.push(() => keysetPage([mkt('a')])); // real market on the next page
+
+    const result = await fetchEndingSoonMarketsViaKeyset(MIN, MAX);
+
+    expect(fetchCalls).toHaveLength(2);
+    expect(result.map((m) => m.id)).toEqual(['a']);
+  });
+
   it('throws and surfaces the status on a non-ok response', async () => {
     fetchQueue.push(() =>
       jsonResponse({ type: 'validation error', error: 'boom' }, 422)
@@ -166,5 +193,102 @@ describe('fetchEndingSoonMarketsViaKeyset', () => {
     await expect(fetchEndingSoonMarketsViaKeyset(MIN, MAX)).rejects.toThrow(
       /422/
     );
+  });
+});
+
+function eventWith(slug: string, markets: PolymarketMarket[]) {
+  return {
+    id: `ev-${slug}`,
+    title: `T ${slug}`,
+    slug,
+    description: '',
+    markets,
+  };
+}
+
+function eventsKeysetPage(
+  events: ReturnType<typeof eventWith>[],
+  next_cursor?: string
+) {
+  return jsonResponse({ events, ...(next_cursor ? { next_cursor } : {}) });
+}
+
+describe('fetchMarketsByEventTags', () => {
+  it('hits /events/keyset, never sends offset, and bounds with end_date_max', async () => {
+    fetchQueue.push(() => eventsKeysetPage([eventWith('e1', [mkt('a')])]));
+
+    await fetchMarketsByEventTags(['earnings'], MAX);
+
+    expect(fetchCalls).toHaveLength(1);
+    const url = fetchCalls[0].url;
+    expect(url).toContain('https://gamma-api.polymarket.com/events/keyset');
+    expect(url).toContain('tag_slug=earnings');
+    expect(url).toContain(
+      `end_date_max=${encodeURIComponent(MAX.toISOString())}`
+    );
+    expect(url).not.toContain('offset=');
+  });
+
+  it('flattens event.markets and injects the parent event for grouping', async () => {
+    fetchQueue.push(() =>
+      eventsKeysetPage([eventWith('e1', [mkt('a'), mkt('b')])])
+    );
+
+    const result = await fetchMarketsByEventTags(['earnings'], MAX);
+
+    expect(result.map((m) => m.id)).toEqual(['a', 'b']);
+    expect(result[0].events?.[0]).toMatchObject({ slug: 'e1', id: 'ev-e1' });
+  });
+
+  it('follows next_cursor across event pages per tag', async () => {
+    fetchQueue.push(() =>
+      eventsKeysetPage([eventWith('e1', [mkt('a')])], 'ec1')
+    );
+    fetchQueue.push(() => eventsKeysetPage([eventWith('e2', [mkt('b')])]));
+
+    const result = await fetchMarketsByEventTags(['earnings'], MAX);
+
+    expect(fetchCalls).toHaveLength(2);
+    expect(fetchCalls[0].url).not.toContain('after_cursor');
+    expect(fetchCalls[1].url).toContain('after_cursor=ec1');
+    expect(result.map((m) => m.id)).toEqual(['a', 'b']);
+  });
+
+  it('drops markets at or beyond maxEndDate', async () => {
+    const beyond = '2026-12-01T00:00:00.000Z';
+    fetchQueue.push(() =>
+      eventsKeysetPage([
+        eventWith('e1', [mkt('in', IN_WINDOW), mkt('out', beyond)]),
+      ])
+    );
+
+    const result = await fetchMarketsByEventTags(['earnings'], MAX);
+
+    expect(result.map((m) => m.id)).toEqual(['in']);
+  });
+
+  it('skips a tag on a non-ok response and continues to the next tag', async () => {
+    fetchQueue.push(() => jsonResponse({ error: 'nope' }, 500)); // tag "a" fails
+    fetchQueue.push(() => eventsKeysetPage([eventWith('e1', [mkt('z')])])); // tag "b" ok
+
+    const result = await fetchMarketsByEventTags(['a', 'b'], MAX);
+
+    expect(fetchCalls).toHaveLength(2);
+    expect(result.map((m) => m.id)).toEqual(['z']);
+  });
+
+  it('stops on an unchanged cursor (guards the keyset cursor-ignored bug)', async () => {
+    const page = [eventWith('e1', [mkt('a')])];
+    fetchQueue.push(() => eventsKeysetPage(page, 'stuck'));
+    fetchQueue.push(() => eventsKeysetPage(page, 'stuck'));
+    fetchQueue.push(() => eventsKeysetPage(page, 'stuck'));
+
+    const result = await fetchMarketsByEventTags(['earnings'], MAX);
+
+    // Terminates after at most 2 requests instead of looping forever. This
+    // fetcher does not dedup (the caller does), so the repeated page may yield a
+    // duplicate — that's expected and harmless downstream.
+    expect(fetchCalls.length).toBeLessThanOrEqual(2);
+    expect(result.every((m) => m.id === 'a')).toBe(true);
   });
 });

--- a/packages/market-keeper/src/generate/market.ts
+++ b/packages/market-keeper/src/generate/market.ts
@@ -8,34 +8,44 @@ import { fetchWithRetry } from '../utils';
 import { runPipeline, printPipelineStats, MARKET_FILTERS } from './pipeline';
 
 /**
- * Fetch markets that end soonest (for --ending-soon mode)
- * Orders by endDate ascending, no volume sorting
- * Iteratively fetches pages by moving end_date_min based on max endDate from previous response
+ * Page through Gamma's /markets/keyset endpoint for markets ending within the
+ * [minEndDate, maxEndDate) window, deduplicated by conditionId.
+ *
+ * Uses cursor-based pagination (after_cursor / next_cursor). Polymarket
+ * deprecated offset pagination on the legacy /markets endpoint (sunset
+ * 2026-05-01) and now returns HTTP 422 — "offset too large, use /markets/keyset
+ * for deeper pagination" — once the offset grows large. Discovery hit this
+ * whenever a large cluster of markets shared a single endDate: the old fetcher's
+ * offset fallback walked deep enough to trip the cap and the keeper crashed.
+ * Keyset has no offset cap, so it walks same-endDate clusters of any size
+ * without truncating.
+ *
+ * Both ends of the window are bounded server-side via end_date_min/end_date_max
+ * so the cursor walk terminates at the window edge instead of paging the entire
+ * active-market set.
  */
-export async function fetchEndingSoonestMarkets(): Promise<PolymarketMarket[]> {
-  // Minimum end time: current time + 1 minute (ISO format for API)
-  let currentMinEndDate = new Date(Date.now() + 60 * 1000).toISOString();
-  // Maximum end time: current time + MAX_END_DATE_DAYS
-  const maxEndDate = new Date(
-    Date.now() + MAX_END_DATE_DAYS * 24 * 60 * 60 * 1000
-  );
-
+export async function fetchEndingSoonMarketsViaKeyset(
+  minEndDate: Date,
+  maxEndDate: Date
+): Promise<PolymarketMarket[]> {
   const allMarkets: PolymarketMarket[] = [];
-  const seenConditionIds = new Set<string>(); // Track seen markets to deduplicate
-  // Polymarket's /markets endpoint silently caps `limit` at 100 server-side;
-  // requesting more returns 100 anyway, and the `markets.length < PAGE_SIZE`
-  // short-page stop signal below would then misfire after page 1.
-  const PAGE_SIZE = 100;
-  let pageCount = 0;
-  let offset = 0;
+  const seenConditionIds = new Set<string>(); // deduplicate across pages
+  const PAGE_SIZE = 100; // keyset max page size (since 2026-05-14)
 
-  console.log(
-    `[Polymarket] Fetching ending-soon markets until ${maxEndDate.toISOString()}...`
-  );
+  const baseParams =
+    `limit=${PAGE_SIZE}` +
+    `&active=true&closed=false` +
+    `&end_date_min=${encodeURIComponent(minEndDate.toISOString())}` +
+    `&end_date_max=${encodeURIComponent(maxEndDate.toISOString())}`;
+
+  let cursor: string | undefined;
+  let pageCount = 0;
 
   while (true) {
     pageCount++;
-    const url = `https://gamma-api.polymarket.com/markets?limit=${PAGE_SIZE}&offset=${offset}&active=true&closed=false&order=endDate&ascending=true&end_date_min=${currentMinEndDate}`;
+    const url =
+      `https://gamma-api.polymarket.com/markets/keyset?${baseParams}` +
+      (cursor ? `&after_cursor=${encodeURIComponent(cursor)}` : '');
 
     const response = await fetchWithRetry(url, {
       headers: { Accept: 'application/json' },
@@ -53,65 +63,71 @@ export async function fetchEndingSoonestMarkets(): Promise<PolymarketMarket[]> {
       );
     }
 
-    const markets: PolymarketMarket[] = await response.json();
+    const body: { markets?: PolymarketMarket[]; next_cursor?: string } =
+      await response.json();
+    const markets = body.markets ?? [];
 
-    if (markets.length === 0) {
-      console.log(`[Polymarket] Page ${pageCount}: No more markets`);
-      break;
+    let newMarketsCount = 0;
+    for (const m of markets) {
+      // end_date_max bounds the window server-side; this guards against any
+      // boundary markets (endDate === maxEndDate) slipping through.
+      if (new Date(m.endDate) >= maxEndDate) continue;
+      if (seenConditionIds.has(m.conditionId)) continue;
+      seenConditionIds.add(m.conditionId);
+      allMarkets.push(m);
+      newMarketsCount++;
     }
-
-    // Find the max endDate in this batch to use as next page's min
-    const maxEndDateInBatch = markets.reduce((max, m) => {
-      const endDate = new Date(m.endDate);
-      return endDate > max ? endDate : max;
-    }, new Date(0));
 
     console.log(
-      `[Polymarket] Page ${pageCount}: Fetched ${markets.length} markets (max endDate: ${maxEndDateInBatch.toISOString()})`
+      `[Polymarket] Page ${pageCount}: fetched ${markets.length} markets (+${newMarketsCount} new, ${allMarkets.length} total)`
     );
 
-    // Add markets that are within our time window
-    const marketsInWindow = markets.filter(
-      (m) => new Date(m.endDate) < maxEndDate
-    );
+    // Normal termination: the server omits next_cursor on the final page.
+    if (!body.next_cursor) break;
 
-    // Deduplicate and add markets that are within our time window
-    let newMarketsCount = 0;
-    for (const m of marketsInWindow) {
-      if (!seenConditionIds.has(m.conditionId)) {
-        seenConditionIds.add(m.conditionId);
-        allMarkets.push(m);
-        newMarketsCount++;
-      }
-    }
-
-    // Stop conditions:
-    // 1. Got less than PAGE_SIZE markets (no more pages)
-    // 2. Max endDate in batch exceeds our window (all remaining markets are beyond our window)
-    // 3. No new markets added (we've seen all markets at this endDate)
-    if (
-      markets.length < PAGE_SIZE ||
-      maxEndDateInBatch >= maxEndDate ||
-      newMarketsCount === 0
-    ) {
+    // Safety net for the reported keyset bug where the server ignores the
+    // cursor and re-serves the first page with a persistent next_cursor: a page
+    // that adds zero new markets means we are not advancing — stop rather than
+    // loop forever.
+    if (newMarketsCount === 0) {
+      console.warn(
+        `[Polymarket] Page ${pageCount} added no new markets despite a next_cursor — stopping to avoid a pagination loop`
+      );
       break;
     }
 
-    // Move the cursor to fetch next page
-    const newMinEndDate = maxEndDateInBatch.toISOString();
-    if (newMinEndDate === currentMinEndDate) {
-      // Cursor didn't advance — many markets share the same endDate.
-      // Use offset to page through them.
-      offset += PAGE_SIZE;
-    } else {
-      currentMinEndDate = newMinEndDate;
-      offset = 0;
-    }
+    cursor = body.next_cursor;
   }
 
   console.log(
     `[Polymarket] Total fetched: ${allMarkets.length} markets across ${pageCount} pages`
   );
+
+  return allMarkets;
+}
+
+/**
+ * Fetch markets that end soonest (for --ending-soon mode), within the
+ * MAX_END_DATE_DAYS window, then augment with supplementary event-tag markets
+ * and run the raw-market filter pipeline.
+ */
+export async function fetchEndingSoonestMarkets(): Promise<PolymarketMarket[]> {
+  // Minimum end time: current time + 1 minute
+  const minEndDate = new Date(Date.now() + 60 * 1000);
+  // Maximum end time: current time + MAX_END_DATE_DAYS
+  const maxEndDate = new Date(
+    Date.now() + MAX_END_DATE_DAYS * 24 * 60 * 60 * 1000
+  );
+
+  console.log(
+    `[Polymarket] Fetching ending-soon markets until ${maxEndDate.toISOString()}...`
+  );
+
+  const allMarkets = await fetchEndingSoonMarketsViaKeyset(
+    minEndDate,
+    maxEndDate
+  );
+  const seenConditionIds = new Set(allMarkets.map((m) => m.conditionId));
 
   // Fetch supplementary markets from /events endpoint by tag slug.
   // The /markets list endpoint has blind spots where some active markets

--- a/packages/market-keeper/src/generate/market.ts
+++ b/packages/market-keeper/src/generate/market.ts
@@ -31,10 +31,19 @@ export async function fetchEndingSoonMarketsViaKeyset(
   const allMarkets: PolymarketMarket[] = [];
   const seenConditionIds = new Set<string>(); // deduplicate across pages
   const PAGE_SIZE = 100; // keyset max page size (since 2026-05-14)
+  // Hard backstop against a pathological non-terminating walk. The window is
+  // bounded to MAX_END_DATE_DAYS so the real page count is small; this only
+  // ever trips if the server keeps issuing fresh cursors without converging.
+  const MAX_PAGES = 5000;
 
+  // Order ending-soonest so the cursor walks the window front-to-back. `order`
+  // must be set for `ascending` to take effect (Gamma ignores `ascending`
+  // otherwise). Both ends of the window are bounded server-side so the walk
+  // terminates at the window edge instead of paging the entire active set.
   const baseParams =
     `limit=${PAGE_SIZE}` +
     `&active=true&closed=false` +
+    `&order=endDate&ascending=true` +
     `&end_date_min=${encodeURIComponent(minEndDate.toISOString())}` +
     `&end_date_max=${encodeURIComponent(maxEndDate.toISOString())}`;
 
@@ -86,12 +95,21 @@ export async function fetchEndingSoonMarketsViaKeyset(
     if (!body.next_cursor) break;
 
     // Safety net for the reported keyset bug where the server ignores the
-    // cursor and re-serves the first page with a persistent next_cursor: a page
-    // that adds zero new markets means we are not advancing — stop rather than
-    // loop forever.
-    if (newMarketsCount === 0) {
+    // cursor and re-serves the same page with an unchanged next_cursor. Detect
+    // the stuck cursor directly (next_cursor === the cursor we just sent) rather
+    // than inferring it from a zero-new-market page — a page can legitimately
+    // add zero markets because every row was deduped or filtered out by the
+    // window guard, and stopping on that would truncate the walk early.
+    if (body.next_cursor === cursor) {
       console.warn(
-        `[Polymarket] Page ${pageCount} added no new markets despite a next_cursor — stopping to avoid a pagination loop`
+        `[Polymarket] Page ${pageCount} returned an unchanged cursor — stopping to avoid a pagination loop`
+      );
+      break;
+    }
+
+    if (pageCount >= MAX_PAGES) {
+      console.error(
+        `[Polymarket] Reached ${MAX_PAGES}-page cap without exhausting the cursor — stopping (results may be incomplete)`
       );
       break;
     }
@@ -165,58 +183,96 @@ export async function fetchEndingSoonestMarkets(): Promise<PolymarketMarket[]> {
 }
 
 /**
- * Fetch markets from the /events endpoint by tag slugs.
+ * Fetch markets from the /events/keyset endpoint by tag slugs.
  * Returns flattened market objects from event.markets[].
  * Injects the parent event into each market's `events` array so downstream
  * grouping logic (which reads market.events[0]) works correctly.
+ *
+ * Uses cursor-based keyset pagination for the same reason as the markets walk:
+ * the legacy /events endpoint is on the same deprecation track (sunset
+ * 2026-05-01) and offset pagination is rejected. end_date_max bounds the window
+ * server-side; the per-tag walk follows next_cursor to exhaustion.
  */
-async function fetchMarketsByEventTags(
+export async function fetchMarketsByEventTags(
   tagSlugs: string[],
   maxEndDate: Date
 ): Promise<PolymarketMarket[]> {
   const markets: PolymarketMarket[] = [];
+  const PAGE_SIZE = 100; // keyset max page size
+  const MAX_PAGES = 5000; // non-termination backstop (see markets walk)
+
+  const baseParams =
+    `limit=${PAGE_SIZE}` +
+    `&active=true&closed=false` +
+    `&end_date_max=${encodeURIComponent(maxEndDate.toISOString())}`;
 
   for (const tag of tagSlugs) {
-    const url = `https://gamma-api.polymarket.com/events?active=true&closed=false&tag_slug=${encodeURIComponent(tag)}&limit=200`;
+    let cursor: string | undefined;
+    let pageCount = 0;
+    let tagMarketCount = 0;
 
-    const response = await fetchWithRetry(url, {
-      headers: { Accept: 'application/json' },
-    });
+    while (true) {
+      pageCount++;
+      const url =
+        `https://gamma-api.polymarket.com/events/keyset?${baseParams}` +
+        `&tag_slug=${encodeURIComponent(tag)}` +
+        (cursor ? `&after_cursor=${encodeURIComponent(cursor)}` : '');
 
-    if (!response.ok) {
-      console.warn(
-        `[Polymarket] Failed to fetch events for tag "${tag}": HTTP ${response.status}`
-      );
-      continue;
-    }
+      const response = await fetchWithRetry(url, {
+        headers: { Accept: 'application/json' },
+      });
 
-    const events: Array<{
-      id?: string;
-      title?: string;
-      slug?: string;
-      description?: string;
-      markets?: PolymarketMarket[];
-    }> = await response.json();
+      if (!response.ok) {
+        console.warn(
+          `[Polymarket] Failed to fetch events for tag "${tag}": HTTP ${response.status}`
+        );
+        break; // give up on this tag, move on to the next
+      }
 
-    for (const event of events) {
-      const parentEvent = {
-        id: event.id,
-        title: event.title,
-        slug: event.slug,
-        description: event.description,
-      };
+      const body: {
+        events?: Array<{
+          id?: string;
+          title?: string;
+          slug?: string;
+          description?: string;
+          markets?: PolymarketMarket[];
+        }>;
+        next_cursor?: string;
+      } = await response.json();
+      const events = body.events ?? [];
 
-      for (const market of event.markets ?? []) {
-        if (new Date(market.endDate) < maxEndDate) {
-          // Inject parent event so grouping logic can read market.events[0]
-          market.events = [parentEvent];
-          markets.push(market);
+      for (const event of events) {
+        const parentEvent = {
+          id: event.id,
+          title: event.title,
+          slug: event.slug,
+          description: event.description,
+        };
+
+        for (const market of event.markets ?? []) {
+          if (new Date(market.endDate) < maxEndDate) {
+            // Inject parent event so grouping logic can read market.events[0]
+            market.events = [parentEvent];
+            markets.push(market);
+            tagMarketCount++;
+          }
         }
       }
+
+      // Normal end (no next_cursor), stuck-cursor guard, and hard backstop —
+      // mirroring the markets/keyset walk.
+      if (!body.next_cursor || body.next_cursor === cursor) break;
+      if (pageCount >= MAX_PAGES) {
+        console.error(
+          `[Polymarket] Tag "${tag}": reached ${MAX_PAGES}-page cap — stopping (results may be incomplete)`
+        );
+        break;
+      }
+      cursor = body.next_cursor;
     }
 
     console.log(
-      `[Polymarket] Tag "${tag}": fetched ${events.length} events with ${markets.length} markets`
+      `[Polymarket] Tag "${tag}": fetched ${tagMarketCount} markets in window across ${pageCount} page(s)`
     );
   }
 


### PR DESCRIPTION
## Problem

Prod and staging **Discovery** keepers crash on `market-keeper:generate`:

```
[Polymarket] Page 235: Fetched 100 markets (max endDate: 2026-07-06T10:00:00.000Z)
[Polymarket API] Failed to fetch ending-soon markets: HTTP 422 Unprocessable Entity
[Polymarket API] Response body: {"type":"validation error","error":"offset too large, use /markets/keyset for deeper pagination"}
```

Polymarket deprecated the legacy Gamma `/markets` and `/events` endpoints (sunset 2026-05-01) and now hard-rejects deep offset pagination.

## Root cause

`fetchEndingSoonestMarkets` (`packages/market-keeper/src/generate/market.ts`) paginated `/markets` primarily by advancing `end_date_min`, but fell back to `limit=100&offset=...` whenever every market in a batch shared a single `endDate` (cursor couldn't advance). A large cluster of markets all closing at one round timestamp (e.g. `2026-07-06T10:00:00Z`, visible as pages 233–235 pinned to the same `endDate` in the logs) drove `offset` past Gamma's newly-enforced cap → HTTP 422 → process exits 1 → `start:discovery` fails.

This is unique to the Discovery generate step, which is why Settlement / Market Data / Metadata are unaffected.

## Fix

Replace offset pagination with cursor-based **keyset pagination** (`after_cursor` / `next_cursor`) on `/markets/keyset`, bounding **both** ends of the window server-side via `end_date_min` / `end_date_max`. Keyset has no offset cap, so same-`endDate` clusters of any size are walked without truncating — fixing both the crash and the latent silent-truncation risk that a naive "cap the offset" fix would have introduced (it would silently drop markets in any cluster larger than the cap).

- Extracted the pagination into `fetchEndingSoonMarketsViaKeyset(minEndDate, maxEndDate)`.
- Preserves **ending-soonest** order via `order=endDate&ascending=true` (Gamma only honors `ascending` when `order` is set, so both are required for a front-to-back window walk).
- **Stuck-cursor guard:** stops when the server returns an unchanged `next_cursor` (the [reported keyset cursor-ignored bug](https://github.com/Polymarket/agents/issues/227)). This is detected directly rather than inferred from a zero-new-market page — a page can legitimately add zero markets because every row was deduped or dropped by the window guard, and stopping on that would truncate the walk early. A `MAX_PAGES` backstop guards against any other non-termination.

### Supplementary `/events` → `/events/keyset`

The supplementary `fetchMarketsByEventTags` (used to backfill markets the `/markets` list misses) called the legacy `/events` endpoint (`limit=200`, unpaginated), which is on the same deprecation track. Migrated it to `/events/keyset` with cursor pagination: response shape is `{ events, next_cursor }`, bounded by `end_date_max`, following `next_cursor` per tag with the same stuck-cursor + `MAX_PAGES` guards. Behavior is otherwise unchanged — it still doesn't dedup (the caller dedups via `seenConditionIds`).

## API contract verification

The keyset contract was confirmed against [the official keyset docs](https://docs.polymarket.com/api-reference/markets/list-markets-keyset-pagination) **and** live read-only probes of the real API:

- `/markets/keyset` accepts `after_cursor`, `order=endDate`, `ascending=true`, `end_date_min/max`; returns `{ markets, next_cursor }` with `next_cursor` omitted on the final page; rejects `offset` with 422; cursor advances and results come back soonest-first.
- `/events/keyset` returns `{ events, next_cursor }`, events carry `markets[]`, and `tag_slug` filters correctly.

## Tests

New `src/__tests__/fetch-ending-soonest-keyset.test.ts` (16 tests, TDD red→green):

**Markets walk**
- hits `/markets/keyset`, never sends `offset=`
- bounds the window with `end_date_min` / `end_date_max`
- preserves `order=endDate&ascending=true`
- follows `next_cursor` across pages as `after_cursor`
- **regression:** paginates a large same-`endDate` cluster purely by cursor (the 422 scenario)
- dedups by `conditionId`; boundary guard at `maxEndDate`; error surfacing
- stops on an unchanged cursor (cursor-stuck guard)
- does **not** stop on a zero-new page while the cursor is still advancing

**Events walk**
- hits `/events/keyset`, never sends `offset`, bounds with `end_date_max`
- flattens `event.markets` and injects the parent event for grouping
- follows `next_cursor` across event pages per tag
- drops markets at/beyond `maxEndDate`
- skips a tag on a non-ok response and continues to the next tag
- stops on an unchanged cursor

Full `@sapience/market-keeper` suite passes (546 passed / 4 skipped); `tsc` build and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
