### PR TITLE
feat(app): r-h-m mainnet endpoint preset + disable mesh signal in presets

### DIFF
--- a/packages/app/src/components/settings/pages/SettingsPageContent.tsx
+++ b/packages/app/src/components/settings/pages/SettingsPageContent.tsx
@@ -22,12 +22,30 @@ import {
 } from '~/lib/ws/MeshAuctionClient';
 import Loader from '~/components/shared/Loader';
 
-const MERIDIAN_TESTNET_SETTINGS = {
+// Endpoint presets applied via keyboard shortcuts on the Settings page:
+//   r → h → t  applies the Meridian testnet (Robinhood testnet) preset
+//   r → h → m  applies the Meridian production (Robinhood mainnet) preset
+// Both presets leave the signal endpoint blank, which disables the mesh so the
+// app never attempts to connect to a signaling server.
+type EndpointPreset = {
+  customRpcURL: string;
+  graphqlEndpoint: string;
+  relayerEndpoint: string;
+  chatBaseUrl: string;
+};
+
+const MERIDIAN_TESTNET_SETTINGS: EndpointPreset = {
   customRpcURL: 'https://rpc.testnet.chain.robinhood.com',
   graphqlEndpoint: 'https://api.predict.meridiantest.net/graphql',
   relayerEndpoint: 'https://relayer.predict.meridiantest.net/auction',
-  signalEndpoint: 'https://relayer.predict.meridiantest.net/signal',
   chatBaseUrl: 'https://api.predict.meridiantest.net/chat',
+} as const;
+
+const MERIDIAN_MAINNET_SETTINGS: EndpointPreset = {
+  customRpcURL: 'https://rpc.chain.robinhood.com',
+  graphqlEndpoint: 'https://api.predict.meridian.xyz/graphql',
+  relayerEndpoint: 'https://relayer.predict.meridian.xyz/auction',
+  chatBaseUrl: 'https://api.predict.meridian.xyz/chat',
 } as const;
 
 type SettingFieldProps = {
@@ -283,43 +301,46 @@ const SettingsPageContent = () => {
     customRpcURL === etherealRpcInput.trim() &&
     DEFAULT_CHAIN_ID !== customChainId;
 
-  const applyMeridianTestnetSettings = useCallback(async () => {
-    setIsDetecting(true);
-    setDetectError(null);
-    const result = await detectAndSetCustomChain(
-      MERIDIAN_TESTNET_SETTINGS.customRpcURL
-    );
-    setIsDetecting(false);
-    if ('error' in result) {
-      setDetectError(result.error);
-      return;
-    }
+  const applyEndpointPreset = useCallback(
+    async (preset: EndpointPreset) => {
+      setIsDetecting(true);
+      setDetectError(null);
+      const result = await detectAndSetCustomChain(preset.customRpcURL);
+      setIsDetecting(false);
+      if ('error' in result) {
+        setDetectError(result.error);
+        return;
+      }
 
-    setGraphqlEndpoint(null);
-    setGraphqlEndpointV2(MERIDIAN_TESTNET_SETTINGS.graphqlEndpoint);
-    setApiBaseUrl(MERIDIAN_TESTNET_SETTINGS.relayerEndpoint);
-    setSignalEndpoint(MERIDIAN_TESTNET_SETTINGS.signalEndpoint);
-    setChatBaseUrl(MERIDIAN_TESTNET_SETTINGS.chatBaseUrl);
-    setEtherealRpcUrl(MERIDIAN_TESTNET_SETTINGS.customRpcURL);
+      setGraphqlEndpoint(null);
+      setGraphqlEndpointV2(preset.graphqlEndpoint);
+      setApiBaseUrl(preset.relayerEndpoint);
+      // Blank signal endpoint disables the mesh: the app won't connect to a
+      // signaling server for either preset.
+      setSignalEndpoint('');
+      setChatBaseUrl(preset.chatBaseUrl);
+      setEtherealRpcUrl(preset.customRpcURL);
 
-    setEtherealRpcInput(MERIDIAN_TESTNET_SETTINGS.customRpcURL);
-    setGqlInput(MERIDIAN_TESTNET_SETTINGS.graphqlEndpoint);
-    setApiInput(MERIDIAN_TESTNET_SETTINGS.relayerEndpoint);
-    setSignalInput(MERIDIAN_TESTNET_SETTINGS.signalEndpoint);
-    setChatInput(MERIDIAN_TESTNET_SETTINGS.chatBaseUrl);
+      setEtherealRpcInput(preset.customRpcURL);
+      setGqlInput(preset.graphqlEndpoint);
+      setApiInput(preset.relayerEndpoint);
+      setSignalInput('');
+      setChatInput(preset.chatBaseUrl);
 
-    if (typeof window !== 'undefined') {
-      window.location.reload();
-    }
-  }, [
-    detectAndSetCustomChain,
-    setApiBaseUrl,
-    setChatBaseUrl,
-    setGraphqlEndpoint,
-    setGraphqlEndpointV2,
-    setEtherealRpcUrl,
-    setSignalEndpoint,
-  ]);
+      if (typeof window !== 'undefined') {
+        window.location.reload();
+      }
+    },
+    [
+      detectAndSetCustomChain,
+      setApiBaseUrl,
+      setChatBaseUrl,
+      setGraphqlEndpoint,
+      setGraphqlEndpointV2,
+      setEtherealRpcUrl,
+      setSignalEndpoint,
+    ]
+  );
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -334,24 +355,27 @@ const SettingsPageContent = () => {
       }
 
       const key = event.key.toLowerCase();
+      if (!/^[a-z]$/.test(key)) return;
       const now = Date.now();
-      if (key === 'r') {
-        lastPresetKeyRef.current = { key, at: now };
-        return;
-      }
-      if (
-        key === 'h' &&
-        lastPresetKeyRef.current?.key === 'r' &&
-        now - lastPresetKeyRef.current.at < 1500
-      ) {
+      const prev = lastPresetKeyRef.current;
+      // Build a rolling buffer of the last few keys typed within the window so
+      // "r h t" and "r h m" can be detected as ordered sequences.
+      const buffer =
+        prev && now - prev.at < 1500 ? `${prev.key}${key}`.slice(-3) : key;
+      lastPresetKeyRef.current = { key: buffer, at: now };
+
+      if (buffer.endsWith('rht')) {
         lastPresetKeyRef.current = null;
-        void applyMeridianTestnetSettings();
+        void applyEndpointPreset(MERIDIAN_TESTNET_SETTINGS);
+      } else if (buffer.endsWith('rhm')) {
+        lastPresetKeyRef.current = null;
+        void applyEndpointPreset(MERIDIAN_MAINNET_SETTINGS);
       }
     };
 
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [applyMeridianTestnetSettings]);
+  }, [applyEndpointPreset]);
 
   return (
     <div className="relative min-h-screen">

--- a/packages/app/src/lib/context/SettingsContext.tsx
+++ b/packages/app/src/lib/context/SettingsContext.tsx
@@ -310,8 +310,12 @@ export const SettingsProvider = ({
         typeof window !== 'undefined'
           ? window.localStorage.getItem(STORAGE_KEYS.signalEndpoint)
           : null;
-      if (sig && isHttpUrl(sig))
+      if (sig !== null && sig.trim() === '') {
+        // Explicit disable: the mesh signal is turned off.
+        setSignalEndpointOverride('');
+      } else if (sig && isHttpUrl(sig)) {
         setSignalEndpointOverride(normalizeBaseUrlPreservePath(sig));
+      }
       if (etherealRpc && isHttpUrl(etherealRpc))
         setEtherealRpcOverride(etherealRpc);
       if (arbitrumRpc && isHttpUrl(arbitrumRpc))
@@ -411,7 +415,11 @@ export const SettingsProvider = ({
     : null;
   const apiBaseUrl = mounted ? apiBaseOverride || defaults.apiBaseUrl : null;
   const signalEndpoint = mounted
-    ? signalEndpointOverride || defaults.signalEndpoint
+    ? // An empty (not null) override means the mesh is explicitly disabled, so
+      // keep it blank instead of falling back to the default endpoint.
+      signalEndpointOverride === ''
+      ? ''
+      : signalEndpointOverride || defaults.signalEndpoint
     : null;
   const chatBaseUrl = mounted ? chatBaseOverride || defaults.chatBaseUrl : null;
   const adminBaseUrl = mounted
@@ -492,9 +500,17 @@ export const SettingsProvider = ({
   const setSignalEndpoint = useCallback((value: string | null) => {
     try {
       if (typeof window === 'undefined') return;
-      if (!value) {
+      // null resets to the default endpoint (removes the override entirely).
+      if (value === null) {
         window.localStorage.removeItem(STORAGE_KEYS.signalEndpoint);
         setSignalEndpointOverride(null);
+        return;
+      }
+      // An explicit empty string disables the mesh: persist a blank value so it
+      // is honored over the default endpoint and getSignalUrl() returns ''.
+      if (value.trim() === '') {
+        window.localStorage.setItem(STORAGE_KEYS.signalEndpoint, '');
+        setSignalEndpointOverride('');
         return;
       }
       const v = normalizeBaseUrlPreservePath(value);

--- a/packages/app/src/lib/ws/MeshAuctionClient.ts
+++ b/packages/app/src/lib/ws/MeshAuctionClient.ts
@@ -65,13 +65,17 @@ class MeshAuctionClient {
 
   private ensureMesh(): MeshClient {
     if (!this.mesh) {
+      const signalUrl = getSignalUrl();
       this.mesh = new MeshClient({
-        signalUrl: getSignalUrl(),
+        signalUrl,
         rateLimitPerSec: readRateLimit(),
         maxPeers: readMaxPeers(),
         maxFanout: readFanout(),
       });
-      this.mesh.connect();
+      // An empty signal URL means the mesh is explicitly disabled in Settings:
+      // build the client (so listeners/getters keep working as no-ops) but never
+      // open the signaling WebSocket.
+      if (signalUrl) this.mesh.connect();
       this.transport = new MeshTransport(this.mesh);
     }
     return this.mesh;

--- a/packages/app/src/lib/ws/__tests__/MeshAuctionClient.test.ts
+++ b/packages/app/src/lib/ws/__tests__/MeshAuctionClient.test.ts
@@ -103,4 +103,22 @@ describe('getSignalUrl', () => {
     const getSignalUrl = await loadGetSignalUrl();
     expect(getSignalUrl()).toBe('wss://env-signal.example.com');
   });
+
+  it('returns empty string (mesh disabled) when signal endpoint is explicitly blank', async () => {
+    store[SIGNAL_KEY] = '';
+    const getSignalUrl = await loadGetSignalUrl();
+    expect(getSignalUrl()).toBe('');
+  });
+
+  it('explicit blank signal disable wins over NEXT_PUBLIC_SIGNAL_URL env', async () => {
+    process.env.NEXT_PUBLIC_SIGNAL_URL = 'wss://env-signal.example.com';
+    store[SIGNAL_KEY] = '';
+    const getSignalUrl = await loadGetSignalUrl();
+    expect(getSignalUrl()).toBe('');
+  });
+
+  it('does not disable when signal key is absent (uses default)', async () => {
+    const getSignalUrl = await loadGetSignalUrl();
+    expect(getSignalUrl()).toBe('wss://relayer.sapience.xyz/signal');
+  });
 });

--- a/packages/app/src/lib/ws/signalUrl.ts
+++ b/packages/app/src/lib/ws/signalUrl.ts
@@ -5,7 +5,14 @@ const SIGNAL_KEY = 'sapience.settings.signalEndpoint';
  * Reads the persisted signal endpoint from settings (http(s)) and converts to ws(s).
  * Falls back to deriving from the relayer base URL or hardcoded production default.
  *
+ * Returns '' when the mesh is explicitly disabled — i.e. the signal endpoint
+ * setting is present in localStorage but blank. Callers treat an empty string
+ * as "do not connect to the mesh". This explicit disable wins over every other
+ * source (including the env override) so turning the mesh off in Settings always
+ * takes effect.
+ *
  * Priority:
+ * 0. Explicit disable: localStorage signal endpoint present but blank → '' (no mesh)
  * 1. NEXT_PUBLIC_SIGNAL_URL env override
  * 2. localStorage signal endpoint (sapience.settings.signalEndpoint)
  * 3. localStorage relayer base (sapience.settings.apiBaseUrl) with /signal path
@@ -14,6 +21,18 @@ const SIGNAL_KEY = 'sapience.settings.signalEndpoint';
  * 6. Hardcoded wss://relayer.sapience.xyz/signal
  */
 export function getSignalUrl(): string {
+  // Explicit disable wins over everything: an empty (but present) signal
+  // endpoint setting means "don't connect to the mesh".
+  try {
+    const stored =
+      typeof window !== 'undefined'
+        ? window.localStorage.getItem(SIGNAL_KEY)
+        : null;
+    if (stored !== null && stored.trim() === '') return '';
+  } catch {
+    /* */
+  }
+
   const explicit = process.env.NEXT_PUBLIC_SIGNAL_URL;
   if (explicit) return explicit;
 


### PR DESCRIPTION
## Summary

Extends the Settings page endpoint-preset keyboard shortcut and makes both presets disable the mesh signal connection.

### Keyboard presets

The preset previously fired on `r` then `h`. It now takes a third key to pick the environment:

- **`r` → `h` → `t`** — Meridian **testnet** (Robinhood testnet), the previous behavior.
- **`r` → `h` → `m`** — Meridian **production** (Robinhood mainnet):
  | endpoint | value |
  |---|---|
  | RPC | `https://rpc.chain.robinhood.com` |
  | Relayer | `https://relayer.predict.meridian.xyz/auction` |
  | GraphQL | `https://api.predict.meridian.xyz/graphql` |
  | Chat | `https://api.predict.meridian.xyz/chat` |

The mainnet GraphQL/Chat URLs are derived from the production domain (`predict.meridian.xyz`) by analogy with the testnet preset's `predict.meridiantest.net` endpoints.

### Blank signal endpoint = mesh disabled

Both presets now leave the **signal endpoint blank**, and a blank-but-present signal setting now means "don't connect to the mesh":

- `getSignalUrl()` returns `''` when the signal endpoint setting is present but blank. This explicit disable wins over the `NEXT_PUBLIC_SIGNAL_URL` env override and the derived default.
- `MeshAuctionClient` builds the client but **skips `connect()`** when the signal URL is empty, so no signaling WebSocket is ever opened. Listeners/getters keep working as no-ops.
- `SettingsContext` persists and reads the explicit-blank state (empty string distinct from "unset → use default"); clearing the field manually still resets to the default.

## Testing

- Added unit tests to `MeshAuctionClient.test.ts` covering: blank signal → `''`, blank disable wins over env, and absent key → default. All 14 tests pass.
- `pnpm --filter @sapience/app run type-check` passes.
- ESLint passes on all changed files.
- Pre-existing unrelated test failures (`sessionKeyManager`, `transactionExecutor`, `MeshTransport` mocking) confirmed present on clean `staging` before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEP9Gyj81PUoLdDzJHp6Jq