### PR TITLE
feat(app): disable chat for Robinhood/Meridian presets, hide bubble when endpoint blank

### DIFF
--- a/packages/app/src/components/settings/pages/SettingsPageContent.tsx
+++ b/packages/app/src/components/settings/pages/SettingsPageContent.tsx
@@ -31,21 +31,18 @@ type EndpointPreset = {
   customRpcURL: string;
   graphqlEndpoint: string;
   relayerEndpoint: string;
-  chatBaseUrl: string;
 };
 
 const MERIDIAN_TESTNET_SETTINGS: EndpointPreset = {
   customRpcURL: 'https://rpc.testnet.chain.robinhood.com',
   graphqlEndpoint: 'https://api.predict.meridiantest.net/graphql',
   relayerEndpoint: 'https://relayer.predict.meridiantest.net/auction',
-  chatBaseUrl: 'https://api.predict.meridiantest.net/chat',
 } as const;
 
 const MERIDIAN_MAINNET_SETTINGS: EndpointPreset = {
   customRpcURL: 'https://rpc.chain.robinhood.com',
   graphqlEndpoint: 'https://api.predict.meridian.xyz/graphql',
   relayerEndpoint: 'https://relayer.predict.meridian.xyz/auction',
-  chatBaseUrl: 'https://api.predict.meridian.xyz/chat',
 } as const;
 
 type SettingFieldProps = {
@@ -324,14 +321,16 @@ const SettingsPageContent = () => {
       // Blank signal endpoint disables the mesh: the app won't connect to a
       // signaling server for either preset.
       setSignalEndpoint('');
-      setChatBaseUrl(preset.chatBaseUrl);
+      // Blank chat endpoint disables chat and hides the chat bubble for the
+      // Robinhood/Meridian presets.
+      setChatBaseUrl('');
       setEtherealRpcUrl(preset.customRpcURL);
 
       setEtherealRpcInput(preset.customRpcURL);
       setGqlInput(preset.graphqlEndpoint);
       setApiInput(preset.relayerEndpoint);
       setSignalInput('');
-      setChatInput(preset.chatBaseUrl);
+      setChatInput('');
 
       if (typeof window !== 'undefined') {
         window.location.reload();
@@ -497,6 +496,7 @@ const SettingsPageContent = () => {
                     onPersist={setChatBaseUrl}
                     validate={isHttpUrl}
                     normalizeOnChange={normalizeBase}
+                    emptyPersistValue=""
                     invalidMessage="Must be an absolute http(s) base URL"
                   />
                   <p className="text-xs text-muted-foreground">
@@ -508,7 +508,8 @@ const SettingsPageContent = () => {
                     >
                       chat widget
                     </button>{' '}
-                    to send and receive signed messages
+                    to send and receive signed messages. Leave blank to disable
+                    chat and hide the chat bubble.
                   </p>
                 </div>
 

--- a/packages/app/src/components/shared/ChatWidget.tsx
+++ b/packages/app/src/components/shared/ChatWidget.tsx
@@ -16,9 +16,13 @@ import { useConnectedWallet } from '~/hooks/useConnectedWallet';
 import { useChat } from '~/lib/context/ChatContext';
 import { useConnectDialog } from '~/lib/context/ConnectDialogContext';
 import { useSession } from '~/lib/context/SessionContext';
+import { useSettings } from '~/lib/context/SettingsContext';
 
 const ChatWidget = () => {
   const { isOpen, closeChat } = useChat();
+  const { chatBaseUrl } = useSettings();
+  // An empty chat endpoint disables chat: don't open a connection or render.
+  const chatEnabled = !!chatBaseUrl;
   const { openConnectDialog } = useConnectDialog();
   const { ready, connectedWallet, hasConnectedWallet } = useConnectedWallet();
   const {
@@ -37,7 +41,7 @@ const ChatWidget = () => {
     state: { messages, pendingText, setPendingText, canChat, canType },
     actions: { sendMessage, loginNow },
   } = useChatConnection({
-    isOpen,
+    isOpen: isOpen && chatEnabled,
     addressOverride,
     sessionApproval: etherealSessionApproval,
     signMessageWithSession: signMessage,
@@ -77,6 +81,10 @@ const ChatWidget = () => {
     },
     [dragControls]
   );
+
+  // Chat disabled (empty endpoint, e.g. Robinhood/Meridian presets): render
+  // nothing so the panel can't be opened against a disabled endpoint.
+  if (!chatEnabled) return null;
 
   return (
     <AnimatePresence initial={false}>

--- a/packages/app/src/components/shared/FloatingChatButton.tsx
+++ b/packages/app/src/components/shared/FloatingChatButton.tsx
@@ -3,9 +3,15 @@
 import { AnimatePresence, motion } from 'framer-motion';
 import ChatButton from '~/components/layout/ChatButton';
 import { useChat } from '~/lib/context/ChatContext';
+import { useSettings } from '~/lib/context/SettingsContext';
 
 const FloatingChatButton = () => {
   const { isOpen } = useChat();
+  const { chatBaseUrl } = useSettings();
+
+  // An empty chat endpoint (e.g. the Robinhood/Meridian presets) disables chat,
+  // so hide the bubble entirely. `chatBaseUrl` is also null before mount.
+  if (!chatBaseUrl) return null;
 
   return (
     <AnimatePresence initial={false}>

--- a/packages/app/src/lib/context/SettingsContext.tsx
+++ b/packages/app/src/lib/context/SettingsContext.tsx
@@ -302,8 +302,12 @@ export const SettingsProvider = ({
       if (gV2 && isHttpUrl(gV2)) setGraphqlV2Override(gV2);
       if (a && isHttpUrl(a))
         setApiBaseOverride(normalizeBaseUrlPreservePath(a));
-      if (c && isHttpUrl(c))
+      if (c !== null && c.trim() === '') {
+        // Explicit disable: chat is turned off and the bubble is hidden.
+        setChatBaseOverride('');
+      } else if (c && isHttpUrl(c)) {
         setChatBaseOverride(normalizeBaseUrlPreservePath(c));
+      }
       if (admin && isHttpUrl(admin))
         setAdminBaseOverride(normalizeBaseUrlPreservePath(admin));
       const sig =
@@ -421,7 +425,13 @@ export const SettingsProvider = ({
       ? ''
       : signalEndpointOverride || defaults.signalEndpoint
     : null;
-  const chatBaseUrl = mounted ? chatBaseOverride || defaults.chatBaseUrl : null;
+  const chatBaseUrl = mounted
+    ? // An empty (not null) override means chat is explicitly disabled, so keep
+      // it blank instead of falling back to the default endpoint.
+      chatBaseOverride === ''
+      ? ''
+      : chatBaseOverride || defaults.chatBaseUrl
+    : null;
   const adminBaseUrl = mounted
     ? adminBaseOverride || defaults.adminBaseUrl
     : null;
@@ -525,9 +535,17 @@ export const SettingsProvider = ({
   const setChatBaseUrl = useCallback((value: string | null) => {
     try {
       if (typeof window === 'undefined') return;
-      if (!value) {
+      // null resets to the default endpoint (removes the override entirely).
+      if (value === null) {
         window.localStorage.removeItem(STORAGE_KEYS.chat);
         setChatBaseOverride(null);
+        return;
+      }
+      // An explicit empty string disables chat: persist a blank value so it is
+      // honored over the default endpoint and the chat bubble stays hidden.
+      if (value.trim() === '') {
+        window.localStorage.setItem(STORAGE_KEYS.chat, '');
+        setChatBaseOverride('');
         return;
       }
       const v = normalizeBaseUrlPreservePath(value);

--- a/packages/app/src/lib/context/SettingsContext.v2.test.tsx
+++ b/packages/app/src/lib/context/SettingsContext.v2.test.tsx
@@ -12,6 +12,7 @@ import { SettingsProvider, useSettings } from './SettingsContext';
 
 const V2_KEY = 'sapience.settings.graphqlEndpointV2';
 const V1_KEY = 'sapience.settings.graphqlEndpoint';
+const CHAT_KEY = 'sapience.settings.chatBaseUrl';
 
 // jsdom in this environment does not ship a working localStorage (it requires
 // node's --localstorage-file flag), so install a minimal in-memory shim. The
@@ -66,6 +67,33 @@ function Probe() {
         onClick={() => setGraphqlEndpointV2(null)}
       >
         clear
+      </button>
+    </div>
+  );
+}
+
+function ChatProbe() {
+  const { chatBaseUrl, setChatBaseUrl, defaults } = useSettings();
+  return (
+    <div>
+      {/* Distinguish '' (disabled) from null (pre-mount) in the DOM. */}
+      <span data-testid="chat">
+        {chatBaseUrl === '' ? '<empty>' : chatBaseUrl}
+      </span>
+      <span data-testid="default-chat">{defaults.chatBaseUrl}</span>
+      <button
+        type="button"
+        data-testid="chat-disable"
+        onClick={() => setChatBaseUrl('')}
+      >
+        disable
+      </button>
+      <button
+        type="button"
+        data-testid="chat-reset"
+        onClick={() => setChatBaseUrl(null)}
+      >
+        reset
       </button>
     </div>
   );
@@ -169,5 +197,80 @@ describe('SettingsContext v2 GraphQL endpoint', () => {
       expect(window.localStorage.getItem(V2_KEY)).toBeNull();
     });
     expect(screen.getByTestId('v2').textContent).toMatch(/\/v2\/graphql$/);
+  });
+});
+
+describe('SettingsContext chat endpoint disable', () => {
+  test('defaults to a non-empty chat endpoint so the bubble shows', async () => {
+    render(
+      <SettingsProvider>
+        <ChatProbe />
+      </SettingsProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat').textContent).not.toBe('');
+    });
+    expect(screen.getByTestId('chat').textContent).not.toBe('<empty>');
+  });
+
+  test('hydrates an explicit blank override as disabled (empty string)', async () => {
+    window.localStorage.setItem(CHAT_KEY, '');
+
+    render(
+      <SettingsProvider>
+        <ChatProbe />
+      </SettingsProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat').textContent).toBe('<empty>');
+    });
+  });
+
+  test('setChatBaseUrl("") persists a blank value and disables chat', async () => {
+    render(
+      <SettingsProvider>
+        <ChatProbe />
+      </SettingsProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat').textContent).not.toBe('');
+    });
+
+    act(() => {
+      screen.getByTestId('chat-disable').click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat').textContent).toBe('<empty>');
+    });
+    // Blank must be persisted (empty string), not removed, so it wins over the
+    // default on the next load.
+    expect(window.localStorage.getItem(CHAT_KEY)).toBe('');
+  });
+
+  test('setChatBaseUrl(null) removes the override and re-enables the default', async () => {
+    window.localStorage.setItem(CHAT_KEY, '');
+
+    render(
+      <SettingsProvider>
+        <ChatProbe />
+      </SettingsProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat').textContent).toBe('<empty>');
+    });
+
+    act(() => {
+      screen.getByTestId('chat-reset').click();
+    });
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(CHAT_KEY)).toBeNull();
+    });
+    expect(screen.getByTestId('chat').textContent).not.toBe('<empty>');
   });
 });


### PR DESCRIPTION
## Summary

The Robinhood/Meridian endpoint presets now **clear the chat endpoint** instead of pointing it at the preset's chat host. A blank chat endpoint **persists as an explicit empty string** (mirroring the signal endpoint) and **disables chat entirely** — the floating chat bubble is hidden and the chat widget no longer renders or opens a connection.

## Changes
- **`SettingsContext.tsx`** — honor an explicit empty chat override the same way the signal endpoint already works: hydrate `''` from localStorage as disabled, persist it via `setChatBaseUrl('')`, and resolve `chatBaseUrl` to `''` instead of falling back to the default. `setChatBaseUrl(null)` still resets to the default (removes the override).
- **`SettingsPageContent.tsx`** — drop `chatBaseUrl` from the `EndpointPreset` type/definitions and blank it on apply (`setChatBaseUrl('')`). The Chat Endpoint field now persists a manual blank as `''` (`emptyPersistValue=""`), with help text noting that blank hides the bubble.
- **`FloatingChatButton.tsx` / `ChatWidget.tsx`** — hide the bubble and skip rendering/connecting when the chat endpoint is empty.
- **Tests** — `SettingsContext.v2.test.tsx` gains coverage for default-enabled, hydrate-blank-as-disabled, `setChatBaseUrl('')` persisting blank, and `setChatBaseUrl(null)` re-enabling the default.

## Behavior
- Apply a Robinhood/Meridian preset → chat endpoint blanked → bubble disappears, no chat connection opened.
- Non-preset users keep the default chat endpoint and bubble.
- Reset (the field's Reset button / `setChatBaseUrl(null)`) restores the default endpoint and the bubble.

## Testing
- `pnpm --filter @sapience/app type-check` ✓
- `pnpm --filter @sapience/app lint` ✓
- `SettingsContext.v2` suite (8 tests) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)