### PR TITLE
feat(admin): Question Ordering page + collapse GraphQL endpoint to one concept

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -26,6 +26,9 @@
     "pin:ipfs": "node scripts/pin-ipfs.mjs"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "3.9.0",
     "@sapience/sdk": "workspace:*",
     "@sapience/ui": "workspace:*",
@@ -66,8 +69,8 @@
     "@next/eslint-plugin-next": "15.5.15",
     "@playwright/test": "1.55.1",
     "@tanstack/react-query-devtools": "5.84.2",
-    "@testing-library/react": "16.3.1",
     "@testing-library/jest-dom": "6.6.3",
+    "@testing-library/react": "16.3.1",
     "@types/react": "19.1.8",
     "autoprefixer": "10.4.20",
     "cross-env": "7.0.3",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -26,9 +26,9 @@
     "pin:ipfs": "node scripts/pin-ipfs.mjs"
   },
   "dependencies": {
-    "@dnd-kit/core": "^6.3.1",
-    "@dnd-kit/sortable": "^10.0.0",
-    "@dnd-kit/utilities": "^3.2.2",
+    "@dnd-kit/core": "6.3.1",
+    "@dnd-kit/sortable": "10.0.0",
+    "@dnd-kit/utilities": "3.2.2",
     "@hookform/resolvers": "3.9.0",
     "@sapience/sdk": "workspace:*",
     "@sapience/ui": "workspace:*",

--- a/packages/app/src/app/admin/question-ordering/page.tsx
+++ b/packages/app/src/app/admin/question-ordering/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { Button } from '@sapience/ui/components/ui/button';
+import { ArrowLeft } from 'lucide-react';
+import QuestionOrdering from '../../../components/admin/QuestionOrdering';
+
+export const metadata: Metadata = {
+  title: 'Question Ordering',
+  description: 'Manually order the questions shown within a condition group',
+  robots: { index: false },
+};
+
+const QuestionOrderingPage = () => {
+  return (
+    <div className="container pt-6 mx-auto px-6 pb-6">
+      <header className="flex items-center justify-between mb-8">
+        <h1 className="text-3xl">Question Ordering</h1>
+        <Link href="/admin">
+          <Button variant="ghost" size="sm">
+            <ArrowLeft className="mr-1 h-4 w-4" />
+            Back to Admin
+          </Button>
+        </Link>
+      </header>
+      <QuestionOrdering />
+    </div>
+  );
+};
+
+export default QuestionOrderingPage;

--- a/packages/app/src/app/og/_prediction-helpers.ts
+++ b/packages/app/src/app/og/_prediction-helpers.ts
@@ -6,7 +6,7 @@ export {
   PREDICTION_BY_ID_QUERY,
   CONDITIONS_BY_IDS_QUERY,
   toPredictionData,
-  type PredictionByIdV2Node,
+  type PredictionByIdNode,
   type PredictionPick,
   type PredictionPickConfig,
   type PredictionData,

--- a/packages/app/src/app/og/_prediction-helpers.ts
+++ b/packages/app/src/app/og/_prediction-helpers.ts
@@ -1,7 +1,7 @@
 // OG-specific formatting utilities + re-exports from shared data layer.
 
 // Re-exports for backward compatibility with OG routes and _profile-helpers
-export { getGraphQLEndpoint, getGraphQLEndpointV2 } from '~/lib/data/graphql';
+export { getGraphQLEndpoint } from '~/lib/data/graphql';
 export {
   PREDICTION_BY_ID_QUERY,
   CONDITIONS_BY_IDS_QUERY,

--- a/packages/app/src/app/og/_profile-helpers.ts
+++ b/packages/app/src/app/og/_profile-helpers.ts
@@ -7,7 +7,7 @@ import { mainnetClient } from '~/lib/utils/util';
 import { getEnsAvatarUrlForAddress } from '~/lib/ens/avatar.server';
 import { SCHEMA_UID } from '~/lib/constants';
 
-// ---------- GraphQL queries (v2 transport) ----------
+// ---------- GraphQL queries ----------
 
 const PROFIT_RANK_QUERY = `
   query ProfileProfitRank($address: Address!) {
@@ -88,9 +88,9 @@ async function gqlFetch<T>(query: string, variables?: object): Promise<T> {
 
 // ---------- Data fetchers ----------
 
-// v2: server-side `account.ranking(metric: PNL)` ranks over the FULL
-// population (v1 sorted the fetched top-100 client-side, so ranks beyond
-// 100 were null and totalParticipants was capped at 100).
+// Server-side `account.ranking(metric: PNL)` ranks over the FULL
+// population (the legacy path sorted the fetched top-100 client-side, so
+// ranks beyond 100 were null and totalParticipants was capped at 100).
 async function fetchProfitRank(address: string): Promise<{
   totalPnL: number | null;
   rank: number | null;
@@ -127,7 +127,7 @@ async function fetchAccuracyRank(address: string): Promise<{
   const totalForecasters = data?.leaderboard?.totalCount ?? 0;
   if (!ranking) return { accuracyScore: null, rank: null, totalForecasters };
   return {
-    // v2 Ranking.accuracy carries the SAME raw avg(twError) scale as v1's
+    // Ranking.accuracy carries the SAME raw avg(twError) scale as the legacy
     // accuracyScore (parity-verified identity; the SDL's old "0-1" doc was
     // wrong) — pass through unscaled; the OG route Math.rounds it as before.
     accuracyScore: ranking.accuracy != null ? ranking.accuracy : 0,
@@ -152,8 +152,8 @@ async function fetchVolume(address: string): Promise<string | null> {
 }
 
 async function fetchForecastsCount(address: string): Promise<number | null> {
-  // v2 `forecasts` is a Relay connection; `first: 0` is a legal count-only
-  // query. Unlike the v1 `take: 100` page fetch, the count is exact (not
+  // `forecasts` is a Relay connection; `first: 0` is a legal count-only
+  // query. Unlike the legacy `take: 100` page fetch, the count is exact (not
   // capped at 100). The Address scalar canonicalizes to lowercase.
   const data = await gqlFetch<{
     forecasts: { totalCount: number } | null;

--- a/packages/app/src/app/og/_profile-helpers.ts
+++ b/packages/app/src/app/og/_profile-helpers.ts
@@ -2,7 +2,7 @@
 
 import { isAddress } from 'viem';
 import { formatUnits } from './_prediction-helpers';
-import { getGraphQLEndpointV2 } from '~/lib/data/graphql';
+import { getGraphQLEndpoint } from '~/lib/data/graphql';
 import { mainnetClient } from '~/lib/utils/util';
 import { getEnsAvatarUrlForAddress } from '~/lib/ens/avatar.server';
 import { SCHEMA_UID } from '~/lib/constants';
@@ -76,7 +76,7 @@ export interface EnsInfo {
 // ---------- Helpers ----------
 
 async function gqlFetch<T>(query: string, variables?: object): Promise<T> {
-  const res = await fetch(getGraphQLEndpointV2(), {
+  const res = await fetch(getGraphQLEndpoint(), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ query, variables }),

--- a/packages/app/src/app/og/prediction/route.tsx
+++ b/packages/app/src/app/og/prediction/route.tsx
@@ -25,7 +25,7 @@ import {
 import {
   PREDICTION_BY_ID_QUERY,
   CONDITIONS_BY_IDS_QUERY,
-  getGraphQLEndpointV2,
+  getGraphQLEndpoint,
   toPredictionData,
   formatUnits,
   normalizeChoiceLabel,
@@ -57,7 +57,7 @@ export async function GET(req: Request) {
       try {
         // Both legs run against /v2/graphql; the prediction node is mapped
         // back to the v1-shaped PredictionData via the shared mapper.
-        const graphqlEndpoint = getGraphQLEndpointV2();
+        const graphqlEndpoint = getGraphQLEndpoint();
         let prediction: PredictionData | null = null;
 
         const response = await fetch(graphqlEndpoint, {

--- a/packages/app/src/app/og/prediction/route.tsx
+++ b/packages/app/src/app/og/prediction/route.tsx
@@ -56,7 +56,7 @@ export async function GET(req: Request) {
     if (predictionId) {
       try {
         // Both legs run against /v2/graphql; the prediction node is mapped
-        // back to the v1-shaped PredictionData via the shared mapper.
+        // back to the legacy-shaped PredictionData via the shared mapper.
         const graphqlEndpoint = getGraphQLEndpoint();
         let prediction: PredictionData | null = null;
 
@@ -85,8 +85,8 @@ export async function GET(req: Request) {
             const conditionsMap = new Map<string, ConditionData>();
             if (conditionIds.length > 0) {
               try {
-                // v2 conditions connection: variables { ids }, nodes under
-                // data.conditions.nodes (the v1-era `where` variables made
+                // conditions connection: variables { ids }, nodes under
+                // data.conditions.nodes (the legacy `where` variables made
                 // this leg dead — it silently rendered no questions).
                 const condResp = await fetch(graphqlEndpoint, {
                   method: 'POST',

--- a/packages/app/src/app/og/question/route.tsx
+++ b/packages/app/src/app/og/question/route.tsx
@@ -153,6 +153,8 @@ function CategoryIcon({
 interface ConditionData {
   question: string | null;
   categorySlug: string | null;
+  chainId: number | null;
+  resolver: string | null;
 }
 
 async function fetchConditionData(
@@ -172,6 +174,8 @@ async function fetchConditionData(
         ) {
           nodes {
             question
+            chainId
+            resolver
             category { slug }
           }
         }
@@ -189,16 +193,30 @@ async function fetchConditionData(
       body: JSON.stringify({ query, variables }),
     });
 
-    if (!response.ok) return { question: null, categorySlug: null };
+    if (!response.ok) {
+      return {
+        question: null,
+        categorySlug: null,
+        chainId: null,
+        resolver: null,
+      };
+    }
 
     const result = await response.json();
     const condition = result?.data?.conditions?.nodes?.[0];
     return {
       question: condition?.question || null,
       categorySlug: condition?.category?.slug || null,
+      chainId: condition?.chainId ?? null,
+      resolver: condition?.resolver ?? null,
     };
   } catch {
-    return { question: null, categorySlug: null };
+    return {
+      question: null,
+      categorySlug: null,
+      chainId: null,
+      resolver: null,
+    };
   }
 }
 
@@ -210,10 +228,20 @@ const ESTIMATE_TIMEOUT_MS = 5000;
  * escrow auction.start, and waits for a bid from PREFERRED_ESTIMATE_QUOTER.
  * Returns probability (0-1) or null on timeout/error.
  */
-async function fetchEstimate(conditionId: string): Promise<number | null> {
+async function fetchEstimate({
+  conditionId,
+  resolver,
+  chainId,
+}: {
+  conditionId: string;
+  resolver?: string;
+  chainId: number;
+}): Promise<number | null> {
   const resolverAddress =
-    conditionalTokensConditionResolver[DEFAULT_CHAIN_ID]?.address;
+    resolver ?? conditionalTokensConditionResolver[chainId]?.address;
   if (!resolverAddress) return null;
+  const escrowAddress = predictionMarketEscrow[chainId]?.address;
+  if (!escrowAddress) return null;
 
   const formattedConditionId = (
     conditionId.startsWith('0x') ? conditionId : `0x${conditionId}`
@@ -221,7 +249,7 @@ async function fetchEstimate(conditionId: string): Promise<number | null> {
 
   const picks = canonicalizePicks([
     {
-      conditionResolver: resolverAddress,
+      conditionResolver: resolverAddress as `0x${string}`,
       conditionId: formattedConditionId,
       predictedOutcome: OutcomeSide.YES,
     },
@@ -250,9 +278,8 @@ async function fetchEstimate(conditionId: string): Promise<number | null> {
           predictor: zeroAddress,
           predictorNonce: 0,
           predictorDeadline: nowSec + 300,
-          chainId: DEFAULT_CHAIN_ID,
-          escrowContract:
-            predictionMarketEscrow[DEFAULT_CHAIN_ID]?.address ?? '',
+          chainId,
+          escrowContract: escrowAddress,
         });
       },
       onAuctionBids: (payload) => {
@@ -326,11 +353,12 @@ export async function GET(req: Request) {
       return createErrorImageResponse(new Error('Missing conditionId'));
     }
 
-    // Fetch condition data and live estimate in parallel
-    const [conditionData, estimate] = await Promise.all([
-      fetchConditionData(conditionId, resolver),
-      fetchEstimate(conditionId),
-    ]);
+    const conditionData = await fetchConditionData(conditionId, resolver);
+    const estimate = await fetchEstimate({
+      conditionId,
+      resolver: conditionData.resolver ?? resolver,
+      chainId: conditionData.chainId ?? DEFAULT_CHAIN_ID,
+    });
 
     const question = conditionData.question || 'Question on Sapience';
     const categorySlug = conditionData.categorySlug;

--- a/packages/app/src/app/og/question/route.tsx
+++ b/packages/app/src/app/og/question/route.tsx
@@ -24,7 +24,7 @@ import {
   createErrorImageResponse,
 } from '../_shared';
 import { PREFERRED_ESTIMATE_QUOTER } from '~/lib/constants';
-import { getGraphQLEndpointV2 } from '~/lib/data/graphql';
+import { getGraphQLEndpoint } from '~/lib/data/graphql';
 
 export const runtime = 'nodejs';
 
@@ -183,7 +183,7 @@ async function fetchConditionData(
       resolvers: resolver ? [resolver] : null,
     };
 
-    const response = await fetch(getGraphQLEndpointV2(), {
+    const response = await fetch(getGraphQLEndpoint(), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ query, variables }),

--- a/packages/app/src/app/og/question/route.tsx
+++ b/packages/app/src/app/og/question/route.tsx
@@ -162,7 +162,7 @@ async function fetchConditionData(
   resolver?: string
 ): Promise<ConditionData> {
   try {
-    // v2: by-ids lookups skip the public-only listing default, and
+    // By-ids lookups skip the public-only listing default, and
     // `resolvers` composes with `conditionIds` for the multi-resolver
     // disambiguation (both matched case-insensitively server-side).
     const query = `

--- a/packages/app/src/app/questions/[...parts]/page.tsx
+++ b/packages/app/src/app/questions/[...parts]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import QuestionPageClient from './QuestionPageClient';
-import { getGraphQLEndpointV2 } from '~/lib/data/graphql';
+import { getGraphQLEndpoint } from '~/lib/data/graphql';
 
 const APP_URL = 'https://sapience.xyz';
 
@@ -40,7 +40,7 @@ async function fetchQuestionTitle(
       resolvers: resolverAddress ? [resolverAddress] : null,
     };
 
-    const response = await fetch(getGraphQLEndpointV2(), {
+    const response = await fetch(getGraphQLEndpoint(), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ query, variables }),

--- a/packages/app/src/app/questions/[...parts]/page.tsx
+++ b/packages/app/src/app/questions/[...parts]/page.tsx
@@ -17,7 +17,7 @@ async function fetchQuestionTitle(
   resolverAddress?: string
 ): Promise<string | null> {
   try {
-    // v2: by-ids lookups skip the public-only listing default, and
+    // By-ids lookups skip the public-only listing default, and
     // `resolvers` composes with `conditionIds` for the multi-resolver
     // disambiguation (both matched case-insensitively server-side).
     const query = `

--- a/packages/app/src/components/admin/QuestionOrdering.tsx
+++ b/packages/app/src/components/admin/QuestionOrdering.tsx
@@ -26,6 +26,7 @@ import { useAccount } from 'wagmi';
 
 import {
   useAdminConditionGroups,
+  useAdminGroupConditions,
   useReorderConditionGroup,
   type AdminConditionGroup,
   type AdminConditionGroupCondition,
@@ -154,6 +155,21 @@ const QuestionOrdering = () => {
 
   const groups = useMemo(() => groupsQuery.data ?? [], [groupsQuery.data]);
 
+  const selectedGroup: AdminConditionGroup | null = useMemo(
+    () => groups.find((group) => group.id === selectedGroupId) ?? null,
+    [groups, selectedGroupId]
+  );
+
+  const conditionsQuery = useAdminGroupConditions(
+    selectedGroup?.globalId,
+    selectedGroupId !== null
+  );
+
+  const activeConditions = useMemo(
+    () => conditionsQuery.data ?? [],
+    [conditionsQuery.data]
+  );
+
   const filteredGroups = useMemo(() => {
     const query = groupFilter.trim().toLowerCase();
     const sorted = [...groups].sort((a, b) => a.name.localeCompare(b.name));
@@ -165,15 +181,16 @@ const QuestionOrdering = () => {
     );
   }, [groups, groupFilter]);
 
-  const selectedGroup: AdminConditionGroup | null = useMemo(
-    () => groups.find((group) => group.id === selectedGroupId) ?? null,
-    [groups, selectedGroupId]
+  const baselineIds = useMemo(
+    () => activeConditions.map((condition) => condition.id),
+    [activeConditions]
   );
 
-  const baselineIds = useMemo(
-    () => selectedGroup?.condition.map((condition) => condition.id) ?? [],
-    [selectedGroup]
-  );
+  const conditionsReady =
+    selectedGroupId !== null &&
+    !conditionsQuery.isLoading &&
+    !conditionsQuery.isFetching &&
+    conditionsQuery.data !== undefined;
 
   const baselineKey = useMemo(() => baselineIds.join('\u0000'), [baselineIds]);
 
@@ -209,11 +226,9 @@ const QuestionOrdering = () => {
 
   const conditionsById = useMemo(() => {
     const map = new Map<string, AdminConditionGroupCondition>();
-    selectedGroup?.condition.forEach((condition) =>
-      map.set(condition.id, condition)
-    );
+    activeConditions.forEach((condition) => map.set(condition.id, condition));
     return map;
-  }, [selectedGroup]);
+  }, [activeConditions]);
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -232,7 +247,7 @@ const QuestionOrdering = () => {
   };
 
   const handleSave = () => {
-    if (selectedGroupId === null) return;
+    if (selectedGroupId === null || !conditionsReady) return;
     // Defense in depth: only ever save a pure reordering of what we loaded.
     if (!isPermutation(baselineIds, order)) {
       toast({
@@ -327,7 +342,10 @@ const QuestionOrdering = () => {
                   >
                     <span className="min-w-0 truncate">{group.name}</span>
                     <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
-                      #{group.id} · {group.condition.length}
+                      #{group.id} ·{' '}
+                      {group.hasMoreConditions
+                        ? `${group.condition.length}+`
+                        : group.condition.length}
                     </span>
                   </button>
                 ))
@@ -340,7 +358,26 @@ const QuestionOrdering = () => {
               <p className="text-sm text-muted-foreground">
                 Select a group to reorder its questions.
               </p>
-            ) : selectedGroup.condition.length === 0 ? (
+            ) : conditionsQuery.isLoading || conditionsQuery.isFetching ? (
+              <p className="text-sm text-muted-foreground">
+                Loading all public conditions…
+              </p>
+            ) : conditionsQuery.isError ? (
+              <div className="space-y-2">
+                <p className="text-sm text-red-500">
+                  {conditionsQuery.error instanceof Error
+                    ? conditionsQuery.error.message
+                    : 'Failed to load conditions for this group.'}
+                </p>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void conditionsQuery.refetch()}
+                >
+                  Retry
+                </Button>
+              </div>
+            ) : activeConditions.length === 0 ? (
               <p className="text-sm text-muted-foreground">
                 This group has no public conditions.
               </p>
@@ -374,14 +411,6 @@ const QuestionOrdering = () => {
                   </SortableContext>
                 </DndContext>
 
-                {selectedGroup.hasMoreConditions ? (
-                  <p className="rounded-md border border-yellow-500/40 bg-yellow-500/10 px-3 py-2 text-xs text-yellow-700 dark:text-yellow-300">
-                    Only the first 100 public conditions are loaded for this
-                    group. Saving will reorder only the loaded conditions and
-                    leave the rest untouched.
-                  </p>
-                ) : null}
-
                 <div className="flex items-center justify-between gap-2">
                   <div className="flex items-center gap-1.5 text-xs">
                     {isDirty ? (
@@ -406,7 +435,11 @@ const QuestionOrdering = () => {
                     <Button
                       variant="ghost"
                       size="sm"
-                      disabled={!isDirty || reorderMutation.isPending}
+                      disabled={
+                        !conditionsReady ||
+                        !isDirty ||
+                        reorderMutation.isPending
+                      }
                       onClick={() => setOrder(baselineIds)}
                     >
                       Reset
@@ -414,7 +447,10 @@ const QuestionOrdering = () => {
                     <Button
                       size="sm"
                       disabled={
-                        !isDirty || !isConnected || reorderMutation.isPending
+                        !conditionsReady ||
+                        !isDirty ||
+                        !isConnected ||
+                        reorderMutation.isPending
                       }
                       onClick={handleSave}
                     >

--- a/packages/app/src/components/admin/QuestionOrdering.tsx
+++ b/packages/app/src/components/admin/QuestionOrdering.tsx
@@ -20,8 +20,8 @@ import { CSS } from '@dnd-kit/utilities';
 import { Button } from '@sapience/ui/components/ui/button';
 import { Input } from '@sapience/ui/components/ui/input';
 import { useToast } from '@sapience/ui/hooks/use-toast';
-import { GripVertical } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { ArrowDown, ArrowUp, Check, GripVertical } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useAccount } from 'wagmi';
 
 import {
@@ -56,9 +56,11 @@ function isPermutation(base: string[], next: string[]): boolean {
 function SortableConditionRow({
   condition,
   position,
+  baselinePosition,
 }: {
   condition: AdminConditionGroupCondition;
   position: number;
+  baselinePosition: number;
 }) {
   const {
     attributes,
@@ -69,12 +71,17 @@ function SortableConditionRow({
     isDragging,
   } = useSortable({ id: condition.id });
 
+  // delta > 0 → moved up the list (toward the top); < 0 → moved down.
+  const delta = baselinePosition - position;
+  const moved = delta !== 0;
+
   return (
     <div
       ref={setNodeRef}
       style={{ transform: CSS.Transform.toString(transform), transition }}
       className={cn(
-        'flex items-center gap-3 rounded-md border bg-background px-3 py-2',
+        'flex items-center gap-3 rounded-md border bg-background px-3 py-2 transition-colors',
+        moved && 'border-amber-500/60 bg-amber-500/10',
         isDragging && 'opacity-70 shadow-sm'
       )}
     >
@@ -87,12 +94,40 @@ function SortableConditionRow({
       >
         <GripVertical className="h-4 w-4" />
       </button>
-      <span className="w-6 shrink-0 text-sm tabular-nums text-muted-foreground">
-        {position}
+      <span className="flex w-12 shrink-0 items-center gap-1 tabular-nums">
+        <span
+          className={cn(
+            'text-sm',
+            moved ? 'font-semibold text-foreground' : 'text-muted-foreground'
+          )}
+        >
+          {position}
+        </span>
+        {moved ? (
+          <span
+            className={cn(
+              'flex items-center text-xs font-medium',
+              delta > 0 ? 'text-emerald-600' : 'text-rose-600'
+            )}
+            aria-label={
+              delta > 0 ? `Moved up ${delta}` : `Moved down ${Math.abs(delta)}`
+            }
+          >
+            {delta > 0 ? (
+              <ArrowUp className="h-3 w-3" />
+            ) : (
+              <ArrowDown className="h-3 w-3" />
+            )}
+            {Math.abs(delta)}
+          </span>
+        ) : null}
       </span>
       <div className="min-w-0 flex-1">
         <p className="truncate text-sm">{conditionLabel(condition)}</p>
         <p className="text-xs text-muted-foreground">
+          {moved ? (
+            <span className="text-amber-600">was #{baselinePosition} · </span>
+          ) : null}
           {volumeFormatter.format(condition.similarMarketVolume)} Vol
         </p>
       </div>
@@ -107,6 +142,10 @@ const QuestionOrdering = () => {
   const [groupFilter, setGroupFilter] = useState('');
   const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null);
   const [order, setOrder] = useState<string[]>([]);
+  const loadedBaselineRef = useRef<{ groupId: number | null; key: string }>({
+    groupId: null,
+    key: '',
+  });
 
   // Loading reads the public GraphQL endpoint, so it is safe to fetch on mount
   // without a wallet or signature.
@@ -136,11 +175,37 @@ const QuestionOrdering = () => {
     [selectedGroup]
   );
 
-  // Reset the working order whenever a different group is selected or the
-  // group's saved order changes (e.g. after a successful save refetch).
-  useEffect(() => {
-    setOrder(baselineIds);
+  const baselineKey = useMemo(() => baselineIds.join('\u0000'), [baselineIds]);
+
+  const baselineIndexById = useMemo(() => {
+    const map = new Map<string, number>();
+    baselineIds.forEach((id, index) => map.set(id, index));
+    return map;
   }, [baselineIds]);
+
+  const isDirty = useMemo(
+    () => order.join(',') !== baselineIds.join(','),
+    [order, baselineIds]
+  );
+
+  const movedCount = useMemo(
+    () => order.reduce((n, id, i) => (baselineIds[i] === id ? n : n + 1), 0),
+    [order, baselineIds]
+  );
+
+  // Reset the working order when the operator selects a different group. For
+  // background refetches of the same group, keep a dirty draft intact.
+  useEffect(() => {
+    const loaded = loadedBaselineRef.current;
+    const groupChanged = loaded.groupId !== selectedGroupId;
+    const baselineChanged = loaded.key !== baselineKey;
+
+    if (groupChanged || (!isDirty && baselineChanged)) {
+      setOrder(baselineIds);
+    }
+
+    loadedBaselineRef.current = { groupId: selectedGroupId, key: baselineKey };
+  }, [baselineIds, baselineKey, isDirty, selectedGroupId]);
 
   const conditionsById = useMemo(() => {
     const map = new Map<string, AdminConditionGroupCondition>();
@@ -149,11 +214,6 @@ const QuestionOrdering = () => {
     );
     return map;
   }, [selectedGroup]);
-
-  const isDirty = useMemo(
-    () => order.join(',') !== baselineIds.join(','),
-    [order, baselineIds]
-  );
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -304,6 +364,9 @@ const QuestionOrdering = () => {
                             key={conditionId}
                             condition={condition}
                             position={index + 1}
+                            baselinePosition={
+                              (baselineIndexById.get(conditionId) ?? index) + 1
+                            }
                           />
                         );
                       })}
@@ -311,28 +374,62 @@ const QuestionOrdering = () => {
                   </SortableContext>
                 </DndContext>
 
-                <div className="flex items-center justify-end gap-2">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    disabled={!isDirty || reorderMutation.isPending}
-                    onClick={() => setOrder(baselineIds)}
-                  >
-                    Reset
-                  </Button>
-                  <Button
-                    size="sm"
-                    disabled={
-                      !isDirty || !isConnected || reorderMutation.isPending
-                    }
-                    onClick={handleSave}
-                  >
-                    {reorderMutation.isPending ? 'Saving…' : 'Save order'}
-                  </Button>
+                {selectedGroup.hasMoreConditions ? (
+                  <p className="rounded-md border border-yellow-500/40 bg-yellow-500/10 px-3 py-2 text-xs text-yellow-700 dark:text-yellow-300">
+                    Only the first 100 public conditions are loaded for this
+                    group. Saving will reorder only the loaded conditions and
+                    leave the rest untouched.
+                  </p>
+                ) : null}
+
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-1.5 text-xs">
+                    {isDirty ? (
+                      <>
+                        <span className="h-2 w-2 rounded-full bg-amber-500" />
+                        <span className="font-medium text-amber-600">
+                          {movedCount}{' '}
+                          {movedCount === 1 ? 'question' : 'questions'} moved ·
+                          unsaved
+                        </span>
+                      </>
+                    ) : (
+                      <>
+                        <Check className="h-3.5 w-3.5 text-emerald-600" />
+                        <span className="text-muted-foreground">
+                          All changes saved
+                        </span>
+                      </>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={!isDirty || reorderMutation.isPending}
+                      onClick={() => setOrder(baselineIds)}
+                    >
+                      Reset
+                    </Button>
+                    <Button
+                      size="sm"
+                      disabled={
+                        !isDirty || !isConnected || reorderMutation.isPending
+                      }
+                      onClick={handleSave}
+                    >
+                      {reorderMutation.isPending ? 'Saving…' : 'Save order'}
+                    </Button>
+                  </div>
                 </div>
                 {!isConnected ? (
                   <p className="text-right text-xs text-muted-foreground">
                     Connect an admin wallet to save.
+                  </p>
+                ) : isDirty ? (
+                  <p className="text-right text-xs text-muted-foreground">
+                    Saving prompts a one-time wallet signature and updates only
+                    display order.
                   </p>
                 ) : null}
               </>

--- a/packages/app/src/components/admin/QuestionOrdering.tsx
+++ b/packages/app/src/components/admin/QuestionOrdering.tsx
@@ -1,0 +1,347 @@
+'use client';
+
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Button } from '@sapience/ui/components/ui/button';
+import { Input } from '@sapience/ui/components/ui/input';
+import { useToast } from '@sapience/ui/hooks/use-toast';
+import { GripVertical } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { useAccount } from 'wagmi';
+
+import {
+  useAdminConditionGroups,
+  useReorderConditionGroup,
+  type AdminConditionGroup,
+  type AdminConditionGroupCondition,
+} from '~/hooks/admin/useAdminConditionGroups';
+import { cn } from '~/lib/utils/util';
+
+const volumeFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  notation: 'compact',
+  maximumFractionDigits: 2,
+});
+
+function conditionLabel(condition: AdminConditionGroupCondition): string {
+  return condition.shortName ?? condition.optionName ?? condition.question;
+}
+
+// True when `next` is a reordering of `base` and nothing else — same length,
+// same set of ids. Guards Save so it can never imply an add/remove.
+function isPermutation(base: string[], next: string[]): boolean {
+  if (base.length !== next.length) return false;
+  const baseSet = new Set(base);
+  return (
+    next.every((id) => baseSet.has(id)) && new Set(next).size === next.length
+  );
+}
+
+function SortableConditionRow({
+  condition,
+  position,
+}: {
+  condition: AdminConditionGroupCondition;
+  position: number;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: condition.id });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn(
+        'flex items-center gap-3 rounded-md border bg-background px-3 py-2',
+        isDragging && 'opacity-70 shadow-sm'
+      )}
+    >
+      <button
+        type="button"
+        className="cursor-grab touch-none text-muted-foreground"
+        aria-label="Drag to reorder"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="h-4 w-4" />
+      </button>
+      <span className="w-6 shrink-0 text-sm tabular-nums text-muted-foreground">
+        {position}
+      </span>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm">{conditionLabel(condition)}</p>
+        <p className="text-xs text-muted-foreground">
+          {volumeFormatter.format(condition.similarMarketVolume)} Vol
+        </p>
+      </div>
+    </div>
+  );
+}
+
+const QuestionOrdering = () => {
+  const { toast } = useToast();
+  const { isConnected } = useAccount();
+
+  const [groupFilter, setGroupFilter] = useState('');
+  const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null);
+  const [order, setOrder] = useState<string[]>([]);
+
+  // Loading reads the public GraphQL endpoint, so it is safe to fetch on mount
+  // without a wallet or signature.
+  const groupsQuery = useAdminConditionGroups(true);
+  const reorderMutation = useReorderConditionGroup();
+
+  const groups = useMemo(() => groupsQuery.data ?? [], [groupsQuery.data]);
+
+  const filteredGroups = useMemo(() => {
+    const query = groupFilter.trim().toLowerCase();
+    const sorted = [...groups].sort((a, b) => a.name.localeCompare(b.name));
+    if (!query) return sorted;
+    return sorted.filter(
+      (group) =>
+        group.name.toLowerCase().includes(query) ||
+        String(group.id).includes(query)
+    );
+  }, [groups, groupFilter]);
+
+  const selectedGroup: AdminConditionGroup | null = useMemo(
+    () => groups.find((group) => group.id === selectedGroupId) ?? null,
+    [groups, selectedGroupId]
+  );
+
+  const baselineIds = useMemo(
+    () => selectedGroup?.condition.map((condition) => condition.id) ?? [],
+    [selectedGroup]
+  );
+
+  // Reset the working order whenever a different group is selected or the
+  // group's saved order changes (e.g. after a successful save refetch).
+  useEffect(() => {
+    setOrder(baselineIds);
+  }, [baselineIds]);
+
+  const conditionsById = useMemo(() => {
+    const map = new Map<string, AdminConditionGroupCondition>();
+    selectedGroup?.condition.forEach((condition) =>
+      map.set(condition.id, condition)
+    );
+    return map;
+  }, [selectedGroup]);
+
+  const isDirty = useMemo(
+    () => order.join(',') !== baselineIds.join(','),
+    [order, baselineIds]
+  );
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    setOrder((current) => {
+      const oldIndex = current.indexOf(String(active.id));
+      const newIndex = current.indexOf(String(over.id));
+      if (oldIndex === -1 || newIndex === -1) return current;
+      return arrayMove(current, oldIndex, newIndex);
+    });
+  };
+
+  const handleSave = () => {
+    if (selectedGroupId === null) return;
+    // Defense in depth: only ever save a pure reordering of what we loaded.
+    if (!isPermutation(baselineIds, order)) {
+      toast({
+        variant: 'destructive',
+        title: 'Refusing to save',
+        description:
+          'The order is not a clean reordering of the loaded conditions.',
+      });
+      return;
+    }
+    reorderMutation.mutate(
+      { groupId: selectedGroupId, conditionIds: order },
+      {
+        onSuccess: () => {
+          toast({ title: 'Order saved' });
+        },
+        onError: (error) => {
+          toast({
+            variant: 'destructive',
+            title: 'Failed to save order',
+            description:
+              error instanceof Error ? error.message : 'Please try again.',
+          });
+        },
+      }
+    );
+  };
+
+  return (
+    <div className="rounded-lg border p-4">
+      <div className="mb-4 flex items-center justify-between gap-2">
+        <div>
+          <h2 className="text-lg font-medium">Question Ordering</h2>
+          <p className="text-sm text-muted-foreground">
+            Drag to set the display order of the questions shown within a group.
+            Loading is read-only; saving requires an admin wallet signature and
+            only updates display order.
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => groupsQuery.refetch()}
+          disabled={groupsQuery.isFetching}
+        >
+          Refresh
+        </Button>
+      </div>
+
+      {groupsQuery.isLoading ? (
+        <p className="text-sm text-muted-foreground">
+          Loading condition groups…
+        </p>
+      ) : groupsQuery.isError ? (
+        <div className="space-y-2">
+          <p className="text-sm text-red-500">
+            {groupsQuery.error instanceof Error
+              ? groupsQuery.error.message
+              : 'Failed to load condition groups.'}
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => groupsQuery.refetch()}
+          >
+            Retry
+          </Button>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <div className="space-y-2">
+            <Input
+              placeholder="Filter by name or id (e.g. 1017)"
+              value={groupFilter}
+              onChange={(event) => setGroupFilter(event.target.value)}
+            />
+            <div className="max-h-96 space-y-1 overflow-y-auto">
+              {filteredGroups.length === 0 ? (
+                <p className="px-1 py-2 text-sm text-muted-foreground">
+                  No groups match “{groupFilter}”.
+                </p>
+              ) : (
+                filteredGroups.map((group) => (
+                  <button
+                    key={group.id}
+                    type="button"
+                    onClick={() => setSelectedGroupId(group.id)}
+                    className={cn(
+                      'flex w-full items-center justify-between gap-2 rounded-md border px-3 py-2 text-left text-sm hover:bg-muted',
+                      selectedGroupId === group.id && 'border-primary bg-muted'
+                    )}
+                  >
+                    <span className="min-w-0 truncate">{group.name}</span>
+                    <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
+                      #{group.id} · {group.condition.length}
+                    </span>
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            {selectedGroup === null ? (
+              <p className="text-sm text-muted-foreground">
+                Select a group to reorder its questions.
+              </p>
+            ) : selectedGroup.condition.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                This group has no public conditions.
+              </p>
+            ) : (
+              <>
+                <DndContext
+                  sensors={sensors}
+                  collisionDetection={closestCenter}
+                  onDragEnd={handleDragEnd}
+                >
+                  <SortableContext
+                    items={order}
+                    strategy={verticalListSortingStrategy}
+                  >
+                    <div className="space-y-1">
+                      {order.map((conditionId, index) => {
+                        const condition = conditionsById.get(conditionId);
+                        if (!condition) return null;
+                        return (
+                          <SortableConditionRow
+                            key={conditionId}
+                            condition={condition}
+                            position={index + 1}
+                          />
+                        );
+                      })}
+                    </div>
+                  </SortableContext>
+                </DndContext>
+
+                <div className="flex items-center justify-end gap-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={!isDirty || reorderMutation.isPending}
+                    onClick={() => setOrder(baselineIds)}
+                  >
+                    Reset
+                  </Button>
+                  <Button
+                    size="sm"
+                    disabled={
+                      !isDirty || !isConnected || reorderMutation.isPending
+                    }
+                    onClick={handleSave}
+                  >
+                    {reorderMutation.isPending ? 'Saving…' : 'Save order'}
+                  </Button>
+                </div>
+                {!isConnected ? (
+                  <p className="text-right text-xs text-muted-foreground">
+                    Connect an admin wallet to save.
+                  </p>
+                ) : null}
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default QuestionOrdering;

--- a/packages/app/src/components/admin/__tests__/QuestionOrdering.test.tsx
+++ b/packages/app/src/components/admin/__tests__/QuestionOrdering.test.tsx
@@ -2,11 +2,16 @@ import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
-import type { AdminConditionGroup } from '~/hooks/admin/useAdminConditionGroups';
+import type {
+  AdminConditionGroup,
+  AdminConditionGroupCondition,
+} from '~/hooks/admin/useAdminConditionGroups';
 
 const toastSpy = vi.fn();
 const reorderMutate = vi.fn();
 let groupsData: AdminConditionGroup[] = [];
+let hydratedByGlobalId = new Map<string, AdminConditionGroupCondition[]>();
+let conditionsLoading = false;
 
 vi.mock('@sapience/ui/hooks/use-toast', () => ({
   useToast: () => ({ toast: toastSpy }),
@@ -111,6 +116,26 @@ vi.mock('~/hooks/admin/useAdminConditionGroups', async () => {
       isFetching: false,
       refetch: vi.fn(),
     }),
+    useAdminGroupConditions: (
+      globalId: string | null | undefined,
+      enabled: boolean
+    ) => {
+      const fallback = groupsData.find(
+        (g) => g.globalId === globalId
+      )?.condition;
+      const data =
+        enabled && globalId
+          ? (hydratedByGlobalId.get(globalId) ?? fallback)
+          : undefined;
+      return {
+        data,
+        isLoading: conditionsLoading,
+        isFetching: conditionsLoading,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      };
+    },
     useReorderConditionGroup: () => ({
       mutate: reorderMutate,
       isPending: false,
@@ -125,6 +150,7 @@ function makeGroup(
 ): AdminConditionGroup {
   return {
     id: 42,
+    globalId: 'gid-42',
     name: 'Test group',
     negRisk: false,
     hasMoreConditions: false,
@@ -153,6 +179,8 @@ function makeGroup(
 describe('QuestionOrdering', () => {
   beforeEach(() => {
     groupsData = [makeGroup()];
+    hydratedByGlobalId = new Map();
+    conditionsLoading = false;
     reorderMutate.mockReset();
     toastSpy.mockReset();
   });
@@ -185,28 +213,55 @@ describe('QuestionOrdering', () => {
     fireEvent.click(screen.getByRole('button', { name: /Test group/ }));
     await screen.findByText('Question A');
 
-    // Nothing changed yet → clean state, no movement annotations.
     expect(screen.getByText('All changes saved')).toBeInTheDocument();
     expect(screen.queryByText(/moved · unsaved/)).not.toBeInTheDocument();
     expect(screen.queryByText(/was #/)).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Move A after B' }));
 
-    // Both rows shifted → unsaved indicator + "was #" annotations appear.
     expect(await screen.findByText(/moved · unsaved/)).toBeInTheDocument();
     expect(screen.getAllByText(/was #/).length).toBeGreaterThan(0);
     expect(screen.queryByText('All changes saved')).not.toBeInTheDocument();
   });
 
-  it('warns when the backend reports more than 100 public conditions', async () => {
+  it('shows loading until all conditions are hydrated', async () => {
+    conditionsLoading = true;
     groupsData = [makeGroup({ hasMoreConditions: true })];
 
     render(<QuestionOrdering />);
-
     fireEvent.click(screen.getByRole('button', { name: /Test group/ }));
 
     expect(
-      await screen.findByText(/Only the first 100 public conditions are loaded/)
+      await screen.findByText(/Loading all public conditions/)
     ).toBeInTheDocument();
+    expect(screen.queryByText('Question A')).not.toBeInTheDocument();
+  });
+
+  it('saves the full hydrated membership for large groups', async () => {
+    const tail: AdminConditionGroupCondition = {
+      id: 'condition-c',
+      question: 'Question C',
+      shortName: null,
+      optionName: null,
+      similarMarketVolume: 300,
+      displayOrder: 2,
+    };
+    groupsData = [makeGroup({ hasMoreConditions: true })];
+    hydratedByGlobalId.set('gid-42', [...makeGroup().condition, tail]);
+
+    render(<QuestionOrdering />);
+    fireEvent.click(screen.getByRole('button', { name: /Test group/ }));
+    await screen.findByText('Question C');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move A after B' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save order' }));
+
+    expect(reorderMutate).toHaveBeenCalledWith(
+      {
+        groupId: 42,
+        conditionIds: ['condition-b', 'condition-a', 'condition-c'],
+      },
+      expect.any(Object)
+    );
   });
 });

--- a/packages/app/src/components/admin/__tests__/QuestionOrdering.test.tsx
+++ b/packages/app/src/components/admin/__tests__/QuestionOrdering.test.tsx
@@ -1,0 +1,212 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import type { AdminConditionGroup } from '~/hooks/admin/useAdminConditionGroups';
+
+const toastSpy = vi.fn();
+const reorderMutate = vi.fn();
+let groupsData: AdminConditionGroup[] = [];
+
+vi.mock('@sapience/ui/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastSpy }),
+}));
+
+vi.mock('wagmi', () => ({
+  useAccount: () => ({ isConnected: true }),
+}));
+
+vi.mock('lucide-react', () => ({
+  GripVertical: () => <span aria-hidden="true">grip</span>,
+  ArrowUp: () => <span aria-hidden="true">up</span>,
+  ArrowDown: () => <span aria-hidden="true">down</span>,
+  Check: () => <span aria-hidden="true">check</span>,
+}));
+
+vi.mock('@sapience/ui/components/ui/button', () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock('@sapience/ui/components/ui/input', () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input {...props} />
+  ),
+}));
+
+vi.mock('@dnd-kit/core', () => ({
+  closestCenter: vi.fn(),
+  DndContext: ({
+    children,
+    onDragEnd,
+  }: {
+    children: React.ReactNode;
+    onDragEnd?: (event: {
+      active: { id: string };
+      over: { id: string } | null;
+    }) => void;
+  }) => (
+    <div>
+      <button
+        type="button"
+        onClick={() =>
+          onDragEnd?.({
+            active: { id: 'condition-a' },
+            over: { id: 'condition-b' },
+          })
+        }
+      >
+        Move A after B
+      </button>
+      {children}
+    </div>
+  ),
+  KeyboardSensor: vi.fn(),
+  PointerSensor: vi.fn(),
+  useSensor: () => ({}),
+  useSensors: () => [],
+}));
+
+vi.mock('@dnd-kit/sortable', () => ({
+  arrayMove: <T,>(items: T[], from: number, to: number) => {
+    const next = [...items];
+    const [item] = next.splice(from, 1);
+    next.splice(to, 0, item);
+    return next;
+  },
+  SortableContext: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  sortableKeyboardCoordinates: vi.fn(),
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+  verticalListSortingStrategy: vi.fn(),
+}));
+
+vi.mock('@dnd-kit/utilities', () => ({
+  CSS: { Transform: { toString: () => undefined } },
+}));
+
+vi.mock('~/hooks/admin/useAdminConditionGroups', async () => {
+  const actual = await vi.importActual<
+    typeof import('~/hooks/admin/useAdminConditionGroups')
+  >('~/hooks/admin/useAdminConditionGroups');
+  return {
+    ...actual,
+    useAdminConditionGroups: () => ({
+      data: groupsData,
+      isLoading: false,
+      isError: false,
+      error: null,
+      isFetching: false,
+      refetch: vi.fn(),
+    }),
+    useReorderConditionGroup: () => ({
+      mutate: reorderMutate,
+      isPending: false,
+    }),
+  };
+});
+
+import QuestionOrdering from '../QuestionOrdering';
+
+function makeGroup(
+  overrides: Partial<AdminConditionGroup> = {}
+): AdminConditionGroup {
+  return {
+    id: 42,
+    name: 'Test group',
+    negRisk: false,
+    hasMoreConditions: false,
+    condition: [
+      {
+        id: 'condition-a',
+        question: 'Question A',
+        shortName: null,
+        optionName: null,
+        similarMarketVolume: 100,
+        displayOrder: 0,
+      },
+      {
+        id: 'condition-b',
+        question: 'Question B',
+        shortName: null,
+        optionName: null,
+        similarMarketVolume: 200,
+        displayOrder: 1,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('QuestionOrdering', () => {
+  beforeEach(() => {
+    groupsData = [makeGroup()];
+    reorderMutate.mockReset();
+    toastSpy.mockReset();
+  });
+
+  it('preserves a dirty draft when the selected group refetches', async () => {
+    const { rerender } = render(<QuestionOrdering />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Test group/ }));
+    await screen.findByText('Question A');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move A after B' }));
+
+    groupsData = [makeGroup()];
+    rerender(<QuestionOrdering />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Save order' })).toBeEnabled();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save order' }));
+
+    expect(reorderMutate).toHaveBeenCalledWith(
+      { groupId: 42, conditionIds: ['condition-b', 'condition-a'] },
+      expect.any(Object)
+    );
+  });
+
+  it('reflects saved vs unsaved state and per-row movement', async () => {
+    render(<QuestionOrdering />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Test group/ }));
+    await screen.findByText('Question A');
+
+    // Nothing changed yet → clean state, no movement annotations.
+    expect(screen.getByText('All changes saved')).toBeInTheDocument();
+    expect(screen.queryByText(/moved · unsaved/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/was #/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move A after B' }));
+
+    // Both rows shifted → unsaved indicator + "was #" annotations appear.
+    expect(await screen.findByText(/moved · unsaved/)).toBeInTheDocument();
+    expect(screen.getAllByText(/was #/).length).toBeGreaterThan(0);
+    expect(screen.queryByText('All changes saved')).not.toBeInTheDocument();
+  });
+
+  it('warns when the backend reports more than 100 public conditions', async () => {
+    groupsData = [makeGroup({ hasMoreConditions: true })];
+
+    render(<QuestionOrdering />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Test group/ }));
+
+    expect(
+      await screen.findByText(/Only the first 100 public conditions are loaded/)
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/app/src/components/admin/index.tsx
+++ b/packages/app/src/components/admin/index.tsx
@@ -10,7 +10,8 @@ import {
 } from '@sapience/ui/components/ui/dialog';
 import { Input } from '@sapience/ui/components/ui/input';
 import { useToast } from '@sapience/ui/hooks/use-toast';
-import { Copy, Plus, Settings } from 'lucide-react';
+import { Copy, ListOrdered, Plus, Settings } from 'lucide-react';
+import Link from 'next/link';
 import { useState } from 'react';
 import type { Address } from 'viem';
 
@@ -68,6 +69,12 @@ const Admin = () => {
       <header className="flex items-center justify-between mb-8">
         <h1 className="text-3xl">Admin</h1>
         <div className="flex items-center gap-2">
+          <Link href="/admin/question-ordering">
+            <Button variant="outline" size="sm">
+              <ListOrdered className="mr-1 h-4 w-4" />
+              Question Ordering
+            </Button>
+          </Link>
           <Dialog
             open={smartAccountLookupOpen}
             onOpenChange={(open) => {
@@ -213,7 +220,7 @@ const Admin = () => {
       </header>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        <aside className="lg:col-span-1">
+        <aside className="lg:col-span-1 space-y-6">
           <div className="rounded-lg border p-4">
             <h2 className="text-lg font-medium mb-4">
               Backfill Protocol Stats

--- a/packages/app/src/components/analytics/OpenInterestByCategoryChart.tsx
+++ b/packages/app/src/components/analytics/OpenInterestByCategoryChart.tsx
@@ -23,7 +23,7 @@ interface SliceDatum {
 
 export default function OpenInterestByCategoryChart() {
   const { data: analytics, isLoading } = useProtocolAnalytics();
-  // v2 categories are slug-keyed (no numeric row id) — the chart already
+  // Categories are slug-keyed (no numeric row id) — the chart already
   // keys slices on `slug`, so the shape change is invisible here.
   const data = analytics?.openInterestByCategory;
 

--- a/packages/app/src/components/analytics/OpenInterestByTimeToResolutionChart.tsx
+++ b/packages/app/src/components/analytics/OpenInterestByTimeToResolutionChart.tsx
@@ -23,7 +23,7 @@ const MONTH_SECONDS = 30 * DAY_SECONDS;
  * `(minSecondsFromNow, maxSecondsFromNow]` — left-EXCLUSIVE,
  * right-INCLUSIVE (server bug #13 fixed the orientation; do not re-derive
  * with `[min, max)`). For the current server buckets
- * (1d / 7d / 30d / 60d / 90d / 180d / beyond) this reproduces the v1
+ * (1d / 7d / 30d / 60d / 90d / 180d / beyond) this reproduces the original
  * labels exactly: "≤1 day", "2-7 days", "8-30 days", "1-2 mo.",
  * "2-3 mo.", "3-6 mo.", "6 mo.+".
  */

--- a/packages/app/src/components/analytics/pages/AnalyticsPageContent.tsx
+++ b/packages/app/src/components/analytics/pages/AnalyticsPageContent.tsx
@@ -202,7 +202,7 @@ function AnalyticsPageContent(): React.ReactElement {
   const [oiPeriod, setOiPeriod] = useState<Period>('1M');
   const [tvlPeriod, setTvlPeriod] = useState<Period>('1M');
 
-  // Fetch protocol-wide analytics (v2): live stats + recorded snapshot series
+  // Fetch protocol-wide analytics: live stats + recorded snapshot series
   const { data: analytics, isLoading: statsLoading } = useProtocolAnalytics();
   const protocolStats = analytics?.statsHistory;
 
@@ -230,7 +230,7 @@ function AnalyticsPageContent(): React.ReactElement {
     return protocolStats.map((point) => {
       const openInterest = parseFloat(point.openInterest) / 1e18;
       // Server-computed TVL: escrow + undeployed assets across EVERY vault
-      // family. Numerically different from v1's client-side
+      // family. Numerically different from the legacy client-side
       // escrow + single-family vaultAvailableAssets sum — intended.
       const protocolTvl = parseFloat(point.totalValueLocked) / 1e18;
       return {
@@ -418,7 +418,7 @@ function AnalyticsPageContent(): React.ReactElement {
                   </div>
                 ) : (
                   <span className="transition-opacity duration-300">
-                    {/* v1 `totalTradeCount` → v2 `cumulativeTradeCount` */}
+                    {/* legacy `totalTradeCount` → `cumulativeTradeCount` */}
                     {formatCount(summary?.cumulativeTradeCount ?? 0)}
                   </span>
                 )}

--- a/packages/app/src/components/leaderboard/Leaderboard.tsx
+++ b/packages/app/src/components/leaderboard/Leaderboard.tsx
@@ -350,9 +350,9 @@ const AccuracyLeaderboard = () => {
         accessorKey: 'accuracyScore',
         cell: ({ getValue }) => {
           const v = getValue<number>();
-          // v2 Ranking.accuracy carries the SAME raw avg(twError) scale as
-          // v1's accuracyScore (parity-verified identity; the SDL's old
-          // "0-1" doc was wrong) — render exactly as v1 did.
+          // Ranking.accuracy carries the SAME raw avg(twError) scale as
+          // the legacy accuracyScore (parity-verified identity; the SDL's old
+          // "0-1" doc was wrong) — render exactly as before.
           const formatted = Number.isFinite(v)
             ? v.toLocaleString('en-US', { maximumFractionDigits: 0 })
             : '-';

--- a/packages/app/src/components/markets/QuestionsTable.tsx
+++ b/packages/app/src/components/markets/QuestionsTable.tsx
@@ -1038,6 +1038,17 @@ export default function QuestionsTable({
                             isLast={idx === data.conditions.length - 1}
                           />
                         ))}
+                      {isExpanded && data.hasMoreConditions ? (
+                        <TableRow className="hover:bg-transparent border-b border-brand-white/10">
+                          <TableCell
+                            colSpan={columns.length}
+                            className="py-2 pl-12 text-xs text-muted-foreground"
+                          >
+                            Showing first {data.conditions.length} options. More
+                            options are available in this market group.
+                          </TableCell>
+                        </TableRow>
+                      ) : null}
                     </React.Fragment>
                   );
                 })}

--- a/packages/app/src/components/markets/market-helpers.tsx
+++ b/packages/app/src/components/markets/market-helpers.tsx
@@ -53,6 +53,7 @@ export type TopLevelRow =
       name: string;
       category?: { name: string; slug: string } | null;
       conditions: ConditionGroupConditionType[];
+      hasMoreConditions?: boolean;
       openInterestWei: bigint;
       maxEndTime: number;
     }
@@ -612,6 +613,7 @@ export function buildTopLevelRows(questions: QuestionType[]): TopLevelRow[] {
           name: group.name,
           category: group.category,
           conditions: group.conditions,
+          hasMoreConditions: group.hasMoreConditions,
           openInterestWei,
           maxEndTime,
         },

--- a/packages/app/src/components/markets/pages/QuestionPageContent.tsx
+++ b/packages/app/src/components/markets/pages/QuestionPageContent.tsx
@@ -131,7 +131,7 @@ export default function QuestionPageContent({
           }
         }
       `;
-      const resp = await graphqlRequest<{
+      type ConditionByIdResponse = {
         conditions: {
           nodes: Array<{
             id: string;
@@ -150,11 +150,24 @@ export default function QuestionPageContent({
             similarMarket?: { markets?: string[] } | null;
           }>;
         };
-      }>(QUERY, {
-        ids: [conditionId],
-        resolvers: resolverAddressFromUrl ? [resolverAddressFromUrl] : null,
-      });
-      const node = resp?.conditions?.nodes?.[0];
+      };
+
+      const fetchCondition = (resolvers: string[] | null) =>
+        graphqlRequest<ConditionByIdResponse>(QUERY, {
+          ids: [conditionId],
+          resolvers,
+        });
+
+      const resp = await fetchCondition(
+        resolverAddressFromUrl ? [resolverAddressFromUrl] : null
+      );
+      let node = resp?.conditions?.nodes?.[0];
+      if (!node && resolverAddressFromUrl) {
+        // Stale/wrong resolver URLs should still load the condition by id so
+        // the canonicalization effect below can repair the route.
+        const fallbackResp = await fetchCondition(null);
+        node = fallbackResp?.conditions?.nodes?.[0];
+      }
       if (!node) return null;
       const { similarMarket, ...rest } = node;
       return {
@@ -219,11 +232,11 @@ export default function QuestionPageContent({
     }
   }, [isPolymarketResolver, data?.similarMarkets]);
 
-  // If the resolver in the URL is wrong, immediately canonicalize to the computed resolver.
+  // Canonicalize legacy URLs and stale/wrong resolver URLs to the computed resolver.
   React.useEffect(() => {
-    if (!resolverAddressFromUrl) return;
     if (!resolverAddress) return;
     if (
+      resolverAddressFromUrl &&
       resolverAddressFromUrl.toLowerCase() === resolverAddress.toLowerCase()
     ) {
       return;

--- a/packages/app/src/components/markets/pages/QuestionPageContent.tsx
+++ b/packages/app/src/components/markets/pages/QuestionPageContent.tsx
@@ -96,11 +96,11 @@ export default function QuestionPageContent({
     enabled: Boolean(conditionId),
     queryFn: async () => {
       if (!conditionId) return null;
-      // v2: by-ids lookups skip the public-only listing default, and
+      // By-ids lookups skip the public-only listing default, and
       // `resolvers` composes with `conditionIds` for the multi-resolver
       // disambiguation (both matched case-insensitively server-side).
       // Untagged literal on purpose: app graphql-eslint validates tagged
-      // documents against the v1 schema.
+      // documents against the legacy schema.
       const QUERY = `
         query ConditionByIdAndResolver($ids: [Bytes!]!, $resolvers: [Address!]) {
           conditions(

--- a/packages/app/src/components/markets/pages/QuestionPageContent.tsx
+++ b/packages/app/src/components/markets/pages/QuestionPageContent.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { graphqlRequestV2 } from '@sapience/sdk/queries/client/graphqlClient';
+import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
 import Image from 'next/image';
 import { PythOracleMark } from '@sapience/ui';
 import dynamic from 'next/dynamic';
@@ -131,7 +131,7 @@ export default function QuestionPageContent({
           }
         }
       `;
-      const resp = await graphqlRequestV2<{
+      const resp = await graphqlRequest<{
         conditions: {
           nodes: Array<{
             id: string;

--- a/packages/app/src/components/markets/polymarket/QuestionsGrid.tsx
+++ b/packages/app/src/components/markets/polymarket/QuestionsGrid.tsx
@@ -249,6 +249,13 @@ export default function QuestionsGrid({
                               );
                             })}
                           </motion.div>
+                          {openGroupRow.hasMoreConditions ? (
+                            <p className="mt-4 text-xs text-white/70">
+                              Showing first {openGroupRow.conditions.length}{' '}
+                              options. More options are available in this market
+                              group.
+                            </p>
+                          ) : null}
                         </motion.div>
                       </motion.div>
                     )}

--- a/packages/app/src/components/markets/question/CombinedPredictionsList.tsx
+++ b/packages/app/src/components/markets/question/CombinedPredictionsList.tsx
@@ -17,7 +17,7 @@ type CombinedConditionDetail = {
   category?: { slug?: string | null } | null;
 };
 
-// v2 document — untagged so graphql-eslint (pinned to the v1 schema) skips it.
+// Untagged so graphql-eslint (pinned to the legacy schema) skips it.
 const COMBINED_CONDITIONS_QUERY = `
   query CombinedConditions($ids: [Bytes!]!) {
     conditions(

--- a/packages/app/src/components/positions/PositionsTable.tsx
+++ b/packages/app/src/components/positions/PositionsTable.tsx
@@ -125,9 +125,9 @@ function PositionRow({
     ((isPredictorToken && result === 'COUNTERPARTY_WINS') ||
       (!isPredictorToken && result === 'PREDICTOR_WINS'));
 
-  // v2 surfaces an explicit SOLD discriminator. (v1 encoded it in the id shape
-  // `${dbId}-sell-${tradeHash}`; the id fallback keeps any pre-migration row
-  // working.)
+  // The schema surfaces an explicit SOLD discriminator. (The legacy schema
+  // encoded it in the id shape `${dbId}-sell-${tradeHash}`; the id fallback
+  // keeps any pre-migration row working.)
   const isSoldRow =
     position.status === 'SOLD' || position.id.includes('-sell-');
   const isClosed = !isResolved && BigInt(position.balance) === 0n;

--- a/packages/app/src/components/profile/ForecastsTable.tsx
+++ b/packages/app/src/components/profile/ForecastsTable.tsx
@@ -229,10 +229,10 @@ const ForecastsTable = ({
     { id: 'rawTime', desc: true },
   ]);
 
-  // v2 orders forecasts by ATTESTED_AT only — sorting picks the direction.
+  // The endpoint orders forecasts by ATTESTED_AT only — sorting picks the direction.
   const orderDirection = sorting[0]?.desc ? 'desc' : 'asc';
 
-  // Cursor-paginated fetch (v2 first/after). Page accumulation lives in the
+  // Cursor-paginated fetch (first/after). Page accumulation lives in the
   // infinite query; changing direction or attester resets via the query key.
   const {
     data: attestations,
@@ -280,7 +280,7 @@ const ForecastsTable = ({
     staleTime: 60_000,
     gcTime: 5 * 60 * 1000,
     queryFn: async () => {
-      // v2 document — untagged so graphql-eslint (v1 schema) skips it.
+      // Untagged so graphql-eslint (pinned to the legacy schema) skips it.
       const query = `
         query ConditionsByIds($ids: [Bytes!]!) {
           conditions(
@@ -448,7 +448,7 @@ const ForecastsTable = ({
       {
         id: 'value',
         accessorFn: (row) => row.value,
-        // v2 has no server-side ordering by forecast value (ATTESTED_AT only),
+        // The endpoint has no server-side ordering by forecast value (ATTESTED_AT only),
         // so this column is no longer sortable.
         enableSorting: false,
         header: () => <span className="text-sm font-medium">Forecast</span>,

--- a/packages/app/src/components/profile/ProfileQuickMetrics.tsx
+++ b/packages/app/src/components/profile/ProfileQuickMetrics.tsx
@@ -111,9 +111,9 @@ export default function ProfileQuickMetrics({
 
   const pnlNumber = Number(profit?.totalPnL || 0);
 
-  // v2 Ranking.accuracy carries the SAME raw avg(twError) scale as v1's
+  // Ranking.accuracy carries the SAME raw avg(twError) scale as the legacy
   // accuracyScore (parity-verified identity; the SDL's old "0-1" doc was
-  // wrong) — render exactly as v1 did.
+  // wrong) — render exactly as before.
   const accValue = accuracyLoading
     ? '—'
     : Number.isFinite(accuracy?.accuracyScore || 0)

--- a/packages/app/src/components/settings/pages/SettingsPageContent.tsx
+++ b/packages/app/src/components/settings/pages/SettingsPageContent.tsx
@@ -190,7 +190,7 @@ const SettingField = ({
 const SettingsPageContent = () => {
   const { openChat } = useChat();
   const {
-    graphqlEndpointV2,
+    graphqlEndpoint,
     apiBaseUrl,
     signalEndpoint,
     chatBaseUrl,
@@ -203,7 +203,6 @@ const SettingsPageContent = () => {
     meshMaxPeers,
     meshFanout,
     setGraphqlEndpoint,
-    setGraphqlEndpointV2,
     setApiBaseUrl,
     setSignalEndpoint,
     setChatBaseUrl,
@@ -242,7 +241,7 @@ const SettingsPageContent = () => {
 
   useEffect(() => {
     if (!mounted) return;
-    setGqlInput(graphqlEndpointV2 || defaults.graphqlEndpointV2);
+    setGqlInput(graphqlEndpoint || defaults.graphqlEndpoint);
     setApiInput(apiBaseUrl ?? defaults.apiBaseUrl);
     setSignalInput(signalEndpoint ?? defaults.signalEndpoint);
     setChatInput(chatBaseUrl ?? defaults.chatBaseUrl);
@@ -274,8 +273,7 @@ const SettingsPageContent = () => {
   };
 
   const persistGraphqlEndpoint = (value: string | null) => {
-    setGraphqlEndpoint(null);
-    setGraphqlEndpointV2(value);
+    setGraphqlEndpoint(value);
   };
 
   const persistPredictionMarketRpcEndpoint = (value: string | null) => {
@@ -330,8 +328,7 @@ const SettingsPageContent = () => {
         return;
       }
 
-      setGraphqlEndpoint(null);
-      setGraphqlEndpointV2(preset.graphqlEndpoint);
+      setGraphqlEndpoint(preset.graphqlEndpoint);
       setApiBaseUrl(preset.relayerEndpoint);
       // Blank signal endpoint disables the mesh: the app won't connect to a
       // signaling server for either preset.
@@ -356,7 +353,6 @@ const SettingsPageContent = () => {
       setApiBaseUrl,
       setChatBaseUrl,
       setGraphqlEndpoint,
-      setGraphqlEndpointV2,
       setEtherealRpcUrl,
       setSignalEndpoint,
     ]
@@ -490,7 +486,7 @@ const SettingsPageContent = () => {
                     id="graphql-endpoint"
                     value={gqlInput}
                     setValue={setGqlInput}
-                    defaultValue={defaults.graphqlEndpointV2}
+                    defaultValue={defaults.graphqlEndpoint}
                     onPersist={persistGraphqlEndpoint}
                     validate={isHttpUrl}
                     invalidMessage="Must be an absolute http(s) URL"

--- a/packages/app/src/components/shared/CommandMenu.tsx
+++ b/packages/app/src/components/shared/CommandMenu.tsx
@@ -48,11 +48,11 @@ const PAGES = [
 ] as const;
 
 /**
- * Lightweight v2 query — only fetches the fields the command palette
+ * Lightweight query — only fetches the fields the command palette
  * needs. `QuestionItem` is a union, so results branch on `__typename`;
- * v2 `QuestionFilter.search` also covers condition shortName server-side.
+ * `QuestionFilter.search` also covers condition shortName server-side.
  * (Untagged literal on purpose: app graphql-eslint validates tagged
- * documents against the v1 schema.)
+ * documents against the legacy schema.)
  */
 const SEARCH_QUESTIONS = `
   query CommandMenuSearch($first: Int, $chainId: Int, $search: String) {

--- a/packages/app/src/components/shared/CommandMenu.tsx
+++ b/packages/app/src/components/shared/CommandMenu.tsx
@@ -28,7 +28,7 @@ import {
   DialogDescription,
   DialogTitle,
 } from '@sapience/ui/components/ui/dialog';
-import { graphqlRequestV2 } from '@sapience/sdk/queries/client/graphqlClient';
+import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
 import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
 import { isAddress, getAddress } from 'viem';
 import { getDeterministicCategoryColor } from '~/lib/theme/categoryPalette';
@@ -137,7 +137,7 @@ function useCommandMenuSearch(search: string | undefined, enabled: boolean) {
   return useQuery<SearchConditionRow[]>({
     queryKey: ['commandMenuSearch', search],
     queryFn: async () => {
-      const data = await graphqlRequestV2<{
+      const data = await graphqlRequest<{
         questions: { edges: Array<{ node: SearchQuestionNode }> };
       }>(SEARCH_QUESTIONS, {
         // Overfetch 3x: groups expand into multiple rows, and we re-sort

--- a/packages/app/src/components/shared/CommandMenu.tsx
+++ b/packages/app/src/components/shared/CommandMenu.tsx
@@ -34,6 +34,7 @@ import { isAddress, getAddress } from 'viem';
 import { getDeterministicCategoryColor } from '~/lib/theme/categoryPalette';
 import { FOCUS_AREAS } from '~/lib/constants/focusAreas';
 import MarketBadge from '~/components/markets/MarketBadge';
+import { useSettings } from '~/lib/context/SettingsContext';
 
 const MAX_RESULTS = 10;
 
@@ -133,9 +134,13 @@ function getCategoryColor(categorySlug?: string | null): string {
   return getDeterministicCategoryColor(categorySlug);
 }
 
-function useCommandMenuSearch(search: string | undefined, enabled: boolean) {
+function useCommandMenuSearch(
+  search: string | undefined,
+  enabled: boolean,
+  chainId: number
+) {
   return useQuery<SearchConditionRow[]>({
-    queryKey: ['commandMenuSearch', search],
+    queryKey: ['commandMenuSearch', search, chainId],
     queryFn: async () => {
       const data = await graphqlRequest<{
         questions: { edges: Array<{ node: SearchQuestionNode }> };
@@ -143,7 +148,7 @@ function useCommandMenuSearch(search: string | undefined, enabled: boolean) {
         // Overfetch 3x: groups expand into multiple rows, and we re-sort
         // client-side to prefer future markets over expired ones
         first: MAX_RESULTS * 3,
-        chainId: DEFAULT_CHAIN_ID,
+        chainId,
         search: search?.trim() || null,
       });
 
@@ -191,6 +196,8 @@ export default function CommandMenu() {
   const [search, setSearch] = React.useState('');
   const [debouncedSearch, setDebouncedSearch] = React.useState('');
   const router = useRouter();
+  const { customChainId } = useSettings();
+  const searchChainId = customChainId ?? DEFAULT_CHAIN_ID;
 
   // Debounce search input
   React.useEffect(() => {
@@ -222,7 +229,7 @@ export default function CommandMenu() {
     data: conditionRows = [],
     isFetching,
     isError,
-  } = useCommandMenuSearch(debouncedSearch || undefined, open);
+  } = useCommandMenuSearch(debouncedSearch || undefined, open, searchChainId);
 
   // Filter pages client-side — use instant search for snappy UX
   const filteredPages = React.useMemo(() => {

--- a/packages/app/src/components/shared/Comments.tsx
+++ b/packages/app/src/components/shared/Comments.tsx
@@ -215,7 +215,7 @@ const Comments = ({
     staleTime: 60_000,
     gcTime: 5 * 60 * 1000,
     queryFn: async () => {
-      // v2 document — untagged so graphql-eslint (v1 schema) skips it.
+      // Untagged so graphql-eslint (pinned to the legacy schema) skips it.
       const query = `
         query ConditionsByIds($ids: [Bytes!]!) {
           conditions(

--- a/packages/app/src/components/vaults/__tests__/VaultPnlChart.test.ts
+++ b/packages/app/src/components/vaults/__tests__/VaultPnlChart.test.ts
@@ -10,7 +10,7 @@ const ONE_DAY = 24 * 60 * 60;
 const NOW_SEC = Date.UTC(2026, 3, 24, 0, 0, 0) / 1000;
 
 // The chart util now consumes the adapted `{ timestamp, pnl, tvl }` point
-// (whole wUSDe) produced by `toVaultStatPoint`, not the raw v1 ProtocolStat.
+// (whole wUSDe) produced by `toVaultStatPoint`, not the raw ProtocolStat it previously consumed.
 function makeStat({
   timestamp,
   tvl,

--- a/packages/app/src/components/vaults/__tests__/VaultPnlChartScaleToggle.test.tsx
+++ b/packages/app/src/components/vaults/__tests__/VaultPnlChartScaleToggle.test.tsx
@@ -76,7 +76,7 @@ import VaultPnlChart from '~/components/vaults/VaultPnlChart';
 const DAY = 24 * 60 * 60;
 const nowSec = Math.floor(Date.now() / 1000);
 
-// v2 VaultStat shape: TVL = balance + deployedCollateral + claimableCollateral,
+// GraphQL VaultStat shape: TVL = balance + deployedCollateral + claimableCollateral,
 // PnL = cumulativePnl (all wei strings).
 const vaultStats = [
   {

--- a/packages/app/src/hooks/admin/__tests__/useAdminConditionGroups.test.ts
+++ b/packages/app/src/hooks/admin/__tests__/useAdminConditionGroups.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchAllGroupConditions } from '../useAdminConditionGroups';
+
+describe('fetchAllGroupConditions', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('cursor-paginates until every public condition is loaded', async () => {
+    const firstPage = Array.from({ length: 100 }, (_, i) => ({
+      conditionId: `0x${i}`,
+      question: `Q${i}`,
+      shortName: null,
+      optionName: null,
+      displayOrder: i,
+      similarMarketVolume: i,
+    }));
+    const secondPage = [
+      {
+        conditionId: '0x100',
+        question: 'Q100',
+        shortName: null,
+        optionName: null,
+        displayOrder: 100,
+        similarMarketVolume: 100,
+      },
+    ];
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: {
+            conditionGroup: {
+              conditions: {
+                nodes: firstPage,
+                pageInfo: { hasNextPage: true, endCursor: 'cursor-100' },
+              },
+            },
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: {
+            conditionGroup: {
+              conditions: {
+                nodes: secondPage,
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          },
+        }),
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchAllGroupConditions(
+      'https://api.example/graphql',
+      'gid-42'
+    );
+
+    expect(result).toHaveLength(101);
+    expect(result[100].id).toBe('0x100');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][1]).toMatchObject({
+      body: expect.stringContaining('"after":"cursor-100"'),
+    });
+  });
+});

--- a/packages/app/src/hooks/admin/useAdminConditionGroups.ts
+++ b/packages/app/src/hooks/admin/useAdminConditionGroups.ts
@@ -191,8 +191,11 @@ export type ReorderConditionGroupInput = {
   conditionIds: string[];
 };
 
-// The only signed call. Hits the reorder-only admin endpoint, which writes
-// nothing but `displayOrder` and never changes group membership.
+// The only signed call. Hits the admin endpoint that sets a group's conditions
+// in display order. We always send the group's full public condition set (the
+// UI's permutation guard enforces this), so it is a pure reorder. The endpoint
+// scopes its membership clear to public conditions, so any hidden conditions in
+// the group keep their group + displayOrder.
 export function useReorderConditionGroup(): UseMutationResult<
   AdminConditionGroup,
   Error,
@@ -202,7 +205,7 @@ export function useReorderConditionGroup(): UseMutationResult<
   const queryClient = useQueryClient();
   return useMutation<AdminConditionGroup, Error, ReorderConditionGroupInput>({
     mutationFn: ({ groupId, conditionIds }) =>
-      putJson<AdminConditionGroup>(`/conditionGroups/${groupId}/reorder`, {
+      putJson<AdminConditionGroup>(`/conditionGroups/${groupId}/conditions`, {
         conditionIds,
       }),
     onSuccess: () => {

--- a/packages/app/src/hooks/admin/useAdminConditionGroups.ts
+++ b/packages/app/src/hooks/admin/useAdminConditionGroups.ts
@@ -8,6 +8,7 @@ import {
   type UseQueryResult,
 } from '@tanstack/react-query';
 import { useAdminApi } from '~/hooks/useAdminApi';
+import { useSettings } from '~/lib/context/SettingsContext';
 
 export type AdminConditionGroupCondition = {
   id: string;
@@ -28,14 +29,19 @@ export type AdminConditionGroup = {
 
 const ADMIN_CONDITION_GROUPS_QUERY_KEY = ['admin', 'conditionGroups'] as const;
 
-// The admin base URL points at the predict backend's signed `/admin` router;
-// its origin also serves the unauthenticated `/graphql` endpoint. We read
-// groups from GraphQL so the operator is never prompted to sign just to
-// browse — only saving (the reorder mutation) is signed. The ids line up with
-// the REST surface: `Condition.conditionId` is the row primary key the reorder
-// endpoint expects, and `ConditionGroup.groupId` is the numeric `:id` param.
-function graphqlEndpointFrom(base: string): string {
-  return `${new URL(base).origin}/graphql`;
+// This page targets a single predict backend origin taken from the
+// `graphqlEndpoint` setting — the field the Meridian env presets actually set
+// (the separate `adminBaseUrl` setting defaults to the legacy sapience origin
+// and is left untouched by those presets, so deriving from it sent loads to the
+// wrong backend). Groups load from that `/graphql` endpoint unauthenticated, so
+// the operator is never prompted to sign just to browse; only saving (the
+// reorder mutation) is signed, and it derives the `/admin` REST base from the
+// same origin so load and save can never drift to different backends. The ids
+// line up with the REST surface: `Condition.conditionId` is the row primary key
+// the reorder endpoint expects, and `ConditionGroup.groupId` is the numeric
+// `:id` param.
+function adminBaseFromGraphqlEndpoint(graphqlEndpoint: string): string {
+  return `${new URL(graphqlEndpoint).origin}/admin`;
 }
 
 // Note: the GraphQL `conditions` connection only returns public conditions, so
@@ -178,11 +184,11 @@ async function fetchAllConditionGroups(
 export function useAdminConditionGroups(
   enabled: boolean
 ): UseQueryResult<AdminConditionGroup[]> {
-  const { base } = useAdminApi();
+  const { graphqlEndpoint } = useSettings();
   return useQuery({
-    queryKey: [...ADMIN_CONDITION_GROUPS_QUERY_KEY, base],
-    queryFn: () => fetchAllConditionGroups(graphqlEndpointFrom(base)),
-    enabled,
+    queryKey: [...ADMIN_CONDITION_GROUPS_QUERY_KEY, graphqlEndpoint],
+    queryFn: () => fetchAllConditionGroups(graphqlEndpoint as string),
+    enabled: enabled && Boolean(graphqlEndpoint),
   });
 }
 
@@ -201,7 +207,11 @@ export function useReorderConditionGroup(): UseMutationResult<
   Error,
   ReorderConditionGroupInput
 > {
-  const { putJson } = useAdminApi();
+  const { graphqlEndpoint } = useSettings();
+  const adminBase = graphqlEndpoint
+    ? adminBaseFromGraphqlEndpoint(graphqlEndpoint)
+    : undefined;
+  const { putJson } = useAdminApi(adminBase);
   const queryClient = useQueryClient();
   return useMutation<AdminConditionGroup, Error, ReorderConditionGroupInput>({
     mutationFn: ({ groupId, conditionIds }) =>

--- a/packages/app/src/hooks/admin/useAdminConditionGroups.ts
+++ b/packages/app/src/hooks/admin/useAdminConditionGroups.ts
@@ -29,19 +29,16 @@ export type AdminConditionGroup = {
 
 const ADMIN_CONDITION_GROUPS_QUERY_KEY = ['admin', 'conditionGroups'] as const;
 
-// This page targets the single GraphQL endpoint the app is actually configured
-// with. That value lives in the `graphqlEndpointV2` setting — the one the
-// "GraphQL Endpoint" Settings field and the Meridian env presets write, and the
-// one the SDK client reads for every app query (Sapience serves it at
-// `/v2/graphql`, Meridian at `/graphql`, so it stores a full URL). The separate
-// `adminBaseUrl` / v1 `graphqlEndpoint` settings are legacy and default to the
-// stale sapience origin, so reading them sent loads to the wrong backend.
-// Groups load from this endpoint unauthenticated, so the operator is never
-// prompted to sign just to browse; only saving (the reorder mutation) is signed,
-// and it derives the `/admin` REST base from the same origin so load and save
-// can never drift to different backends. The ids line up with the REST surface:
-// `Condition.conditionId` is the row primary key the reorder endpoint expects,
-// and `ConditionGroup.groupId` is the numeric `:id` param.
+// This page targets the single GraphQL endpoint the app is configured with: the
+// `graphqlEndpoint` setting that the "GraphQL Endpoint" Settings field and the
+// Meridian env presets write, and that the SDK client reads for every app query
+// (Sapience serves it at `/v2/graphql`, Meridian at `/graphql`, so it stores a
+// full URL). Groups load from this endpoint unauthenticated, so the operator is
+// never prompted to sign just to browse; only saving (the reorder mutation) is
+// signed, and it derives the `/admin` REST base from the same origin so load and
+// save can never drift to different backends. The ids line up with the REST
+// surface: `Condition.conditionId` is the row primary key the reorder endpoint
+// expects, and `ConditionGroup.groupId` is the numeric `:id` param.
 function adminBaseFromGraphqlEndpoint(graphqlEndpoint: string): string {
   return `${new URL(graphqlEndpoint).origin}/admin`;
 }
@@ -186,11 +183,11 @@ async function fetchAllConditionGroups(
 export function useAdminConditionGroups(
   enabled: boolean
 ): UseQueryResult<AdminConditionGroup[]> {
-  const { graphqlEndpointV2 } = useSettings();
+  const { graphqlEndpoint } = useSettings();
   return useQuery({
-    queryKey: [...ADMIN_CONDITION_GROUPS_QUERY_KEY, graphqlEndpointV2],
-    queryFn: () => fetchAllConditionGroups(graphqlEndpointV2 as string),
-    enabled: enabled && Boolean(graphqlEndpointV2),
+    queryKey: [...ADMIN_CONDITION_GROUPS_QUERY_KEY, graphqlEndpoint],
+    queryFn: () => fetchAllConditionGroups(graphqlEndpoint as string),
+    enabled: enabled && Boolean(graphqlEndpoint),
   });
 }
 
@@ -209,9 +206,9 @@ export function useReorderConditionGroup(): UseMutationResult<
   Error,
   ReorderConditionGroupInput
 > {
-  const { graphqlEndpointV2 } = useSettings();
-  const adminBase = graphqlEndpointV2
-    ? adminBaseFromGraphqlEndpoint(graphqlEndpointV2)
+  const { graphqlEndpoint } = useSettings();
+  const adminBase = graphqlEndpoint
+    ? adminBaseFromGraphqlEndpoint(graphqlEndpoint)
     : undefined;
   const { putJson } = useAdminApi(adminBase);
   const queryClient = useQueryClient();

--- a/packages/app/src/hooks/admin/useAdminConditionGroups.ts
+++ b/packages/app/src/hooks/admin/useAdminConditionGroups.ts
@@ -23,6 +23,7 @@ export type AdminConditionGroup = {
   name: string;
   negRisk: boolean;
   condition: AdminConditionGroupCondition[];
+  hasMoreConditions: boolean;
 };
 
 const ADMIN_CONDITION_GROUPS_QUERY_KEY = ['admin', 'conditionGroups'] as const;
@@ -60,6 +61,9 @@ const ADMIN_CONDITION_GROUPS_QUERY = `
             displayOrder
             similarMarketVolume
           }
+          pageInfo {
+            hasNextPage
+          }
         }
       }
       pageInfo {
@@ -83,7 +87,10 @@ type GqlGroupNode = {
   groupId: number;
   name: string;
   negRisk: boolean;
-  conditions: { nodes: GqlConditionNode[] };
+  conditions: {
+    nodes: GqlConditionNode[];
+    pageInfo?: { hasNextPage: boolean };
+  };
 };
 
 type AdminConditionGroupsResponse = {
@@ -98,6 +105,25 @@ type AdminConditionGroupsResponse = {
 
 // Safety cap on pagination: 20 * 100 = 2000 groups. Well above the real count.
 const MAX_GROUP_PAGES = 20;
+
+async function readErrorMessage(resp: Response): Promise<string> {
+  const fallback = `Failed to load condition groups (${resp.status})`;
+  const text = await resp.text().catch(() => '');
+  if (!text) return fallback;
+
+  try {
+    const parsed = JSON.parse(text) as {
+      errors?: { message?: string }[];
+      message?: string;
+      error?: string;
+    };
+    const message =
+      parsed.errors?.[0]?.message ?? parsed.message ?? parsed.error ?? text;
+    return `${fallback}: ${message}`;
+  } catch {
+    return `${fallback}: ${text}`;
+  }
+}
 
 async function fetchAllConditionGroups(
   endpoint: string
@@ -115,7 +141,7 @@ async function fetchAllConditionGroups(
       }),
     });
     if (!resp.ok) {
-      throw new Error(`Failed to load condition groups (${resp.status})`);
+      throw new Error(await readErrorMessage(resp));
     }
     const json = (await resp.json()) as AdminConditionGroupsResponse;
     if (Array.isArray(json.errors) && json.errors.length > 0) {
@@ -128,6 +154,7 @@ async function fetchAllConditionGroups(
         id: node.groupId,
         name: node.name,
         negRisk: node.negRisk,
+        hasMoreConditions: node.conditions?.pageInfo?.hasNextPage ?? false,
         condition: (node.conditions?.nodes ?? []).map((c) => ({
           id: c.conditionId,
           question: c.question,

--- a/packages/app/src/hooks/admin/useAdminConditionGroups.ts
+++ b/packages/app/src/hooks/admin/useAdminConditionGroups.ts
@@ -20,14 +20,22 @@ export type AdminConditionGroupCondition = {
 };
 
 export type AdminConditionGroup = {
+  /** Numeric DB id — REST `:id` param for reorder. */
   id: number;
+  /** Relay global id — `conditionGroup(id:)` for cursor hydration. */
+  globalId: string;
   name: string;
   negRisk: boolean;
   condition: AdminConditionGroupCondition[];
+  /** True when the list query's first nested page reported more conditions. */
   hasMoreConditions: boolean;
 };
 
 const ADMIN_CONDITION_GROUPS_QUERY_KEY = ['admin', 'conditionGroups'] as const;
+const ADMIN_GROUP_CONDITIONS_QUERY_KEY = [
+  'admin',
+  'conditionGroupConditions',
+] as const;
 
 // This page targets the single GraphQL endpoint the app is configured with: the
 // `graphqlEndpoint` setting that the "GraphQL Endpoint" Settings field and the
@@ -43,9 +51,6 @@ function adminBaseFromGraphqlEndpoint(graphqlEndpoint: string): string {
   return `${new URL(graphqlEndpoint).origin}/admin`;
 }
 
-// Note: the GraphQL `conditions` connection only returns public conditions, so
-// the reorder endpoint is intentionally partial — it reorders the ids we send
-// and leaves any hidden condition's displayOrder untouched (never detaching).
 const ADMIN_CONDITION_GROUPS_QUERY = `
   query AdminConditionGroups($first: Int!, $after: String) {
     conditionGroups(
@@ -54,6 +59,7 @@ const ADMIN_CONDITION_GROUPS_QUERY = `
       orderBy: { field: NAME, direction: ASC }
     ) {
       nodes {
+        id
         groupId
         name
         negRisk
@@ -79,6 +85,27 @@ const ADMIN_CONDITION_GROUPS_QUERY = `
   }
 `;
 
+const ADMIN_GROUP_CONDITIONS_QUERY = `
+  query AdminGroupConditions($id: ID!, $first: Int!, $after: String) {
+    conditionGroup(id: $id) {
+      conditions(first: $first, after: $after) {
+        nodes {
+          conditionId
+          question
+          shortName
+          optionName
+          displayOrder
+          similarMarketVolume
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+`;
+
 type GqlConditionNode = {
   conditionId: string;
   question: string;
@@ -89,6 +116,7 @@ type GqlConditionNode = {
 };
 
 type GqlGroupNode = {
+  id: string;
   groupId: number;
   name: string;
   negRisk: boolean;
@@ -108,8 +136,36 @@ type AdminConditionGroupsResponse = {
   errors?: { message?: string }[];
 };
 
+type AdminGroupConditionsResponse = {
+  data?: {
+    conditionGroup?: {
+      conditions?: {
+        nodes: GqlConditionNode[];
+        pageInfo?: { hasNextPage: boolean; endCursor: string | null };
+      };
+    } | null;
+  };
+  errors?: { message?: string }[];
+};
+
 // Safety cap on pagination: 20 * 100 = 2000 groups. Well above the real count.
 const MAX_GROUP_PAGES = 20;
+const MAX_CONDITION_PAGE_SIZE = 100;
+// 50 * 100 = 5000 public conditions per group — admin safety cap.
+const MAX_CONDITION_PAGES = 50;
+
+function mapConditionNode(
+  node: GqlConditionNode
+): AdminConditionGroupCondition {
+  return {
+    id: node.conditionId,
+    question: node.question,
+    shortName: node.shortName,
+    optionName: node.optionName,
+    displayOrder: node.displayOrder,
+    similarMarketVolume: node.similarMarketVolume,
+  };
+}
 
 async function readErrorMessage(resp: Response): Promise<string> {
   const fallback = `Failed to load condition groups (${resp.status})`;
@@ -130,6 +186,53 @@ async function readErrorMessage(resp: Response): Promise<string> {
   }
 }
 
+async function graphqlPost<T>(
+  endpoint: string,
+  query: string,
+  variables: Record<string, unknown>
+): Promise<T> {
+  const resp = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (!resp.ok) {
+    throw new Error(await readErrorMessage(resp));
+  }
+  const json = (await resp.json()) as T & { errors?: { message?: string }[] };
+  if (Array.isArray(json.errors) && json.errors.length > 0) {
+    throw new Error(json.errors[0]?.message ?? 'GraphQL error');
+  }
+  return json;
+}
+
+/** Cursor-paginates every public condition on a group (for reorder save). */
+export async function fetchAllGroupConditions(
+  endpoint: string,
+  globalId: string
+): Promise<AdminConditionGroupCondition[]> {
+  const conditions: AdminConditionGroupCondition[] = [];
+  let after: string | null = null;
+
+  for (let page = 0; page < MAX_CONDITION_PAGES; page++) {
+    const json: AdminGroupConditionsResponse =
+      await graphqlPost<AdminGroupConditionsResponse>(
+        endpoint,
+        ADMIN_GROUP_CONDITIONS_QUERY,
+        { id: globalId, first: MAX_CONDITION_PAGE_SIZE, after }
+      );
+    const connection = json.data?.conditionGroup?.conditions;
+    const nodes = connection?.nodes ?? [];
+    conditions.push(...nodes.map(mapConditionNode));
+
+    const pageInfo = connection?.pageInfo;
+    if (!pageInfo?.hasNextPage || !pageInfo.endCursor) break;
+    after = pageInfo.endCursor;
+  }
+
+  return conditions;
+}
+
 async function fetchAllConditionGroups(
   endpoint: string
 ): Promise<AdminConditionGroup[]> {
@@ -137,37 +240,22 @@ async function fetchAllConditionGroups(
   let after: string | null = null;
 
   for (let page = 0; page < MAX_GROUP_PAGES; page++) {
-    const resp = await fetch(endpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        query: ADMIN_CONDITION_GROUPS_QUERY,
-        variables: { first: 100, after },
-      }),
-    });
-    if (!resp.ok) {
-      throw new Error(await readErrorMessage(resp));
-    }
-    const json = (await resp.json()) as AdminConditionGroupsResponse;
-    if (Array.isArray(json.errors) && json.errors.length > 0) {
-      throw new Error(json.errors[0]?.message ?? 'GraphQL error');
-    }
+    const json: AdminConditionGroupsResponse =
+      await graphqlPost<AdminConditionGroupsResponse>(
+        endpoint,
+        ADMIN_CONDITION_GROUPS_QUERY,
+        { first: 100, after }
+      );
     const connection = json.data?.conditionGroups;
     const nodes: GqlGroupNode[] = connection?.nodes ?? [];
     for (const node of nodes) {
       groups.push({
         id: node.groupId,
+        globalId: node.id,
         name: node.name,
         negRisk: node.negRisk,
         hasMoreConditions: node.conditions?.pageInfo?.hasNextPage ?? false,
-        condition: (node.conditions?.nodes ?? []).map((c) => ({
-          id: c.conditionId,
-          question: c.question,
-          shortName: c.shortName,
-          optionName: c.optionName,
-          displayOrder: c.displayOrder,
-          similarMarketVolume: c.similarMarketVolume,
-        })),
+        condition: (node.conditions?.nodes ?? []).map(mapConditionNode),
       });
     }
     if (!connection?.pageInfo?.hasNextPage) break;
@@ -191,16 +279,28 @@ export function useAdminConditionGroups(
   });
 }
 
+/** Hydrates every public condition for one group via cursor pagination. */
+export function useAdminGroupConditions(
+  globalId: string | null | undefined,
+  enabled: boolean
+): UseQueryResult<AdminConditionGroupCondition[]> {
+  const { graphqlEndpoint } = useSettings();
+  return useQuery({
+    queryKey: [...ADMIN_GROUP_CONDITIONS_QUERY_KEY, graphqlEndpoint, globalId],
+    queryFn: () =>
+      fetchAllGroupConditions(graphqlEndpoint as string, globalId as string),
+    enabled: enabled && Boolean(graphqlEndpoint) && Boolean(globalId),
+  });
+}
+
 export type ReorderConditionGroupInput = {
   groupId: number;
   conditionIds: string[];
 };
 
 // The only signed call. Hits the admin endpoint that sets a group's conditions
-// in display order. We always send the group's full public condition set (the
-// UI's permutation guard enforces this), so it is a pure reorder. The endpoint
-// scopes its membership clear to public conditions, so any hidden conditions in
-// the group keep their group + displayOrder.
+// in display order. The UI hydrates the full public set via cursor before save
+// and the permutation guard enforces a pure reorder of that set.
 export function useReorderConditionGroup(): UseMutationResult<
   AdminConditionGroup,
   Error,
@@ -220,6 +320,9 @@ export function useReorderConditionGroup(): UseMutationResult<
     onSuccess: () => {
       void queryClient.invalidateQueries({
         queryKey: ADMIN_CONDITION_GROUPS_QUERY_KEY,
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ADMIN_GROUP_CONDITIONS_QUERY_KEY,
       });
     },
   });

--- a/packages/app/src/hooks/admin/useAdminConditionGroups.ts
+++ b/packages/app/src/hooks/admin/useAdminConditionGroups.ts
@@ -29,17 +29,19 @@ export type AdminConditionGroup = {
 
 const ADMIN_CONDITION_GROUPS_QUERY_KEY = ['admin', 'conditionGroups'] as const;
 
-// This page targets a single predict backend origin taken from the
-// `graphqlEndpoint` setting — the field the Meridian env presets actually set
-// (the separate `adminBaseUrl` setting defaults to the legacy sapience origin
-// and is left untouched by those presets, so deriving from it sent loads to the
-// wrong backend). Groups load from that `/graphql` endpoint unauthenticated, so
-// the operator is never prompted to sign just to browse; only saving (the
-// reorder mutation) is signed, and it derives the `/admin` REST base from the
-// same origin so load and save can never drift to different backends. The ids
-// line up with the REST surface: `Condition.conditionId` is the row primary key
-// the reorder endpoint expects, and `ConditionGroup.groupId` is the numeric
-// `:id` param.
+// This page targets the single GraphQL endpoint the app is actually configured
+// with. That value lives in the `graphqlEndpointV2` setting — the one the
+// "GraphQL Endpoint" Settings field and the Meridian env presets write, and the
+// one the SDK client reads for every app query (Sapience serves it at
+// `/v2/graphql`, Meridian at `/graphql`, so it stores a full URL). The separate
+// `adminBaseUrl` / v1 `graphqlEndpoint` settings are legacy and default to the
+// stale sapience origin, so reading them sent loads to the wrong backend.
+// Groups load from this endpoint unauthenticated, so the operator is never
+// prompted to sign just to browse; only saving (the reorder mutation) is signed,
+// and it derives the `/admin` REST base from the same origin so load and save
+// can never drift to different backends. The ids line up with the REST surface:
+// `Condition.conditionId` is the row primary key the reorder endpoint expects,
+// and `ConditionGroup.groupId` is the numeric `:id` param.
 function adminBaseFromGraphqlEndpoint(graphqlEndpoint: string): string {
   return `${new URL(graphqlEndpoint).origin}/admin`;
 }
@@ -184,11 +186,11 @@ async function fetchAllConditionGroups(
 export function useAdminConditionGroups(
   enabled: boolean
 ): UseQueryResult<AdminConditionGroup[]> {
-  const { graphqlEndpoint } = useSettings();
+  const { graphqlEndpointV2 } = useSettings();
   return useQuery({
-    queryKey: [...ADMIN_CONDITION_GROUPS_QUERY_KEY, graphqlEndpoint],
-    queryFn: () => fetchAllConditionGroups(graphqlEndpoint as string),
-    enabled: enabled && Boolean(graphqlEndpoint),
+    queryKey: [...ADMIN_CONDITION_GROUPS_QUERY_KEY, graphqlEndpointV2],
+    queryFn: () => fetchAllConditionGroups(graphqlEndpointV2 as string),
+    enabled: enabled && Boolean(graphqlEndpointV2),
   });
 }
 
@@ -207,9 +209,9 @@ export function useReorderConditionGroup(): UseMutationResult<
   Error,
   ReorderConditionGroupInput
 > {
-  const { graphqlEndpoint } = useSettings();
-  const adminBase = graphqlEndpoint
-    ? adminBaseFromGraphqlEndpoint(graphqlEndpoint)
+  const { graphqlEndpointV2 } = useSettings();
+  const adminBase = graphqlEndpointV2
+    ? adminBaseFromGraphqlEndpoint(graphqlEndpointV2)
     : undefined;
   const { putJson } = useAdminApi(adminBase);
   const queryClient = useQueryClient();

--- a/packages/app/src/hooks/admin/useAdminConditionGroups.ts
+++ b/packages/app/src/hooks/admin/useAdminConditionGroups.ts
@@ -1,0 +1,187 @@
+'use client';
+
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+import { useAdminApi } from '~/hooks/useAdminApi';
+
+export type AdminConditionGroupCondition = {
+  id: string;
+  question: string;
+  shortName: string | null;
+  optionName: string | null;
+  similarMarketVolume: number;
+  displayOrder: number | null;
+};
+
+export type AdminConditionGroup = {
+  id: number;
+  name: string;
+  negRisk: boolean;
+  condition: AdminConditionGroupCondition[];
+};
+
+const ADMIN_CONDITION_GROUPS_QUERY_KEY = ['admin', 'conditionGroups'] as const;
+
+// The admin base URL points at the predict backend's signed `/admin` router;
+// its origin also serves the unauthenticated `/graphql` endpoint. We read
+// groups from GraphQL so the operator is never prompted to sign just to
+// browse — only saving (the reorder mutation) is signed. The ids line up with
+// the REST surface: `Condition.conditionId` is the row primary key the reorder
+// endpoint expects, and `ConditionGroup.groupId` is the numeric `:id` param.
+function graphqlEndpointFrom(base: string): string {
+  return `${new URL(base).origin}/graphql`;
+}
+
+// Note: the GraphQL `conditions` connection only returns public conditions, so
+// the reorder endpoint is intentionally partial — it reorders the ids we send
+// and leaves any hidden condition's displayOrder untouched (never detaching).
+const ADMIN_CONDITION_GROUPS_QUERY = `
+  query AdminConditionGroups($first: Int!, $after: String) {
+    conditionGroups(
+      first: $first
+      after: $after
+      orderBy: { field: NAME, direction: ASC }
+    ) {
+      nodes {
+        groupId
+        name
+        negRisk
+        conditions(first: 100) {
+          nodes {
+            conditionId
+            question
+            shortName
+            optionName
+            displayOrder
+            similarMarketVolume
+          }
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`;
+
+type GqlConditionNode = {
+  conditionId: string;
+  question: string;
+  shortName: string | null;
+  optionName: string | null;
+  displayOrder: number | null;
+  similarMarketVolume: number;
+};
+
+type GqlGroupNode = {
+  groupId: number;
+  name: string;
+  negRisk: boolean;
+  conditions: { nodes: GqlConditionNode[] };
+};
+
+type AdminConditionGroupsResponse = {
+  data?: {
+    conditionGroups?: {
+      nodes: GqlGroupNode[];
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    };
+  };
+  errors?: { message?: string }[];
+};
+
+// Safety cap on pagination: 20 * 100 = 2000 groups. Well above the real count.
+const MAX_GROUP_PAGES = 20;
+
+async function fetchAllConditionGroups(
+  endpoint: string
+): Promise<AdminConditionGroup[]> {
+  const groups: AdminConditionGroup[] = [];
+  let after: string | null = null;
+
+  for (let page = 0; page < MAX_GROUP_PAGES; page++) {
+    const resp = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query: ADMIN_CONDITION_GROUPS_QUERY,
+        variables: { first: 100, after },
+      }),
+    });
+    if (!resp.ok) {
+      throw new Error(`Failed to load condition groups (${resp.status})`);
+    }
+    const json = (await resp.json()) as AdminConditionGroupsResponse;
+    if (Array.isArray(json.errors) && json.errors.length > 0) {
+      throw new Error(json.errors[0]?.message ?? 'GraphQL error');
+    }
+    const connection = json.data?.conditionGroups;
+    const nodes: GqlGroupNode[] = connection?.nodes ?? [];
+    for (const node of nodes) {
+      groups.push({
+        id: node.groupId,
+        name: node.name,
+        negRisk: node.negRisk,
+        condition: (node.conditions?.nodes ?? []).map((c) => ({
+          id: c.conditionId,
+          question: c.question,
+          shortName: c.shortName,
+          optionName: c.optionName,
+          displayOrder: c.displayOrder,
+          similarMarketVolume: c.similarMarketVolume,
+        })),
+      });
+    }
+    if (!connection?.pageInfo?.hasNextPage) break;
+    after = connection.pageInfo.endCursor ?? null;
+    if (!after) break;
+  }
+
+  return groups;
+}
+
+// Reads the public GraphQL endpoint — no signature. Still gated behind an
+// explicit `enabled` flag so the request only fires once the page opts in.
+export function useAdminConditionGroups(
+  enabled: boolean
+): UseQueryResult<AdminConditionGroup[]> {
+  const { base } = useAdminApi();
+  return useQuery({
+    queryKey: [...ADMIN_CONDITION_GROUPS_QUERY_KEY, base],
+    queryFn: () => fetchAllConditionGroups(graphqlEndpointFrom(base)),
+    enabled,
+  });
+}
+
+export type ReorderConditionGroupInput = {
+  groupId: number;
+  conditionIds: string[];
+};
+
+// The only signed call. Hits the reorder-only admin endpoint, which writes
+// nothing but `displayOrder` and never changes group membership.
+export function useReorderConditionGroup(): UseMutationResult<
+  AdminConditionGroup,
+  Error,
+  ReorderConditionGroupInput
+> {
+  const { putJson } = useAdminApi();
+  const queryClient = useQueryClient();
+  return useMutation<AdminConditionGroup, Error, ReorderConditionGroupInput>({
+    mutationFn: ({ groupId, conditionIds }) =>
+      putJson<AdminConditionGroup>(`/conditionGroups/${groupId}/reorder`, {
+        conditionIds,
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ADMIN_CONDITION_GROUPS_QUERY_KEY,
+      });
+    },
+  });
+}

--- a/packages/app/src/hooks/graphql/__tests__/useAccountActivity.test.ts
+++ b/packages/app/src/hooks/graphql/__tests__/useAccountActivity.test.ts
@@ -28,7 +28,7 @@ async function getModule() {
   return import('../useAccountActivity');
 }
 
-// ─── v2 wire fixtures ────────────────────────────────────────────────────────
+// ─── wire fixtures ───────────────────────────────────────────────────────────
 
 function makePickConfigNode(overrides: Record<string, unknown> = {}) {
   return {
@@ -144,8 +144,8 @@ beforeEach(() => {
 
 // ─── Document shape ──────────────────────────────────────────────────────────
 
-describe('v2 activity document', () => {
-  it('queries the v2 activity connection with edge timestamps and inline fragments', async () => {
+describe('activity document', () => {
+  it('queries the activity connection with edge timestamps and inline fragments', async () => {
     const mod = await getModule();
     const doc = mod.ACCOUNT_ACTIVITY_QUERY as string;
     expect(doc).toContain('activity(');
@@ -157,9 +157,9 @@ describe('v2 activity document', () => {
     expect(doc).toContain('... on Prediction');
     expect(doc).toContain('... on Trade');
     expect(doc).toContain('__typename');
-    // v1 envelope is gone
+    // old envelope is gone
     expect(doc).not.toContain('accountActivity');
-    // untagged document — app graphql-eslint validates tagged docs against v1
+    // untagged document — app graphql-eslint (pinned to the legacy schema) skips it
     expect(doc).not.toContain('GraphQL */');
   });
 });
@@ -167,7 +167,7 @@ describe('v2 activity document', () => {
 // ─── Hook behavior ───────────────────────────────────────────────────────────
 
 describe('useAccountActivity', () => {
-  it('runs the v2 query for the global feed with null filters', async () => {
+  it('runs the query for the global feed with null filters', async () => {
     const mod = await getModule();
 
     renderHook(() => mod.useAccountActivity({}), {
@@ -274,7 +274,7 @@ describe('useAccountActivity', () => {
     expect(mockGraphqlRequest).not.toHaveBeenCalled();
   });
 
-  it('maps the filter surface to v2 ActivityFilter variables', async () => {
+  it('maps the filter surface to ActivityFilter variables', async () => {
     const mod = await getModule();
 
     renderHook(

--- a/packages/app/src/hooks/graphql/__tests__/useAccountActivity.test.ts
+++ b/packages/app/src/hooks/graphql/__tests__/useAccountActivity.test.ts
@@ -4,11 +4,9 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
 const mockGraphqlRequest = vi.fn();
-const mockGraphqlRequestV2 = vi.fn();
 
 vi.mock('@sapience/sdk/queries/client/graphqlClient', () => ({
   graphqlRequest: (...args: unknown[]) => mockGraphqlRequest(...args),
-  graphqlRequestV2: (...args: unknown[]) => mockGraphqlRequestV2(...args),
 }));
 
 function createWrapper() {
@@ -141,10 +139,7 @@ function makeConnection(
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockGraphqlRequest.mockRejectedValue(
-    new Error('v1 transport must not be used')
-  );
-  mockGraphqlRequestV2.mockResolvedValue(makeConnection([]));
+  mockGraphqlRequest.mockResolvedValue(makeConnection([]));
 });
 
 // ─── Document shape ──────────────────────────────────────────────────────────
@@ -180,11 +175,10 @@ describe('useAccountActivity', () => {
     });
 
     await waitFor(() => {
-      expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
+      expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
     });
-    expect(mockGraphqlRequest).not.toHaveBeenCalled();
 
-    const [, variables] = mockGraphqlRequestV2.mock.calls[0];
+    const [, variables] = mockGraphqlRequest.mock.calls[0];
     expect(variables).toMatchObject({
       account: null,
       conditionIds: null,
@@ -199,7 +193,7 @@ describe('useAccountActivity', () => {
   it('maps a Prediction edge through the shared pickConfig adapter', async () => {
     const mod = await getModule();
 
-    mockGraphqlRequestV2.mockResolvedValue(
+    mockGraphqlRequest.mockResolvedValue(
       makeConnection([{ timestamp: 1700000123, node: makePredictionNode() }])
     );
 
@@ -240,7 +234,7 @@ describe('useAccountActivity', () => {
 
     // edge timestamp deliberately differs from executedAt to pin the edge
     // as the single source of time
-    mockGraphqlRequestV2.mockResolvedValue(
+    mockGraphqlRequest.mockResolvedValue(
       makeConnection([{ timestamp: 1700009999, node: makeTradeNode() }])
     );
 
@@ -277,7 +271,7 @@ describe('useAccountActivity', () => {
     });
 
     await new Promise((r) => setTimeout(r, 20));
-    expect(mockGraphqlRequestV2).not.toHaveBeenCalled();
+    expect(mockGraphqlRequest).not.toHaveBeenCalled();
   });
 
   it('maps the filter surface to v2 ActivityFilter variables', async () => {
@@ -297,10 +291,10 @@ describe('useAccountActivity', () => {
     );
 
     await waitFor(() => {
-      expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
+      expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
     });
 
-    const [, variables] = mockGraphqlRequestV2.mock.calls[0];
+    const [, variables] = mockGraphqlRequest.mock.calls[0];
     expect(variables).toMatchObject({
       account: '0xABCDEF0000000000000000000000000000000001',
       pickConfigId: '0xpc1',
@@ -318,9 +312,9 @@ describe('useAccountActivity', () => {
       wrapper,
     });
     await waitFor(() => {
-      expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
+      expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
     });
-    expect(mockGraphqlRequestV2.mock.calls[0][1]).toMatchObject({
+    expect(mockGraphqlRequest.mock.calls[0][1]).toMatchObject({
       types: ['PREDICTION'],
     });
 
@@ -328,9 +322,9 @@ describe('useAccountActivity', () => {
       wrapper: createWrapper(),
     });
     await waitFor(() => {
-      expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(2);
+      expect(mockGraphqlRequest).toHaveBeenCalledTimes(2);
     });
-    expect(mockGraphqlRequestV2.mock.calls[1][1]).toMatchObject({
+    expect(mockGraphqlRequest.mock.calls[1][1]).toMatchObject({
       types: null,
     });
   });
@@ -338,7 +332,7 @@ describe('useAccountActivity', () => {
   it('paginates by threading pageInfo.endCursor into after', async () => {
     const mod = await getModule();
 
-    mockGraphqlRequestV2
+    mockGraphqlRequest
       .mockResolvedValueOnce(
         makeConnection(
           [{ timestamp: 1700000002, node: makePredictionNode() }],
@@ -380,12 +374,12 @@ describe('useAccountActivity', () => {
       ]);
     });
 
-    expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(2);
-    expect(mockGraphqlRequestV2.mock.calls[0][1]).toMatchObject({
+    expect(mockGraphqlRequest).toHaveBeenCalledTimes(2);
+    expect(mockGraphqlRequest.mock.calls[0][1]).toMatchObject({
       first: 1,
       after: null,
     });
-    expect(mockGraphqlRequestV2.mock.calls[1][1]).toMatchObject({
+    expect(mockGraphqlRequest.mock.calls[1][1]).toMatchObject({
       first: 1,
       after: 'CUR1',
     });
@@ -395,7 +389,7 @@ describe('useAccountActivity', () => {
   it('dedupes items across pages on the domain id', async () => {
     const mod = await getModule();
 
-    mockGraphqlRequestV2
+    mockGraphqlRequest
       .mockResolvedValueOnce(
         makeConnection(
           [

--- a/packages/app/src/hooks/graphql/__tests__/useForecasts.test.ts
+++ b/packages/app/src/hooks/graphql/__tests__/useForecasts.test.ts
@@ -5,7 +5,7 @@ import React from 'react';
 
 // ---- mocks ----
 // Fully mock the SDK queries module (no importActual) so a stale SDK dist
-// can't leak the old v1 implementations into these tests.
+// can't leak the old implementations into these tests.
 
 const mockFetchForecasts = vi.fn();
 const mockFetchForecastsPage = vi.fn();
@@ -48,7 +48,7 @@ function createWrapper() {
 
 function makeFormatted(uid: string, overrides: Record<string, unknown> = {}) {
   return {
-    id: uid, // v2 identity: EAS uid, no numeric row id
+    id: uid, // identity: EAS uid, no numeric row id
     uid,
     attester: '0x1234567890abcdef1234567890abcdef12345678',
     shortAttester: '0x1234...5678',

--- a/packages/app/src/hooks/graphql/__tests__/useInfiniteQuestions.test.ts
+++ b/packages/app/src/hooks/graphql/__tests__/useInfiniteQuestions.test.ts
@@ -4,14 +4,12 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
 const mockGraphqlRequest = vi.fn();
-const mockGraphqlRequestV2 = vi.fn();
 
 // Transport boundary (used by useCursorPagination) is mocked; the
 // questions document/builder/mapper come from the real SDK SOURCE so a
 // stale dist build can't bite.
 vi.mock('@sapience/sdk/queries/client/graphqlClient', () => ({
   graphqlRequest: (...args: unknown[]) => mockGraphqlRequest(...args),
-  graphqlRequestV2: (...args: unknown[]) => mockGraphqlRequestV2(...args),
 }));
 vi.mock('@sapience/sdk/queries', async () => {
   return await import('../../../../../sdk/queries/questions');
@@ -84,17 +82,14 @@ function page(
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockGraphqlRequest.mockRejectedValue(
-    new Error('v1 transport must not be used')
-  );
-  mockGraphqlRequestV2.mockResolvedValue(
+  mockGraphqlRequest.mockResolvedValue(
     page([], { hasNextPage: false, endCursor: null })
   );
 });
 
 describe('useInfiniteQuestions', () => {
   it('fetches the first page with cursor variables and explicit orderBy', async () => {
-    mockGraphqlRequestV2.mockResolvedValue(
+    mockGraphqlRequest.mockResolvedValue(
       page([conditionNode('0xa'), groupNode('g1')], {
         hasNextPage: true,
         endCursor: 'cursor-1',
@@ -108,8 +103,8 @@ describe('useInfiniteQuestions', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
-    const [doc, vars] = mockGraphqlRequestV2.mock.calls[0];
+    expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
+    const [doc, vars] = mockGraphqlRequest.mock.calls[0];
     expect(doc).toContain('... on Condition');
     expect(vars.first).toBe(2);
     expect(vars.after).toBeNull();
@@ -129,7 +124,7 @@ describe('useInfiniteQuestions', () => {
   });
 
   it('threads endCursor into the next page and dedupes repeated items', async () => {
-    mockGraphqlRequestV2
+    mockGraphqlRequest
       .mockResolvedValueOnce(
         page([conditionNode('0xa')], { hasNextPage: true, endCursor: 'c-a' })
       )
@@ -150,7 +145,7 @@ describe('useInfiniteQuestions', () => {
     act(() => result.current.fetchMore());
 
     await waitFor(() => expect(result.current.hasMore).toBe(false));
-    const [, vars2] = mockGraphqlRequestV2.mock.calls[1];
+    const [, vars2] = mockGraphqlRequest.mock.calls[1];
     expect(vars2.after).toBe('c-a');
     // 0xa repeated on page 2 is dropped
     expect(result.current.data.map((q) => q.condition?.id)).toEqual([
@@ -176,7 +171,7 @@ describe('useInfiniteQuestions', () => {
     );
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    const [, vars] = mockGraphqlRequestV2.mock.calls[0];
+    const [, vars] = mockGraphqlRequest.mock.calls[0];
     expect(vars.filter).toEqual({
       search: 'eth',
       tag: 'btc',
@@ -194,6 +189,5 @@ describe('useInfiniteQuestions', () => {
       wrapper: createWrapper(),
     });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(mockGraphqlRequest).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/hooks/graphql/__tests__/useInfiniteQuestions.test.ts
+++ b/packages/app/src/hooks/graphql/__tests__/useInfiniteQuestions.test.ts
@@ -111,7 +111,7 @@ describe('useInfiniteQuestions', () => {
     // defaults: openInterest desc, explicit
     expect(vars.orderBy).toEqual({ field: 'OPEN_INTEREST', direction: 'DESC' });
 
-    // mapped back into the v1 QuestionType envelope
+    // mapped back into the QuestionType envelope
     expect(result.current.data).toHaveLength(2);
     expect(result.current.data[0].questionType).toBe('condition');
     expect(result.current.data[0].condition?.id).toBe('0xa');
@@ -154,7 +154,7 @@ describe('useInfiniteQuestions', () => {
     ]);
   });
 
-  it('maps feed options into the v2 filter and drops non-finite minEndTime', async () => {
+  it('maps feed options into the filter and drops non-finite minEndTime', async () => {
     const { useInfiniteQuestions } = await getModule();
 
     const { result } = renderHook(
@@ -183,7 +183,7 @@ describe('useInfiniteQuestions', () => {
     });
   });
 
-  it('never touches the v1 transport', async () => {
+  it('loads through the GraphQL endpoint', async () => {
     const { useInfiniteQuestions } = await getModule();
     const { result } = renderHook(() => useInfiniteQuestions({}), {
       wrapper: createWrapper(),

--- a/packages/app/src/hooks/graphql/__tests__/usePickConfigsByTokens.test.ts
+++ b/packages/app/src/hooks/graphql/__tests__/usePickConfigsByTokens.test.ts
@@ -4,11 +4,9 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
 const mockGraphqlRequest = vi.fn();
-const mockGraphqlRequestV2 = vi.fn();
 
 vi.mock('@sapience/sdk/queries/client/graphqlClient', () => ({
   graphqlRequest: (...args: unknown[]) => mockGraphqlRequest(...args),
-  graphqlRequestV2: (...args: unknown[]) => mockGraphqlRequestV2(...args),
 }));
 
 function createWrapper() {
@@ -73,10 +71,7 @@ function makeNode(overrides: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockGraphqlRequest.mockRejectedValue(
-    new Error('v1 transport must not be used')
-  );
-  mockGraphqlRequestV2.mockResolvedValue({
+  mockGraphqlRequest.mockResolvedValue({
     pickConfigurations: { nodes: [] },
   });
 });
@@ -106,12 +101,11 @@ describe('usePickConfigsByTokens', () => {
     });
 
     await waitFor(() => {
-      expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
+      expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
     });
 
-    const [, variables] = mockGraphqlRequestV2.mock.calls[0];
+    const [, variables] = mockGraphqlRequest.mock.calls[0];
     expect(variables).toEqual({ tokens: ['0xaaa', '0xbbb'] });
-    expect(mockGraphqlRequest).not.toHaveBeenCalled();
   });
 
   it('does not fetch with an empty token list', async () => {
@@ -122,12 +116,12 @@ describe('usePickConfigsByTokens', () => {
     });
 
     await new Promise((r) => setTimeout(r, 50));
-    expect(mockGraphqlRequestV2).not.toHaveBeenCalled();
+    expect(mockGraphqlRequest).not.toHaveBeenCalled();
   });
 
   it('keys the map by both predictor and counterparty tokens with side flags', async () => {
     const mod = await getModule();
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       pickConfigurations: { nodes: [makeNode()] },
     });
 
@@ -146,7 +140,7 @@ describe('usePickConfigsByTokens', () => {
 
   it('omits configs whose tokens were not requested', async () => {
     const mod = await getModule();
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       pickConfigurations: { nodes: [makeNode()] },
     });
 
@@ -164,7 +158,7 @@ describe('usePickConfigsByTokens', () => {
 
   it('adapts v2 nodes into the existing PickConfigData shape', async () => {
     const mod = await getModule();
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       pickConfigurations: { nodes: [makeNode()] },
     });
 

--- a/packages/app/src/hooks/graphql/__tests__/usePickConfigsByTokens.test.ts
+++ b/packages/app/src/hooks/graphql/__tests__/usePickConfigsByTokens.test.ts
@@ -77,7 +77,7 @@ beforeEach(() => {
 });
 
 describe('PICK_CONFIGS_BY_TOKENS_QUERY', () => {
-  it('targets the v2 pickConfigurations connection with explicit filter and orderBy', async () => {
+  it('targets the pickConfigurations connection with explicit filter and orderBy', async () => {
     const mod = await getModule();
     const doc = mod.PICK_CONFIGS_BY_TOKENS_QUERY as string;
     expect(doc).toContain('filter: { tokens: $tokens }');
@@ -93,7 +93,7 @@ describe('PICK_CONFIGS_BY_TOKENS_QUERY', () => {
 });
 
 describe('usePickConfigsByTokens', () => {
-  it('requests v2 with deduped, lowercased, sorted tokens', async () => {
+  it('requests with deduped, lowercased, sorted tokens', async () => {
     const mod = await getModule();
 
     renderHook(() => mod.usePickConfigsByTokens(['0xBBB', '0xAAA', '0xaaa']), {
@@ -156,7 +156,7 @@ describe('usePickConfigsByTokens', () => {
     expect(result.current.map.has('0xbbb')).toBe(false);
   });
 
-  it('adapts v2 nodes into the existing PickConfigData shape', async () => {
+  it('adapts nodes into the existing PickConfigData shape', async () => {
     const mod = await getModule();
     mockGraphqlRequest.mockResolvedValue({
       pickConfigurations: { nodes: [makeNode()] },

--- a/packages/app/src/hooks/graphql/__tests__/usePositions.predictions.test.ts
+++ b/packages/app/src/hooks/graphql/__tests__/usePositions.predictions.test.ts
@@ -93,7 +93,7 @@ beforeEach(() => {
 
 // ─── Document shapes ─────────────────────────────────────────────────────────
 
-describe('v2 prediction documents', () => {
+describe('prediction documents', () => {
   it('predictions list query filters by participant with explicit orderBy', async () => {
     const mod = await getModule();
     const doc = mod.PREDICTIONS_QUERY as string;
@@ -133,9 +133,9 @@ describe('v2 prediction documents', () => {
     expect(doc).not.toContain('predictionCount');
   });
 
-  it('positions documents stay on v1 (wave 3)', async () => {
+  it('does not export a POSITION_BALANCES_QUERY document', async () => {
     const mod = await getModule();
-    // The v1 positions half is untouched: no v2 connection args.
+    // No standalone POSITION_BALANCES_QUERY export; positions go through POSITIONS_QUERY.
     expect(mod.POSITION_BALANCES_QUERY).toBeUndefined();
   });
 });
@@ -143,7 +143,7 @@ describe('v2 prediction documents', () => {
 // ─── Hooks ───────────────────────────────────────────────────────────────────
 
 describe('usePredictions', () => {
-  it('maps v2 nodes to the app Prediction shape via the shared adapter', async () => {
+  it('maps nodes to the app Prediction shape via the shared adapter', async () => {
     const mod = await getModule();
     mockGraphqlRequest.mockResolvedValue({
       predictions: { nodes: [makePredictionNode()] },
@@ -175,7 +175,7 @@ describe('usePredictions', () => {
     expect(p.isLegacy).toBe(false);
     expect(p.pickConfig?.id).toBe('0xpc1');
     expect(p.pickConfig?.marketAddress).toBe('0xescrow');
-    // v1 pickConfig.predictionId is backfilled from the parent prediction
+    // legacy pickConfig.predictionId is backfilled from the parent prediction
     expect(p.pickConfig?.predictionId).toBe('0xpred1');
     expect(p.pickConfig?.picks[0]?.conditionResolver).toBe('0xresolver');
     expect(p.pickConfig?.picks[0]?.predictedOutcome).toBe(1);

--- a/packages/app/src/hooks/graphql/__tests__/usePositions.predictions.test.ts
+++ b/packages/app/src/hooks/graphql/__tests__/usePositions.predictions.test.ts
@@ -4,11 +4,9 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
 const mockGraphqlRequest = vi.fn();
-const mockGraphqlRequestV2 = vi.fn();
 
 vi.mock('@sapience/sdk/queries/client/graphqlClient', () => ({
   graphqlRequest: (...args: unknown[]) => mockGraphqlRequest(...args),
-  graphqlRequestV2: (...args: unknown[]) => mockGraphqlRequestV2(...args),
 }));
 
 function createWrapper() {
@@ -90,10 +88,7 @@ function makePredictionNode(overrides: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockGraphqlRequest.mockRejectedValue(
-    new Error('v1 transport must not be used for predictions')
-  );
-  mockGraphqlRequestV2.mockResolvedValue({ predictions: { nodes: [] } });
+  mockGraphqlRequest.mockResolvedValue({ predictions: { nodes: [] } });
 });
 
 // ─── Document shapes ─────────────────────────────────────────────────────────
@@ -150,7 +145,7 @@ describe('v2 prediction documents', () => {
 describe('usePredictions', () => {
   it('maps v2 nodes to the app Prediction shape via the shared adapter', async () => {
     const mod = await getModule();
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       predictions: { nodes: [makePredictionNode()] },
     });
 
@@ -162,9 +157,8 @@ describe('usePredictions', () => {
     await waitFor(() => {
       expect(result.current.data.length).toBe(1);
     });
-    expect(mockGraphqlRequest).not.toHaveBeenCalled();
 
-    const [, variables] = mockGraphqlRequestV2.mock.calls[0];
+    const [, variables] = mockGraphqlRequest.mock.calls[0];
     expect(variables).toMatchObject({
       participant: '0xaaa',
       chainId: 8453,
@@ -190,7 +184,7 @@ describe('usePredictions', () => {
 
   it('maps null result to UNRESOLVED', async () => {
     const mod = await getModule();
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       predictions: {
         nodes: [
           makePredictionNode({
@@ -218,7 +212,7 @@ describe('usePredictions', () => {
 describe('usePredictionsCount', () => {
   it('reads totalCount from the first: 0 connection', async () => {
     const mod = await getModule();
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       predictions: { totalCount: 7 },
     });
 
@@ -230,7 +224,7 @@ describe('usePredictionsCount', () => {
     await waitFor(() => {
       expect(result.current).toBe(7);
     });
-    const [, variables] = mockGraphqlRequestV2.mock.calls[0];
+    const [, variables] = mockGraphqlRequest.mock.calls[0];
     expect(variables).toMatchObject({ participant: '0xaaa', chainId: 8453 });
   });
 });
@@ -238,7 +232,7 @@ describe('usePredictionsCount', () => {
 describe('usePrediction', () => {
   it('fetches a single prediction by predictionId', async () => {
     const mod = await getModule();
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       prediction: makePredictionNode(),
     });
 
@@ -249,21 +243,21 @@ describe('usePrediction', () => {
     await waitFor(() => {
       expect(result.current.data).not.toBeNull();
     });
-    const [, variables] = mockGraphqlRequestV2.mock.calls[0];
+    const [, variables] = mockGraphqlRequest.mock.calls[0];
     expect(variables).toMatchObject({ predictionId: '0xpred1' });
     expect(result.current.data?.marketAddress).toBe('0xescrow');
   });
 
   it('returns null when the prediction does not exist', async () => {
     const mod = await getModule();
-    mockGraphqlRequestV2.mockResolvedValue({ prediction: null });
+    mockGraphqlRequest.mockResolvedValue({ prediction: null });
 
     const { result } = renderHook(() => mod.usePrediction('0xmissing'), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => {
-      expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
+      expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
     });
     expect(result.current.data).toBeNull();
   });
@@ -272,7 +266,7 @@ describe('usePrediction', () => {
 describe('usePredictionsByConditionId', () => {
   it('maps the slim projection for the question-page chart', async () => {
     const mod = await getModule();
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       predictions: {
         nodes: [
           {
@@ -322,7 +316,7 @@ describe('usePredictionsByConditionId', () => {
       expect(result.current.data.length).toBe(1);
     });
 
-    const [, variables] = mockGraphqlRequestV2.mock.calls[0];
+    const [, variables] = mockGraphqlRequest.mock.calls[0];
     expect(variables).toMatchObject({ conditionId: '0xcond1', first: 50 });
 
     const p = result.current.data[0];

--- a/packages/app/src/hooks/graphql/__tests__/usePositions.test.ts
+++ b/packages/app/src/hooks/graphql/__tests__/usePositions.test.ts
@@ -3,12 +3,12 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
-const mockGraphqlRequestV2 = vi.fn();
+const mockGraphqlRequest = vi.fn();
 
 // The position hooks page via `useCursorPagination`, which issues its requests
-// through `graphqlRequestV2`. Mock that single transport export.
+// through `graphqlRequest`. Mock that single transport export.
 vi.mock('@sapience/sdk/queries/client/graphqlClient', () => ({
-  graphqlRequestV2: (...args: unknown[]) => mockGraphqlRequestV2(...args),
+  graphqlRequest: (...args: unknown[]) => mockGraphqlRequest(...args),
 }));
 
 function createWrapper() {
@@ -72,14 +72,14 @@ const conn = (
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockGraphqlRequestV2.mockResolvedValue(conn([], false));
+  mockGraphqlRequest.mockResolvedValue(conn([], false));
 });
 
 describe('usePositionBalances — pagination', () => {
   it('stops paginating when the server reports hasNextPage=false', async () => {
     const { usePositionBalances } = await getHooks();
 
-    mockGraphqlRequestV2
+    mockGraphqlRequest
       .mockResolvedValueOnce(conn([makeNode('1')], true))
       .mockResolvedValueOnce(conn([], false));
 
@@ -97,7 +97,7 @@ describe('usePositionBalances — pagination', () => {
       result.current.fetchMore();
     });
     await waitFor(() => {
-      expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(2);
+      expect(mockGraphqlRequest).toHaveBeenCalledTimes(2);
     });
 
     expect(result.current.hasMore).toBe(false);
@@ -108,7 +108,7 @@ describe('usePositionBalances — pagination', () => {
     // behind it — page on pageInfo, never on node count.
     const { usePositionBalances } = await getHooks();
 
-    mockGraphqlRequestV2
+    mockGraphqlRequest
       .mockResolvedValueOnce(conn([], true, 'cursor-after-empty'))
       .mockResolvedValueOnce(conn([makeNode('99')], false));
 
@@ -146,9 +146,9 @@ describe('usePositionBalances — pagination', () => {
     );
 
     await waitFor(() => {
-      expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
+      expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
     });
-    expect(mockGraphqlRequestV2.mock.calls[0][1]).toMatchObject({
+    expect(mockGraphqlRequest.mock.calls[0][1]).toMatchObject({
       filter: { holder: HOLDER, chainId: 42, settled: true },
       first: 25,
       after: null,
@@ -163,9 +163,9 @@ describe('usePositionBalances — pagination', () => {
     });
 
     await waitFor(() => {
-      expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
+      expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
     });
-    expect(mockGraphqlRequestV2.mock.calls[0][1].filter).toEqual({
+    expect(mockGraphqlRequest.mock.calls[0][1].filter).toEqual({
       holder: HOLDER,
     });
   });
@@ -176,7 +176,7 @@ describe('usePositionBalances — pagination', () => {
     renderHook(() => usePositionBalances({}), { wrapper: createWrapper() });
 
     await new Promise((r) => setTimeout(r, 20));
-    expect(mockGraphqlRequestV2).not.toHaveBeenCalled();
+    expect(mockGraphqlRequest).not.toHaveBeenCalled();
   });
 });
 
@@ -184,7 +184,7 @@ describe('usePositionBalancesByConditionId — pagination', () => {
   it('stops paginating when hasNextPage=false (same rule as the holder hook)', async () => {
     const { usePositionBalancesByConditionId } = await getHooks();
 
-    mockGraphqlRequestV2
+    mockGraphqlRequest
       .mockResolvedValueOnce(conn([makeNode('1')], true))
       .mockResolvedValueOnce(conn([], false));
 
@@ -206,7 +206,7 @@ describe('usePositionBalancesByConditionId — pagination', () => {
       result.current.fetchMore();
     });
     await waitFor(() => {
-      expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(2);
+      expect(mockGraphqlRequest).toHaveBeenCalledTimes(2);
     });
     expect(result.current.hasMore).toBe(false);
   });
@@ -220,9 +220,9 @@ describe('usePositionBalancesByConditionId — pagination', () => {
     );
 
     await waitFor(() => {
-      expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
+      expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
     });
-    expect(mockGraphqlRequestV2.mock.calls[0][1].filter).toEqual({
+    expect(mockGraphqlRequest.mock.calls[0][1].filter).toEqual({
       conditionIds: [CONDITION_ID],
     });
   });

--- a/packages/app/src/hooks/graphql/__tests__/usePositions.test.ts
+++ b/packages/app/src/hooks/graphql/__tests__/usePositions.test.ts
@@ -37,7 +37,7 @@ async function getHooks() {
 const HOLDER = '0xabc';
 const CONDITION_ID = '0xcond';
 
-// A v2 `Position` node (the adapter maps it to a PositionBalance).
+// A `Position` node (the adapter maps it to a PositionBalance).
 const makeNode = (id: string) => ({
   id,
   chainId: 1,
@@ -55,7 +55,7 @@ const makeNode = (id: string) => ({
   pickConfig: null,
 });
 
-// A Relay `PositionConnection` page. Per the v2 contract, an all-synthesized-
+// A Relay `PositionConnection` page. Per the connection contract, an all-synthesized-
 // away page still reports an advancing `endCursor` while more raw rows exist,
 // so `endCursor` is independent of whether `nodes` is empty.
 const conn = (

--- a/packages/app/src/hooks/graphql/__tests__/useSecondaryTrades.test.ts
+++ b/packages/app/src/hooks/graphql/__tests__/useSecondaryTrades.test.ts
@@ -50,7 +50,7 @@ beforeEach(() => {
   mockGraphqlRequest.mockResolvedValue({ trades: { nodes: [] } });
 });
 
-describe('v2 trade documents', () => {
+describe('trade documents', () => {
   it('participant query collapses seller+buyer into one filter with explicit orderBy', async () => {
     const mod = await getModule();
     const doc = mod.TRADES_BY_PARTICIPANT_QUERY as string;
@@ -83,7 +83,7 @@ describe('v2 trade documents', () => {
 });
 
 describe('useSecondaryTradesByAddress', () => {
-  it('issues a single v2 request keyed on participant (no seller/buyer double query)', async () => {
+  it('issues a single request keyed on participant (no seller/buyer double query)', async () => {
     const mod = await getModule();
 
     renderHook(
@@ -171,7 +171,7 @@ describe('useSecondaryTradesByAddress', () => {
 });
 
 describe('useSecondaryTrades (all trades)', () => {
-  it('requests the v2 trades connection filtered by chainId', async () => {
+  it('requests the trades connection filtered by chainId', async () => {
     const mod = await getModule();
 
     renderHook(() => mod.useSecondaryTrades({ chainId: 8453 }), {

--- a/packages/app/src/hooks/graphql/__tests__/useSecondaryTrades.test.ts
+++ b/packages/app/src/hooks/graphql/__tests__/useSecondaryTrades.test.ts
@@ -4,11 +4,9 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
 const mockGraphqlRequest = vi.fn();
-const mockGraphqlRequestV2 = vi.fn();
 
 vi.mock('@sapience/sdk/queries/client/graphqlClient', () => ({
   graphqlRequest: (...args: unknown[]) => mockGraphqlRequest(...args),
-  graphqlRequestV2: (...args: unknown[]) => mockGraphqlRequestV2(...args),
 }));
 
 function createWrapper() {
@@ -49,10 +47,7 @@ function makeTradeNode(overrides: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockGraphqlRequest.mockRejectedValue(
-    new Error('v1 transport must not be used')
-  );
-  mockGraphqlRequestV2.mockResolvedValue({ trades: { nodes: [] } });
+  mockGraphqlRequest.mockResolvedValue({ trades: { nodes: [] } });
 });
 
 describe('v2 trade documents', () => {
@@ -97,16 +92,15 @@ describe('useSecondaryTradesByAddress', () => {
     );
 
     await waitFor(() => {
-      expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
+      expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
     });
 
-    const [, variables] = mockGraphqlRequestV2.mock.calls[0];
+    const [, variables] = mockGraphqlRequest.mock.calls[0];
     expect(variables).toEqual({
       participant: '0xme',
       chainId: 8453,
       first: 50,
     });
-    expect(mockGraphqlRequest).not.toHaveBeenCalled();
   });
 
   it('passes chainId: null when chainId is omitted', async () => {
@@ -117,10 +111,10 @@ describe('useSecondaryTradesByAddress', () => {
     });
 
     await waitFor(() => {
-      expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
+      expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
     });
 
-    const [, variables] = mockGraphqlRequestV2.mock.calls[0];
+    const [, variables] = mockGraphqlRequest.mock.calls[0];
     expect(variables).toEqual({
       participant: '0xme',
       chainId: null,
@@ -130,7 +124,7 @@ describe('useSecondaryTradesByAddress', () => {
 
   it('returns mapped trades without numeric row ids', async () => {
     const mod = await getModule();
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       trades: { nodes: [makeTradeNode({ id: 42 })] },
     });
 
@@ -172,7 +166,7 @@ describe('useSecondaryTradesByAddress', () => {
     });
 
     await new Promise((r) => setTimeout(r, 50));
-    expect(mockGraphqlRequestV2).not.toHaveBeenCalled();
+    expect(mockGraphqlRequest).not.toHaveBeenCalled();
   });
 });
 
@@ -185,17 +179,16 @@ describe('useSecondaryTrades (all trades)', () => {
     });
 
     await waitFor(() => {
-      expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
+      expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
     });
 
-    const [, variables] = mockGraphqlRequestV2.mock.calls[0];
+    const [, variables] = mockGraphqlRequest.mock.calls[0];
     expect(variables).toEqual({ chainId: 8453, first: 50 });
-    expect(mockGraphqlRequest).not.toHaveBeenCalled();
   });
 
   it('normalizes BigInt wire values to strings', async () => {
     const mod = await getModule();
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       trades: { nodes: [makeTradeNode({ tokenAmount: 5, price: 7 })] },
     });
 
@@ -215,7 +208,7 @@ describe('useSecondaryTrades (all trades)', () => {
 describe('useSecondaryTrade', () => {
   it('looks up a single trade by tradeHash', async () => {
     const mod = await getModule();
-    mockGraphqlRequestV2.mockResolvedValue({ trade: makeTradeNode() });
+    mockGraphqlRequest.mockResolvedValue({ trade: makeTradeNode() });
 
     const { result } = renderHook(() => mod.useSecondaryTrade('0xhash1'), {
       wrapper: createWrapper(),
@@ -225,7 +218,7 @@ describe('useSecondaryTrade', () => {
       expect(result.current.data).not.toBeNull();
     });
 
-    const [, variables] = mockGraphqlRequestV2.mock.calls[0];
+    const [, variables] = mockGraphqlRequest.mock.calls[0];
     expect(variables).toEqual({ tradeHash: '0xhash1' });
     expect(result.current.data?.tradeHash).toBe('0xhash1');
     expect(result.current.data).not.toHaveProperty('id');
@@ -233,14 +226,14 @@ describe('useSecondaryTrade', () => {
 
   it('returns null when the trade is missing', async () => {
     const mod = await getModule();
-    mockGraphqlRequestV2.mockResolvedValue({ trade: null });
+    mockGraphqlRequest.mockResolvedValue({ trade: null });
 
     const { result } = renderHook(() => mod.useSecondaryTrade('0xmissing'), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => {
-      expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
+      expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
     });
 
     expect(result.current.data).toBeNull();

--- a/packages/app/src/hooks/graphql/useAccountActivity.ts
+++ b/packages/app/src/hooks/graphql/useAccountActivity.ts
@@ -3,7 +3,7 @@
 import { useCallback, useMemo } from 'react';
 import type { Address } from 'viem';
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { graphqlRequestV2 } from '@sapience/sdk/queries/client/graphqlClient';
+import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
 import {
   PREDICTION_V2_FIELDS,
   toPrediction,
@@ -266,7 +266,7 @@ export function useAccountActivity({
         ? (lastPage.pageInfo.endCursor ?? undefined)
         : undefined,
     queryFn: async ({ pageParam }) => {
-      const resp = await graphqlRequestV2<{
+      const resp = await graphqlRequest<{
         activity: ActivityConnectionV2 | null;
       }>(ACCOUNT_ACTIVITY_QUERY, {
         account: account ?? null,

--- a/packages/app/src/hooks/graphql/useAccountActivity.ts
+++ b/packages/app/src/hooks/graphql/useAccountActivity.ts
@@ -5,17 +5,17 @@ import type { Address } from 'viem';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
 import {
-  PREDICTION_V2_FIELDS,
+  PREDICTION_FIELDS,
   toPrediction,
   type Prediction,
-  type PredictionV2Node,
+  type PredictionNode,
   type PickConfigData,
 } from '~/hooks/graphql/usePositions';
 import type { SecondaryTrade } from '~/hooks/graphql/useSecondaryTrades';
 import {
-  PICK_CONFIGURATION_V2_FIELDS,
+  PICK_CONFIGURATION_FIELDS,
   toPickConfigData,
-  type PickConfigurationV2Node,
+  type PickConfigurationNode,
 } from '~/lib/adapters/pickConfig';
 
 export type PredictionActivity = {
@@ -36,11 +36,11 @@ export type TradeActivity = {
 
 export type ActivityItem = PredictionActivity | TradeActivity;
 
-// v2 returns the Prediction | Trade union directly under
-// `edges { node }` — v1's `accountActivity` envelope (with its
+// The endpoint returns the Prediction | Trade union directly under
+// `edges { node }` — the old `accountActivity` envelope (with its
 // per-type `prediction` / `trade` wrappers and double query) is gone.
 // `edges { timestamp }` (epoch seconds) is the interleave sort key for
-// BOTH types; using it as the single source of time kills the v1
+// BOTH types; using it as the single source of time kills the old
 // mixed-units bug (trades in seconds vs predictions in ISO strings).
 export const ACCOUNT_ACTIVITY_QUERY = `
   query AccountActivity(
@@ -73,7 +73,7 @@ export const ACCOUNT_ACTIVITY_QUERY = `
         node {
           __typename
           ... on Prediction {
-            ${PREDICTION_V2_FIELDS}
+            ${PREDICTION_FIELDS}
           }
           ... on Trade {
             tradeHash
@@ -88,7 +88,7 @@ export const ACCOUNT_ACTIVITY_QUERY = `
             blockNumber
             executedAt
             pickConfig {
-              ${PICK_CONFIGURATION_V2_FIELDS}
+              ${PICK_CONFIGURATION_FIELDS}
             }
           }
         }
@@ -97,9 +97,9 @@ export const ACCOUNT_ACTIVITY_QUERY = `
   }
 `;
 
-/** v2 wire shape of a Trade in the activity union (BigInt scalars may
+/** Wire shape of a Trade in the activity union (BigInt scalars may
  *  arrive as numbers). */
-type TradeV2ActivityNode = {
+type TradeActivityNode = {
   __typename: 'Trade';
   tradeHash: string;
   chainId: number;
@@ -112,39 +112,39 @@ type TradeV2ActivityNode = {
   txHash: string;
   blockNumber: number;
   executedAt: number;
-  pickConfig?: PickConfigurationV2Node | null;
+  pickConfig?: PickConfigurationNode | null;
 };
 
-type PredictionV2ActivityNode = PredictionV2Node & {
+type PredictionActivityNode = PredictionNode & {
   __typename: 'Prediction';
 };
 
-type ActivityEdgeV2 = {
+type ActivityEdge = {
   /** Interleave sort key: `Trade.executedAt` for trades, epoch seconds of
    *  `Prediction.createdAt` for predictions. */
   timestamp: number;
-  node: PredictionV2ActivityNode | TradeV2ActivityNode;
+  node: PredictionActivityNode | TradeActivityNode;
 };
 
-type ActivityConnectionV2 = {
+type ActivityConnection = {
   totalCount: number;
   pageInfo: { hasNextPage: boolean; endCursor: string | null };
-  edges: ActivityEdgeV2[];
+  edges: ActivityEdge[];
 };
 
-const EMPTY_ACTIVITY_PAGE: ActivityConnectionV2 = {
+const EMPTY_ACTIVITY_PAGE: ActivityConnection = {
   totalCount: 0,
   pageInfo: { hasNextPage: false, endCursor: null },
   edges: [],
 };
 
 /**
- * Pure mapper: one v2 activity edge → the hook's item envelope. The edge's
+ * Pure mapper: one activity edge → the hook's item envelope. The edge's
  * `timestamp` (epoch seconds) is THE time for every item type (×1000 for
  * ms); pickConfigs map through the shared adapter.
  */
 function toActivityItem(
-  edge: ActivityEdgeV2,
+  edge: ActivityEdge,
   account?: string
 ): ActivityItem | null {
   const timestampMs = edge.timestamp * 1000;
@@ -229,7 +229,7 @@ export function useAccountActivity({
 
   const typeFilter =
     activityType && activityType !== 'all' ? activityType : undefined;
-  // v2 ActivityFilter.types: null means "all"; [] would be a zero-result
+  // ActivityFilter.types: null means "all"; [] would be a zero-result
   // query, so the unfiltered case must send null.
   const types =
     typeFilter === 'prediction'
@@ -259,15 +259,15 @@ export function useAccountActivity({
     gcTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
     // Forward-only cursor pagination: thread the previous page's endCursor
-    // in as `after` (v1 was skip/take with a length-based stop signal).
+    // in as `after` (the previous skip/take approach used a length-based stop signal).
     initialPageParam: null as string | null,
-    getNextPageParam: (lastPage: ActivityConnectionV2) =>
+    getNextPageParam: (lastPage: ActivityConnection) =>
       lastPage.pageInfo.hasNextPage
         ? (lastPage.pageInfo.endCursor ?? undefined)
         : undefined,
     queryFn: async ({ pageParam }) => {
       const resp = await graphqlRequest<{
-        activity: ActivityConnectionV2 | null;
+        activity: ActivityConnection | null;
       }>(ACCOUNT_ACTIVITY_QUERY, {
         account: account ?? null,
         conditionIds: conditionId ? [conditionId] : null,

--- a/packages/app/src/hooks/graphql/useAnalytics.ts
+++ b/packages/app/src/hooks/graphql/useAnalytics.ts
@@ -14,9 +14,9 @@ import {
 const CACHE_TIME_MS = 60 * 1000;
 
 /**
- * Per-vault snapshot series from the v2 `vault(address:).statsHistory`
+ * Per-vault snapshot series from the `vault(address:).statsHistory`
  * surface. Backs the vault dashboard (VaultsPageContent, VaultPnlChart) — the
- * migration off v1's `protocolStats(vaultAddress:)`.
+ * migration off the old `protocolStats(vaultAddress:)`.
  *
  * Returns an empty array (not undefined) when no address is provided so call
  * sites can read it unconditionally; `enabled` keeps the network call gated.
@@ -59,7 +59,7 @@ export function useVaultAccountValue(vaultAddress?: string) {
 }
 
 /**
- * Latest v2 protocol stats only. Use this when callers need the live aggregate
+ * Latest protocol stats only. Use this when callers need the live aggregate
  * numbers without the heavier history/open-interest analytics payload.
  */
 export function useProtocolStats() {
@@ -72,7 +72,7 @@ export function useProtocolStats() {
 }
 
 /**
- * v2 protocol analytics: live stats, the recorded snapshot series and both
+ * Protocol analytics: live stats, the recorded snapshot series and both
  * open-interest breakdowns in a single `protocol { ... }` query.
  */
 export function useProtocolAnalytics() {

--- a/packages/app/src/hooks/graphql/useForecasts.ts
+++ b/packages/app/src/hooks/graphql/useForecasts.ts
@@ -58,7 +58,7 @@ export const useForecasts = ({
     refetchOnWindowFocus: options?.refetchOnWindowFocus ?? false,
   });
 
-  // The SDK already returns render-ready FormattedAttestation rows (v2).
+  // The SDK already returns render-ready FormattedAttestation rows.
   return { data: data ?? EMPTY_FORECASTS, isLoading, error, refetch };
 };
 
@@ -132,7 +132,7 @@ interface UseUserForecastsParams {
   conditionId?: string;
   /** Rows per page (`first`). */
   pageSize?: number;
-  /** Direction of the fixed v2 ATTESTED_AT ordering. */
+  /** Direction of the fixed ATTESTED_AT ordering. */
   orderDirection: 'asc' | 'desc';
 }
 

--- a/packages/app/src/hooks/graphql/useInfiniteQuestions.ts
+++ b/packages/app/src/hooks/graphql/useInfiniteQuestions.ts
@@ -3,7 +3,7 @@ import {
   GET_QUESTIONS,
   buildQuestionsVariables,
   toQuestionType,
-  type QuestionItemV2,
+  type QuestionItem,
   type QuestionType,
   type SortField,
   type SortDirection,
@@ -39,13 +39,13 @@ export interface UseInfiniteQuestionsResult {
 }
 
 /**
- * Infinite questions feed over the v2 cursor connection.
+ * Infinite questions feed over the cursor connection.
  *
- * v1 emulated "has more" with a `take: pageSize + 1` over-fetch and a
- * skip-offset state machine; v2's `QuestionConnection` is forward-cursor
- * native (`pageInfo.hasNextPage` + `endCursor`), so paging is delegated
- * to the shared `useCursorPagination` adapter. Raw `QuestionItem` union
- * nodes are mapped back into the stable v1 `QuestionType` envelope for
+ * The previous implementation emulated "has more" with a `take: pageSize + 1`
+ * over-fetch and a skip-offset state machine; the `QuestionConnection` is
+ * forward-cursor native (`pageInfo.hasNextPage` + `endCursor`), so paging is
+ * delegated to the shared `useCursorPagination` adapter. Raw `QuestionItem`
+ * union nodes are mapped back into the stable `QuestionType` envelope for
  * MarketsPage / QuestionsTable.
  */
 export function useInfiniteQuestions(
@@ -95,7 +95,7 @@ export function useInfiniteQuestions(
     isFetchingMore,
     hasNextPage,
     loadMore,
-  } = useCursorPagination<QuestionItemV2>({
+  } = useCursorPagination<QuestionItem>({
     // Filters/sort ride in `variables`, which useCursorPagination folds
     // into the React Query key — any change resets to a fresh first page.
     queryKey: ['infiniteQuestions'],
@@ -105,7 +105,7 @@ export function useInfiniteQuestions(
     variables: { filter: filter ?? null, orderBy },
   });
 
-  // Map union nodes back into v1 envelopes and drop duplicates that can
+  // Map union nodes back into the stable envelopes and drop duplicates that can
   // appear when rows shift between cursor pages under volatile sorts.
   const data = useMemo(() => {
     const seen = new Set<string>();

--- a/packages/app/src/hooks/graphql/usePickConfigsByTokens.ts
+++ b/packages/app/src/hooks/graphql/usePickConfigsByTokens.ts
@@ -4,17 +4,17 @@ import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
 import {
-  PICK_CONFIGURATION_V2_FIELDS,
+  PICK_CONFIGURATION_FIELDS,
   toPickConfigData,
   type AdaptedPickConfigData,
   type AdaptedPickData,
-  type PickConfigurationV2Node,
+  type PickConfigurationNode,
 } from '~/lib/adapters/pickConfig';
 
 // `picks.condition` is fetched inline so callers can build their
-// conditionsMap from a single round trip. v2: tokens move into `filter`,
-// `take` becomes `first`, and orderBy is explicit (v2 defaults can differ
-// from v1's). Node mapping (escrow → marketAddress, resolver →
+// conditionsMap from a single round trip. Tokens move into `filter`,
+// `take` becomes `first`, and orderBy is explicit (server defaults can differ
+// from the previous query's). Node mapping (escrow → marketAddress, resolver →
 // conditionResolver, YES/NO → 1/0, …) lives in the shared adapter.
 export const PICK_CONFIGS_BY_TOKENS_QUERY = `
   query PickConfigsByTokens($tokens: [Address!]) {
@@ -24,7 +24,7 @@ export const PICK_CONFIGS_BY_TOKENS_QUERY = `
       orderBy: { field: CREATED_AT, direction: DESC }
     ) {
       nodes {
-        ${PICK_CONFIGURATION_V2_FIELDS}
+        ${PICK_CONFIGURATION_FIELDS}
       }
     }
   }
@@ -51,7 +51,7 @@ export function usePickConfigsByTokens(tokens: string[]) {
     refetchOnWindowFocus: false,
     queryFn: async () => {
       const resp = await graphqlRequest<{
-        pickConfigurations: { nodes: PickConfigurationV2Node[] } | null;
+        pickConfigurations: { nodes: PickConfigurationNode[] } | null;
       }>(PICK_CONFIGS_BY_TOKENS_QUERY, { tokens: sorted });
       return (resp?.pickConfigurations?.nodes ?? []).map(toPickConfigData);
     },

--- a/packages/app/src/hooks/graphql/usePickConfigsByTokens.ts
+++ b/packages/app/src/hooks/graphql/usePickConfigsByTokens.ts
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { graphqlRequestV2 } from '@sapience/sdk/queries/client/graphqlClient';
+import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
 import {
   PICK_CONFIGURATION_V2_FIELDS,
   toPickConfigData,
@@ -50,7 +50,7 @@ export function usePickConfigsByTokens(tokens: string[]) {
     gcTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
     queryFn: async () => {
-      const resp = await graphqlRequestV2<{
+      const resp = await graphqlRequest<{
         pickConfigurations: { nodes: PickConfigurationV2Node[] } | null;
       }>(PICK_CONFIGS_BY_TOKENS_QUERY, { tokens: sorted });
       return (resp?.pickConfigurations?.nodes ?? []).map(toPickConfigData);

--- a/packages/app/src/hooks/graphql/usePositions.ts
+++ b/packages/app/src/hooks/graphql/usePositions.ts
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { graphqlRequestV2 } from '@sapience/sdk/queries/client/graphqlClient';
+import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
 import {
   PICK_CONFIGURATION_V2_FIELDS,
   toPickConfigData,
@@ -405,7 +405,7 @@ export function usePredictionsCount(address?: string, chainId?: number) {
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     queryFn: async () => {
-      const resp = await graphqlRequestV2<{
+      const resp = await graphqlRequest<{
         predictions: { totalCount: number } | null;
       }>(PREDICTIONS_COUNT_QUERY, {
         participant: address,
@@ -440,7 +440,7 @@ export function usePredictions(params: {
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     queryFn: async () => {
-      const resp = await graphqlRequestV2<{
+      const resp = await graphqlRequest<{
         predictions: { nodes: PredictionV2Node[] } | null;
       }>(PREDICTIONS_QUERY, {
         participant: address,
@@ -617,7 +617,7 @@ export function usePredictionsByConditionId(params: {
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     queryFn: async () => {
-      const resp = await graphqlRequestV2<{
+      const resp = await graphqlRequest<{
         predictions: { nodes: PredictionByConditionV2Node[] } | null;
       }>(PREDICTIONS_BY_CONDITION_QUERY, { conditionId, first: take });
       return (resp?.predictions?.nodes ?? []).map(toScatterPrediction);
@@ -646,7 +646,7 @@ export function usePrediction(predictionId?: string) {
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     queryFn: async () => {
-      const resp = await graphqlRequestV2<{
+      const resp = await graphqlRequest<{
         prediction: PredictionV2Node | null;
       }>(PREDICTION_QUERY, { predictionId });
       return resp?.prediction ? toPrediction(resp.prediction) : null;

--- a/packages/app/src/hooks/graphql/usePositions.ts
+++ b/packages/app/src/hooks/graphql/usePositions.ts
@@ -4,19 +4,19 @@ import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
 import {
-  PICK_CONFIGURATION_V2_FIELDS,
+  PICK_CONFIGURATION_FIELDS,
   toPickConfigData,
-  type PickConfigurationV2Node,
+  type PickConfigurationNode,
 } from '~/lib/adapters/pickConfig';
 import {
-  POSITION_V2_FIELDS,
+  POSITION_FIELDS,
   toPositionBalance,
-  type PositionV2Node,
+  type PositionNode,
 } from '~/lib/adapters/position';
 import { useCursorPagination } from '~/hooks/useCursorPagination';
 
 /**
- * Prediction - individual prediction record. v2 drops the numeric Prisma
+ * Prediction - individual prediction record. There is no numeric Prisma
  * row id — predictions are keyed by their on-chain `predictionId`.
  */
 export type Prediction = {
@@ -68,9 +68,9 @@ export type PickConditionData = {
 
 /** Pick in a pick configuration.
  *
- *  `id` is transitional: v2 sources re-key it to the stable string
- *  `${pickConfigId}:${conditionId}` (the numeric Prisma row id is gone),
- *  while the v1 positions half still returns numbers until wave 3.
+ *  `id` is transitional: prediction-sourced rows re-key it to the stable
+ *  string `${pickConfigId}:${conditionId}` (the numeric Prisma row id is gone),
+ *  while position-sourced rows still return numbers until wave 3.
  *  Collapses to `string` once positions flip. */
 export type PickData = {
   id: number | string;
@@ -115,28 +115,28 @@ export type PositionBalance = {
   userCollateral?: string | null;
   totalPayout?: string | null;
   realizedPnL?: string | null;
-  /** v2 lifecycle discriminator. v1 encoded SOLD rows implicitly in the id
-   *  shape (`<rowId>-sell-<tradeHash>`); v2 surfaces it explicitly. Absent on
-   *  rows not produced by the positions synthesis. */
+  /** Lifecycle discriminator. SOLD rows used to be encoded implicitly in the id
+   *  shape (`<rowId>-sell-<tradeHash>`); now it is surfaced explicitly. Absent
+   *  on rows not produced by the positions synthesis. */
   status?: 'OPEN' | 'SOLD' | null;
   createdAt: string;
   updatedAt: string;
   pickConfig?: PickConfigData | null;
 };
 
-// ─── v2 prediction documents + mapper ────────────────────────────────────────
+// ─── prediction documents + mapper ───────────────────────────────────────────
 //
-// The prediction half of this module runs against /v2/graphql. Documents are
-// plain untagged template literals (the app's graphql-eslint validates tagged
-// docs against the v1 schema). The positions half below stays on v1 until
-// wave 3.
+// The whole module runs against the GraphQL endpoint (/v2/graphql). Documents
+// are plain untagged template literals so the app's graphql-eslint (which
+// validates tagged docs against the legacy schema) skips them. The positions
+// half below still returns numeric ids until wave 3.
 
 /**
- * Selection set for a v2 `Prediction` node, matching {@link PredictionV2Node}.
+ * Selection set for a `Prediction` node, matching {@link PredictionNode}.
  * Shared with the activity feed's `... on Prediction` inline fragment
  * (useAccountActivity).
  */
-export const PREDICTION_V2_FIELDS = `
+export const PREDICTION_FIELDS = `
   predictionId
   chainId
   escrow
@@ -159,12 +159,12 @@ export const PREDICTION_V2_FIELDS = `
   refCode
   isLegacy
   pickConfig {
-    ${PICK_CONFIGURATION_V2_FIELDS}
+    ${PICK_CONFIGURATION_FIELDS}
   }
 `;
 
-/** v2 wire shape of a Prediction node (BigInt scalars may arrive as numbers). */
-export type PredictionV2Node = {
+/** Wire shape of a Prediction node (BigInt scalars may arrive as numbers). */
+export type PredictionNode = {
   predictionId: string;
   chainId: number;
   escrow: string;
@@ -186,22 +186,22 @@ export type PredictionV2Node = {
   createdAt: string;
   refCode?: string | null;
   isLegacy: boolean;
-  pickConfig?: PickConfigurationV2Node | null;
+  pickConfig?: PickConfigurationNode | null;
 };
 
 /**
- * Pure mapper: v2 Prediction node → app `Prediction`.
+ * Pure mapper: Prediction node → app `Prediction`.
  *
  * - `marketAddress` := `escrow`
- * - `result` := `result ?? 'UNRESOLVED'` (v2 result is nullable)
+ * - `result` := `result ?? 'UNRESOLVED'` (result is nullable)
  * - BigInt scalars normalized via `String()`
- * - `pickConfig` via the shared adapter; its v1-only `predictionId` field is
- *   backfilled from the parent prediction (v2 dropped it — the parent is the
- *   prediction).
- * - v2's nullable tokens collapse to `''` to keep the v1 non-null field
+ * - `pickConfig` via the shared adapter; its legacy `predictionId` field is
+ *   backfilled from the parent prediction (the schema dropped it — the parent
+ *   is the prediction).
+ * - nullable tokens collapse to `''` to keep the non-null field
  *   shape (no consumer reads tokens off predictions today).
  */
-export function toPrediction(node: PredictionV2Node): Prediction {
+export function toPrediction(node: PredictionNode): Prediction {
   return {
     predictionId: node.predictionId,
     chainId: node.chainId,
@@ -248,7 +248,7 @@ export const PREDICTIONS_QUERY = `
       orderBy: { field: CREATED_AT, direction: DESC }
     ) {
       nodes {
-        ${PREDICTION_V2_FIELDS}
+        ${PREDICTION_FIELDS}
       }
     }
   }
@@ -256,8 +256,8 @@ export const PREDICTIONS_QUERY = `
 
 // Slim projection for the question page chart — only the fields scatterData
 // reads. Picks deliberately omit the embedded `condition` objects: the full
-// embed blew the server-side complexity budget at 100 rows (same reason v1
-// slimmed this doc), and the chart never reads them.
+// embed blew the server-side complexity budget at 100 rows (the same reason
+// this doc was slimmed before), and the chart never reads them.
 export const PREDICTIONS_BY_CONDITION_QUERY = `
   query PredictionsByCondition($conditionId: Bytes!, $first: Int) {
     predictions(
@@ -304,8 +304,8 @@ export const PREDICTIONS_BY_CONDITION_QUERY = `
 /** Wire shape of the slim by-condition projection. `pickConfig` carries the
  *  full scalar set (so the shared adapter maps it) but its picks have no
  *  embedded condition. */
-type PredictionByConditionV2Node = Pick<
-  PredictionV2Node,
+type PredictionByConditionNode = Pick<
+  PredictionNode,
   | 'predictionId'
   | 'chainId'
   | 'escrow'
@@ -318,9 +318,9 @@ type PredictionByConditionV2Node = Pick<
   | 'pickConfig'
 >;
 
-// The chart reads a subset of Prediction; v1 returned the same partial rows
-// under the full type, so the cast preserves the existing contract.
-function toScatterPrediction(node: PredictionByConditionV2Node): Prediction {
+// The chart reads a subset of Prediction; the previous query returned the same
+// partial rows under the full type, so the cast preserves the existing contract.
+function toScatterPrediction(node: PredictionByConditionNode): Prediction {
   const partial: Partial<Prediction> = {
     predictionId: node.predictionId,
     chainId: node.chainId,
@@ -357,19 +357,19 @@ export const PREDICTIONS_COUNT_QUERY = `
 export const PREDICTION_QUERY = `
   query Prediction($predictionId: Bytes32!) {
     prediction(predictionId: $predictionId) {
-      ${PREDICTION_V2_FIELDS}
+      ${PREDICTION_FIELDS}
     }
   }
 `;
 
-// v2 connection over synthesized position rows — replaces v1's skip/take
+// Cursor connection over synthesized position rows — replaces the old skip/take
 // `positionsPage`. Both the by-holder and by-condition hooks share this
 // document; only the `PositionFilter` differs (passed as a variable).
 //
 // `pageInfo.hasNextPage` is raw-row truth: a page whose rows all synthesized
 // away still reports `true` while more underlying rows exist, so always page
 // on `pageInfo` (which `useCursorPagination` does), never on node count.
-export const POSITIONS_V2_QUERY = `
+export const POSITIONS_QUERY = `
   query Positions(
     $filter: PositionFilter
     $first: Int!
@@ -379,7 +379,7 @@ export const POSITIONS_V2_QUERY = `
     positions(filter: $filter, first: $first, after: $after, orderBy: $orderBy) {
       edges {
         node {
-          ${POSITION_V2_FIELDS}
+          ${POSITION_FIELDS}
         }
         cursor
       }
@@ -424,9 +424,9 @@ export function usePredictions(params: {
   address?: string;
   chainId?: number;
   take?: number;
-  /** v1 offset pagination; v2 is keyset-based, so only the first page
-   *  (skip = 0, the only value call sites use) is addressable. Kept for
-   *  signature stability. */
+  /** Legacy offset pagination; the connection is keyset-based, so only the
+   *  first page (skip = 0, the only value call sites use) is addressable. Kept
+   *  for signature stability. */
   skip?: number;
 }) {
   const { address, chainId, take = 50, skip = 0 } = params;
@@ -441,7 +441,7 @@ export function usePredictions(params: {
     refetchOnReconnect: false,
     queryFn: async () => {
       const resp = await graphqlRequest<{
-        predictions: { nodes: PredictionV2Node[] } | null;
+        predictions: { nodes: PredictionNode[] } | null;
       }>(PREDICTIONS_QUERY, {
         participant: address,
         chainId: chainId ?? null,
@@ -506,7 +506,7 @@ export function usePositionBalances(params: {
     loadMore,
     error,
     refetch,
-  } = useCursorPagination<PositionV2Node>({
+  } = useCursorPagination<PositionNode>({
     // orderBy in the key so switching/toggling sort resets pagination.
     queryKey: [
       'positionBalances',
@@ -516,7 +516,7 @@ export function usePositionBalances(params: {
       orderBy?.field ?? null,
       orderBy?.direction ?? null,
     ],
-    query: POSITIONS_V2_QUERY,
+    query: POSITIONS_QUERY,
     connectionKey: 'positions',
     pageSize,
     variables: { filter, orderBy },
@@ -568,7 +568,7 @@ export function usePositionBalancesByConditionId(params: {
     loadMore,
     error,
     refetch,
-  } = useCursorPagination<PositionV2Node>({
+  } = useCursorPagination<PositionNode>({
     queryKey: [
       'positionBalancesByCondition',
       conditionId,
@@ -576,7 +576,7 @@ export function usePositionBalancesByConditionId(params: {
       orderBy?.field ?? null,
       orderBy?.direction ?? null,
     ],
-    query: POSITIONS_V2_QUERY,
+    query: POSITIONS_QUERY,
     connectionKey: 'positions',
     pageSize,
     variables: { filter, orderBy },
@@ -618,7 +618,7 @@ export function usePredictionsByConditionId(params: {
     refetchOnReconnect: false,
     queryFn: async () => {
       const resp = await graphqlRequest<{
-        predictions: { nodes: PredictionByConditionV2Node[] } | null;
+        predictions: { nodes: PredictionByConditionNode[] } | null;
       }>(PREDICTIONS_BY_CONDITION_QUERY, { conditionId, first: take });
       return (resp?.predictions?.nodes ?? []).map(toScatterPrediction);
     },
@@ -647,7 +647,7 @@ export function usePrediction(predictionId?: string) {
     refetchOnReconnect: false,
     queryFn: async () => {
       const resp = await graphqlRequest<{
-        prediction: PredictionV2Node | null;
+        prediction: PredictionNode | null;
       }>(PREDICTION_QUERY, { predictionId });
       return resp?.prediction ? toPrediction(resp.prediction) : null;
     },

--- a/packages/app/src/hooks/graphql/useSecondaryTrades.ts
+++ b/packages/app/src/hooks/graphql/useSecondaryTrades.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { graphqlRequestV2 } from '@sapience/sdk/queries/client/graphqlClient';
+import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
 
 /**
  * Secondary-market trade as consumed by the app. v2 drops the numeric
@@ -139,7 +139,7 @@ export function useSecondaryTradesByAddress(params: {
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     queryFn: async () => {
-      const resp = await graphqlRequestV2<TradesV2Response>(
+      const resp = await graphqlRequest<TradesV2Response>(
         TRADES_BY_PARTICIPANT_QUERY,
         {
           participant: address,
@@ -171,7 +171,7 @@ export function useSecondaryTrade(tradeHash?: string) {
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     queryFn: async () => {
-      const resp = await graphqlRequestV2<{ trade: TradeV2Node | null }>(
+      const resp = await graphqlRequest<{ trade: TradeV2Node | null }>(
         TRADE_QUERY,
         { tradeHash }
       );
@@ -201,7 +201,7 @@ export function useSecondaryTrades(params: {
     gcTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
     queryFn: async () => {
-      const resp = await graphqlRequestV2<TradesV2Response>(ALL_TRADES_QUERY, {
+      const resp = await graphqlRequest<TradesV2Response>(ALL_TRADES_QUERY, {
         chainId: chainId ?? null,
         first: take,
       });

--- a/packages/app/src/hooks/graphql/useSecondaryTrades.ts
+++ b/packages/app/src/hooks/graphql/useSecondaryTrades.ts
@@ -4,9 +4,9 @@ import { useQuery } from '@tanstack/react-query';
 import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
 
 /**
- * Secondary-market trade as consumed by the app. v2 drops the numeric
+ * Secondary-market trade as consumed by the app. There is no numeric
  * Prisma row id — trades are keyed by their canonical on-chain `tradeHash`.
- * `executedAt` is epoch seconds in both v1 and v2 (UnixSeconds).
+ * `executedAt` is epoch seconds (UnixSeconds).
  */
 export type SecondaryTrade = {
   tradeHash: string;
@@ -22,8 +22,8 @@ export type SecondaryTrade = {
   executedAt: number;
 };
 
-/** v2 wire shape of a Trade node (BigInt scalars may arrive as numbers). */
-type TradeV2Node = {
+/** Wire shape of a Trade node (BigInt scalars may arrive as numbers). */
+type TradeNode = {
   tradeHash: string;
   chainId: number;
   token: string;
@@ -52,9 +52,9 @@ const TRADE_FIELDS = `
 `;
 
 /**
- * v2 collapses v1's seller-query + buyer-query + client merge into a single
- * `participant` filter (either side). Explicit orderBy — v2 defaults can
- * differ from v1's.
+ * A single `participant` filter (either side) collapses what used to be a
+ * separate seller-query + buyer-query + client merge. Explicit orderBy —
+ * server defaults can differ from the previous query's.
  */
 export const TRADES_BY_PARTICIPANT_QUERY = `
   query TradesByParticipant(
@@ -97,11 +97,11 @@ export const TRADE_QUERY = `
 `;
 
 /**
- * Pure mapper: v2 Trade node → SecondaryTrade. Normalizes BigInt scalar
+ * Pure mapper: Trade node → SecondaryTrade. Normalizes BigInt scalar
  * fields via `String()` (the BigInt scalar can serialize small values as
  * numbers) and drops anything the app shape doesn't declare.
  */
-function toSecondaryTrade(node: TradeV2Node): SecondaryTrade {
+function toSecondaryTrade(node: TradeNode): SecondaryTrade {
   return {
     tradeHash: node.tradeHash,
     chainId: node.chainId,
@@ -117,15 +117,15 @@ function toSecondaryTrade(node: TradeV2Node): SecondaryTrade {
   };
 }
 
-type TradesV2Response = { trades: { nodes: TradeV2Node[] } | null };
+type TradesResponse = { trades: { nodes: TradeNode[] } | null };
 
 export function useSecondaryTradesByAddress(params: {
   address?: string;
   chainId?: number;
   take?: number;
-  /** v1 offset pagination; v2 is keyset-based, so only the first page
-   *  (skip = 0, the only value call sites use) is addressable. Kept for
-   *  signature stability. */
+  /** Legacy offset pagination; the connection is keyset-based, so only the
+   *  first page (skip = 0, the only value call sites use) is addressable. Kept
+   *  for signature stability. */
   skip?: number;
 }) {
   const { address, chainId, take = 50, skip = 0 } = params;
@@ -139,7 +139,7 @@ export function useSecondaryTradesByAddress(params: {
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     queryFn: async () => {
-      const resp = await graphqlRequest<TradesV2Response>(
+      const resp = await graphqlRequest<TradesResponse>(
         TRADES_BY_PARTICIPANT_QUERY,
         {
           participant: address,
@@ -147,7 +147,7 @@ export function useSecondaryTradesByAddress(params: {
           first: take,
         }
       );
-      // Server-side EXECUTED_AT DESC replaces the v1 client merge + sort.
+      // Server-side EXECUTED_AT DESC replaces the old client merge + sort.
       return (resp?.trades?.nodes ?? []).map(toSecondaryTrade);
     },
   });
@@ -171,7 +171,7 @@ export function useSecondaryTrade(tradeHash?: string) {
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     queryFn: async () => {
-      const resp = await graphqlRequest<{ trade: TradeV2Node | null }>(
+      const resp = await graphqlRequest<{ trade: TradeNode | null }>(
         TRADE_QUERY,
         { tradeHash }
       );
@@ -201,7 +201,7 @@ export function useSecondaryTrades(params: {
     gcTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
     queryFn: async () => {
-      const resp = await graphqlRequest<TradesV2Response>(ALL_TRADES_QUERY, {
+      const resp = await graphqlRequest<TradesResponse>(ALL_TRADES_QUERY, {
         chainId: chainId ?? null,
         first: take,
       });

--- a/packages/app/src/hooks/referrals/useReferrals.ts
+++ b/packages/app/src/hooks/referrals/useReferrals.ts
@@ -13,8 +13,8 @@ function getPublicApiBaseUrl(): string {
 
 /**
  * Per-user referral status + referrals, from the public REST endpoint
- * `GET /referrals/users/:address`. Referral data is attribution-only and v2
- * GraphQL deliberately does not expose it, so all referral reads go through
+ * `GET /referrals/users/:address`. Referral data is attribution-only and the
+ * GraphQL endpoint deliberately does not expose it, so all referral reads go through
  * REST. A missing user resolves to the empty/no-referral shape (never null).
  */
 export type UserReferralStatus = {

--- a/packages/app/src/hooks/useAdminApi.ts
+++ b/packages/app/src/hooks/useAdminApi.ts
@@ -5,10 +5,10 @@ import { useSignMessage } from 'wagmi';
 import { useSettings } from '~/lib/context/SettingsContext';
 import { ADMIN_AUTHENTICATE_MSG } from '~/lib/constants';
 
-export function useAdminApi() {
+export function useAdminApi(baseOverride?: string) {
   const { signMessageAsync } = useSignMessage();
   const { adminBaseUrl, defaults } = useSettings();
-  const base = adminBaseUrl ?? `${defaults.adminBaseUrl}`;
+  const base = baseOverride ?? adminBaseUrl ?? `${defaults.adminBaseUrl}`;
   const lastSignatureRef = useRef<{ sig: string; ts: number } | null>(null);
   const SIGN_TTL_SEC = 60; // reuse signature for 60s to prevent sign loops
 

--- a/packages/app/src/hooks/useCursorPagination.test.tsx
+++ b/packages/app/src/hooks/useCursorPagination.test.tsx
@@ -7,7 +7,7 @@ const mockGraphqlRequest = vi.fn();
 
 // The hook uses the v2 transport (/v2/graphql) — mock that symbol, not v1.
 vi.mock('@sapience/sdk/queries/client/graphqlClient', () => ({
-  graphqlRequestV2: (...args: unknown[]) => mockGraphqlRequest(...args),
+  graphqlRequest: (...args: unknown[]) => mockGraphqlRequest(...args),
 }));
 
 // One client per test, torn down in afterEach so an in-flight fetchNextPage

--- a/packages/app/src/hooks/useCursorPagination.test.tsx
+++ b/packages/app/src/hooks/useCursorPagination.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 const mockGraphqlRequest = vi.fn();
 
-// The hook uses the v2 transport (/v2/graphql) — mock that symbol, not v1.
+// The hook uses the GraphQL transport (/v2/graphql) — mock that symbol.
 vi.mock('@sapience/sdk/queries/client/graphqlClient', () => ({
   graphqlRequest: (...args: unknown[]) => mockGraphqlRequest(...args),
 }));
@@ -38,7 +38,7 @@ type Node = { id: string; name: string };
 
 const node = (id: string): Node => ({ id, name: `n${id}` });
 
-// A v2 forward-only Relay connection page, keyed under `things`.
+// A forward-only Relay connection page, keyed under `things`.
 const conn = (
   nodes: Node[],
   hasNextPage: boolean,

--- a/packages/app/src/hooks/useCursorPagination.ts
+++ b/packages/app/src/hooks/useCursorPagination.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useMemo } from 'react';
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { graphqlRequestV2 } from '@sapience/sdk/queries/client/graphqlClient';
+import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
 
 /**
  * Forward-only cursor pagination for v2 GraphQL connections.
@@ -127,13 +127,14 @@ export function useCursorPagination<TNode>(
         ? (lastPage.pageInfo.endCursor ?? undefined)
         : undefined,
     queryFn: async ({ pageParam }) => {
-      const resp = await graphqlRequestV2<
-        Record<string, RelayConnection<TNode>>
-      >(query, {
-        ...(variables ?? {}),
-        first: pageSize,
-        after: pageParam ?? null,
-      });
+      const resp = await graphqlRequest<Record<string, RelayConnection<TNode>>>(
+        query,
+        {
+          ...(variables ?? {}),
+          first: pageSize,
+          after: pageParam ?? null,
+        }
+      );
       return resp?.[connectionKey] ?? EMPTY_CONNECTION;
     },
   });

--- a/packages/app/src/hooks/useCursorPagination.ts
+++ b/packages/app/src/hooks/useCursorPagination.ts
@@ -5,12 +5,12 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
 
 /**
- * Forward-only cursor pagination for v2 GraphQL connections.
+ * Forward-only cursor pagination for GraphQL connections.
  *
- * v1 plural queries are skip/take with a `+1` over-fetch to detect "more"
- * (see `usePositions`, `useAccountActivity`). v2 is Relay forward-only:
+ * The old plural queries were skip/take with a `+1` over-fetch to detect "more"
+ * (see `usePositions`, `useAccountActivity`). Connections are Relay forward-only:
  * `first` / `after` in, `{ edges { node, cursor }, pageInfo, totalCount }`
- * out. This hook is the shared adapter for that shape so every v2 consumer
+ * out. This hook is the shared adapter for that shape so every consumer
  * gets the same loadMore / hasNextPage / accumulated-nodes contract instead
  * of reimplementing cursor threading per query.
  *
@@ -19,7 +19,7 @@ import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
  * `edges[].node` across all loaded pages into `data`.
  */
 
-/** The Relay connection shape v2 resolvers return under `connectionKey`. */
+/** The Relay connection shape resolvers return under `connectionKey`. */
 export type RelayPageInfo = {
   hasNextPage: boolean;
   endCursor: string | null;
@@ -48,7 +48,7 @@ export interface UseCursorPaginationParams {
   /** React Query cache key. The hook does not append page params — the
    *  cursor lives in `useInfiniteQuery`'s page list, not the key. */
   queryKey: readonly unknown[];
-  /** A v2 connection query exposing `first: Int!` and `after: String`. */
+  /** A connection query exposing `first: Int!` and `after: String`. */
   query: string;
   /** Top-level field name the connection is returned under (e.g. `questions`). */
   connectionKey: string;
@@ -80,7 +80,7 @@ export interface UseCursorPaginationResult<TNode> {
 }
 
 /**
- * Generic forward-cursor pagination over a v2 Relay connection.
+ * Generic forward-cursor pagination over a Relay connection.
  *
  * @example
  * const { data, loadMore, hasNextPage } = useCursorPagination<Question>({
@@ -144,7 +144,7 @@ export function useCursorPagination<TNode>(
     [data]
   );
 
-  // totalCount is a page-invariant extent in v2; read it off the latest page.
+  // totalCount is a page-invariant extent; read it off the latest page.
   const totalCount = data?.pages.at(-1)?.totalCount ?? 0;
 
   const loadMore = useCallback(() => {

--- a/packages/app/src/hooks/useProfileVolume.ts
+++ b/packages/app/src/hooks/useProfileVolume.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { graphqlRequestV2 } from '@sapience/sdk/queries/client/graphqlClient';
+import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
 import { formatUnits } from 'viem';
 
 // v2: top-level `accountTotalVolume(address:)` became
@@ -26,7 +26,7 @@ export function useProfileVolume(address?: string) {
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     queryFn: async () => {
-      const resp = await graphqlRequestV2<{
+      const resp = await graphqlRequest<{
         account: { stats: { totalVolume: string | number } } | null;
       }>(TRADING_VOLUME_QUERY, { address: address?.toLowerCase() });
 

--- a/packages/app/src/hooks/useProfileVolume.ts
+++ b/packages/app/src/hooks/useProfileVolume.ts
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
 import { formatUnits } from 'viem';
 
-// v2: top-level `accountTotalVolume(address:)` became
+// The GraphQL schema exposes account total volume as
 // `account(address:) { stats { totalVolume } }`. `account` synthesizes a
 // record for addresses with no User row (G6), so this works for any address.
 const TRADING_VOLUME_QUERY = `

--- a/packages/app/src/hooks/useTradeSettledNotifications.tsx
+++ b/packages/app/src/hooks/useTradeSettledNotifications.tsx
@@ -7,8 +7,8 @@ import { useRouter } from 'next/navigation';
 import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
 import { useTerminalLogs } from '~/components/terminal/TerminalLogsContext';
 
-// v2: participant filter collapses v1's address arg; orderBy is explicit.
-// v2 drops the numeric row id — notifications key on `predictionId`.
+// The GraphQL participant filter replaces a separate address arg; orderBy is explicit.
+// The GraphQL schema has no numeric row id — notifications key on `predictionId`.
 const RECENT_PREDICTIONS_QUERY = `
   query RecentCounterpartyPredictions($participant: Address!, $first: Int) {
     predictions(
@@ -49,8 +49,8 @@ export function useTradeSettledNotifications() {
 
   // Only notify for predictions created after mount…
   const mountTsRef = useRef<number>(Math.floor(Date.now() / 1000));
-  // …and never twice for the same prediction. Keyed on predictionId — the
-  // v1 moving created-at cutoff silently dropped same-second predictions.
+  // …and never twice for the same prediction. Keyed on predictionId — a
+  // moving created-at cutoff would silently drop same-second predictions.
   const notifiedRef = useRef<Set<string>>(new Set());
 
   const { data: predictions } = useQuery({

--- a/packages/app/src/hooks/useTradeSettledNotifications.tsx
+++ b/packages/app/src/hooks/useTradeSettledNotifications.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useToast } from '@sapience/ui/hooks/use-toast';
 import { ToastAction } from '@sapience/ui/components/ui/toast';
 import { useRouter } from 'next/navigation';
-import { graphqlRequestV2 } from '@sapience/sdk/queries/client/graphqlClient';
+import { graphqlRequest } from '@sapience/sdk/queries/client/graphqlClient';
 import { useTerminalLogs } from '~/components/terminal/TerminalLogsContext';
 
 // v2: participant filter collapses v1's address arg; orderBy is explicit.
@@ -57,7 +57,7 @@ export function useTradeSettledNotifications() {
     queryKey: ['recentCounterpartyPredictions', address],
     queryFn: async () => {
       if (!address) return [];
-      const result = await graphqlRequestV2<PredictionsQueryResponse>(
+      const result = await graphqlRequest<PredictionsQueryResponse>(
         RECENT_PREDICTIONS_QUERY,
         {
           participant: address.toLowerCase(),

--- a/packages/app/src/lib/adapters/pickConfig.test.ts
+++ b/packages/app/src/lib/adapters/pickConfig.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from 'vitest';
 import {
-  PICK_CONFIGURATION_V2_FIELDS,
+  PICK_CONFIGURATION_FIELDS,
   toPickConfigData,
-  type PickConfigurationV2Node,
-  type PickV2Node,
+  type PickConfigurationNode,
+  type PickNode,
 } from './pickConfig';
 
-function makePick(overrides: Partial<PickV2Node> = {}): PickV2Node {
+function makePick(overrides: Partial<PickNode> = {}): PickNode {
   return {
     conditionId: '0xcond1',
     resolver: '0xresolver1',
@@ -30,8 +30,8 @@ function makePick(overrides: Partial<PickV2Node> = {}): PickV2Node {
 }
 
 function makeNode(
-  overrides: Partial<PickConfigurationV2Node> = {}
-): PickConfigurationV2Node {
+  overrides: Partial<PickConfigurationNode> = {}
+): PickConfigurationNode {
   return {
     pickConfigId: '0xpc1',
     chainId: 8453,
@@ -81,7 +81,7 @@ describe('toPickConfigData', () => {
     ).toBe('NON_DECISIVE');
   });
 
-  test('keeps v2-native resolved and isLegacy flags', () => {
+  test('keeps GraphQL-native resolved and isLegacy flags', () => {
     const result = toPickConfigData(
       makeNode({ resolved: true, isLegacy: true })
     );
@@ -130,7 +130,7 @@ describe('toPickConfigData', () => {
 
   test('returns empty picks when picks are missing', () => {
     const node = makeNode();
-    delete (node as Partial<PickConfigurationV2Node>).picks;
+    delete (node as Partial<PickConfigurationNode>).picks;
     expect(toPickConfigData(node).picks).toEqual([]);
   });
 
@@ -227,32 +227,32 @@ describe('toPickConfigData', () => {
     expect(result.picks[0].condition).not.toHaveProperty('createdAt');
   });
 
-  test('does not invent predictionId (absent from the v2 node)', () => {
+  test('does not invent predictionId (absent from the GraphQL node)', () => {
     const result = toPickConfigData(makeNode());
     expect('predictionId' in result).toBe(false);
   });
 });
 
-describe('PICK_CONFIGURATION_V2_FIELDS', () => {
-  test('selects v2 field names, not v1 aliases', () => {
-    expect(PICK_CONFIGURATION_V2_FIELDS).toContain('pickConfigId');
-    expect(PICK_CONFIGURATION_V2_FIELDS).toContain('escrow');
-    expect(PICK_CONFIGURATION_V2_FIELDS).toContain('isLegacy');
-    expect(PICK_CONFIGURATION_V2_FIELDS).toContain('predictedOutcome');
-    expect(PICK_CONFIGURATION_V2_FIELDS).not.toContain('marketAddress');
-    expect(PICK_CONFIGURATION_V2_FIELDS).not.toContain('conditionResolver');
+describe('PICK_CONFIGURATION_FIELDS', () => {
+  test('selects the GraphQL field names, not the old aliases', () => {
+    expect(PICK_CONFIGURATION_FIELDS).toContain('pickConfigId');
+    expect(PICK_CONFIGURATION_FIELDS).toContain('escrow');
+    expect(PICK_CONFIGURATION_FIELDS).toContain('isLegacy');
+    expect(PICK_CONFIGURATION_FIELDS).toContain('predictedOutcome');
+    expect(PICK_CONFIGURATION_FIELDS).not.toContain('marketAddress');
+    expect(PICK_CONFIGURATION_FIELDS).not.toContain('conditionResolver');
   });
 
-  test('selects no bare id field (numeric row ids are gone in v2 consumers)', () => {
-    expect(PICK_CONFIGURATION_V2_FIELDS).not.toMatch(/\bid\b/);
+  test('selects no bare id field (the GraphQL schema has no numeric row ids)', () => {
+    expect(PICK_CONFIGURATION_FIELDS).not.toMatch(/\bid\b/);
   });
 
   test('selects the embedded condition by CTF conditionId with convenience flags', () => {
-    expect(PICK_CONFIGURATION_V2_FIELDS).toContain('condition {');
-    expect(PICK_CONFIGURATION_V2_FIELDS).toContain('conditionId');
-    expect(PICK_CONFIGURATION_V2_FIELDS).toContain('settled');
-    expect(PICK_CONFIGURATION_V2_FIELDS).toContain('resolvedToYes');
-    expect(PICK_CONFIGURATION_V2_FIELDS).toContain('nonDecisive');
-    expect(PICK_CONFIGURATION_V2_FIELDS).toContain('estimatedPrice');
+    expect(PICK_CONFIGURATION_FIELDS).toContain('condition {');
+    expect(PICK_CONFIGURATION_FIELDS).toContain('conditionId');
+    expect(PICK_CONFIGURATION_FIELDS).toContain('settled');
+    expect(PICK_CONFIGURATION_FIELDS).toContain('resolvedToYes');
+    expect(PICK_CONFIGURATION_FIELDS).toContain('nonDecisive');
+    expect(PICK_CONFIGURATION_FIELDS).toContain('estimatedPrice');
   });
 });

--- a/packages/app/src/lib/adapters/pickConfig.ts
+++ b/packages/app/src/lib/adapters/pickConfig.ts
@@ -1,19 +1,19 @@
 /**
- * Shared adapter: v2 `PickConfiguration` node → the existing app-side
- * `PickConfigData` shape (usePositions). Every v2 consumer that embeds a
+ * Shared adapter: GraphQL `PickConfiguration` node → the existing app-side
+ * `PickConfigData` shape (usePositions). Every consumer that embeds a
  * pick configuration (trades, activity, predictions, positions) maps the
- * wire node through `toPickConfigData` so the semantic v1→v2 renames live
+ * wire node through `toPickConfigData` so the semantic wire-to-app renames live
  * in exactly one place:
  *
- * - `id`            := `pickConfigId` (deterministic 0x-hash, v2 drops row ids)
+ * - `id`            := `pickConfigId` (deterministic 0x-hash; the schema has no row ids)
  * - `marketAddress` := `escrow`
- * - `result`        := `result ?? 'UNRESOLVED'` (v2 result is nullable)
+ * - `result`        := `result ?? 'UNRESOLVED'` (the GraphQL result is nullable)
  * - picks: `conditionResolver` := `resolver`,
  *          `predictedOutcome`  := `'YES' → 1`, otherwise `0`,
  *          `condition.id`      := `conditionId` (the CTF hash — field name
  *          stays `id` so app hash-matching sites keep working)
  * - pick `id` is re-keyed to the stable string `${pickConfigId}:${conditionId}`
- *   (v1's numeric Prisma row id is gone in v2; we never invent fake numbers)
+ *   (the GraphQL schema exposes no numeric Prisma row id; we never invent fake numbers)
  */
 import type {
   PickConditionData,
@@ -21,8 +21,8 @@ import type {
   PickData,
 } from '~/hooks/graphql/usePositions';
 
-/** v2 wire shape of an embedded pick condition (CTF hash + metadata). */
-export type PickConditionV2Node = {
+/** GraphQL wire shape of an embedded pick condition (CTF hash + metadata). */
+export type PickConditionNode = {
   conditionId: string;
   shortName?: string | null;
   optionName?: string | null;
@@ -37,16 +37,16 @@ export type PickConditionV2Node = {
   category?: { slug?: string | null } | null;
 };
 
-/** v2 wire shape of a pick (no row id; `resolver` instead of `conditionResolver`). */
-export type PickV2Node = {
+/** GraphQL wire shape of a pick (no row id; `resolver` instead of `conditionResolver`). */
+export type PickNode = {
   conditionId: string;
   resolver: string;
   predictedOutcome: 'YES' | 'NO';
-  condition?: PickConditionV2Node | null;
+  condition?: PickConditionNode | null;
 };
 
-/** v2 wire shape of a PickConfiguration node. */
-export type PickConfigurationV2Node = {
+/** GraphQL wire shape of a PickConfiguration node. */
+export type PickConfigurationNode = {
   pickConfigId: string;
   chainId: number;
   escrow: string;
@@ -61,7 +61,7 @@ export type PickConfigurationV2Node = {
   counterpartyToken?: string | null;
   endsAt?: number | null;
   isLegacy: boolean;
-  picks?: PickV2Node[] | null;
+  picks?: PickNode[] | null;
 };
 
 /**
@@ -76,11 +76,11 @@ export type AdaptedPickConfigData = Omit<PickConfigData, 'picks'> & {
 };
 
 /**
- * Selection set for a v2 `PickConfiguration` node, matching
- * {@link PickConfigurationV2Node}. Interpolate inside a `nodes { ... }`
+ * Selection set for a GraphQL `PickConfiguration` node, matching
+ * {@link PickConfigurationNode}. Interpolate inside a `nodes { ... }`
  * (or single-object) selection.
  */
-export const PICK_CONFIGURATION_V2_FIELDS = `
+export const PICK_CONFIGURATION_FIELDS = `
   pickConfigId
   chainId
   escrow
@@ -119,7 +119,7 @@ export const PICK_CONFIGURATION_V2_FIELDS = `
 `;
 
 function toPickConditionData(
-  condition: PickConditionV2Node | null | undefined
+  condition: PickConditionNode | null | undefined
 ): PickConditionData | null {
   if (!condition) return null;
   return {
@@ -138,10 +138,7 @@ function toPickConditionData(
   };
 }
 
-function toAdaptedPick(
-  pickConfigId: string,
-  pick: PickV2Node
-): AdaptedPickData {
+function toAdaptedPick(pickConfigId: string, pick: PickNode): AdaptedPickData {
   return {
     id: `${pickConfigId}:${pick.conditionId}`,
     pickConfigId,
@@ -153,12 +150,12 @@ function toAdaptedPick(
 }
 
 /**
- * Pure mapper: v2 `PickConfiguration` node → `PickConfigData`. BigInt
+ * Pure mapper: GraphQL `PickConfiguration` node → `PickConfigData`. BigInt
  * scalar fields are normalized via `String()` so collateral values are
  * always strings regardless of how the BigInt scalar serialized.
  */
 export function toPickConfigData(
-  node: PickConfigurationV2Node
+  node: PickConfigurationNode
 ): AdaptedPickConfigData {
   return {
     id: node.pickConfigId,

--- a/packages/app/src/lib/adapters/position.test.ts
+++ b/packages/app/src/lib/adapters/position.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from 'vitest';
 import {
-  POSITION_V2_FIELDS,
+  POSITION_FIELDS,
   toPositionBalance,
-  type PositionV2Node,
+  type PositionNode,
 } from './position';
-import { PICK_CONFIGURATION_V2_FIELDS } from './pickConfig';
+import { PICK_CONFIGURATION_FIELDS } from './pickConfig';
 
-function makeNode(overrides: Partial<PositionV2Node> = {}): PositionV2Node {
+function makeNode(overrides: Partial<PositionNode> = {}): PositionNode {
   return {
     id: 'cG9zaXRpb246MQ==',
     chainId: 8453,
@@ -71,7 +71,7 @@ describe('toPositionBalance', () => {
     ).toBe(false);
   });
 
-  test('surfaces the explicit OPEN/SOLD status (v1 encoded it in the id)', () => {
+  test('surfaces the explicit OPEN/SOLD status (previously encoded in the id)', () => {
     expect(toPositionBalance(makeNode({ status: 'OPEN' })).status).toBe('OPEN');
     expect(toPositionBalance(makeNode({ status: 'SOLD' })).status).toBe('SOLD');
   });
@@ -123,8 +123,8 @@ describe('toPositionBalance', () => {
   });
 });
 
-describe('POSITION_V2_FIELDS', () => {
-  test('selects the v2 names the mapper reads', () => {
+describe('POSITION_FIELDS', () => {
+  test('selects the GraphQL names the mapper reads', () => {
     for (const field of [
       'token',
       'side',
@@ -135,11 +135,11 @@ describe('POSITION_V2_FIELDS', () => {
       'totalPayout',
       'realizedPnl',
     ]) {
-      expect(POSITION_V2_FIELDS).toContain(field);
+      expect(POSITION_FIELDS).toContain(field);
     }
   });
 
   test('embeds the shared pickConfig selection set', () => {
-    expect(POSITION_V2_FIELDS).toContain(PICK_CONFIGURATION_V2_FIELDS.trim());
+    expect(POSITION_FIELDS).toContain(PICK_CONFIGURATION_FIELDS.trim());
   });
 });

--- a/packages/app/src/lib/adapters/position.ts
+++ b/packages/app/src/lib/adapters/position.ts
@@ -1,31 +1,31 @@
 /**
- * Shared adapter: v2 `Position` node → the app-side `PositionBalance` shape
- * (usePositions). The v1→v2 renames live here in one place:
+ * Shared adapter: GraphQL `Position` node → the app-side `PositionBalance` shape
+ * (usePositions). The wire-to-app renames live here in one place:
  *
  * - `tokenAddress`     := `token`
  * - `isPredictorToken` := `side === 'PREDICTOR'`
  * - `realizedPnL`      := `realizedPnl` (case-only rename)
- * - `status`           := v2's explicit `OPEN`/`SOLD` discriminator. v1 encoded
- *   SOLD rows implicitly in the id shape (`<rowId>-sell-<tradeHash>`); v2 makes
- *   it explicit, so consumers stop parsing the opaque Relay id.
+ * - `status`           := the explicit `OPEN`/`SOLD` discriminator. The id shape
+ *   previously encoded SOLD rows implicitly (`<rowId>-sell-<tradeHash>`); the schema
+ *   now makes it explicit, so consumers stop parsing the opaque Relay id.
  * - `pickConfig`       := `toPickConfigData(node.pickConfig)` (shared mapper),
- *   with `predictionId` backfilled from `node.prediction` — v2 dropped the v1
- *   `pickConfig.predictionId` field, but claim/redeem (`handleClaim`) and the
+ *   with `predictionId` backfilled from `node.prediction` — the schema no longer
+ *   exposes a `pickConfig.predictionId` field, but claim/redeem (`handleClaim`) and the
  *   prediction permalink still read it, so the holder's prediction id is
  *   surfaced via `Position.prediction` and grafted back on.
  *
  * BigInt scalars can arrive as string or number over the wire; normalized to
- * decimal strings so consumers can `BigInt()` them (v1 returned strings).
+ * decimal strings so consumers can `BigInt()` them (the field previously returned strings).
  */
 import {
-  PICK_CONFIGURATION_V2_FIELDS,
+  PICK_CONFIGURATION_FIELDS,
   toPickConfigData,
-  type PickConfigurationV2Node,
+  type PickConfigurationNode,
 } from '~/lib/adapters/pickConfig';
 import type { PositionBalance } from '~/hooks/graphql/usePositions';
 
-/** v2 wire shape of a `Position` node (BigInt scalars may arrive as numbers). */
-export type PositionV2Node = {
+/** GraphQL wire shape of a `Position` node (BigInt scalars may arrive as numbers). */
+export type PositionNode = {
   id: string;
   chainId: number;
   holder: string;
@@ -39,17 +39,17 @@ export type PositionV2Node = {
   realizedPnl?: string | number | null;
   createdAt: string;
   updatedAt: string;
-  pickConfig?: PickConfigurationV2Node | null;
-  // The holder's prediction for this pickConfig — v2's home for the id that v1
-  // carried on `pickConfig.predictionId` (claim/redeem + permalink read it).
+  pickConfig?: PickConfigurationNode | null;
+  // The holder's prediction for this pickConfig — the schema's home for the id that
+  // previously lived on `pickConfig.predictionId` (claim/redeem + permalink read it).
   prediction?: { predictionId: string } | null;
 };
 
 /**
- * Selection set for a v2 `Position` node, matching {@link PositionV2Node}.
+ * Selection set for a GraphQL `Position` node, matching {@link PositionNode}.
  * Interpolate inside a connection's `edges { node { ... } }` selection.
  */
-export const POSITION_V2_FIELDS = `
+export const POSITION_FIELDS = `
   id
   chainId
   holder
@@ -64,7 +64,7 @@ export const POSITION_V2_FIELDS = `
   createdAt
   updatedAt
   pickConfig {
-    ${PICK_CONFIGURATION_V2_FIELDS}
+    ${PICK_CONFIGURATION_FIELDS}
   }
   prediction {
     predictionId
@@ -72,12 +72,12 @@ export const POSITION_V2_FIELDS = `
 `;
 
 // The BigInt scalar serializes as string or number depending on the transport;
-// normalize present values to decimal strings, keep nulls null (v1 parity).
+// normalize present values to decimal strings, keep nulls null.
 const wei = (value: string | number | null | undefined): string | null =>
   value == null ? null : String(value);
 
-/** Pure mapper: v2 `Position` node → app `PositionBalance`. */
-export function toPositionBalance(node: PositionV2Node): PositionBalance {
+/** Pure mapper: GraphQL `Position` node → app `PositionBalance`. */
+export function toPositionBalance(node: PositionNode): PositionBalance {
   return {
     id: node.id,
     chainId: node.chainId,
@@ -95,8 +95,8 @@ export function toPositionBalance(node: PositionV2Node): PositionBalance {
     pickConfig: node.pickConfig
       ? {
           ...toPickConfigData(node.pickConfig),
-          // v2 dropped pickConfig.predictionId; graft it back from the
-          // holder's prediction so claim/redeem + permalinks keep working.
+          // The schema no longer exposes pickConfig.predictionId; graft it back from
+          // the holder's prediction so claim/redeem + permalinks keep working.
           predictionId: node.prediction?.predictionId ?? null,
         }
       : null,

--- a/packages/app/src/lib/adapters/vaultStat.ts
+++ b/packages/app/src/lib/adapters/vaultStat.ts
@@ -1,15 +1,15 @@
 /**
- * Shared adapter: v2 `VaultStat` node → the chart point shape the vault PnL
+ * Shared adapter: GraphQL `VaultStat` node → the chart point shape the vault PnL
  * chart util consumes (`{ timestamp, pnl, tvl }`, both in whole wUSDe). This
  * is the one place the migrated TVL/PnL semantics live:
  *
  * - `tvl` := `balance + deployedCollateral + claimableCollateral` (whole wUSDe).
- *   v1 used `vaultBalance + chain-wide escrowBalance`, which over-counted by
- *   mixing the vault's balance with the protocol-wide escrow; the v2 line is
+ *   The previous field used `vaultBalance + chain-wide escrowBalance`, which over-counted by
+ *   mixing the vault's balance with the protocol-wide escrow; the current line is
  *   the vault's own AUM plus its settled-but-unredeemed winnings.
  * - `pnl` := `cumulativePnl` (whole wUSDe).
  *
- * Wei → whole-token conversion divides by 1e18 (same as the v1 chart did).
+ * Wei → whole-token conversion divides by 1e18 (same as the chart previously did).
  */
 import type { VaultStat } from '@sapience/sdk/queries';
 
@@ -24,7 +24,7 @@ const WEI_PER_WUSDE = 1e18;
 const toWhole = (wei: string | null | undefined): number =>
   wei ? Number(BigInt(wei)) / WEI_PER_WUSDE : 0;
 
-/** Pure mapper: v2 `VaultStat` → chart point in whole wUSDe. */
+/** Pure mapper: GraphQL `VaultStat` → chart point in whole wUSDe. */
 export function toVaultStatPoint(stat: VaultStat): VaultStatPoint {
   const tvlWei =
     BigInt(stat.balance || '0') +

--- a/packages/app/src/lib/context/SettingsContext.graphqlEndpoint.test.tsx
+++ b/packages/app/src/lib/context/SettingsContext.graphqlEndpoint.test.tsx
@@ -1,8 +1,9 @@
 /**
- * Tests for the v2 GraphQL endpoint wiring in SettingsContext.
+ * Tests for the single GraphQL endpoint wiring in SettingsContext.
  *
- * Covers the default `/v2/graphql` resolution, localStorage override
- * hydration, and the setter persisting under its own key without disturbing v1.
+ * Covers the default `/v2/graphql` resolution, localStorage override hydration,
+ * migration from the legacy `graphqlEndpointV2` key, and the setter persisting
+ * under the single key while clearing the legacy one.
  */
 
 import { render, screen, waitFor, act } from '@testing-library/react';
@@ -10,8 +11,8 @@ import { beforeAll, describe, test, expect, beforeEach } from 'vitest';
 
 import { SettingsProvider, useSettings } from './SettingsContext';
 
-const V2_KEY = 'sapience.settings.graphqlEndpointV2';
-const V1_KEY = 'sapience.settings.graphqlEndpoint';
+const KEY = 'sapience.settings.graphqlEndpoint';
+const LEGACY_KEY = 'sapience.settings.graphqlEndpointV2';
 const CHAT_KEY = 'sapience.settings.chatBaseUrl';
 
 // jsdom in this environment does not ship a working localStorage (it requires
@@ -45,18 +46,16 @@ beforeAll(() => {
 });
 
 function Probe() {
-  const { graphqlEndpoint, graphqlEndpointV2, setGraphqlEndpointV2, defaults } =
-    useSettings();
+  const { graphqlEndpoint, setGraphqlEndpoint, defaults } = useSettings();
   return (
     <div>
-      <span data-testid="v1">{graphqlEndpoint ?? ''}</span>
-      <span data-testid="v2">{graphqlEndpointV2 ?? ''}</span>
-      <span data-testid="default-v2">{defaults.graphqlEndpointV2}</span>
+      <span data-testid="endpoint">{graphqlEndpoint ?? ''}</span>
+      <span data-testid="default">{defaults.graphqlEndpoint}</span>
       <button
         type="button"
         data-testid="set"
         onClick={() =>
-          setGraphqlEndpointV2('https://staging.example.com/v2/graphql')
+          setGraphqlEndpoint('https://staging.example.com/v2/graphql')
         }
       >
         set
@@ -64,7 +63,7 @@ function Probe() {
       <button
         type="button"
         data-testid="clear"
-        onClick={() => setGraphqlEndpointV2(null)}
+        onClick={() => setGraphqlEndpoint(null)}
       >
         clear
       </button>
@@ -103,8 +102,8 @@ beforeEach(() => {
   window.localStorage.clear();
 });
 
-describe('SettingsContext v2 GraphQL endpoint', () => {
-  test('defaults v2 endpoint to the /v2/graphql path of the API origin', async () => {
+describe('SettingsContext GraphQL endpoint', () => {
+  test('defaults the endpoint to the /v2/graphql path of the API origin', async () => {
     render(
       <SettingsProvider>
         <Probe />
@@ -112,24 +111,15 @@ describe('SettingsContext v2 GraphQL endpoint', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('v2').textContent).toMatch(/\/v2\/graphql$/);
+      expect(screen.getByTestId('endpoint').textContent).toMatch(
+        /\/v2\/graphql$/
+      );
     });
-
-    // v1 must remain on the bare /graphql path, not /v2/graphql.
-    const v1 = screen.getByTestId('v1').textContent ?? '';
-    expect(v1.endsWith('/graphql')).toBe(true);
-    expect(v1.endsWith('/v2/graphql')).toBe(false);
-
-    expect(screen.getByTestId('default-v2').textContent).toMatch(
-      /\/v2\/graphql$/
-    );
+    expect(screen.getByTestId('default').textContent).toMatch(/\/v2\/graphql$/);
   });
 
-  test('hydrates the v2 endpoint from its dedicated localStorage key', async () => {
-    window.localStorage.setItem(
-      V2_KEY,
-      'https://override.example.com/v2/graphql'
-    );
+  test('hydrates the endpoint from its localStorage key', async () => {
+    window.localStorage.setItem(KEY, 'https://override.example.com/v2/graphql');
 
     render(
       <SettingsProvider>
@@ -138,13 +128,18 @@ describe('SettingsContext v2 GraphQL endpoint', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('v2').textContent).toBe(
+      expect(screen.getByTestId('endpoint').textContent).toBe(
         'https://override.example.com/v2/graphql'
       );
     });
   });
 
-  test('setter persists under the v2 key and leaves the v1 key untouched', async () => {
+  test('migrates from the legacy v2 key when the new key is absent', async () => {
+    window.localStorage.setItem(
+      LEGACY_KEY,
+      'https://api.predict.meridian.xyz/graphql'
+    );
+
     render(
       <SettingsProvider>
         <Probe />
@@ -152,7 +147,26 @@ describe('SettingsContext v2 GraphQL endpoint', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('v2').textContent).not.toBe('');
+      expect(screen.getByTestId('endpoint').textContent).toBe(
+        'https://api.predict.meridian.xyz/graphql'
+      );
+    });
+  });
+
+  test('setter persists under the key and clears the legacy key', async () => {
+    window.localStorage.setItem(
+      LEGACY_KEY,
+      'https://api.predict.meridian.xyz/graphql'
+    );
+
+    render(
+      <SettingsProvider>
+        <Probe />
+      </SettingsProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('endpoint').textContent).not.toBe('');
     });
 
     act(() => {
@@ -160,22 +174,19 @@ describe('SettingsContext v2 GraphQL endpoint', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId('v2').textContent).toBe(
+      expect(screen.getByTestId('endpoint').textContent).toBe(
         'https://staging.example.com/v2/graphql'
       );
     });
-    expect(window.localStorage.getItem(V2_KEY)).toBe(
+    expect(window.localStorage.getItem(KEY)).toBe(
       'https://staging.example.com/v2/graphql'
     );
-    // Writing v2 must not write the v1 override key.
-    expect(window.localStorage.getItem(V1_KEY)).toBeNull();
+    // The legacy key must be removed so a stale value can't resurface.
+    expect(window.localStorage.getItem(LEGACY_KEY)).toBeNull();
   });
 
-  test('clearing the v2 override removes the key and falls back to the default', async () => {
-    window.localStorage.setItem(
-      V2_KEY,
-      'https://override.example.com/v2/graphql'
-    );
+  test('clearing the override removes the key and falls back to the default', async () => {
+    window.localStorage.setItem(KEY, 'https://override.example.com/v2/graphql');
 
     render(
       <SettingsProvider>
@@ -184,7 +195,7 @@ describe('SettingsContext v2 GraphQL endpoint', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('v2').textContent).toBe(
+      expect(screen.getByTestId('endpoint').textContent).toBe(
         'https://override.example.com/v2/graphql'
       );
     });
@@ -194,9 +205,11 @@ describe('SettingsContext v2 GraphQL endpoint', () => {
     });
 
     await waitFor(() => {
-      expect(window.localStorage.getItem(V2_KEY)).toBeNull();
+      expect(window.localStorage.getItem(KEY)).toBeNull();
     });
-    expect(screen.getByTestId('v2').textContent).toMatch(/\/v2\/graphql$/);
+    expect(screen.getByTestId('endpoint').textContent).toMatch(
+      /\/v2\/graphql$/
+    );
   });
 });
 

--- a/packages/app/src/lib/context/SettingsContext.tsx
+++ b/packages/app/src/lib/context/SettingsContext.tsx
@@ -19,9 +19,8 @@ import {
 } from 'react';
 
 type SettingsContextValue = {
-  graphqlEndpoint: string | null;
   /** GraphQL endpoint used by the app. The full path is stored as configured. */
-  graphqlEndpointV2: string | null;
+  graphqlEndpoint: string | null;
   /**
    * Auction relayer base URL (stored as http(s) and typically includes the `/auction` path).
    * This is used to construct the auction WebSocket URL via `toAuctionWsUrl(...)`.
@@ -45,7 +44,6 @@ type SettingsContextValue = {
   meshMaxPeers: number | null;
   meshFanout: number | null;
   setGraphqlEndpoint: (value: string | null) => void;
-  setGraphqlEndpointV2: (value: string | null) => void;
   setApiBaseUrl: (value: string | null) => void;
   setChatBaseUrl: (value: string | null) => void;
   setAdminBaseUrl: (value: string | null) => void;
@@ -73,7 +71,6 @@ type SettingsContextValue = {
   setMeshFanout: (value: number | null) => void;
   defaults: {
     graphqlEndpoint: string;
-    graphqlEndpointV2: string;
     apiBaseUrl: string;
     chatBaseUrl: string;
     adminBaseUrl: string;
@@ -89,7 +86,8 @@ type SettingsContextValue = {
 
 const STORAGE_KEYS = {
   graphql: 'sapience.settings.graphqlEndpoint',
-  graphqlV2: 'sapience.settings.graphqlEndpointV2',
+  // Legacy key, read once for migration into `graphql` then removed on save.
+  legacyGraphqlV2: 'sapience.settings.graphqlEndpointV2',
   api: 'sapience.settings.apiBaseUrl',
   chat: 'sapience.settings.chatBaseUrl',
   admin: 'sapience.settings.adminBaseUrl',
@@ -160,19 +158,9 @@ function getDefaultRelayerBase(): string {
   }
 }
 
+// Default app GraphQL endpoint. Sapience serves the schema at `/v2/graphql`;
+// Meridian exposes the same schema at `/graphql` and overrides the full URL.
 function getDefaultGraphqlEndpoint(): string {
-  const baseUrl =
-    process.env.NEXT_PUBLIC_FOIL_API_URL || 'https://api.sapience.xyz';
-  try {
-    const u = new URL(baseUrl);
-    return `${u.origin}/graphql`;
-  } catch {
-    return 'https://api.sapience.xyz/graphql';
-  }
-}
-
-// Default app GraphQL endpoint for Sapience deployments.
-function getDefaultGraphqlEndpointV2(): string {
   const baseUrl =
     process.env.NEXT_PUBLIC_FOIL_API_URL || 'https://api.sapience.xyz';
   try {
@@ -233,9 +221,6 @@ export const SettingsProvider = ({
   children: React.ReactNode;
 }) => {
   const [graphqlOverride, setGraphqlOverride] = useState<string | null>(null);
-  const [graphqlV2Override, setGraphqlV2Override] = useState<string | null>(
-    null
-  );
   const [apiBaseOverride, setApiBaseOverride] = useState<string | null>(null);
   const [chatBaseOverride, setChatBaseOverride] = useState<string | null>(null);
   const [adminBaseOverride, setAdminBaseOverride] = useState<string | null>(
@@ -276,9 +261,10 @@ export const SettingsProvider = ({
         typeof window !== 'undefined'
           ? window.localStorage.getItem(STORAGE_KEYS.graphql)
           : null;
-      const gV2 =
+      // Migration: older sessions stored the endpoint under the legacy v2 key.
+      const gLegacy =
         typeof window !== 'undefined'
-          ? window.localStorage.getItem(STORAGE_KEYS.graphqlV2)
+          ? window.localStorage.getItem(STORAGE_KEYS.legacyGraphqlV2)
           : null;
       const a =
         typeof window !== 'undefined'
@@ -304,8 +290,8 @@ export const SettingsProvider = ({
         typeof window !== 'undefined'
           ? window.localStorage.getItem(STORAGE_KEYS.connectionDurationHours)
           : null;
-      if (g && isHttpUrl(g)) setGraphqlOverride(g);
-      if (gV2 && isHttpUrl(gV2)) setGraphqlV2Override(gV2);
+      const gResolved = g && isHttpUrl(g) ? g : gLegacy;
+      if (gResolved && isHttpUrl(gResolved)) setGraphqlOverride(gResolved);
       if (a && isHttpUrl(a))
         setApiBaseOverride(normalizeBaseUrlPreservePath(a));
       if (c !== null && c.trim() === '') {
@@ -384,7 +370,6 @@ export const SettingsProvider = ({
   const defaults = useMemo(
     () => ({
       graphqlEndpoint: getDefaultGraphqlEndpoint(),
-      graphqlEndpointV2: getDefaultGraphqlEndpointV2(),
       apiBaseUrl: getDefaultRelayerBase(),
       signalEndpoint: getDefaultSignalEndpoint(),
       chatBaseUrl: getDefaultChatBase(),
@@ -419,9 +404,6 @@ export const SettingsProvider = ({
 
   const graphqlEndpoint = mounted
     ? graphqlOverride || defaults.graphqlEndpoint
-    : null;
-  const graphqlEndpointV2 = mounted
-    ? graphqlV2Override || defaults.graphqlEndpointV2
     : null;
   const apiBaseUrl = mounted ? apiBaseOverride || defaults.apiBaseUrl : null;
   const signalEndpoint = mounted
@@ -465,6 +447,8 @@ export const SettingsProvider = ({
   const setGraphqlEndpoint = useCallback((value: string | null) => {
     try {
       if (typeof window === 'undefined') return;
+      // Always clear the legacy v2 key so a stale value can't resurface.
+      window.localStorage.removeItem(STORAGE_KEYS.legacyGraphqlV2);
       if (!value) {
         window.localStorage.removeItem(STORAGE_KEYS.graphql);
         setGraphqlOverride(null);
@@ -474,23 +458,6 @@ export const SettingsProvider = ({
       if (!isHttpUrl(v)) return;
       window.localStorage.setItem(STORAGE_KEYS.graphql, v);
       setGraphqlOverride(v);
-    } catch {
-      /* noop */
-    }
-  }, []);
-
-  const setGraphqlEndpointV2 = useCallback((value: string | null) => {
-    try {
-      if (typeof window === 'undefined') return;
-      if (!value) {
-        window.localStorage.removeItem(STORAGE_KEYS.graphqlV2);
-        setGraphqlV2Override(null);
-        return;
-      }
-      const v = value.trim();
-      if (!isHttpUrl(v)) return;
-      window.localStorage.setItem(STORAGE_KEYS.graphqlV2, v);
-      setGraphqlV2Override(v);
     } catch {
       /* noop */
     }
@@ -749,7 +716,6 @@ export const SettingsProvider = ({
 
   const value: SettingsContextValue = {
     graphqlEndpoint,
-    graphqlEndpointV2,
     apiBaseUrl,
     signalEndpoint,
     chatBaseUrl,
@@ -763,7 +729,6 @@ export const SettingsProvider = ({
     meshMaxPeers,
     meshFanout,
     setGraphqlEndpoint,
-    setGraphqlEndpointV2,
     setApiBaseUrl,
     setSignalEndpoint,
     setChatBaseUrl,

--- a/packages/app/src/lib/context/__tests__/CreatePositionContext.test.tsx
+++ b/packages/app/src/lib/context/__tests__/CreatePositionContext.test.tsx
@@ -59,7 +59,7 @@ function makeSelection(overrides: Record<string, unknown> = {}) {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('CreatePositionContext — settled-condition pruning (v2 contract)', () => {
+describe('CreatePositionContext — settled-condition pruning (GraphQL contract)', () => {
   const STORAGE_KEY_SELECTIONS = 'sapience:position-selections';
 
   function seedSelections(conditionIds: string[]) {
@@ -79,7 +79,7 @@ describe('CreatePositionContext — settled-condition pruning (v2 contract)', ()
     mockFetchConditionsByIds.mockResolvedValue([]);
   });
 
-  it('rehydrates with a v2 conditions-by-ids document', async () => {
+  it('rehydrates with a GraphQL conditions-by-ids document', async () => {
     seedSelections(['0xaaa', '0xbbb']);
 
     renderHook(() => useCreatePositionContext(), { wrapper });
@@ -87,8 +87,8 @@ describe('CreatePositionContext — settled-condition pruning (v2 contract)', ()
     await waitFor(() => expect(mockFetchConditionsByIds).toHaveBeenCalled());
     const [query, ids] = mockFetchConditionsByIds.mock.calls[0];
 
-    // v2 contract: $ids variable, conditionIds filter, hash aliased onto id,
-    // connection nodes, explicit orderBy. No v1 vocabulary.
+    // GraphQL contract: $ids variable, conditionIds filter, hash aliased onto id,
+    // connection nodes, explicit orderBy. No legacy vocabulary.
     expect(query).toContain('$ids: [Bytes!]!');
     expect(query).toContain('filter: { conditionIds: $ids }');
     expect(query).toContain('id: conditionId');

--- a/packages/app/src/lib/data/forecasts.test.ts
+++ b/packages/app/src/lib/data/forecasts.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
   process.env = { ...ORIGINAL_ENV };
 });
 
-function v2Forecast(overrides: Record<string, unknown> = {}) {
+function makeForecast(overrides: Record<string, unknown> = {}) {
   return {
     uid: '0xabc123',
     attester: '0x1234567890abcdef1234567890abcdef12345678',
@@ -26,7 +26,7 @@ function v2Forecast(overrides: Record<string, unknown> = {}) {
     comment: 'I think yes',
     conditionId: '0xcond1',
     condition: {
-      id: '0xcond1', // aliased from conditionId in the v2 document
+      id: '0xcond1', // aliased from conditionId in the GraphQL document
       question: 'Will it happen?',
       shortName: 'It happens',
       endTime: 1800000000,
@@ -47,8 +47,8 @@ function okResponse(forecast: unknown) {
   };
 }
 
-describe('FORECAST_BY_UID_QUERY (v2 document)', () => {
-  test('targets the v2 forecast(uid:) lookup, not v1 attestations', async () => {
+describe('FORECAST_BY_UID_QUERY (GraphQL document)', () => {
+  test('targets the forecast(uid:) lookup, not the old attestations query', async () => {
     const { FORECAST_BY_UID_QUERY } = await import('./forecasts');
     expect(FORECAST_BY_UID_QUERY).toContain('forecast(uid: $uid)');
     expect(FORECAST_BY_UID_QUERY).not.toContain('attestations(');
@@ -56,7 +56,7 @@ describe('FORECAST_BY_UID_QUERY (v2 document)', () => {
     expect(FORECAST_BY_UID_QUERY).not.toContain('prediction');
   });
 
-  test('selects v2 field names and re-keys condition id to the hash', async () => {
+  test('selects the GraphQL field names and re-keys condition id to the hash', async () => {
     const { FORECAST_BY_UID_QUERY } = await import('./forecasts');
     expect(FORECAST_BY_UID_QUERY).toContain('attestedAt');
     expect(FORECAST_BY_UID_QUERY).toContain('value');
@@ -66,8 +66,8 @@ describe('FORECAST_BY_UID_QUERY (v2 document)', () => {
 });
 
 describe('fetchAttestationByUid', () => {
-  test('POSTs to the v2 endpoint with the uid variable', async () => {
-    mockFetch.mockResolvedValue(okResponse(v2Forecast()));
+  test('POSTs to the GraphQL endpoint with the uid variable', async () => {
+    mockFetch.mockResolvedValue(okResponse(makeForecast()));
     const { fetchAttestationByUid } = await import('./forecasts');
 
     await fetchAttestationByUid('0xabc123');
@@ -80,14 +80,14 @@ describe('fetchAttestationByUid', () => {
     expect(body.variables).toEqual({ uid: '0xabc123' });
   });
 
-  test('maps the v2 node onto the stable AttestationData shape', async () => {
-    mockFetch.mockResolvedValue(okResponse(v2Forecast()));
+  test('maps the GraphQL node onto the stable AttestationData shape', async () => {
+    mockFetch.mockResolvedValue(okResponse(makeForecast()));
     const { fetchAttestationByUid } = await import('./forecasts');
 
     const result = await fetchAttestationByUid('0xabc123');
 
     expect(result).not.toBeNull();
-    // v1 renames undone for consumers: attestedAt -> time, value -> prediction
+    // GraphQL renames undone for consumers: attestedAt -> time, value -> prediction
     expect(result?.time).toBe(1700000000);
     expect(result?.prediction).toBe('750000000000000000');
     expect(result?.uid).toBe('0xabc123');
@@ -99,7 +99,7 @@ describe('fetchAttestationByUid', () => {
     expect(result?.condition?.question).toBe('Will it happen?');
     expect(result?.condition?.endTime).toBe(1800000000);
     expect(result?.condition?.resolver).toBe('0xresolver');
-    // no numeric attestation row id on the v2 shape
+    // no numeric attestation row id on the GraphQL shape
     expect(result).not.toHaveProperty('id');
   });
 
@@ -117,7 +117,7 @@ describe('fetchAttestationByUid', () => {
 
   test('preserves a null condition relation', async () => {
     mockFetch.mockResolvedValue(
-      okResponse(v2Forecast({ condition: null, conditionId: null }))
+      okResponse(makeForecast({ condition: null, conditionId: null }))
     );
     const { fetchAttestationByUid } = await import('./forecasts');
     const result = await fetchAttestationByUid('0xabc123');

--- a/packages/app/src/lib/data/forecasts.ts
+++ b/packages/app/src/lib/data/forecasts.ts
@@ -1,7 +1,7 @@
 // Forecast data types, queries, and fetch helpers.
 // Shared across SSR pages, client components, and OG image routes.
 
-import { getGraphQLEndpointV2 } from './graphql';
+import { getGraphQLEndpoint } from './graphql';
 
 // v2 document — untagged so graphql-eslint (v1 schema) skips it.
 // `forecast(uid:)` is the v2 lookup for an EAS forecast attestation; the
@@ -95,7 +95,7 @@ export function d18ToPercentage(d18Value: string): number {
 export async function fetchAttestationByUid(
   uid: string
 ): Promise<AttestationData | null> {
-  const endpoint = getGraphQLEndpointV2();
+  const endpoint = getGraphQLEndpoint();
   const resp = await fetch(endpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/packages/app/src/lib/data/forecasts.ts
+++ b/packages/app/src/lib/data/forecasts.ts
@@ -3,10 +3,10 @@
 
 import { getGraphQLEndpoint } from './graphql';
 
-// v2 document — untagged so graphql-eslint (v1 schema) skips it.
-// `forecast(uid:)` is the v2 lookup for an EAS forecast attestation; the
+// Untagged so graphql-eslint skips it.
+// `forecast(uid:)` is the GraphQL lookup for an EAS forecast attestation; the
 // condition relation re-keys `id` to the on-chain conditionId hash (numeric
-// Prisma row ids are not exposed in v2).
+// Prisma row ids are not exposed by the schema).
 export const FORECAST_BY_UID_QUERY = `
   query ForecastByUid($uid: String!) {
     forecast(uid: $uid) {
@@ -47,7 +47,7 @@ export interface AttestationCondition {
 }
 
 // Stable consumer shape (/forecast/<uid> SSR + OG route). Field names keep
-// the v1 vocabulary (`time`, `prediction`) — the v2 renames are undone in
+// the original vocabulary (`time`, `prediction`) — the GraphQL renames are undone in
 // `toAttestationData` so consumers stay unchanged. The numeric attestation
 // row id is gone; `uid` is the public domain id.
 export interface AttestationData {
@@ -60,7 +60,7 @@ export interface AttestationData {
   condition?: AttestationCondition | null;
 }
 
-/** Wire shape of the v2 `forecast(uid:)` node selected above. */
+/** Wire shape of the GraphQL `forecast(uid:)` node selected above. */
 interface ForecastByUidNode {
   uid: string;
   attester: string;
@@ -89,7 +89,7 @@ export function d18ToPercentage(d18Value: string): number {
   return Number(value) / 1e18;
 }
 
-// Fetch a forecast attestation by uid from the v2 GraphQL API.
+// Fetch a forecast attestation by uid from the GraphQL API.
 // Returns null if the forecast doesn't exist.
 // Throws on network/parse errors so callers can distinguish failure from not-found.
 export async function fetchAttestationByUid(

--- a/packages/app/src/lib/data/graphql.test.ts
+++ b/packages/app/src/lib/data/graphql.test.ts
@@ -11,36 +11,28 @@ afterEach(() => {
   process.env = { ...ORIGINAL_ENV };
 });
 
-describe('getGraphQLEndpoint (v1) stays on /graphql', () => {
-  test('derives /graphql from the API base URL', async () => {
-    process.env.NEXT_PUBLIC_FOIL_API_URL = 'https://api.example.com';
-    const { getGraphQLEndpoint } = await import('./graphql');
-    expect(getGraphQLEndpoint()).toBe('https://api.example.com/graphql');
-  });
-});
-
-describe('getGraphQLEndpointV2', () => {
+describe('getGraphQLEndpoint', () => {
   test('derives /v2/graphql from the API base URL', async () => {
     process.env.NEXT_PUBLIC_FOIL_API_URL = 'https://api.example.com';
-    const { getGraphQLEndpointV2 } = await import('./graphql');
-    expect(getGraphQLEndpointV2()).toBe('https://api.example.com/v2/graphql');
+    const { getGraphQLEndpoint } = await import('./graphql');
+    expect(getGraphQLEndpoint()).toBe('https://api.example.com/v2/graphql');
   });
 
-  test('falls back to the production v2 endpoint when base URL is unset', async () => {
+  test('falls back to the production endpoint when base URL is unset', async () => {
     delete process.env.NEXT_PUBLIC_FOIL_API_URL;
-    const { getGraphQLEndpointV2 } = await import('./graphql');
-    expect(getGraphQLEndpointV2()).toBe('https://api.sapience.xyz/v2/graphql');
+    const { getGraphQLEndpoint } = await import('./graphql');
+    expect(getGraphQLEndpoint()).toBe('https://api.sapience.xyz/v2/graphql');
   });
 
   test('keeps only origin + /v2/graphql, dropping any base path', async () => {
     process.env.NEXT_PUBLIC_FOIL_API_URL = 'https://api.example.com/nested';
-    const { getGraphQLEndpointV2 } = await import('./graphql');
-    expect(getGraphQLEndpointV2()).toBe('https://api.example.com/v2/graphql');
+    const { getGraphQLEndpoint } = await import('./graphql');
+    expect(getGraphQLEndpoint()).toBe('https://api.example.com/v2/graphql');
   });
 
-  test('falls back to production v2 endpoint for an unparseable base URL', async () => {
+  test('falls back to the production endpoint for an unparseable base URL', async () => {
     process.env.NEXT_PUBLIC_FOIL_API_URL = 'not a url';
-    const { getGraphQLEndpointV2 } = await import('./graphql');
-    expect(getGraphQLEndpointV2()).toBe('https://api.sapience.xyz/v2/graphql');
+    const { getGraphQLEndpoint } = await import('./graphql');
+    expect(getGraphQLEndpoint()).toBe('https://api.sapience.xyz/v2/graphql');
   });
 });

--- a/packages/app/src/lib/data/graphql.test.ts
+++ b/packages/app/src/lib/data/graphql.test.ts
@@ -9,6 +9,7 @@ beforeEach(() => {
 
 afterEach(() => {
   process.env = { ...ORIGINAL_ENV };
+  vi.unstubAllGlobals();
 });
 
 describe('getGraphQLEndpoint', () => {
@@ -34,5 +35,21 @@ describe('getGraphQLEndpoint', () => {
     process.env.NEXT_PUBLIC_FOIL_API_URL = 'not a url';
     const { getGraphQLEndpoint } = await import('./graphql');
     expect(getGraphQLEndpoint()).toBe('https://api.sapience.xyz/v2/graphql');
+  });
+
+  test('prefers the Settings override in localStorage when running in the browser', async () => {
+    process.env.NEXT_PUBLIC_FOIL_API_URL = 'https://api.example.com';
+    const store: Record<string, string> = {
+      'sapience.settings.graphqlEndpoint':
+        'https://api.predict.meridian.xyz/graphql',
+    };
+    vi.stubGlobal('window', {
+      localStorage: { getItem: (key: string) => store[key] ?? null },
+    });
+
+    const { getGraphQLEndpoint } = await import('./graphql');
+    expect(getGraphQLEndpoint()).toBe(
+      'https://api.predict.meridian.xyz/graphql'
+    );
   });
 });

--- a/packages/app/src/lib/data/graphql.ts
+++ b/packages/app/src/lib/data/graphql.ts
@@ -1,9 +1,21 @@
-// Shared GraphQL endpoint resolution (server/OG contexts). Sapience serves the
-// schema at `/v2/graphql`; Meridian exposes the same schema at `/graphql`. This
-// env-only resolver returns the default endpoint; client code reads any user
-// override via the SDK's `getGraphQLEndpoint`.
+// Shared GraphQL endpoint resolution. Sapience serves the schema at
+// `/v2/graphql`; Meridian exposes the same schema at `/graphql`.
+
+const GRAPHQL_ENDPOINT_KEY = 'sapience.settings.graphqlEndpoint';
+const LEGACY_GRAPHQL_ENDPOINT_KEY = 'sapience.settings.graphqlEndpointV2';
 
 export function getGraphQLEndpoint(): string {
+  try {
+    if (typeof window !== 'undefined') {
+      const override =
+        window.localStorage.getItem(GRAPHQL_ENDPOINT_KEY) ??
+        window.localStorage.getItem(LEGACY_GRAPHQL_ENDPOINT_KEY);
+      if (override) return override;
+    }
+  } catch {
+    /* noop */
+  }
+
   const baseUrl =
     process.env.NEXT_PUBLIC_FOIL_API_URL || 'https://api.sapience.xyz';
   try {

--- a/packages/app/src/lib/data/graphql.ts
+++ b/packages/app/src/lib/data/graphql.ts
@@ -1,18 +1,9 @@
-// Shared GraphQL endpoint resolution
+// Shared GraphQL endpoint resolution (server/OG contexts). Sapience serves the
+// schema at `/v2/graphql`; Meridian exposes the same schema at `/graphql`. This
+// env-only resolver returns the default endpoint; client code reads any user
+// override via the SDK's `getGraphQLEndpoint`.
 
 export function getGraphQLEndpoint(): string {
-  const baseUrl =
-    process.env.NEXT_PUBLIC_FOIL_API_URL || 'https://api.sapience.xyz';
-  try {
-    const u = new URL(baseUrl);
-    return `${u.origin}/graphql`;
-  } catch {
-    return 'https://api.sapience.xyz/graphql';
-  }
-}
-
-// v2 transport: same origin resolution as v1, but targets `/v2/graphql`.
-export function getGraphQLEndpointV2(): string {
   const baseUrl =
     process.env.NEXT_PUBLIC_FOIL_API_URL || 'https://api.sapience.xyz';
   try {

--- a/packages/app/src/lib/data/predictions.test.ts
+++ b/packages/app/src/lib/data/predictions.test.ts
@@ -47,8 +47,8 @@ function makePredictionNode(overrides: Record<string, unknown> = {}) {
   };
 }
 
-describe('PREDICTION_BY_ID_QUERY (v2)', () => {
-  it('looks up by predictionId with v2 field names', () => {
+describe('PREDICTION_BY_ID_QUERY (GraphQL)', () => {
+  it('looks up by predictionId with the GraphQL field names', () => {
     expect(PREDICTION_BY_ID_QUERY).toContain(
       'prediction(predictionId: $predictionId)'
     );
@@ -61,7 +61,7 @@ describe('PREDICTION_BY_ID_QUERY (v2)', () => {
 });
 
 describe('toPredictionData', () => {
-  it('maps the v2 node to the SSR PredictionData shape', () => {
+  it('maps the GraphQL node to the SSR PredictionData shape', () => {
     const mapped = toPredictionData(
       makePredictionNode() as Parameters<typeof toPredictionData>[0]
     );
@@ -105,7 +105,7 @@ describe('fetchPredictionWithConditions', () => {
     vi.unstubAllGlobals();
   });
 
-  it('posts both legs to the v2 endpoint and maps the prediction', async () => {
+  it('posts both legs to the GraphQL endpoint and maps the prediction', async () => {
     fetchMock
       .mockResolvedValueOnce({
         ok: true,

--- a/packages/app/src/lib/data/predictions.ts
+++ b/packages/app/src/lib/data/predictions.ts
@@ -4,10 +4,10 @@
 import { getGraphQLEndpoint } from './graphql';
 import {
   toPickConfigData,
-  type PickConfigurationV2Node,
+  type PickConfigurationNode,
 } from '~/lib/adapters/pickConfig';
 
-// v2 document — runs against the /v2/graphql endpoint. Variables:
+// GraphQL document — runs against the /v2/graphql endpoint. Variables:
 // { predictionId }. The pickConfig carries the full scalar set (mapped via
 // the shared adapter) but slim picks: condition metadata comes from the
 // separate CONDITIONS_BY_IDS_QUERY leg, so the heavy embed is skipped.
@@ -52,7 +52,7 @@ export const PREDICTION_BY_ID_QUERY = `
   }
 `;
 
-// v2 document — runs against the /v2/graphql endpoint. Variables: { ids }.
+// GraphQL document — runs against the /v2/graphql endpoint. Variables: { ids }.
 // `id: conditionId` keeps the CTF hash under the stable `id` name.
 export const CONDITIONS_BY_IDS_QUERY = `
   query ConditionsByIds($ids: [Bytes!]!) {
@@ -77,8 +77,8 @@ export const CONDITIONS_BY_IDS_QUERY = `
 `;
 
 export interface PredictionPick {
-  /** Re-keyed stable string `${pickConfigId}:${conditionId}` — v2 drops the
-   *  numeric Prisma row id. */
+  /** Re-keyed stable string `${pickConfigId}:${conditionId}` — the GraphQL schema
+   *  has no numeric Prisma row id. */
   id: string;
   conditionResolver: string;
   conditionId: string;
@@ -113,9 +113,9 @@ export interface PredictionData {
   pickConfig?: PredictionPickConfig | null;
 }
 
-/** v2 wire shape of the PREDICTION_BY_ID_QUERY node (BigInt scalars may
+/** GraphQL wire shape of the PREDICTION_BY_ID_QUERY node (BigInt scalars may
  *  arrive as numbers). */
-export type PredictionByIdV2Node = {
+export type PredictionByIdNode = {
   predictionId: string;
   chainId: number;
   escrow: string;
@@ -129,19 +129,19 @@ export type PredictionByIdV2Node = {
   settledAt?: number | null;
   result: 'PREDICTOR_WINS' | 'COUNTERPARTY_WINS' | 'NON_DECISIVE' | null;
   createdAt: string;
-  pickConfig?: PickConfigurationV2Node | null;
+  pickConfig?: PickConfigurationNode | null;
 };
 
 /**
- * Pure mapper: v2 Prediction node → SSR `PredictionData`.
+ * Pure mapper: GraphQL Prediction node → SSR `PredictionData`.
  *
  * - `marketAddress` := `escrow`
- * - `result` := `result ?? 'UNRESOLVED'` (v2 result is nullable)
+ * - `result` := `result ?? 'UNRESOLVED'` (the GraphQL result is nullable)
  * - BigInt scalars normalized via `String()`
  * - `pickConfig` via the shared adapter (escrow → marketAddress,
  *   resolver → conditionResolver, YES/NO → 1/0)
  */
-export function toPredictionData(node: PredictionByIdV2Node): PredictionData {
+export function toPredictionData(node: PredictionByIdNode): PredictionData {
   return {
     predictionId: node.predictionId,
     chainId: node.chainId,
@@ -191,7 +191,7 @@ export async function fetchPredictionWithConditions(
   });
   if (!resp.ok) return { prediction: null, conditions: [] };
   const json = await resp.json();
-  const node: PredictionByIdV2Node | null = json?.data?.prediction ?? null;
+  const node: PredictionByIdNode | null = json?.data?.prediction ?? null;
   if (!node) return { prediction: null, conditions: [] };
   const prediction = toPredictionData(node);
 

--- a/packages/app/src/lib/data/predictions.ts
+++ b/packages/app/src/lib/data/predictions.ts
@@ -1,7 +1,7 @@
 // Prediction data types, queries, and fetch helpers.
 // Shared across SSR pages, client components, and OG image routes.
 
-import { getGraphQLEndpointV2 } from './graphql';
+import { getGraphQLEndpoint } from './graphql';
 import {
   toPickConfigData,
   type PickConfigurationV2Node,
@@ -181,7 +181,7 @@ export async function fetchPredictionWithConditions(
   prediction: PredictionData | null;
   conditions: (ConditionData & { id: string })[];
 }> {
-  const resp = await fetch(getGraphQLEndpointV2(), {
+  const resp = await fetch(getGraphQLEndpoint(), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -201,7 +201,7 @@ export async function fetchPredictionWithConditions(
 
   let conditions: (ConditionData & { id: string })[] = [];
   try {
-    const condResp = await fetch(getGraphQLEndpointV2(), {
+    const condResp = await fetch(getGraphQLEndpoint(), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/packages/sdk/queries/__tests__/categories.test.ts
+++ b/packages/sdk/queries/__tests__/categories.test.ts
@@ -11,7 +11,7 @@ beforeEach(() => {
 });
 
 describe('fetchCategories', () => {
-  test('queries the v2 categories connection ordered by name', () => {
+  test('queries the categories connection ordered by name', () => {
     expect(GET_CATEGORIES).toContain(
       'categories(first: 100, orderBy: { field: NAME, direction: ASC })'
     );

--- a/packages/sdk/queries/__tests__/categories.test.ts
+++ b/packages/sdk/queries/__tests__/categories.test.ts
@@ -1,9 +1,9 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { fetchCategories, GET_CATEGORIES } from '../categories';
 
-const mockGraphqlRequestV2 = vi.fn();
+const mockGraphqlRequest = vi.fn();
 vi.mock('../client/graphqlClient', () => ({
-  graphqlRequestV2: (...args: unknown[]) => mockGraphqlRequestV2(...args),
+  graphqlRequest: (...args: unknown[]) => mockGraphqlRequest(...args),
 }));
 
 beforeEach(() => {
@@ -22,7 +22,7 @@ describe('fetchCategories', () => {
   });
 
   test('unwraps connection nodes into id-less categories', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       categories: {
         nodes: [
           { name: 'Crypto', slug: 'crypto' },
@@ -36,11 +36,11 @@ describe('fetchCategories', () => {
       { name: 'Crypto', slug: 'crypto' },
       { name: 'Politics', slug: 'politics' },
     ]);
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(GET_CATEGORIES);
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(GET_CATEGORIES);
   });
 
   test('drops extra node fields so consumers cannot key on row ids', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       categories: {
         nodes: [{ id: 7, name: 'Crypto', slug: 'crypto', createdAt: 'x' }],
       },
@@ -52,21 +52,21 @@ describe('fetchCategories', () => {
   });
 
   test('throws on null response', async () => {
-    mockGraphqlRequestV2.mockResolvedValue(null);
+    mockGraphqlRequest.mockResolvedValue(null);
     await expect(fetchCategories()).rejects.toThrow(
       'Failed to fetch categories: Invalid response structure'
     );
   });
 
   test('throws when categories connection is missing', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({});
+    mockGraphqlRequest.mockResolvedValue({});
     await expect(fetchCategories()).rejects.toThrow(
       'Failed to fetch categories: Invalid response structure'
     );
   });
 
   test('throws when nodes is not an array', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       categories: { nodes: 'not-an-array' },
     });
     await expect(fetchCategories()).rejects.toThrow(
@@ -75,7 +75,7 @@ describe('fetchCategories', () => {
   });
 
   test('returns empty array when connection has no nodes', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({ categories: { nodes: [] } });
+    mockGraphqlRequest.mockResolvedValue({ categories: { nodes: [] } });
     const result = await fetchCategories();
     expect(result).toEqual([]);
   });

--- a/packages/sdk/queries/__tests__/conditionGroups.test.ts
+++ b/packages/sdk/queries/__tests__/conditionGroups.test.ts
@@ -6,8 +6,8 @@ vi.mock('../client/graphqlClient', () => ({
   graphqlRequest: (...args: unknown[]) => mockGraphqlRequest(...args),
 }));
 
-/** A v2 conditionGroups node with one public + one private condition. */
-const v2GroupNode = (overrides: Record<string, unknown> = {}) => ({
+/** A conditionGroups node with one public + one private condition. */
+const makeGroup = (overrides: Record<string, unknown> = {}) => ({
   id: 'cg-opaque-1',
   createdAt: '2026-01-02T00:00:00.000Z',
   name: 'Super Bowl winner',
@@ -67,11 +67,11 @@ beforeEach(() => {
 });
 
 // ============================================================================
-// GET_CONDITION_GROUPS document (v2)
+// GET_CONDITION_GROUPS document
 // ============================================================================
 
-describe('GET_CONDITION_GROUPS v2 document', () => {
-  test('orders explicitly by CREATED_AT DESC (v2 default is MAX_END_TIME ASC)', () => {
+describe('GET_CONDITION_GROUPS document', () => {
+  test('orders explicitly by CREATED_AT DESC (server default is MAX_END_TIME ASC)', () => {
     expect(GET_CONDITION_GROUPS).toContain(
       'orderBy: { field: CREATED_AT, direction: DESC }'
     );
@@ -82,7 +82,7 @@ describe('GET_CONDITION_GROUPS v2 document', () => {
     expect(GET_CONDITION_GROUPS).toContain('nodes');
   });
 
-  test('does not use v1 vocabulary or dropped fields', () => {
+  test('does not use stale vocabulary or dropped fields', () => {
     expect(GET_CONDITION_GROUPS).not.toContain('$where');
     expect(GET_CONDITION_GROUPS).not.toContain('$conditionsWhere');
     expect(GET_CONDITION_GROUPS).not.toContain('$take');
@@ -124,12 +124,12 @@ describe('fetchConditionGroups', () => {
     );
   });
 
-  test('multiple categorySlugs filter client-side (v2 filter only accepts one slug)', async () => {
+  test('multiple categorySlugs filter client-side (filter only accepts one slug)', async () => {
     mockGraphqlRequest
       .mockResolvedValueOnce({
         conditionGroups: {
           nodes: [
-            v2GroupNode({
+            makeGroup({
               id: 'cg-opaque-0',
               name: 'Crypto',
               category: { name: 'Crypto', slug: 'crypto' },
@@ -141,13 +141,13 @@ describe('fetchConditionGroups', () => {
       .mockResolvedValueOnce({
         conditionGroups: {
           nodes: [
-            v2GroupNode(),
-            v2GroupNode({
+            makeGroup(),
+            makeGroup({
               id: 'cg-opaque-2',
               name: 'Election winner',
               category: { name: 'Politics', slug: 'politics' },
             }),
-            v2GroupNode({
+            makeGroup({
               id: 'cg-opaque-3',
               name: 'Oscars',
               category: { name: 'Culture', slug: 'culture' },
@@ -174,12 +174,12 @@ describe('fetchConditionGroups', () => {
     expect(result.map((g) => g.id)).toEqual(['cg-opaque-1', 'cg-opaque-2']);
   });
 
-  test('uses cursors when take + skip exceeds the v2 page cap', async () => {
+  test('uses cursors when take + skip exceeds the page cap', async () => {
     const firstPage = Array.from({ length: 100 }, (_, i) =>
-      v2GroupNode({ id: `g${i}` })
+      makeGroup({ id: `g${i}` })
     );
     const secondPage = Array.from({ length: 50 }, (_, i) =>
-      v2GroupNode({ id: `g${i + 100}` })
+      makeGroup({ id: `g${i + 100}` })
     );
     mockGraphqlRequest
       .mockResolvedValueOnce({
@@ -214,11 +214,11 @@ describe('fetchConditionGroups', () => {
 
   test('fetches additional nested condition pages for large groups', async () => {
     const firstConditions = Array.from({ length: 100 }, (_, i) => ({
-      ...(v2GroupNode().conditions.nodes[0] as Record<string, unknown>),
+      ...(makeGroup().conditions.nodes[0] as Record<string, unknown>),
       conditionId: `0x${i}`,
     }));
     const secondConditions = Array.from({ length: 20 }, (_, i) => ({
-      ...(v2GroupNode().conditions.nodes[0] as Record<string, unknown>),
+      ...(makeGroup().conditions.nodes[0] as Record<string, unknown>),
       conditionId: `0x${i + 100}`,
     }));
 
@@ -226,7 +226,7 @@ describe('fetchConditionGroups', () => {
       .mockResolvedValueOnce({
         conditionGroups: {
           nodes: [
-            v2GroupNode({
+            makeGroup({
               id: 'big-group',
               conditions: {
                 nodes: firstConditions,
@@ -254,7 +254,7 @@ describe('fetchConditionGroups', () => {
 
   test('maps groups onto the stable shape with opaque string ids', async () => {
     mockGraphqlRequest.mockResolvedValue({
-      conditionGroups: { nodes: [v2GroupNode()] },
+      conditionGroups: { nodes: [makeGroup()] },
     });
     const [group] = await fetchConditionGroups();
     expect(group.id).toBe('cg-opaque-1');
@@ -293,9 +293,9 @@ describe('fetchConditionGroups', () => {
     expect(b.category).toBeNull();
   });
 
-  test('publicOnly filters nested conditions client-side (v2 nested connection has no filter)', async () => {
+  test('publicOnly filters nested conditions client-side (nested connection has no filter)', async () => {
     mockGraphqlRequest.mockResolvedValue({
-      conditionGroups: { nodes: [v2GroupNode()] },
+      conditionGroups: { nodes: [makeGroup()] },
     });
     const [group] = await fetchConditionGroups({
       filters: { publicOnly: true },
@@ -305,7 +305,7 @@ describe('fetchConditionGroups', () => {
 
   test('chainId filters nested conditions client-side', async () => {
     mockGraphqlRequest.mockResolvedValue({
-      conditionGroups: { nodes: [v2GroupNode()] },
+      conditionGroups: { nodes: [makeGroup()] },
     });
     const [group] = await fetchConditionGroups({ chainId: 8453 });
     expect(group.conditions.map((c) => c.id)).toEqual(['0xbbb']);
@@ -315,8 +315,8 @@ describe('fetchConditionGroups', () => {
     mockGraphqlRequest.mockResolvedValue({
       conditionGroups: {
         nodes: [
-          v2GroupNode(),
-          v2GroupNode({ id: 'cg-empty', conditions: { nodes: [] } }),
+          makeGroup(),
+          makeGroup({ id: 'cg-empty', conditions: { nodes: [] } }),
         ],
       },
     });
@@ -327,19 +327,19 @@ describe('fetchConditionGroups', () => {
   test('includeEmptyGroups keeps empty groups when no nested filters apply', async () => {
     mockGraphqlRequest.mockResolvedValue({
       conditionGroups: {
-        nodes: [v2GroupNode({ id: 'cg-empty', conditions: { nodes: [] } })],
+        nodes: [makeGroup({ id: 'cg-empty', conditions: { nodes: [] } })],
       },
     });
     const result = await fetchConditionGroups({ includeEmptyGroups: true });
     expect(result.map((g) => g.id)).toEqual(['cg-empty']);
   });
 
-  test('includeEmptyGroups still requires a match when nested filters apply (v1 parity)', async () => {
+  test('includeEmptyGroups still requires a match when nested filters apply', async () => {
     mockGraphqlRequest.mockResolvedValue({
-      conditionGroups: { nodes: [v2GroupNode()] },
+      conditionGroups: { nodes: [makeGroup()] },
     });
     // chainId 999 matches neither condition → group is dropped even though
-    // includeEmptyGroups is set, mirroring v1's conditions.some semantics.
+    // includeEmptyGroups is set, mirroring conditions.some semantics.
     const result = await fetchConditionGroups({
       chainId: 999,
       includeEmptyGroups: true,
@@ -347,13 +347,13 @@ describe('fetchConditionGroups', () => {
     expect(result).toEqual([]);
   });
 
-  test('emulates v1 skip by over-fetching and slicing', async () => {
+  test('pages the cursor connection then slices to the skip window', async () => {
     mockGraphqlRequest.mockResolvedValue({
       conditionGroups: {
         nodes: [
-          v2GroupNode({ id: 'g1' }),
-          v2GroupNode({ id: 'g2' }),
-          v2GroupNode({ id: 'g3' }),
+          makeGroup({ id: 'g1' }),
+          makeGroup({ id: 'g2' }),
+          makeGroup({ id: 'g3' }),
         ],
       },
     });

--- a/packages/sdk/queries/__tests__/conditionGroups.test.ts
+++ b/packages/sdk/queries/__tests__/conditionGroups.test.ts
@@ -78,7 +78,7 @@ describe('GET_CONDITION_GROUPS v2 document', () => {
   });
 
   test('pages the nested conditions connection explicitly', () => {
-    expect(GET_CONDITION_GROUPS).toContain('conditions(first: 50)');
+    expect(GET_CONDITION_GROUPS).toContain('conditions(first: 100)');
     expect(GET_CONDITION_GROUPS).toContain('nodes');
   });
 
@@ -103,6 +103,7 @@ describe('fetchConditionGroups', () => {
     await fetchConditionGroups();
     expect(mockGraphqlRequest).toHaveBeenCalledWith(GET_CONDITION_GROUPS, {
       first: 100,
+      after: null,
       filter: undefined,
     });
   });
@@ -124,32 +125,131 @@ describe('fetchConditionGroups', () => {
   });
 
   test('multiple categorySlugs filter client-side (v2 filter only accepts one slug)', async () => {
-    mockGraphqlRequest.mockResolvedValue({
-      conditionGroups: {
-        nodes: [
-          v2GroupNode(),
-          v2GroupNode({
-            id: 'cg-opaque-2',
-            name: 'Election winner',
-            category: { name: 'Politics', slug: 'politics' },
-          }),
-          v2GroupNode({
-            id: 'cg-opaque-3',
-            name: 'Oscars',
-            category: { name: 'Culture', slug: 'culture' },
-          }),
-        ],
-      },
-    });
+    mockGraphqlRequest
+      .mockResolvedValueOnce({
+        conditionGroups: {
+          nodes: [
+            v2GroupNode({
+              id: 'cg-opaque-0',
+              name: 'Crypto',
+              category: { name: 'Crypto', slug: 'crypto' },
+            }),
+          ],
+          pageInfo: { hasNextPage: true, endCursor: 'page-1' },
+        },
+      })
+      .mockResolvedValueOnce({
+        conditionGroups: {
+          nodes: [
+            v2GroupNode(),
+            v2GroupNode({
+              id: 'cg-opaque-2',
+              name: 'Election winner',
+              category: { name: 'Politics', slug: 'politics' },
+            }),
+            v2GroupNode({
+              id: 'cg-opaque-3',
+              name: 'Oscars',
+              category: { name: 'Culture', slug: 'culture' },
+            }),
+          ],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      });
     const result = await fetchConditionGroups({
+      take: 2,
       filters: { categorySlugs: ['sports', 'politics'] },
     });
-    // no server-side categorySlug — applied client-side over the page
-    expect(mockGraphqlRequest).toHaveBeenCalledWith(
+    // no server-side categorySlug — applied client-side across cursor pages
+    expect(mockGraphqlRequest).toHaveBeenNthCalledWith(
+      1,
       GET_CONDITION_GROUPS,
-      expect.objectContaining({ filter: undefined })
+      expect.objectContaining({ filter: undefined, after: null })
+    );
+    expect(mockGraphqlRequest).toHaveBeenNthCalledWith(
+      2,
+      GET_CONDITION_GROUPS,
+      expect.objectContaining({ filter: undefined, after: 'page-1' })
     );
     expect(result.map((g) => g.id)).toEqual(['cg-opaque-1', 'cg-opaque-2']);
+  });
+
+  test('uses cursors when take + skip exceeds the v2 page cap', async () => {
+    const firstPage = Array.from({ length: 100 }, (_, i) =>
+      v2GroupNode({ id: `g${i}` })
+    );
+    const secondPage = Array.from({ length: 50 }, (_, i) =>
+      v2GroupNode({ id: `g${i + 100}` })
+    );
+    mockGraphqlRequest
+      .mockResolvedValueOnce({
+        conditionGroups: {
+          nodes: firstPage,
+          pageInfo: { hasNextPage: true, endCursor: 'cursor-100' },
+        },
+      })
+      .mockResolvedValueOnce({
+        conditionGroups: {
+          nodes: secondPage,
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      });
+
+    const result = await fetchConditionGroups({ take: 100, skip: 50 });
+
+    expect(mockGraphqlRequest).toHaveBeenNthCalledWith(
+      1,
+      GET_CONDITION_GROUPS,
+      expect.objectContaining({ first: 100, after: null })
+    );
+    expect(mockGraphqlRequest).toHaveBeenNthCalledWith(
+      2,
+      GET_CONDITION_GROUPS,
+      expect.objectContaining({ first: 50, after: 'cursor-100' })
+    );
+    expect(result).toHaveLength(100);
+    expect(result[0].id).toBe('g50');
+    expect(result[99].id).toBe('g149');
+  });
+
+  test('fetches additional nested condition pages for large groups', async () => {
+    const firstConditions = Array.from({ length: 100 }, (_, i) => ({
+      ...(v2GroupNode().conditions.nodes[0] as Record<string, unknown>),
+      conditionId: `0x${i}`,
+    }));
+    const secondConditions = Array.from({ length: 20 }, (_, i) => ({
+      ...(v2GroupNode().conditions.nodes[0] as Record<string, unknown>),
+      conditionId: `0x${i + 100}`,
+    }));
+
+    mockGraphqlRequest
+      .mockResolvedValueOnce({
+        conditionGroups: {
+          nodes: [
+            v2GroupNode({
+              id: 'big-group',
+              conditions: {
+                nodes: firstConditions,
+                pageInfo: { hasNextPage: true, endCursor: 'cond-100' },
+              },
+            }),
+          ],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      })
+      .mockResolvedValueOnce({
+        conditionGroup: {
+          conditions: {
+            nodes: secondConditions,
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      });
+
+    const [group] = await fetchConditionGroups();
+
+    expect(group.conditions).toHaveLength(120);
+    expect(group.conditions[119].id).toBe('0x119');
   });
 
   test('maps groups onto the stable shape with opaque string ids', async () => {

--- a/packages/sdk/queries/__tests__/conditionGroups.test.ts
+++ b/packages/sdk/queries/__tests__/conditionGroups.test.ts
@@ -1,9 +1,9 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { fetchConditionGroups, GET_CONDITION_GROUPS } from '../conditionGroups';
 
-const mockGraphqlRequestV2 = vi.fn();
+const mockGraphqlRequest = vi.fn();
 vi.mock('../client/graphqlClient', () => ({
-  graphqlRequestV2: (...args: unknown[]) => mockGraphqlRequestV2(...args),
+  graphqlRequest: (...args: unknown[]) => mockGraphqlRequest(...args),
 }));
 
 /** A v2 conditionGroups node with one public + one private condition. */
@@ -63,7 +63,7 @@ const v2GroupNode = (overrides: Record<string, unknown> = {}) => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockGraphqlRequestV2.mockResolvedValue({ conditionGroups: { nodes: [] } });
+  mockGraphqlRequest.mockResolvedValue({ conditionGroups: { nodes: [] } });
 });
 
 // ============================================================================
@@ -101,7 +101,7 @@ describe('GET_CONDITION_GROUPS v2 document', () => {
 describe('fetchConditionGroups', () => {
   test('requests first=take (default 100) with no filter by default', async () => {
     await fetchConditionGroups();
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(GET_CONDITION_GROUPS, {
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(GET_CONDITION_GROUPS, {
       first: 100,
       filter: undefined,
     });
@@ -109,7 +109,7 @@ describe('fetchConditionGroups', () => {
 
   test('search filter passes trimmed search', async () => {
     await fetchConditionGroups({ filters: { search: '  election  ' } });
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(
       GET_CONDITION_GROUPS,
       expect.objectContaining({ filter: { search: 'election' } })
     );
@@ -117,14 +117,14 @@ describe('fetchConditionGroups', () => {
 
   test('single categorySlug is pushed to the server filter', async () => {
     await fetchConditionGroups({ filters: { categorySlugs: ['crypto'] } });
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(
       GET_CONDITION_GROUPS,
       expect.objectContaining({ filter: { categorySlug: 'crypto' } })
     );
   });
 
   test('multiple categorySlugs filter client-side (v2 filter only accepts one slug)', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       conditionGroups: {
         nodes: [
           v2GroupNode(),
@@ -145,7 +145,7 @@ describe('fetchConditionGroups', () => {
       filters: { categorySlugs: ['sports', 'politics'] },
     });
     // no server-side categorySlug — applied client-side over the page
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(
       GET_CONDITION_GROUPS,
       expect.objectContaining({ filter: undefined })
     );
@@ -153,7 +153,7 @@ describe('fetchConditionGroups', () => {
   });
 
   test('maps groups onto the stable shape with opaque string ids', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       conditionGroups: { nodes: [v2GroupNode()] },
     });
     const [group] = await fetchConditionGroups();
@@ -194,7 +194,7 @@ describe('fetchConditionGroups', () => {
   });
 
   test('publicOnly filters nested conditions client-side (v2 nested connection has no filter)', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       conditionGroups: { nodes: [v2GroupNode()] },
     });
     const [group] = await fetchConditionGroups({
@@ -204,7 +204,7 @@ describe('fetchConditionGroups', () => {
   });
 
   test('chainId filters nested conditions client-side', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       conditionGroups: { nodes: [v2GroupNode()] },
     });
     const [group] = await fetchConditionGroups({ chainId: 8453 });
@@ -212,7 +212,7 @@ describe('fetchConditionGroups', () => {
   });
 
   test('drops groups with no matching conditions by default', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       conditionGroups: {
         nodes: [
           v2GroupNode(),
@@ -225,7 +225,7 @@ describe('fetchConditionGroups', () => {
   });
 
   test('includeEmptyGroups keeps empty groups when no nested filters apply', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       conditionGroups: {
         nodes: [v2GroupNode({ id: 'cg-empty', conditions: { nodes: [] } })],
       },
@@ -235,7 +235,7 @@ describe('fetchConditionGroups', () => {
   });
 
   test('includeEmptyGroups still requires a match when nested filters apply (v1 parity)', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       conditionGroups: { nodes: [v2GroupNode()] },
     });
     // chainId 999 matches neither condition → group is dropped even though
@@ -248,7 +248,7 @@ describe('fetchConditionGroups', () => {
   });
 
   test('emulates v1 skip by over-fetching and slicing', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       conditionGroups: {
         nodes: [
           v2GroupNode({ id: 'g1' }),
@@ -258,7 +258,7 @@ describe('fetchConditionGroups', () => {
       },
     });
     const result = await fetchConditionGroups({ take: 1, skip: 1 });
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(
       GET_CONDITION_GROUPS,
       expect.objectContaining({ first: 2 })
     );
@@ -266,11 +266,11 @@ describe('fetchConditionGroups', () => {
   });
 
   test('throws on invalid response structure', async () => {
-    mockGraphqlRequestV2.mockResolvedValue(null);
+    mockGraphqlRequest.mockResolvedValue(null);
     await expect(fetchConditionGroups()).rejects.toThrow(
       'Failed to fetch condition groups: Invalid response structure'
     );
-    mockGraphqlRequestV2.mockResolvedValue({});
+    mockGraphqlRequest.mockResolvedValue({});
     await expect(fetchConditionGroups()).rejects.toThrow(
       'Failed to fetch condition groups: Invalid response structure'
     );

--- a/packages/sdk/queries/__tests__/conditions.test.ts
+++ b/packages/sdk/queries/__tests__/conditions.test.ts
@@ -8,9 +8,9 @@ import {
   CONDITIONS_BY_IDS_QUERY,
 } from '../conditions';
 
-const mockGraphqlRequestV2 = vi.fn();
+const mockGraphqlRequest = vi.fn();
 vi.mock('../client/graphqlClient', () => ({
-  graphqlRequestV2: (...args: unknown[]) => mockGraphqlRequestV2(...args),
+  graphqlRequest: (...args: unknown[]) => mockGraphqlRequest(...args),
 }));
 
 beforeEach(() => {
@@ -221,25 +221,25 @@ describe('buildConditionFilter', () => {
 
 describe('fetchConditions', () => {
   test('requests first=take with the built filter', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({ conditions: { nodes: [] } });
+    mockGraphqlRequest.mockResolvedValue({ conditions: { nodes: [] } });
     await fetchConditions();
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(GET_CONDITIONS, {
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(GET_CONDITIONS, {
       first: 50,
       filter: { public: true },
     });
   });
 
   test('passes chainId into the filter', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({ conditions: { nodes: [] } });
+    mockGraphqlRequest.mockResolvedValue({ conditions: { nodes: [] } });
     await fetchConditions({ chainId: 5064014 });
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(GET_CONDITIONS, {
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(GET_CONDITIONS, {
       first: 50,
       filter: { chainId: 5064014, public: true },
     });
   });
 
   test('maps v2 nodes onto the stable ConditionType shape', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       conditions: { nodes: [v2Node] },
     });
     const [c] = await fetchConditions();
@@ -269,7 +269,7 @@ describe('fetchConditions', () => {
   });
 
   test('coerces openInterest to string and endTime to number', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       conditions: {
         nodes: [{ ...v2Node, openInterest: 12345, endTime: '1767225600' }],
       },
@@ -280,7 +280,7 @@ describe('fetchConditions', () => {
   });
 
   test('null similarMarket/conditionGroup/category map to empty/flat nulls', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       conditions: {
         nodes: [
           {
@@ -305,9 +305,9 @@ describe('fetchConditions', () => {
       ...v2Node,
       conditionId: `0x${i}`,
     }));
-    mockGraphqlRequestV2.mockResolvedValue({ conditions: { nodes } });
+    mockGraphqlRequest.mockResolvedValue({ conditions: { nodes } });
     const result = await fetchConditions({ take: 5, skip: 2 });
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(
       GET_CONDITIONS,
       expect.objectContaining({ first: 7 })
     );
@@ -321,20 +321,20 @@ describe('fetchConditions', () => {
   });
 
   test('clamps first to the v2 maxTake of 100', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({ conditions: { nodes: [] } });
+    mockGraphqlRequest.mockResolvedValue({ conditions: { nodes: [] } });
     await fetchConditions({ take: 100, skip: 50 });
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(
       GET_CONDITIONS,
       expect.objectContaining({ first: 100 })
     );
   });
 
   test('throws on invalid response structure', async () => {
-    mockGraphqlRequestV2.mockResolvedValue(null);
+    mockGraphqlRequest.mockResolvedValue(null);
     await expect(fetchConditions()).rejects.toThrow(
       'Failed to fetch conditions: Invalid response structure'
     );
-    mockGraphqlRequestV2.mockResolvedValue({});
+    mockGraphqlRequest.mockResolvedValue({});
     await expect(fetchConditions()).rejects.toThrow(
       'Failed to fetch conditions: Invalid response structure'
     );
@@ -351,15 +351,15 @@ describe('fetchConditionsByIds', () => {
   test('returns empty array for empty ids without a request', async () => {
     const result = await fetchConditionsByIds(query, []);
     expect(result).toEqual([]);
-    expect(mockGraphqlRequestV2).not.toHaveBeenCalled();
+    expect(mockGraphqlRequest).not.toHaveBeenCalled();
   });
 
   test('passes ids as the $ids variable and unwraps connection nodes', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       conditions: { nodes: [{ id: '0xa' }, { id: '0xb' }] },
     });
     const result = await fetchConditionsByIds(query, ['0xa', '0xb']);
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(query, {
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(query, {
       ids: ['0xa', '0xb'],
     });
     expect(result).toEqual([{ id: '0xa' }, { id: '0xb' }]);
@@ -367,27 +367,27 @@ describe('fetchConditionsByIds', () => {
 
   test('exactly 100 ids uses a single request', async () => {
     const ids = Array.from({ length: 100 }, (_, i) => `id-${i}`);
-    mockGraphqlRequestV2.mockResolvedValue({ conditions: { nodes: [] } });
+    mockGraphqlRequest.mockResolvedValue({ conditions: { nodes: [] } });
     await fetchConditionsByIds(query, ids);
-    expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
+    expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
   });
 
   test('chunks ids exceeding 100 into batched requests', async () => {
     const ids = Array.from({ length: 250 }, (_, i) => `id-${i}`);
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       conditions: { nodes: [{ id: 'result' }] },
     });
     const result = await fetchConditionsByIds(query, ids);
-    expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(3);
+    expect(mockGraphqlRequest).toHaveBeenCalledTimes(3);
     expect(result).toHaveLength(3);
     // each chunk rides the same $ids contract
-    expect(mockGraphqlRequestV2.mock.calls[0][1].ids).toHaveLength(100);
-    expect(mockGraphqlRequestV2.mock.calls[2][1].ids).toHaveLength(50);
+    expect(mockGraphqlRequest.mock.calls[0][1].ids).toHaveLength(100);
+    expect(mockGraphqlRequest.mock.calls[2][1].ids).toHaveLength(50);
   });
 
   test('flattens results from multiple chunks', async () => {
     const ids = Array.from({ length: 200 }, (_, i) => `id-${i}`);
-    mockGraphqlRequestV2
+    mockGraphqlRequest
       .mockResolvedValueOnce({
         conditions: { nodes: [{ id: 'a' }, { id: 'b' }] },
       })
@@ -397,7 +397,7 @@ describe('fetchConditionsByIds', () => {
   });
 
   test('uses custom resultKey', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       myCustomKey: { nodes: [{ id: 'id-1' }] },
     });
     const result = await fetchConditionsByIds(query, ['id-1'], 'myCustomKey');
@@ -405,7 +405,7 @@ describe('fetchConditionsByIds', () => {
   });
 
   test('handles null connection gracefully', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({ conditions: null });
+    mockGraphqlRequest.mockResolvedValue({ conditions: null });
     const result = await fetchConditionsByIds(query, ['id-1']);
     expect(result).toEqual([]);
   });
@@ -430,11 +430,11 @@ describe('CONDITIONS_BY_IDS_QUERY v2 document', () => {
 describe('fetchConditionsByIdsQuery', () => {
   test('no request for empty ids', async () => {
     await fetchConditionsByIdsQuery([]);
-    expect(mockGraphqlRequestV2).not.toHaveBeenCalled();
+    expect(mockGraphqlRequest).not.toHaveBeenCalled();
   });
 
   test('maps similarMarket.markets back onto flat similarMarkets', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       conditions: {
         nodes: [
           {
@@ -460,7 +460,7 @@ describe('fetchConditionsByIdsQuery', () => {
   });
 
   test('missing similarMarket maps to empty similarMarkets', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       conditions: { nodes: [{ id: '0xa', similarMarket: null }] },
     });
     const result = await fetchConditionsByIdsQuery(['0xa']);

--- a/packages/sdk/queries/__tests__/conditions.test.ts
+++ b/packages/sdk/queries/__tests__/conditions.test.ts
@@ -17,8 +17,8 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-/** A fully-populated v2 condition node as served by /v2/graphql. */
-const v2Node = {
+/** A fully-populated condition node as served by /v2/graphql. */
+const baseNode = {
   conditionId: '0xabc123',
   createdAt: '2026-01-01T00:00:00.000Z',
   question: 'Will BTC hit 100k?',
@@ -44,11 +44,11 @@ const v2Node = {
 };
 
 // ============================================================================
-// GET_CONDITIONS document (v2)
+// GET_CONDITIONS document
 // ============================================================================
 
-describe('GET_CONDITIONS v2 document', () => {
-  test('queries the v2 conditions connection with explicit orderBy', () => {
+describe('GET_CONDITIONS document', () => {
+  test('queries the conditions connection with explicit orderBy', () => {
     expect(GET_CONDITIONS).toContain(
       'orderBy: { field: CREATED_AT, direction: DESC }'
     );
@@ -59,7 +59,7 @@ describe('GET_CONDITIONS v2 document', () => {
     expect(GET_CONDITIONS).toContain('isPublic');
   });
 
-  test('does not use v1 vocabulary (take/skip/where/assertion fields)', () => {
+  test('does not use stale vocabulary (take/skip/where/assertion fields)', () => {
     expect(GET_CONDITIONS).not.toContain('$take');
     expect(GET_CONDITIONS).not.toContain('$skip');
     expect(GET_CONDITIONS).not.toContain('$where');
@@ -85,7 +85,7 @@ describe('GET_CONDITIONS v2 document', () => {
 // ============================================================================
 
 describe('buildConditionFilter', () => {
-  test('defaults to explicit public: true (never relies on the v2 silent default)', () => {
+  test('defaults to explicit public: true (never relies on the server silent default)', () => {
     expect(buildConditionFilter()).toEqual({ public: true });
     expect(buildConditionFilter(undefined, {})).toEqual({ public: true });
   });
@@ -116,8 +116,8 @@ describe('buildConditionFilter', () => {
       ).toEqual({ public: false });
     });
 
-    test('visibility=all omits public — v2 listing surfaces then degrade to public-only (documented gap)', () => {
-      // v2's ConditionFilter has no both-visibilities representation on list
+    test('visibility=all omits public — listing surfaces then degrade to public-only (documented gap)', () => {
+      // The ConditionFilter has no both-visibilities representation on list
       // surfaces: omitting `public` makes the server force `public: true`
       // unless `conditionIds` is present (conditionListFilters.ts). The
       // closest expressible mapping is to omit the key.
@@ -126,7 +126,7 @@ describe('buildConditionFilter', () => {
       expect('public' in filter).toBe(false);
     });
 
-    test('visibility=all wins over publicOnly (v1 precedence preserved)', () => {
+    test('visibility=all wins over publicOnly', () => {
       expect(
         buildConditionFilter(undefined, { visibility: 'all', publicOnly: true })
       ).toEqual({});
@@ -166,7 +166,7 @@ describe('buildConditionFilter', () => {
     });
   });
 
-  describe('endTime range (v2 IntRangeFilter)', () => {
+  describe('endTime range (IntRangeFilter)', () => {
     test('gte only', () => {
       expect(buildConditionFilter(undefined, { endTimeGte: 1000 })).toEqual({
         public: true,
@@ -240,9 +240,9 @@ describe('fetchConditions', () => {
     });
   });
 
-  test('maps v2 nodes onto the stable ConditionType shape', async () => {
+  test('maps nodes onto the stable ConditionType shape', async () => {
     mockGraphqlRequest.mockResolvedValue({
-      conditions: { nodes: [v2Node] },
+      conditions: { nodes: [baseNode] },
     });
     const [c] = await fetchConditions();
     expect(c).toEqual({
@@ -264,7 +264,7 @@ describe('fetchConditions', () => {
       estimatedPrice: 0.42,
       similarMarketVolume: 123.45,
       similarMarketImage: 'https://img.example/x.png', // nested → flat
-      conditionGroupId: 'cg-opaque-1', // opaque v2 id, no numeric row id
+      conditionGroupId: 'cg-opaque-1', // opaque id, no numeric row id
       conditionGroup: { name: 'BTC group' },
       category: { name: 'Crypto', slug: 'crypto' },
     });
@@ -273,7 +273,7 @@ describe('fetchConditions', () => {
   test('coerces openInterest to string and endTime to number', async () => {
     mockGraphqlRequest.mockResolvedValue({
       conditions: {
-        nodes: [{ ...v2Node, openInterest: 12345, endTime: '1767225600' }],
+        nodes: [{ ...baseNode, openInterest: 12345, endTime: '1767225600' }],
       },
     });
     const [c] = await fetchConditions();
@@ -286,7 +286,7 @@ describe('fetchConditions', () => {
       conditions: {
         nodes: [
           {
-            ...v2Node,
+            ...baseNode,
             similarMarket: null,
             conditionGroup: null,
             category: null,
@@ -302,9 +302,9 @@ describe('fetchConditions', () => {
     expect(c.category).toBeNull();
   });
 
-  test('emulates v1 skip by over-fetching and slicing', async () => {
+  test('pages the cursor connection then slices to the skip window', async () => {
     const nodes = Array.from({ length: 12 }, (_, i) => ({
-      ...v2Node,
+      ...baseNode,
       conditionId: `0x${i}`,
     }));
     mockGraphqlRequest.mockResolvedValue({ conditions: { nodes } });
@@ -322,7 +322,7 @@ describe('fetchConditions', () => {
     ]);
   });
 
-  test('clamps first to the v2 maxTake of 100', async () => {
+  test('clamps first to the max page size of 100', async () => {
     mockGraphqlRequest.mockResolvedValue({ conditions: { nodes: [] } });
     await fetchConditions({ take: 100, skip: 50 });
     expect(mockGraphqlRequest).toHaveBeenCalledWith(
@@ -331,13 +331,13 @@ describe('fetchConditions', () => {
     );
   });
 
-  test('uses cursors when take + skip exceeds the v2 page cap', async () => {
+  test('uses cursors when take + skip exceeds the page cap', async () => {
     const firstPage = Array.from({ length: 100 }, (_, i) => ({
-      ...v2Node,
+      ...baseNode,
       conditionId: `0x${i}`,
     }));
     const secondPage = Array.from({ length: 50 }, (_, i) => ({
-      ...v2Node,
+      ...baseNode,
       conditionId: `0x${i + 100}`,
     }));
     mockGraphqlRequest
@@ -384,7 +384,7 @@ describe('fetchConditions', () => {
 });
 
 // ============================================================================
-// fetchConditionsByIds (generic helper — v2 contract)
+// fetchConditionsByIds (generic helper)
 // ============================================================================
 
 describe('fetchConditionsByIds', () => {
@@ -457,7 +457,7 @@ describe('fetchConditionsByIds', () => {
 // fetchConditionsByIdsQuery (sdk-owned document + mapper)
 // ============================================================================
 
-describe('CONDITIONS_BY_IDS_QUERY v2 document', () => {
+describe('CONDITIONS_BY_IDS_QUERY document', () => {
   test('filters by conditionIds and aliases the hash onto id', () => {
     expect(CONDITIONS_BY_IDS_QUERY).toContain('$ids: [Bytes!]!');
     expect(CONDITIONS_BY_IDS_QUERY).toContain('filter: { conditionIds: $ids }');

--- a/packages/sdk/queries/__tests__/conditions.test.ts
+++ b/packages/sdk/queries/__tests__/conditions.test.ts
@@ -225,6 +225,7 @@ describe('fetchConditions', () => {
     await fetchConditions();
     expect(mockGraphqlRequest).toHaveBeenCalledWith(GET_CONDITIONS, {
       first: 50,
+      after: null,
       filter: { public: true },
     });
   });
@@ -234,6 +235,7 @@ describe('fetchConditions', () => {
     await fetchConditions({ chainId: 5064014 });
     expect(mockGraphqlRequest).toHaveBeenCalledWith(GET_CONDITIONS, {
       first: 50,
+      after: null,
       filter: { chainId: 5064014, public: true },
     });
   });
@@ -327,6 +329,46 @@ describe('fetchConditions', () => {
       GET_CONDITIONS,
       expect.objectContaining({ first: 100 })
     );
+  });
+
+  test('uses cursors when take + skip exceeds the v2 page cap', async () => {
+    const firstPage = Array.from({ length: 100 }, (_, i) => ({
+      ...v2Node,
+      conditionId: `0x${i}`,
+    }));
+    const secondPage = Array.from({ length: 50 }, (_, i) => ({
+      ...v2Node,
+      conditionId: `0x${i + 100}`,
+    }));
+    mockGraphqlRequest
+      .mockResolvedValueOnce({
+        conditions: {
+          nodes: firstPage,
+          pageInfo: { hasNextPage: true, endCursor: 'cursor-100' },
+        },
+      })
+      .mockResolvedValueOnce({
+        conditions: {
+          nodes: secondPage,
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      });
+
+    const result = await fetchConditions({ take: 100, skip: 50 });
+
+    expect(mockGraphqlRequest).toHaveBeenNthCalledWith(
+      1,
+      GET_CONDITIONS,
+      expect.objectContaining({ first: 100, after: null })
+    );
+    expect(mockGraphqlRequest).toHaveBeenNthCalledWith(
+      2,
+      GET_CONDITIONS,
+      expect.objectContaining({ first: 50, after: 'cursor-100' })
+    );
+    expect(result).toHaveLength(100);
+    expect(result[0].id).toBe('0x50');
+    expect(result[99].id).toBe('0x149');
   });
 
   test('throws on invalid response structure', async () => {

--- a/packages/sdk/queries/__tests__/forecasts.test.ts
+++ b/packages/sdk/queries/__tests__/forecasts.test.ts
@@ -34,10 +34,10 @@ function makeNode(overrides: Record<string, unknown> = {}) {
 }
 
 // ============================================================================
-// v2 documents
+// forecast documents
 // ============================================================================
 
-describe('v2 forecast documents', () => {
+describe('forecast documents', () => {
   test('list query targets the forecasts connection with explicit ATTESTED_AT DESC', () => {
     expect(GET_FORECASTS_QUERY).toContain('forecasts(');
     expect(GET_FORECASTS_QUERY).toContain(
@@ -46,7 +46,7 @@ describe('v2 forecast documents', () => {
     expect(GET_FORECASTS_QUERY).toContain('first: $first');
     expect(GET_FORECASTS_QUERY).toContain('filter: $filter');
     expect(GET_FORECASTS_QUERY).toContain('nodes');
-    // v2 field names — not the v1 attestation row shape
+    // current field names — not the legacy attestation row shape
     expect(GET_FORECASTS_QUERY).toContain('attestedAt');
     expect(GET_FORECASTS_QUERY).toContain('value');
     expect(GET_FORECASTS_QUERY).not.toContain('prediction');
@@ -71,11 +71,11 @@ describe('v2 forecast documents', () => {
 // ============================================================================
 
 describe('formatAttestationData', () => {
-  test('maps v2 value straight through', () => {
+  test('maps value straight through', () => {
     expect(formatAttestationData(makeNode()).value).toBe('75');
   });
 
-  test('keys id on the EAS uid (no numeric row id in v2)', () => {
+  test('keys id on the EAS uid (no numeric row id)', () => {
     const result = formatAttestationData(makeNode());
     expect(result.id).toBe('0xabc123');
     expect(result.uid).toBe('0xabc123');
@@ -104,11 +104,11 @@ describe('formatAttestationData', () => {
     expect(result.conditionId).toBe('0xcond1');
   });
 
-  test('null comment becomes empty string (v2 comment is nullable)', () => {
+  test('null comment becomes empty string (comment is nullable)', () => {
     expect(formatAttestationData(makeNode({ comment: null })).comment).toBe('');
   });
 
-  test('null conditionId becomes undefined (v2 conditionId is nullable)', () => {
+  test('null conditionId becomes undefined (conditionId is nullable)', () => {
     expect(
       formatAttestationData(makeNode({ conditionId: null })).conditionId
     ).toBeUndefined();
@@ -177,7 +177,7 @@ describe('fetchForecasts', () => {
     expect(vars.filter.schemaId).toBe(DEFAULT_SCHEMA_UID);
   });
 
-  test('requests max 100 forecasts (v2 maxTake)', async () => {
+  test('requests max 100 forecasts (connection max page size)', async () => {
     mockGraphqlRequest.mockResolvedValue({ forecasts: { nodes: [] } });
     await fetchForecasts({});
     expect(mockGraphqlRequest.mock.calls[0][1].first).toBe(100);
@@ -201,7 +201,7 @@ describe('fetchForecasts', () => {
     );
   });
 
-  test('maps single conditionId onto the v2 conditionIds list filter', async () => {
+  test('maps single conditionId onto the conditionIds list filter', async () => {
     mockGraphqlRequest.mockResolvedValue({ forecasts: { nodes: [] } });
     await fetchForecasts({ conditionId: '0xcond1' });
     expect(mockGraphqlRequest.mock.calls[0][1].filter.conditionIds).toEqual([

--- a/packages/sdk/queries/__tests__/forecasts.test.ts
+++ b/packages/sdk/queries/__tests__/forecasts.test.ts
@@ -9,9 +9,9 @@ import {
   fetchUserForecasts,
 } from '../forecasts';
 
-const mockGraphqlRequestV2 = vi.fn();
+const mockGraphqlRequest = vi.fn();
 vi.mock('../client/graphqlClient', () => ({
-  graphqlRequestV2: (...args: unknown[]) => mockGraphqlRequestV2(...args),
+  graphqlRequest: (...args: unknown[]) => mockGraphqlRequest(...args),
 }));
 
 beforeEach(() => {
@@ -170,47 +170,47 @@ describe('generateForecastsQueryKey', () => {
 
 describe('fetchForecasts', () => {
   test('defaults filter.schemaId to the forecast schema UID', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({ forecasts: { nodes: [] } });
+    mockGraphqlRequest.mockResolvedValue({ forecasts: { nodes: [] } });
     await fetchForecasts({});
-    const [doc, vars] = mockGraphqlRequestV2.mock.calls[0];
+    const [doc, vars] = mockGraphqlRequest.mock.calls[0];
     expect(doc).toBe(GET_FORECASTS_QUERY);
     expect(vars.filter.schemaId).toBe(DEFAULT_SCHEMA_UID);
   });
 
   test('requests max 100 forecasts (v2 maxTake)', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({ forecasts: { nodes: [] } });
+    mockGraphqlRequest.mockResolvedValue({ forecasts: { nodes: [] } });
     await fetchForecasts({});
-    expect(mockGraphqlRequestV2.mock.calls[0][1].first).toBe(100);
+    expect(mockGraphqlRequest.mock.calls[0][1].first).toBe(100);
   });
 
   test('normalizes attester address with EIP-55 checksum', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({ forecasts: { nodes: [] } });
+    mockGraphqlRequest.mockResolvedValue({ forecasts: { nodes: [] } });
     await fetchForecasts({
       attesterAddress: '0x1234567890abcdef1234567890abcdef12345678',
     });
-    expect(mockGraphqlRequestV2.mock.calls[0][1].filter.attester).toBe(
+    expect(mockGraphqlRequest.mock.calls[0][1].filter.attester).toBe(
       '0x1234567890AbcdEF1234567890aBcdef12345678'
     );
   });
 
   test('keeps an unparseable attester address as provided', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({ forecasts: { nodes: [] } });
+    mockGraphqlRequest.mockResolvedValue({ forecasts: { nodes: [] } });
     await fetchForecasts({ attesterAddress: 'not-an-address' });
-    expect(mockGraphqlRequestV2.mock.calls[0][1].filter.attester).toBe(
+    expect(mockGraphqlRequest.mock.calls[0][1].filter.attester).toBe(
       'not-an-address'
     );
   });
 
   test('maps single conditionId onto the v2 conditionIds list filter', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({ forecasts: { nodes: [] } });
+    mockGraphqlRequest.mockResolvedValue({ forecasts: { nodes: [] } });
     await fetchForecasts({ conditionId: '0xcond1' });
-    expect(mockGraphqlRequestV2.mock.calls[0][1].filter.conditionIds).toEqual([
+    expect(mockGraphqlRequest.mock.calls[0][1].filter.conditionIds).toEqual([
       '0xcond1',
     ]);
   });
 
   test('returns nodes mapped through formatAttestationData', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       forecasts: { nodes: [makeNode()] },
     });
     const result = await fetchForecasts({});
@@ -221,7 +221,7 @@ describe('fetchForecasts', () => {
   });
 
   test('throws on invalid response structure', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({});
+    mockGraphqlRequest.mockResolvedValue({});
     await expect(fetchForecasts({})).rejects.toThrow(
       'Failed to fetch forecasts: Invalid response structure'
     );
@@ -242,9 +242,9 @@ describe('fetchForecastsPage', () => {
   });
 
   test('sends first with explicit ATTESTED_AT DESC by default', async () => {
-    mockGraphqlRequestV2.mockResolvedValue(page());
+    mockGraphqlRequest.mockResolvedValue(page());
     await fetchForecastsPage({}, { first: 20 });
-    const [doc, vars] = mockGraphqlRequestV2.mock.calls[0];
+    const [doc, vars] = mockGraphqlRequest.mock.calls[0];
     expect(doc).toBe(GET_FORECASTS_PAGINATED_QUERY);
     expect(vars.first).toBe(20);
     expect(vars.after).toBeNull();
@@ -252,22 +252,22 @@ describe('fetchForecastsPage', () => {
   });
 
   test('threads the after cursor', async () => {
-    mockGraphqlRequestV2.mockResolvedValue(page());
+    mockGraphqlRequest.mockResolvedValue(page());
     await fetchForecastsPage({}, { first: 20, after: 'cursor-0' });
-    expect(mockGraphqlRequestV2.mock.calls[0][1].after).toBe('cursor-0');
+    expect(mockGraphqlRequest.mock.calls[0][1].after).toBe('cursor-0');
   });
 
   test('supports ascending direction', async () => {
-    mockGraphqlRequestV2.mockResolvedValue(page());
+    mockGraphqlRequest.mockResolvedValue(page());
     await fetchForecastsPage({}, { first: 20, orderDirection: 'asc' });
-    expect(mockGraphqlRequestV2.mock.calls[0][1].orderBy).toEqual({
+    expect(mockGraphqlRequest.mock.calls[0][1].orderBy).toEqual({
       field: 'ATTESTED_AT',
       direction: 'ASC',
     });
   });
 
   test('returns formatted items plus pageInfo', async () => {
-    mockGraphqlRequestV2.mockResolvedValue(page());
+    mockGraphqlRequest.mockResolvedValue(page());
     const result = await fetchForecastsPage({}, { first: 20 });
     expect(result.items).toHaveLength(1);
     expect(result.items[0].uid).toBe('0xabc123');
@@ -278,7 +278,7 @@ describe('fetchForecastsPage', () => {
   });
 
   test('normalizes a missing endCursor to null', async () => {
-    mockGraphqlRequestV2.mockResolvedValue(
+    mockGraphqlRequest.mockResolvedValue(
       page({ pageInfo: { hasNextPage: false } })
     );
     const result = await fetchForecastsPage({}, { first: 20 });
@@ -286,7 +286,7 @@ describe('fetchForecastsPage', () => {
   });
 
   test('throws on invalid response structure', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({ forecasts: null });
+    mockGraphqlRequest.mockResolvedValue({ forecasts: null });
     await expect(fetchForecastsPage({}, { first: 20 })).rejects.toThrow(
       'Failed to fetch forecasts: Invalid response structure'
     );
@@ -299,7 +299,7 @@ describe('fetchForecastsPage', () => {
 
 describe('fetchUserForecasts', () => {
   test('filters by attester and returns a formatted page', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       forecasts: {
         nodes: [makeNode({ value: '80' })],
         pageInfo: { hasNextPage: false, endCursor: null },
@@ -312,7 +312,7 @@ describe('fetchUserForecasts', () => {
       orderDirection: 'desc',
     });
 
-    const vars = mockGraphqlRequestV2.mock.calls[0][1];
+    const vars = mockGraphqlRequest.mock.calls[0][1];
     expect(vars.filter.attester).toBe(
       '0x1234567890AbcdEF1234567890aBcdef12345678'
     );
@@ -323,7 +323,7 @@ describe('fetchUserForecasts', () => {
   });
 
   test('passes after cursor and ascending direction', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       forecasts: {
         nodes: [],
         pageInfo: { hasNextPage: false, endCursor: null },
@@ -336,14 +336,14 @@ describe('fetchUserForecasts', () => {
       orderDirection: 'asc',
     });
 
-    const vars = mockGraphqlRequestV2.mock.calls[0][1];
+    const vars = mockGraphqlRequest.mock.calls[0][1];
     expect(vars.after).toBe('cursor-5');
     expect(vars.first).toBe(10);
     expect(vars.orderBy).toEqual({ field: 'ATTESTED_AT', direction: 'ASC' });
   });
 
   test('returns empty items when the page has no nodes', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       forecasts: {
         nodes: [],
         pageInfo: { hasNextPage: false, endCursor: null },

--- a/packages/sdk/queries/__tests__/graphqlClient.test.ts
+++ b/packages/sdk/queries/__tests__/graphqlClient.test.ts
@@ -13,36 +13,67 @@ beforeEach(() => {
 
 afterEach(() => {
   process.env = { ...ORIGINAL_ENV };
+  vi.unstubAllGlobals();
 });
 
-describe('getGraphQLEndpointV2', () => {
+describe('getGraphQLEndpoint', () => {
   test('targets /v2/graphql derived from the API base URL', async () => {
     process.env.NEXT_PUBLIC_FOIL_API_URL = 'https://api.example.com';
-    const { getGraphQLEndpointV2 } = await import('../client/graphqlClient');
-    expect(getGraphQLEndpointV2()).toBe('https://api.example.com/v2/graphql');
+    const { getGraphQLEndpoint } = await import('../client/graphqlClient');
+    expect(getGraphQLEndpoint()).toBe('https://api.example.com/v2/graphql');
   });
 
-  test('falls back to the production v2 endpoint when base URL is unset', async () => {
+  test('falls back to the production endpoint when base URL is unset', async () => {
     delete process.env.NEXT_PUBLIC_FOIL_API_URL;
-    const { getGraphQLEndpointV2 } = await import('../client/graphqlClient');
-    expect(getGraphQLEndpointV2()).toBe('https://api.sapience.xyz/v2/graphql');
+    const { getGraphQLEndpoint } = await import('../client/graphqlClient');
+    expect(getGraphQLEndpoint()).toBe('https://api.sapience.xyz/v2/graphql');
   });
 
   test('strips any path on the base URL, keeping only origin + /v2/graphql', async () => {
     process.env.NEXT_PUBLIC_FOIL_API_URL = 'https://api.example.com/some/path';
-    const { getGraphQLEndpointV2 } = await import('../client/graphqlClient');
-    expect(getGraphQLEndpointV2()).toBe('https://api.example.com/v2/graphql');
+    const { getGraphQLEndpoint } = await import('../client/graphqlClient');
+    expect(getGraphQLEndpoint()).toBe('https://api.example.com/v2/graphql');
   });
 
-  test('falls back to production v2 endpoint for an unparseable base URL', async () => {
+  test('falls back to the production endpoint for an unparseable base URL', async () => {
     process.env.NEXT_PUBLIC_FOIL_API_URL = 'not a url';
-    const { getGraphQLEndpointV2 } = await import('../client/graphqlClient');
-    expect(getGraphQLEndpointV2()).toBe('https://api.sapience.xyz/v2/graphql');
+    const { getGraphQLEndpoint } = await import('../client/graphqlClient');
+    expect(getGraphQLEndpoint()).toBe('https://api.sapience.xyz/v2/graphql');
+  });
+
+  test('prefers the stored override over the env default', async () => {
+    process.env.NEXT_PUBLIC_FOIL_API_URL = 'https://api.example.com';
+    const store: Record<string, string> = {
+      'sapience.settings.graphqlEndpoint':
+        'https://api.predict.meridian.xyz/graphql',
+    };
+    vi.stubGlobal('window', {
+      localStorage: { getItem: (k: string) => store[k] ?? null },
+    });
+    const { getGraphQLEndpoint } = await import('../client/graphqlClient');
+    expect(getGraphQLEndpoint()).toBe(
+      'https://api.predict.meridian.xyz/graphql'
+    );
+  });
+
+  test('migrates: falls back to the legacy v2 key when the new key is absent', async () => {
+    process.env.NEXT_PUBLIC_FOIL_API_URL = 'https://api.example.com';
+    const store: Record<string, string> = {
+      'sapience.settings.graphqlEndpointV2':
+        'https://api.predict.meridian.xyz/graphql',
+    };
+    vi.stubGlobal('window', {
+      localStorage: { getItem: (k: string) => store[k] ?? null },
+    });
+    const { getGraphQLEndpoint } = await import('../client/graphqlClient');
+    expect(getGraphQLEndpoint()).toBe(
+      'https://api.predict.meridian.xyz/graphql'
+    );
   });
 });
 
-describe('graphqlRequestV2', () => {
-  test('issues the request against the v2 endpoint', async () => {
+describe('graphqlRequest', () => {
+  test('issues the request against the resolved endpoint', async () => {
     process.env.NEXT_PUBLIC_FOIL_API_URL = 'https://api.example.com';
 
     const requestMock = vi.fn().mockResolvedValue({ ok: true });
@@ -57,8 +88,8 @@ describe('graphqlRequestV2', () => {
       },
     }));
 
-    const { graphqlRequestV2 } = await import('../client/graphqlClient');
-    const result = await graphqlRequestV2<{ ok: boolean }>('query { ok }');
+    const { graphqlRequest } = await import('../client/graphqlClient');
+    const result = await graphqlRequest<{ ok: boolean }>('query { ok }');
 
     expect(constructed).toContain('https://api.example.com/v2/graphql');
     expect(requestMock).toHaveBeenCalledWith('query { ok }', undefined);
@@ -73,8 +104,8 @@ describe('graphqlRequestV2', () => {
       },
     }));
 
-    const { graphqlRequestV2 } = await import('../client/graphqlClient');
-    await graphqlRequestV2('query', { id: '7' });
+    const { graphqlRequest } = await import('../client/graphqlClient');
+    await graphqlRequest('query', { id: '7' });
 
     expect(requestMock).toHaveBeenCalledWith('query', { id: '7' });
   });
@@ -87,7 +118,7 @@ describe('graphqlRequestV2', () => {
       },
     }));
 
-    const { graphqlRequestV2 } = await import('../client/graphqlClient');
-    await expect(graphqlRequestV2('query')).rejects.toThrow('boom');
+    const { graphqlRequest } = await import('../client/graphqlClient');
+    await expect(graphqlRequest('query')).rejects.toThrow('boom');
   });
 });

--- a/packages/sdk/queries/__tests__/leaderboard.test.ts
+++ b/packages/sdk/queries/__tests__/leaderboard.test.ts
@@ -10,9 +10,9 @@ import {
   GET_USER_PROFIT_RANK,
 } from '../leaderboard';
 
-const mockGraphqlRequestV2 = vi.fn();
+const mockGraphqlRequest = vi.fn();
 vi.mock('../client/graphqlClient', () => ({
-  graphqlRequestV2: (...args: unknown[]) => mockGraphqlRequestV2(...args),
+  graphqlRequest: (...args: unknown[]) => mockGraphqlRequest(...args),
 }));
 
 beforeEach(() => {
@@ -35,7 +35,7 @@ describe('fetchLeaderboard', () => {
   });
 
   test('maps ranking edges to { address, totalPnL } with totalPnL := pnlFormatted', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       leaderboard: {
         edges: [
           {
@@ -63,17 +63,17 @@ describe('fetchLeaderboard', () => {
     ]);
     // No internal/extra fields leak (rank is derivable from order).
     expect(Object.keys(result[0])).toEqual(['address', 'totalPnL']);
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(GET_PROFIT_LEADERBOARD);
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(GET_PROFIT_LEADERBOARD);
   });
 
   test('returns empty array when connection has no edges', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({ leaderboard: { edges: [] } });
+    mockGraphqlRequest.mockResolvedValue({ leaderboard: { edges: [] } });
     const result = await fetchLeaderboard();
     expect(result).toEqual([]);
   });
 
   test('returns empty array when leaderboard is missing', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({ leaderboard: null });
+    mockGraphqlRequest.mockResolvedValue({ leaderboard: null });
     const result = await fetchLeaderboard();
     expect(result).toEqual([]);
   });
@@ -86,7 +86,7 @@ describe('fetchLeaderboard', () => {
         account: { address: `0x${i.toString(16).padStart(40, '0')}` },
       },
     }));
-    mockGraphqlRequestV2.mockResolvedValue({ leaderboard: { edges } });
+    mockGraphqlRequest.mockResolvedValue({ leaderboard: { edges } });
 
     const result = await fetchLeaderboard();
     expect(result).toHaveLength(100);
@@ -110,29 +110,23 @@ describe('fetchAccuracyLeaderboard', () => {
   });
 
   test('uses default limit of 10', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({ leaderboard: { edges: [] } });
+    mockGraphqlRequest.mockResolvedValue({ leaderboard: { edges: [] } });
     await fetchAccuracyLeaderboard();
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(
-      GET_ACCURACY_LEADERBOARD,
-      {
-        first: 10,
-      }
-    );
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(GET_ACCURACY_LEADERBOARD, {
+      first: 10,
+    });
   });
 
   test('passes custom limit', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({ leaderboard: { edges: [] } });
+    mockGraphqlRequest.mockResolvedValue({ leaderboard: { edges: [] } });
     await fetchAccuracyLeaderboard(25);
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(
-      GET_ACCURACY_LEADERBOARD,
-      {
-        first: 25,
-      }
-    );
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(GET_ACCURACY_LEADERBOARD, {
+      first: 25,
+    });
   });
 
   test('maps edges to slim { address, rank, accuracyScore } rows (accuracy is 0-1)', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       leaderboard: {
         edges: [
           { node: { rank: 1, accuracy: 0.92, account: { address: '0xa' } } },
@@ -154,7 +148,7 @@ describe('fetchAccuracyLeaderboard', () => {
   });
 
   test('defaults accuracyScore to 0 when node accuracy is null', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       leaderboard: {
         edges: [
           { node: { rank: 1, accuracy: null, account: { address: '0xa' } } },
@@ -167,7 +161,7 @@ describe('fetchAccuracyLeaderboard', () => {
   });
 
   test('returns empty array when no data', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({ leaderboard: null });
+    mockGraphqlRequest.mockResolvedValue({ leaderboard: null });
     const result = await fetchAccuracyLeaderboard();
     expect(result).toEqual([]);
   });
@@ -188,18 +182,18 @@ describe('fetchForecasterRank', () => {
   });
 
   test('lowercases address before sending', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       account: { ranking: { rank: 5, accuracy: 0.85 } },
       leaderboard: { totalCount: 100 },
     });
 
     await fetchForecasterRank('0xAbCdEf1234567890');
-    const call = mockGraphqlRequestV2.mock.calls[0];
+    const call = mockGraphqlRequest.mock.calls[0];
     expect(call[1].address).toBe('0xabcdef1234567890');
   });
 
   test('returns rank data when ranked', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       account: { ranking: { rank: 5, accuracy: 0.85 } },
       leaderboard: { totalCount: 100 },
     });
@@ -213,7 +207,7 @@ describe('fetchForecasterRank', () => {
   });
 
   test('returns nulls when unranked (ranking is null)', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       account: { ranking: null },
       leaderboard: { totalCount: 42 },
     });
@@ -227,7 +221,7 @@ describe('fetchForecasterRank', () => {
   });
 
   test('defaults accuracyScore to 0 when ranked with null accuracy', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       account: { ranking: { rank: 3, accuracy: null } },
       leaderboard: { totalCount: 50 },
     });
@@ -238,7 +232,7 @@ describe('fetchForecasterRank', () => {
   });
 
   test('defaults totalForecasters to 0 when count is missing', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       account: { ranking: { rank: 1, accuracy: 0.5 } },
       leaderboard: null,
     });
@@ -264,18 +258,18 @@ describe('fetchUserProfitRank', () => {
   });
 
   test('lowercases address before sending', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       account: { ranking: { rank: 1, pnlFormatted: '10' } },
       leaderboard: { totalCount: 4 },
     });
 
     await fetchUserProfitRank('0xBoB');
-    const call = mockGraphqlRequestV2.mock.calls[0];
+    const call = mockGraphqlRequest.mock.calls[0];
     expect(call[1].address).toBe('0xbob');
   });
 
   test('returns server-computed rank, pnl and full participant count', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       account: { ranking: { rank: 137, pnlFormatted: '500.25' } },
       leaderboard: { totalCount: 5000 },
     });
@@ -291,7 +285,7 @@ describe('fetchUserProfitRank', () => {
   });
 
   test('returns null rank and zero pnl when unranked', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       account: { ranking: null },
       leaderboard: { totalCount: 4 },
     });
@@ -303,7 +297,7 @@ describe('fetchUserProfitRank', () => {
   });
 
   test('handles missing account and count gracefully', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       account: null,
       leaderboard: null,
     });

--- a/packages/sdk/queries/__tests__/leaderboard.test.ts
+++ b/packages/sdk/queries/__tests__/leaderboard.test.ts
@@ -20,11 +20,11 @@ beforeEach(() => {
 });
 
 // ============================================================================
-// fetchLeaderboard — v2 leaderboard(metric: PNL)
+// fetchLeaderboard — leaderboard(metric: PNL)
 // ============================================================================
 
 describe('fetchLeaderboard', () => {
-  test('queries the v2 PNL leaderboard connection', () => {
+  test('queries the PNL leaderboard connection', () => {
     expect(GET_PROFIT_LEADERBOARD).toContain(
       'leaderboard(metric: PNL, first: 100)'
     );
@@ -94,17 +94,17 @@ describe('fetchLeaderboard', () => {
 });
 
 // ============================================================================
-// fetchAccuracyLeaderboard — v2 leaderboard(metric: ACCURACY)
+// fetchAccuracyLeaderboard — leaderboard(metric: ACCURACY)
 // ============================================================================
 
 describe('fetchAccuracyLeaderboard', () => {
-  test('queries the v2 ACCURACY leaderboard connection', () => {
+  test('queries the ACCURACY leaderboard connection', () => {
     expect(GET_ACCURACY_LEADERBOARD).toContain(
       'leaderboard(metric: ACCURACY, first: $first)'
     );
     expect(GET_ACCURACY_LEADERBOARD).toContain('accuracy');
     expect(GET_ACCURACY_LEADERBOARD).not.toContain('accuracyLeaderboard');
-    // v1 Brier components are gone from the v2 surface.
+    // The Brier components are not part of this surface.
     expect(GET_ACCURACY_LEADERBOARD).not.toContain('numScored');
     expect(GET_ACCURACY_LEADERBOARD).not.toContain('sumErrorSquared');
   });
@@ -168,7 +168,7 @@ describe('fetchAccuracyLeaderboard', () => {
 });
 
 // ============================================================================
-// fetchForecasterRank — v2 account.ranking(ACCURACY) + count-only leaderboard
+// fetchForecasterRank — account.ranking(ACCURACY) + count-only leaderboard
 // ============================================================================
 
 describe('fetchForecasterRank', () => {
@@ -243,8 +243,8 @@ describe('fetchForecasterRank', () => {
 });
 
 // ============================================================================
-// fetchUserProfitRank — v2 account.ranking(PNL); rank is over the FULL
-// ranked population now, not the client-sorted top 100 of v1.
+// fetchUserProfitRank — account.ranking(PNL); rank is over the FULL
+// ranked population.
 // ============================================================================
 
 describe('fetchUserProfitRank', () => {
@@ -275,8 +275,8 @@ describe('fetchUserProfitRank', () => {
     });
 
     const result = await fetchUserProfitRank('0xalice');
-    // Rank 137 with 5000 participants was impossible under v1's
-    // client-side top-100 sort — the rank is now over the full population.
+    // The rank is over the full ranked population, so rank 137 with 5000
+    // participants is expected.
     expect(result).toEqual({
       totalPnL: '500.25',
       rank: 137,

--- a/packages/sdk/queries/__tests__/pickConfigurations.test.ts
+++ b/packages/sdk/queries/__tests__/pickConfigurations.test.ts
@@ -87,6 +87,7 @@ describe('fetchPickConfigurations', () => {
     await fetchPickConfigurations();
     expect(mockGraphqlRequest).toHaveBeenCalledWith(GET_PICK_CONFIGURATIONS, {
       first: 10,
+      after: null,
       filter: undefined,
     });
   });
@@ -102,6 +103,7 @@ describe('fetchPickConfigurations', () => {
     });
     expect(mockGraphqlRequest).toHaveBeenCalledWith(GET_PICK_CONFIGURATIONS, {
       first: 50,
+      after: null,
       filter: { chainId: 42161, resolved: false },
     });
   });
@@ -113,6 +115,7 @@ describe('fetchPickConfigurations', () => {
     await fetchPickConfigurations({ take: 5, resolved: true });
     expect(mockGraphqlRequest).toHaveBeenCalledWith(GET_PICK_CONFIGURATIONS, {
       first: 5,
+      after: null,
       filter: { resolved: true },
     });
   });
@@ -190,6 +193,44 @@ describe('fetchPickConfigurations', () => {
       expect.objectContaining({ first: 3 })
     );
     expect(result.map((pc) => pc.id)).toEqual(['0x2', '0x3']);
+  });
+
+  test('uses cursors when take + skip exceeds the v2 page cap', async () => {
+    const firstPage = Array.from({ length: 100 }, (_, i) =>
+      v2Node({ pickConfigId: `0x${i}` })
+    );
+    const secondPage = Array.from({ length: 50 }, (_, i) =>
+      v2Node({ pickConfigId: `0x${i + 100}` })
+    );
+    mockGraphqlRequest
+      .mockResolvedValueOnce({
+        pickConfigurations: {
+          nodes: firstPage,
+          pageInfo: { hasNextPage: true, endCursor: 'cursor-100' },
+        },
+      })
+      .mockResolvedValueOnce({
+        pickConfigurations: {
+          nodes: secondPage,
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      });
+
+    const result = await fetchPickConfigurations({ take: 100, skip: 50 });
+
+    expect(mockGraphqlRequest).toHaveBeenNthCalledWith(
+      1,
+      GET_PICK_CONFIGURATIONS,
+      expect.objectContaining({ first: 100, after: null })
+    );
+    expect(mockGraphqlRequest).toHaveBeenNthCalledWith(
+      2,
+      GET_PICK_CONFIGURATIONS,
+      expect.objectContaining({ first: 50, after: 'cursor-100' })
+    );
+    expect(result).toHaveLength(100);
+    expect(result[0].id).toBe('0x50');
+    expect(result[99].id).toBe('0x149');
   });
 
   test('throws on invalid response structure', async () => {

--- a/packages/sdk/queries/__tests__/pickConfigurations.test.ts
+++ b/packages/sdk/queries/__tests__/pickConfigurations.test.ts
@@ -13,8 +13,8 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-/** A v2 pickConfigurations node as served by /v2/graphql. */
-const v2Node = (overrides: Record<string, unknown> = {}) => ({
+/** A pickConfigurations node as served by /v2/graphql. */
+const makeNode = (overrides: Record<string, unknown> = {}) => ({
   pickConfigId: '0xpickcfg1',
   chainId: 5064014,
   totalPredictorCollateral: '100',
@@ -51,11 +51,11 @@ const v2Node = (overrides: Record<string, unknown> = {}) => ({
 });
 
 // ============================================================================
-// GET_PICK_CONFIGURATIONS document (v2)
+// GET_PICK_CONFIGURATIONS document
 // ============================================================================
 
-describe('GET_PICK_CONFIGURATIONS v2 document', () => {
-  test('queries the v2 connection with explicit orderBy and filter', () => {
+describe('GET_PICK_CONFIGURATIONS document', () => {
+  test('queries the connection with explicit orderBy and filter', () => {
     expect(GET_PICK_CONFIGURATIONS).toContain(
       'orderBy: { field: CREATED_AT, direction: DESC }'
     );
@@ -65,8 +65,8 @@ describe('GET_PICK_CONFIGURATIONS v2 document', () => {
     expect(GET_PICK_CONFIGURATIONS).toContain('pickConfigId');
   });
 
-  test('uses v2 field names on picks and aliases the condition hash', () => {
-    // Pick.resolver replaces v1 conditionResolver on the wire
+  test('uses current field names on picks and aliases the condition hash', () => {
+    // Pick.resolver replaces conditionResolver on the wire
     expect(GET_PICK_CONFIGURATIONS).not.toContain('conditionResolver');
     expect(GET_PICK_CONFIGURATIONS).toContain('id: conditionId');
     expect(GET_PICK_CONFIGURATIONS).not.toContain('$take');
@@ -92,7 +92,7 @@ describe('fetchPickConfigurations', () => {
     });
   });
 
-  test('passes chainId and resolved through the v2 filter', async () => {
+  test('passes chainId and resolved through the filter', async () => {
     mockGraphqlRequest.mockResolvedValue({
       pickConfigurations: { nodes: [] },
     });
@@ -120,9 +120,9 @@ describe('fetchPickConfigurations', () => {
     });
   });
 
-  test('maps v2 nodes onto the stable PickConfigurationResult shape', async () => {
+  test('maps nodes onto the stable PickConfigurationResult shape', async () => {
     mockGraphqlRequest.mockResolvedValue({
-      pickConfigurations: { nodes: [v2Node()] },
+      pickConfigurations: { nodes: [makeNode()] },
     });
     const [pc] = await fetchPickConfigurations();
     expect(pc).toEqual({
@@ -165,7 +165,7 @@ describe('fetchPickConfigurations', () => {
     mockGraphqlRequest.mockResolvedValue({
       pickConfigurations: {
         nodes: [
-          v2Node({
+          makeNode({
             totalPredictorCollateral: 100,
             totalCounterpartyCollateral: 200,
           }),
@@ -177,13 +177,13 @@ describe('fetchPickConfigurations', () => {
     expect(pc.totalCounterpartyCollateral).toBe('200');
   });
 
-  test('emulates v1 skip by over-fetching and slicing', async () => {
+  test('pages the cursor connection then slices to the skip window', async () => {
     mockGraphqlRequest.mockResolvedValue({
       pickConfigurations: {
         nodes: [
-          v2Node({ pickConfigId: '0x1' }),
-          v2Node({ pickConfigId: '0x2' }),
-          v2Node({ pickConfigId: '0x3' }),
+          makeNode({ pickConfigId: '0x1' }),
+          makeNode({ pickConfigId: '0x2' }),
+          makeNode({ pickConfigId: '0x3' }),
         ],
       },
     });
@@ -195,12 +195,12 @@ describe('fetchPickConfigurations', () => {
     expect(result.map((pc) => pc.id)).toEqual(['0x2', '0x3']);
   });
 
-  test('uses cursors when take + skip exceeds the v2 page cap', async () => {
+  test('uses cursors when take + skip exceeds the page cap', async () => {
     const firstPage = Array.from({ length: 100 }, (_, i) =>
-      v2Node({ pickConfigId: `0x${i}` })
+      makeNode({ pickConfigId: `0x${i}` })
     );
     const secondPage = Array.from({ length: 50 }, (_, i) =>
-      v2Node({ pickConfigId: `0x${i + 100}` })
+      makeNode({ pickConfigId: `0x${i + 100}` })
     );
     mockGraphqlRequest
       .mockResolvedValueOnce({

--- a/packages/sdk/queries/__tests__/pickConfigurations.test.ts
+++ b/packages/sdk/queries/__tests__/pickConfigurations.test.ts
@@ -4,9 +4,9 @@ import {
   GET_PICK_CONFIGURATIONS,
 } from '../pickConfigurations';
 
-const mockGraphqlRequestV2 = vi.fn();
+const mockGraphqlRequest = vi.fn();
 vi.mock('../client/graphqlClient', () => ({
-  graphqlRequestV2: (...args: unknown[]) => mockGraphqlRequestV2(...args),
+  graphqlRequest: (...args: unknown[]) => mockGraphqlRequest(...args),
 }));
 
 beforeEach(() => {
@@ -81,18 +81,18 @@ describe('GET_PICK_CONFIGURATIONS v2 document', () => {
 
 describe('fetchPickConfigurations', () => {
   test('uses default first=10 and no filter when no opts provided', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       pickConfigurations: { nodes: [] },
     });
     await fetchPickConfigurations();
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(GET_PICK_CONFIGURATIONS, {
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(GET_PICK_CONFIGURATIONS, {
       first: 10,
       filter: undefined,
     });
   });
 
   test('passes chainId and resolved through the v2 filter', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       pickConfigurations: { nodes: [] },
     });
     await fetchPickConfigurations({
@@ -100,25 +100,25 @@ describe('fetchPickConfigurations', () => {
       chainId: 42161,
       resolved: false,
     });
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(GET_PICK_CONFIGURATIONS, {
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(GET_PICK_CONFIGURATIONS, {
       first: 50,
       filter: { chainId: 42161, resolved: false },
     });
   });
 
   test('omits unset filter keys', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       pickConfigurations: { nodes: [] },
     });
     await fetchPickConfigurations({ take: 5, resolved: true });
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(GET_PICK_CONFIGURATIONS, {
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(GET_PICK_CONFIGURATIONS, {
       first: 5,
       filter: { resolved: true },
     });
   });
 
   test('maps v2 nodes onto the stable PickConfigurationResult shape', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       pickConfigurations: { nodes: [v2Node()] },
     });
     const [pc] = await fetchPickConfigurations();
@@ -159,7 +159,7 @@ describe('fetchPickConfigurations', () => {
   });
 
   test('coerces collateral BigInt values to strings', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       pickConfigurations: {
         nodes: [
           v2Node({
@@ -175,7 +175,7 @@ describe('fetchPickConfigurations', () => {
   });
 
   test('emulates v1 skip by over-fetching and slicing', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       pickConfigurations: {
         nodes: [
           v2Node({ pickConfigId: '0x1' }),
@@ -185,7 +185,7 @@ describe('fetchPickConfigurations', () => {
       },
     });
     const result = await fetchPickConfigurations({ take: 2, skip: 1 });
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(
       GET_PICK_CONFIGURATIONS,
       expect.objectContaining({ first: 3 })
     );
@@ -193,11 +193,11 @@ describe('fetchPickConfigurations', () => {
   });
 
   test('throws on invalid response structure', async () => {
-    mockGraphqlRequestV2.mockResolvedValue(null);
+    mockGraphqlRequest.mockResolvedValue(null);
     await expect(fetchPickConfigurations()).rejects.toThrow(
       'Failed to fetch pick configurations: Invalid response structure'
     );
-    mockGraphqlRequestV2.mockResolvedValue({});
+    mockGraphqlRequest.mockResolvedValue({});
     await expect(fetchPickConfigurations()).rejects.toThrow(
       'Failed to fetch pick configurations: Invalid response structure'
     );

--- a/packages/sdk/queries/__tests__/protocol.test.ts
+++ b/packages/sdk/queries/__tests__/protocol.test.ts
@@ -5,9 +5,9 @@ import {
   GET_PROTOCOL_STATS_HISTORY_PAGE,
 } from '../protocol';
 
-const mockGraphqlRequestV2 = vi.fn();
+const mockGraphqlRequest = vi.fn();
 vi.mock('../client/graphqlClient', () => ({
-  graphqlRequestV2: (...args: unknown[]) => mockGraphqlRequestV2(...args),
+  graphqlRequest: (...args: unknown[]) => mockGraphqlRequest(...args),
 }));
 
 beforeEach(() => {
@@ -96,10 +96,10 @@ describe('GET_PROTOCOL_ANALYTICS document', () => {
 
 describe('fetchProtocolAnalytics', () => {
   test('requests the daily-bucketed series in one page (interval DAY, first null)', async () => {
-    mockGraphqlRequestV2.mockResolvedValue(fullResponse());
+    mockGraphqlRequest.mockResolvedValue(fullResponse());
     await fetchProtocolAnalytics();
-    expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(GET_PROTOCOL_ANALYTICS, {
+    expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(GET_PROTOCOL_ANALYTICS, {
       interval: 'DAY',
       first: null,
       after: null,
@@ -112,7 +112,7 @@ describe('fetchProtocolAnalytics', () => {
       nodes: [stat(1700000100), stat(1700000200)],
       pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
     };
-    mockGraphqlRequestV2.mockResolvedValueOnce(page1).mockResolvedValueOnce({
+    mockGraphqlRequest.mockResolvedValueOnce(page1).mockResolvedValueOnce({
       protocol: {
         statsHistory: {
           nodes: [stat(1700000300)],
@@ -123,15 +123,15 @@ describe('fetchProtocolAnalytics', () => {
 
     const result = await fetchProtocolAnalytics();
 
-    expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(2);
+    expect(mockGraphqlRequest).toHaveBeenCalledTimes(2);
     // First call: the combined analytics query, daily-bucketed first page.
-    expect(mockGraphqlRequestV2).toHaveBeenNthCalledWith(
+    expect(mockGraphqlRequest).toHaveBeenNthCalledWith(
       1,
       GET_PROTOCOL_ANALYTICS,
       { interval: 'DAY', first: null, after: null }
     );
     // Second call: the lighter history-only page query, threading the cursor.
-    expect(mockGraphqlRequestV2).toHaveBeenNthCalledWith(
+    expect(mockGraphqlRequest).toHaveBeenNthCalledWith(
       2,
       GET_PROTOCOL_STATS_HISTORY_PAGE,
       { interval: 'DAY', first: null, after: 'cursor-1' }
@@ -142,7 +142,7 @@ describe('fetchProtocolAnalytics', () => {
   });
 
   test('unwraps the protocol payload, with history as a plain array', async () => {
-    mockGraphqlRequestV2.mockResolvedValue(fullResponse());
+    mockGraphqlRequest.mockResolvedValue(fullResponse());
 
     const result = await fetchProtocolAnalytics();
     expect(result.stats.timestamp).toBe(1700000300);
@@ -167,7 +167,7 @@ describe('fetchProtocolAnalytics', () => {
       totalValueLocked: 900,
       periodVolume: 100,
     }) as never;
-    mockGraphqlRequestV2.mockResolvedValue(resp);
+    mockGraphqlRequest.mockResolvedValue(resp);
 
     const result = await fetchProtocolAnalytics();
     expect(result.stats.cumulativeVolume).toBe('1000');
@@ -184,7 +184,7 @@ describe('fetchProtocolAnalytics', () => {
       stat(1700000100),
       stat(1700000150),
     ];
-    mockGraphqlRequestV2.mockResolvedValue(resp);
+    mockGraphqlRequest.mockResolvedValue(resp);
 
     const result = await fetchProtocolAnalytics();
     expect(result.statsHistory.map((s) => s.timestamp)).toEqual([
@@ -199,7 +199,7 @@ describe('fetchProtocolAnalytics', () => {
       resp.protocol.openInterestByTimeToResolution[1], // (1d, 7d]
       resp.protocol.openInterestByTimeToResolution[0], // (null, 1d]
     ];
-    mockGraphqlRequestV2.mockResolvedValue(resp);
+    mockGraphqlRequest.mockResolvedValue(resp);
 
     const result = await fetchProtocolAnalytics();
     expect(
@@ -215,7 +215,7 @@ describe('fetchProtocolAnalytics', () => {
         openInterest: '300',
       } as never,
     ];
-    mockGraphqlRequestV2.mockResolvedValue(resp);
+    mockGraphqlRequest.mockResolvedValue(resp);
 
     const result = await fetchProtocolAnalytics();
     expect(result.openInterestByCategory[0].category).toEqual({
@@ -225,12 +225,12 @@ describe('fetchProtocolAnalytics', () => {
   });
 
   test('throws on invalid response structure', async () => {
-    mockGraphqlRequestV2.mockResolvedValue(null);
+    mockGraphqlRequest.mockResolvedValue(null);
     await expect(fetchProtocolAnalytics()).rejects.toThrow(
       'Failed to fetch protocol analytics: Invalid response structure'
     );
 
-    mockGraphqlRequestV2.mockResolvedValue({});
+    mockGraphqlRequest.mockResolvedValue({});
     await expect(fetchProtocolAnalytics()).rejects.toThrow(
       'Failed to fetch protocol analytics: Invalid response structure'
     );

--- a/packages/sdk/queries/__tests__/protocol.test.ts
+++ b/packages/sdk/queries/__tests__/protocol.test.ts
@@ -73,10 +73,10 @@ describe('GET_PROTOCOL_ANALYTICS document', () => {
     expect(GET_PROTOCOL_ANALYTICS).toContain('openInterestByTimeToResolution');
   });
 
-  test('uses v2 field names: totalValueLocked + cumulativeTradeCount', () => {
+  test('uses field names: totalValueLocked + cumulativeTradeCount', () => {
     expect(GET_PROTOCOL_ANALYTICS).toContain('totalValueLocked');
     expect(GET_PROTOCOL_ANALYTICS).toContain('cumulativeTradeCount');
-    // v1-only fields must not appear.
+    // Stale fields must not appear.
     expect(GET_PROTOCOL_ANALYTICS).not.toContain('totalTradeCount');
     expect(GET_PROTOCOL_ANALYTICS).not.toContain('vaultAvailableAssets');
     expect(GET_PROTOCOL_ANALYTICS).not.toContain('vaultBalance');
@@ -88,7 +88,7 @@ describe('GET_PROTOCOL_ANALYTICS document', () => {
     expect(GET_PROTOCOL_ANALYTICS).toContain('predictionCount');
     expect(GET_PROTOCOL_ANALYTICS).toContain('slug');
     expect(GET_PROTOCOL_ANALYTICS).not.toMatch(/\bid\b/);
-    // v1 server-computed bucket label/index are gone.
+    // Server-computed bucket label/index are not present.
     expect(GET_PROTOCOL_ANALYTICS).not.toContain('label');
     expect(GET_PROTOCOL_ANALYTICS).not.toContain('bucket');
   });

--- a/packages/sdk/queries/__tests__/questions.test.ts
+++ b/packages/sdk/queries/__tests__/questions.test.ts
@@ -4,7 +4,7 @@ import {
   buildQuestionsVariables,
   toQuestionType,
   fetchQuestionsSorted,
-  type QuestionItemV2,
+  type QuestionItem,
 } from '../questions';
 
 const mockGraphqlRequest = vi.fn();
@@ -21,7 +21,7 @@ const emptyConnection = {
 
 function makeConditionNode(
   overrides: Record<string, unknown> = {}
-): QuestionItemV2 {
+): QuestionItem {
   return {
     __typename: 'Condition',
     conditionId: '0xc1',
@@ -51,12 +51,10 @@ function makeConditionNode(
     similarMarket: { image: 'img.png', markets: ['https://pm.example'] },
     category: { name: 'Crypto', slug: 'crypto' },
     ...overrides,
-  } as QuestionItemV2;
+  } as QuestionItem;
 }
 
-function makeGroupNode(
-  overrides: Record<string, unknown> = {}
-): QuestionItemV2 {
+function makeGroupNode(overrides: Record<string, unknown> = {}): QuestionItem {
   return {
     __typename: 'ConditionGroup',
     id: 'Q29uZGl0aW9uR3JvdXA6MQ==',
@@ -97,7 +95,7 @@ function makeGroupNode(
       ],
     },
     ...overrides,
-  } as QuestionItemV2;
+  } as QuestionItem;
 }
 
 beforeEach(() => {
@@ -106,7 +104,7 @@ beforeEach(() => {
 });
 
 describe('GET_QUESTIONS document', () => {
-  test('targets the v2 questions connection with union branching', () => {
+  test('targets the questions connection with union branching', () => {
     expect(GET_QUESTIONS).toContain('questions(');
     expect(GET_QUESTIONS).toContain('$first: Int');
     expect(GET_QUESTIONS).toContain('$after: String');
@@ -172,8 +170,8 @@ describe('buildQuestionsVariables — orderBy', () => {
   });
 
   test('windowless volume sort falls back to the documented 7d proxy', () => {
-    // v1 sorted by all-time similarMarketVolume; v2 has no all-time sort
-    // variant, 7d is the closest window.
+    // There is no all-time similarMarketVolume sort variant; 7d is the
+    // closest window.
     const { orderBy } = buildQuestionsVariables({
       sortField: 'similarMarketVolume',
       sortDirection: 'desc',
@@ -222,7 +220,7 @@ describe('buildQuestionsVariables — filter', () => {
     ).toEqual({ endsAt: { gte: 1000 } });
   });
 
-  test('maps resolutionStatus values to v2 enum keys', () => {
+  test('maps resolutionStatus values to enum keys', () => {
     expect(
       buildQuestionsVariables({ ...base, resolutionStatus: 'resolvedYes' })
         .filter
@@ -252,7 +250,7 @@ describe('buildQuestionsVariables — filter', () => {
     ).toEqual({ estimatedPrice: { gte: 0.1, lte: 0.9 } });
   });
 
-  test('maps volume bounds + window to FloatFilter + v2 window enum', () => {
+  test('maps volume bounds + window to FloatFilter + window enum', () => {
     expect(
       buildQuestionsVariables({
         ...base,
@@ -345,7 +343,7 @@ describe('fetchQuestionsSorted', () => {
     sortDirection: 'desc' as const,
   };
 
-  test('requests the v2 document with explicit orderBy', async () => {
+  test('requests the document with explicit orderBy', async () => {
     await fetchQuestionsSorted(baseParams);
     expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
     const [doc, vars] = mockGraphqlRequest.mock.calls[0];
@@ -354,7 +352,7 @@ describe('fetchQuestionsSorted', () => {
     expect(vars.filter).toBeUndefined();
   });
 
-  test('emulates v1 offset paging: first = take + skip, sliced locally', async () => {
+  test('offset paging: first = take + skip, sliced locally', async () => {
     const edges = ['0xa', '0xb', '0xc', '0xd'].map((id) => ({
       cursor: `cur-${id}`,
       node: makeConditionNode({ conditionId: id }),
@@ -374,13 +372,13 @@ describe('fetchQuestionsSorted', () => {
     expect(result.map((q) => q.condition!.id)).toEqual(['0xb', '0xc']);
   });
 
-  test('caps first at the v2 maxTake of 100', async () => {
+  test('caps first at the max page size of 100', async () => {
     await fetchQuestionsSorted({ ...baseParams, take: 80, skip: 40 });
     const [, vars] = mockGraphqlRequest.mock.calls[0];
     expect(vars.first).toBe(100);
   });
 
-  test('uses cursors when take + skip exceeds the v2 page cap', async () => {
+  test('uses cursors when take + skip exceeds the page cap', async () => {
     const firstPage = Array.from({ length: 100 }, (_, i) => ({
       cursor: `cur-${i}`,
       node: makeConditionNode({ conditionId: `0x${i}` }),
@@ -441,7 +439,7 @@ describe('fetchQuestionsSorted', () => {
     });
   });
 
-  test('maps union edges into v1 QuestionType envelopes', async () => {
+  test('maps union edges into QuestionType envelopes', async () => {
     mockGraphqlRequest.mockResolvedValue({
       questions: {
         edges: [
@@ -472,7 +470,7 @@ describe('fetchQuestionsSorted', () => {
     );
   });
 
-  test('never touches the v1 transport', async () => {
+  test('issues its request against the GraphQL transport', async () => {
     await fetchQuestionsSorted(baseParams);
   });
 });

--- a/packages/sdk/queries/__tests__/questions.test.ts
+++ b/packages/sdk/queries/__tests__/questions.test.ts
@@ -380,6 +380,50 @@ describe('fetchQuestionsSorted', () => {
     expect(vars.first).toBe(100);
   });
 
+  test('uses cursors when take + skip exceeds the v2 page cap', async () => {
+    const firstPage = Array.from({ length: 100 }, (_, i) => ({
+      cursor: `cur-${i}`,
+      node: makeConditionNode({ conditionId: `0x${i}` }),
+    }));
+    const secondPage = Array.from({ length: 50 }, (_, i) => ({
+      cursor: `cur-${i + 100}`,
+      node: makeConditionNode({ conditionId: `0x${i + 100}` }),
+    }));
+    mockGraphqlRequest
+      .mockResolvedValueOnce({
+        questions: {
+          edges: firstPage,
+          pageInfo: { hasNextPage: true, endCursor: 'cur-99' },
+        },
+      })
+      .mockResolvedValueOnce({
+        questions: {
+          edges: secondPage,
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      });
+
+    const result = await fetchQuestionsSorted({
+      ...baseParams,
+      take: 100,
+      skip: 50,
+    });
+
+    expect(mockGraphqlRequest).toHaveBeenNthCalledWith(
+      1,
+      GET_QUESTIONS,
+      expect.objectContaining({ first: 100, after: null })
+    );
+    expect(mockGraphqlRequest).toHaveBeenNthCalledWith(
+      2,
+      GET_QUESTIONS,
+      expect.objectContaining({ first: 50, after: 'cur-99' })
+    );
+    expect(result).toHaveLength(100);
+    expect(result[0].condition!.id).toBe('0x50');
+    expect(result[99].condition!.id).toBe('0x149');
+  });
+
   test('passes filters through buildQuestionsVariables', async () => {
     await fetchQuestionsSorted({
       ...baseParams,

--- a/packages/sdk/queries/__tests__/questions.test.ts
+++ b/packages/sdk/queries/__tests__/questions.test.ts
@@ -93,6 +93,7 @@ function makeGroupNode(overrides: Record<string, unknown> = {}): QuestionItem {
           category: null,
         },
       ],
+      pageInfo: { hasNextPage: true, endCursor: 'child-cursor' },
     },
     ...overrides,
   } as QuestionItem;
@@ -115,6 +116,8 @@ describe('GET_QUESTIONS document', () => {
     expect(GET_QUESTIONS).toContain('edges');
     expect(GET_QUESTIONS).toContain('hasNextPage');
     expect(GET_QUESTIONS).toContain('endCursor');
+    expect(GET_QUESTIONS).toContain('conditions(first: 50)');
+    expect(GET_QUESTIONS).toContain('pageInfo');
     expect(GET_QUESTIONS).not.toContain('totalCount');
   });
 });
@@ -320,6 +323,8 @@ describe('toQuestionType', () => {
     expect(g.name).toBe('Who wins?');
     expect(g.category).toEqual({ name: 'Sports', slug: 'sports' });
     expect(g.conditions).toHaveLength(1);
+    expect(g.hasMoreConditions).toBe(true);
+    expect(g.conditionsEndCursor).toBe('child-cursor');
     const gc = g.conditions[0];
     expect(gc.id).toBe('0xg1');
     expect(gc.optionName).toBe('Team A');

--- a/packages/sdk/queries/__tests__/questions.test.ts
+++ b/packages/sdk/queries/__tests__/questions.test.ts
@@ -8,10 +8,8 @@ import {
 } from '../questions';
 
 const mockGraphqlRequest = vi.fn();
-const mockGraphqlRequestV2 = vi.fn();
 vi.mock('../client/graphqlClient', () => ({
   graphqlRequest: (...args: unknown[]) => mockGraphqlRequest(...args),
-  graphqlRequestV2: (...args: unknown[]) => mockGraphqlRequestV2(...args),
 }));
 
 const emptyConnection = {
@@ -104,10 +102,7 @@ function makeGroupNode(
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockGraphqlRequest.mockRejectedValue(
-    new Error('v1 transport must not be used')
-  );
-  mockGraphqlRequestV2.mockResolvedValue(emptyConnection);
+  mockGraphqlRequest.mockResolvedValue(emptyConnection);
 });
 
 describe('GET_QUESTIONS document', () => {
@@ -352,8 +347,8 @@ describe('fetchQuestionsSorted', () => {
 
   test('requests the v2 document with explicit orderBy', async () => {
     await fetchQuestionsSorted(baseParams);
-    expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
-    const [doc, vars] = mockGraphqlRequestV2.mock.calls[0];
+    expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
+    const [doc, vars] = mockGraphqlRequest.mock.calls[0];
     expect(doc).toBe(GET_QUESTIONS);
     expect(vars.orderBy).toEqual({ field: 'CREATED_AT', direction: 'DESC' });
     expect(vars.filter).toBeUndefined();
@@ -364,7 +359,7 @@ describe('fetchQuestionsSorted', () => {
       cursor: `cur-${id}`,
       node: makeConditionNode({ conditionId: id }),
     }));
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       questions: { edges, pageInfo: { hasNextPage: false, endCursor: null } },
     });
 
@@ -374,14 +369,14 @@ describe('fetchQuestionsSorted', () => {
       skip: 1,
     });
 
-    const [, vars] = mockGraphqlRequestV2.mock.calls[0];
+    const [, vars] = mockGraphqlRequest.mock.calls[0];
     expect(vars.first).toBe(3);
     expect(result.map((q) => q.condition!.id)).toEqual(['0xb', '0xc']);
   });
 
   test('caps first at the v2 maxTake of 100', async () => {
     await fetchQuestionsSorted({ ...baseParams, take: 80, skip: 40 });
-    const [, vars] = mockGraphqlRequestV2.mock.calls[0];
+    const [, vars] = mockGraphqlRequest.mock.calls[0];
     expect(vars.first).toBe(100);
   });
 
@@ -393,7 +388,7 @@ describe('fetchQuestionsSorted', () => {
       minEndTime: 1700,
       resolutionStatus: 'unresolved',
     });
-    const [, vars] = mockGraphqlRequestV2.mock.calls[0];
+    const [, vars] = mockGraphqlRequest.mock.calls[0];
     expect(vars.filter).toEqual({
       chainId: 5064014,
       search: 'eth',
@@ -403,7 +398,7 @@ describe('fetchQuestionsSorted', () => {
   });
 
   test('maps union edges into v1 QuestionType envelopes', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       questions: {
         edges: [
           { cursor: 'c1', node: makeConditionNode() },
@@ -427,7 +422,7 @@ describe('fetchQuestionsSorted', () => {
   });
 
   test('throws on an invalid response structure', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({ questions: null });
+    mockGraphqlRequest.mockResolvedValue({ questions: null });
     await expect(fetchQuestionsSorted(baseParams)).rejects.toThrow(
       'Invalid response structure'
     );
@@ -435,6 +430,5 @@ describe('fetchQuestionsSorted', () => {
 
   test('never touches the v1 transport', async () => {
     await fetchQuestionsSorted(baseParams);
-    expect(mockGraphqlRequest).not.toHaveBeenCalled();
   });
 });

--- a/packages/sdk/queries/__tests__/tags.test.ts
+++ b/packages/sdk/queries/__tests__/tags.test.ts
@@ -1,9 +1,9 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { fetchPopularTags, GET_POPULAR_TAGS } from '../tags';
 
-const mockGraphqlRequestV2 = vi.fn();
+const mockGraphqlRequest = vi.fn();
 vi.mock('../client/graphqlClient', () => ({
-  graphqlRequestV2: (...args: unknown[]) => mockGraphqlRequestV2(...args),
+  graphqlRequest: (...args: unknown[]) => mockGraphqlRequest(...args),
 }));
 
 beforeEach(() => {
@@ -21,7 +21,7 @@ describe('fetchPopularTags', () => {
   });
 
   test('maps connection nodes to tag names', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       tags: {
         nodes: [
           { name: 'bitcoin', conditionCount: 12 },
@@ -32,23 +32,23 @@ describe('fetchPopularTags', () => {
 
     const result = await fetchPopularTags();
     expect(result).toEqual(['bitcoin', 'elections']);
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(GET_POPULAR_TAGS);
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(GET_POPULAR_TAGS);
   });
 
   test('returns empty array when tags connection is missing', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({});
+    mockGraphqlRequest.mockResolvedValue({});
     const result = await fetchPopularTags();
     expect(result).toEqual([]);
   });
 
   test('returns empty array when nodes is missing', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({ tags: {} });
+    mockGraphqlRequest.mockResolvedValue({ tags: {} });
     const result = await fetchPopularTags();
     expect(result).toEqual([]);
   });
 
   test('returns empty array when connection has no nodes', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({ tags: { nodes: [] } });
+    mockGraphqlRequest.mockResolvedValue({ tags: { nodes: [] } });
     const result = await fetchPopularTags();
     expect(result).toEqual([]);
   });

--- a/packages/sdk/queries/__tests__/tags.test.ts
+++ b/packages/sdk/queries/__tests__/tags.test.ts
@@ -11,7 +11,7 @@ beforeEach(() => {
 });
 
 describe('fetchPopularTags', () => {
-  test('queries the v2 tags connection ordered by condition count', () => {
+  test('queries the tags connection ordered by condition count', () => {
     expect(GET_POPULAR_TAGS).toContain(
       'tags(first: 20, orderBy: { field: CONDITION_COUNT, direction: DESC })'
     );

--- a/packages/sdk/queries/__tests__/vault.test.ts
+++ b/packages/sdk/queries/__tests__/vault.test.ts
@@ -36,7 +36,7 @@ const responseWith = (
 });
 
 describe('GET_VAULT_STATS document', () => {
-  test('queries vault(address, chainId).statsHistory with the v2 fields', () => {
+  test('queries vault(address, chainId).statsHistory with the expected fields', () => {
     expect(GET_VAULT_STATS).toContain(
       'vault(address: $address, chainId: $chainId)'
     );
@@ -54,7 +54,7 @@ describe('GET_VAULT_STATS document', () => {
     expect(GET_VAULT_STATS).toContain('undeployedCollateral');
     expect(GET_VAULT_STATS).toContain('cumulativePnl');
     expect(GET_VAULT_STATS).toContain('claimableCollateral');
-    // v1-only field names must not leak into the v2 query.
+    // Stale field names must not leak into the query.
     expect(GET_VAULT_STATS).not.toContain('vaultBalance');
     expect(GET_VAULT_STATS).not.toContain('escrowBalance');
     expect(GET_VAULT_STATS).not.toContain('vaultCumulativePnL');

--- a/packages/sdk/queries/__tests__/vault.test.ts
+++ b/packages/sdk/queries/__tests__/vault.test.ts
@@ -6,9 +6,9 @@ import {
   GET_VAULT_STATS,
 } from '../vault';
 
-const mockGraphqlRequestV2 = vi.fn();
+const mockGraphqlRequest = vi.fn();
 vi.mock('../client/graphqlClient', () => ({
-  graphqlRequestV2: (...args: unknown[]) => mockGraphqlRequestV2(...args),
+  graphqlRequest: (...args: unknown[]) => mockGraphqlRequest(...args),
 }));
 
 beforeEach(() => {
@@ -63,10 +63,10 @@ describe('GET_VAULT_STATS document', () => {
 
 describe('fetchVaultStats', () => {
   test('single request (no pageSize) sends a null `first`, address lowercased', async () => {
-    mockGraphqlRequestV2.mockResolvedValue(responseWith([node(1700000100)]));
+    mockGraphqlRequest.mockResolvedValue(responseWith([node(1700000100)]));
     await fetchVaultStats('0xABCDEF', 42161);
-    expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(GET_VAULT_STATS, {
+    expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(GET_VAULT_STATS, {
       address: '0xabcdef',
       chainId: 42161,
       first: null,
@@ -75,14 +75,14 @@ describe('fetchVaultStats', () => {
   });
 
   test('one request returns the bounded series when the server signals no next page', async () => {
-    mockGraphqlRequestV2.mockResolvedValue(
+    mockGraphqlRequest.mockResolvedValue(
       responseWith([node(1700000300), node(1700000200), node(1700000100)])
     );
 
     const result = await fetchVaultStats('0xabc', 42161);
 
     // Single round-trip: the resolver's cap covers the whole series.
-    expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(1);
+    expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
     // All snapshots accumulated, sorted oldest-first.
     expect(result.map((s) => s.timestamp)).toEqual([
       1700000100, 1700000200, 1700000300,
@@ -90,7 +90,7 @@ describe('fetchVaultStats', () => {
   });
 
   test('pages on `pageInfo` when a vault exceeds the server cap', async () => {
-    mockGraphqlRequestV2
+    mockGraphqlRequest
       .mockResolvedValueOnce(
         responseWith([node(1700000300), node(1700000200)], {
           hasNextPage: true,
@@ -106,9 +106,9 @@ describe('fetchVaultStats', () => {
 
     const result = await fetchVaultStats('0xabc', 42161);
 
-    expect(mockGraphqlRequestV2).toHaveBeenCalledTimes(2);
+    expect(mockGraphqlRequest).toHaveBeenCalledTimes(2);
     // Second page threads the first page's endCursor as `after`.
-    expect(mockGraphqlRequestV2.mock.calls[1][1]).toMatchObject({
+    expect(mockGraphqlRequest.mock.calls[1][1]).toMatchObject({
       after: 'cursor-1',
     });
     expect(result.map((s) => s.timestamp)).toEqual([
@@ -117,9 +117,9 @@ describe('fetchVaultStats', () => {
   });
 
   test('forwards an explicit pageSize as the per-page `first`', async () => {
-    mockGraphqlRequestV2.mockResolvedValue(responseWith([node(1700000100)]));
+    mockGraphqlRequest.mockResolvedValue(responseWith([node(1700000100)]));
     await fetchVaultStats('0xabc', 42161, 100);
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(GET_VAULT_STATS, {
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(GET_VAULT_STATS, {
       address: '0xabc',
       chainId: 42161,
       first: 100,
@@ -128,7 +128,7 @@ describe('fetchVaultStats', () => {
   });
 
   test('maps wire nodes to the adapted vault stat shape', async () => {
-    mockGraphqlRequestV2.mockResolvedValue(
+    mockGraphqlRequest.mockResolvedValue(
       responseWith([node(1700000100), node(1700000200)])
     );
     const result = await fetchVaultStats('0xabc', 42161);
@@ -153,7 +153,7 @@ describe('fetchVaultStats', () => {
   });
 
   test('sorts snapshots oldest-first (statsHistory defaults to DESC)', async () => {
-    mockGraphqlRequestV2.mockResolvedValue(
+    mockGraphqlRequest.mockResolvedValue(
       responseWith([node(1700000200), node(1700000100), node(1700000150)])
     );
     const result = await fetchVaultStats('0xabc', 42161);
@@ -163,7 +163,7 @@ describe('fetchVaultStats', () => {
   });
 
   test('normalizes BigInt-scalar wire values (number or string) to decimal strings', async () => {
-    mockGraphqlRequestV2.mockResolvedValue(
+    mockGraphqlRequest.mockResolvedValue(
       responseWith([
         node(1700000100, {
           balance: 1000,
@@ -181,9 +181,9 @@ describe('fetchVaultStats', () => {
   });
 
   test('returns an empty array when the vault is unknown (null vault)', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({ vault: null });
+    mockGraphqlRequest.mockResolvedValue({ vault: null });
     expect(await fetchVaultStats('0xabc', 42161)).toEqual([]);
-    mockGraphqlRequestV2.mockResolvedValue(null);
+    mockGraphqlRequest.mockResolvedValue(null);
     expect(await fetchVaultStats('0xabc', 42161)).toEqual([]);
   });
 });
@@ -208,7 +208,7 @@ describe('GET_VAULT_ACCOUNT_VALUE document', () => {
 
 describe('fetchVaultAccountValue', () => {
   test('lowercases the address and sums vault balance, deployed, and claimable collateral', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       vault: {
         stats: {
           timestamp: 1700000100,
@@ -221,7 +221,7 @@ describe('fetchVaultAccountValue', () => {
 
     const result = await fetchVaultAccountValue('0xABCDEF', 42161);
 
-    expect(mockGraphqlRequestV2).toHaveBeenCalledWith(GET_VAULT_ACCOUNT_VALUE, {
+    expect(mockGraphqlRequest).toHaveBeenCalledWith(GET_VAULT_ACCOUNT_VALUE, {
       address: '0xabcdef',
       chainId: 42161,
     });
@@ -235,7 +235,7 @@ describe('fetchVaultAccountValue', () => {
   });
 
   test('defaults to zeros when the vault has no stats snapshot yet', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({
+    mockGraphqlRequest.mockResolvedValue({
       vault: { stats: null },
     });
 
@@ -249,7 +249,7 @@ describe('fetchVaultAccountValue', () => {
   });
 
   test('defaults to zeros when the address is not a configured vault', async () => {
-    mockGraphqlRequestV2.mockResolvedValue({ vault: null });
+    mockGraphqlRequest.mockResolvedValue({ vault: null });
 
     await expect(fetchVaultAccountValue('0xabc', 42161)).resolves.toEqual({
       collateralBalance: '0',

--- a/packages/sdk/queries/categories.ts
+++ b/packages/sdk/queries/categories.ts
@@ -5,7 +5,7 @@ export type CategoryQueryResult = {
   slug: string;
 };
 
-type CategoriesV2Response = {
+type CategoriesResponse = {
   categories: {
     nodes: Array<{ name: string; slug: string }>;
   };
@@ -23,7 +23,7 @@ export const GET_CATEGORIES = /* GraphQL */ `
 `;
 
 function toCategoryQueryResults(
-  data: CategoriesV2Response | null
+  data: CategoriesResponse | null
 ): CategoryQueryResult[] {
   const nodes = data?.categories?.nodes;
   if (!Array.isArray(nodes)) {
@@ -33,6 +33,6 @@ function toCategoryQueryResults(
 }
 
 export async function fetchCategories(): Promise<CategoryQueryResult[]> {
-  const data = await graphqlRequest<CategoriesV2Response>(GET_CATEGORIES);
+  const data = await graphqlRequest<CategoriesResponse>(GET_CATEGORIES);
   return toCategoryQueryResults(data);
 }

--- a/packages/sdk/queries/categories.ts
+++ b/packages/sdk/queries/categories.ts
@@ -1,4 +1,4 @@
-import { graphqlRequestV2 } from './client/graphqlClient';
+import { graphqlRequest } from './client/graphqlClient';
 
 export type CategoryQueryResult = {
   name: string;
@@ -33,6 +33,6 @@ function toCategoryQueryResults(
 }
 
 export async function fetchCategories(): Promise<CategoryQueryResult[]> {
-  const data = await graphqlRequestV2<CategoriesV2Response>(GET_CATEGORIES);
+  const data = await graphqlRequest<CategoriesV2Response>(GET_CATEGORIES);
   return toCategoryQueryResults(data);
 }

--- a/packages/sdk/queries/client/graphqlClient.ts
+++ b/packages/sdk/queries/client/graphqlClient.ts
@@ -1,20 +1,21 @@
 import { GraphQLClient } from 'graphql-request';
 
-const getGraphQLEndpoint = () => {
-  return getGraphQLEndpointV2();
-};
+const GRAPHQL_ENDPOINT_KEY = 'sapience.settings.graphqlEndpoint';
+// Legacy key kept only for migration: older sessions stored the endpoint under
+// a `graphqlEndpointV2` key before v1/v2 were collapsed into one concept.
+const LEGACY_GRAPHQL_ENDPOINT_KEY = 'sapience.settings.graphqlEndpointV2';
 
 /**
  * Resolves the GraphQL endpoint used by app queries. Sapience deployments use
  * `/v2/graphql`; Meridian exposes the same schema at `/graphql`, so the setting
  * stores the full endpoint path rather than deriving one from an origin.
  */
-export const getGraphQLEndpointV2 = () => {
+export const getGraphQLEndpoint = () => {
   try {
     if (typeof window !== 'undefined') {
-      const override = window.localStorage.getItem(
-        'sapience.settings.graphqlEndpointV2'
-      );
+      const override =
+        window.localStorage.getItem(GRAPHQL_ENDPOINT_KEY) ??
+        window.localStorage.getItem(LEGACY_GRAPHQL_ENDPOINT_KEY);
       if (override) return override;
     }
   } catch {
@@ -32,17 +33,6 @@ export const getGraphQLEndpointV2 = () => {
 
 export const createGraphQLClient = () =>
   new GraphQLClient(getGraphQLEndpoint(), {
-    method: 'GET',
-    headers: {
-      'X-Request-ID':
-        typeof crypto !== 'undefined' && crypto.randomUUID
-          ? crypto.randomUUID().slice(0, 8)
-          : Math.random().toString(36).slice(2, 10),
-    },
-  });
-
-export const createGraphQLClientV2 = () =>
-  new GraphQLClient(getGraphQLEndpointV2(), {
     method: 'GET',
     headers: {
       'X-Request-ID':
@@ -74,38 +64,6 @@ export async function typedGraphqlRequest<
     return await client.request<TQuery>(query, variables);
   } catch (error) {
     console.error('GraphQL request failed:', error);
-    throw error;
-  }
-}
-
-/**
- * Issues a request against the v2 GraphQL transport (`/v2/graphql`).
- *
- * Identical shape to {@link graphqlRequest} so callers can swap transports
- * without changing call sites; only the endpoint differs.
- */
-export async function graphqlRequestV2<T>(
-  query: string,
-  variables?: Record<string, unknown>
-): Promise<T> {
-  try {
-    const client = createGraphQLClientV2();
-    return await client.request<T>(query, variables);
-  } catch (error) {
-    console.error('GraphQL v2 request failed:', error);
-    throw error;
-  }
-}
-
-export async function typedGraphqlRequestV2<
-  TQuery,
-  TVariables extends Record<string, unknown> = Record<string, never>,
->(query: string, variables?: TVariables): Promise<TQuery> {
-  try {
-    const client = createGraphQLClientV2();
-    return await client.request<TQuery>(query, variables);
-  } catch (error) {
-    console.error('GraphQL v2 request failed:', error);
     throw error;
   }
 }

--- a/packages/sdk/queries/conditionGroups.ts
+++ b/packages/sdk/queries/conditionGroups.ts
@@ -1,7 +1,7 @@
 import { graphqlRequest } from './client/graphqlClient';
 
 export interface ConditionGroupConditionType {
-  /** CTF on-chain condition id (lowercase 0x-hex) — v2 `conditionId`. */
+  /** CTF on-chain condition id (lowercase 0x-hex) — `conditionId`. */
   id: string;
   createdAt: string;
   question: string;
@@ -20,7 +20,7 @@ export interface ConditionGroupConditionType {
   openInterest: string;
   similarMarketVolume?: number;
   similarMarketImage?: string | null;
-  /** Opaque v2 ConditionGroup id of the parent group. */
+  /** Opaque ConditionGroup id of the parent group. */
   conditionGroupId?: string | null;
   displayOrder?: number | null;
   estimatedPrice?: number | null;
@@ -35,7 +35,7 @@ export interface ConditionGroupConditionType {
 }
 
 export interface ConditionGroupType {
-  /** Opaque v2 ConditionGroup id — grouping identity only, not a row id. */
+  /** Opaque ConditionGroup id — grouping identity only, not a row id. */
   id: string;
   createdAt: string;
   name: string;
@@ -151,13 +151,13 @@ const CONDITION_GROUP_CONDITIONS_PAGE = /* GraphQL */ `
   }
 `;
 
-/** v2 maxTake for the conditionGroups connection. */
-const V2_MAX_FIRST = 100;
+/** The conditionGroups connection's max page size. */
+const MAX_PAGE_SIZE = 100;
 
 /**
- * Builds the v2 `ConditionGroupFilter`. v2 only accepts `search` and a
+ * Builds the `ConditionGroupFilter`. The filter only accepts `search` and a
  * SINGLE `categorySlug`; multi-slug selection and the nested public/chainId
- * condition filters are applied client-side in the mapper (the v2 nested
+ * condition filters are applied client-side in the mapper (the nested
  * conditions connection has no filter argument).
  */
 function buildConditionGroupFilter(
@@ -176,7 +176,7 @@ function buildConditionGroupFilter(
   return filter;
 }
 
-type ConditionGroupConditionV2Node = {
+type ConditionGroupConditionNode = {
   conditionId: string;
   createdAt: string;
   question: string;
@@ -198,20 +198,20 @@ type ConditionGroupConditionV2Node = {
   category?: { name: string; slug: string } | null;
 };
 
-type ConditionGroupV2Node = {
+type ConditionGroupNode = {
   id: string;
   createdAt: string;
   name: string;
   category?: { name: string; slug: string } | null;
   conditions?: {
-    nodes?: ConditionGroupConditionV2Node[];
+    nodes?: ConditionGroupConditionNode[];
     pageInfo?: { hasNextPage: boolean; endCursor: string | null };
   } | null;
 };
 
-type ConditionGroupsV2Response = {
+type ConditionGroupsResponse = {
   conditionGroups: {
-    nodes: ConditionGroupV2Node[];
+    nodes: ConditionGroupNode[];
     pageInfo?: { hasNextPage: boolean; endCursor: string | null };
   };
 };
@@ -219,14 +219,14 @@ type ConditionGroupsV2Response = {
 type ConditionGroupConditionsPageResponse = {
   conditionGroup: {
     conditions: {
-      nodes: ConditionGroupConditionV2Node[];
+      nodes: ConditionGroupConditionNode[];
       pageInfo?: { hasNextPage: boolean; endCursor: string | null };
     };
   } | null;
 };
 
 function toGroupCondition(
-  node: ConditionGroupConditionV2Node,
+  node: ConditionGroupConditionNode,
   groupId: string
 ): ConditionGroupConditionType {
   return {
@@ -257,7 +257,7 @@ function toGroupCondition(
 }
 
 function toConditionGroupTypes(
-  nodes: ConditionGroupV2Node[],
+  nodes: ConditionGroupNode[],
   opts: {
     chainId?: number;
     filters?: ConditionGroupFilters;
@@ -271,7 +271,7 @@ function toConditionGroupTypes(
 
   return nodes
     .filter(
-      // v2's ConditionGroupFilter accepts a single slug; for multi-slug OR
+      // The ConditionGroupFilter accepts a single slug; for multi-slug OR
       // semantics we scan cursor pages and filter the accumulated rows here.
       (group) =>
         slugs.length < 2 ||
@@ -293,7 +293,7 @@ function toConditionGroupTypes(
         .map((c) => toGroupCondition(c, group.id)),
     }))
     .filter(
-      // v1 parity: a group must contain at least one condition matching the
+      // A group must contain at least one condition matching the
       // nested filters; truly empty groups survive only with
       // includeEmptyGroups and no nested filters.
       (group) =>
@@ -302,8 +302,8 @@ function toConditionGroupTypes(
 }
 
 async function hydrateAllGroupConditions(
-  group: ConditionGroupV2Node
-): Promise<ConditionGroupV2Node> {
+  group: ConditionGroupNode
+): Promise<ConditionGroupNode> {
   const conditions = group.conditions;
   const nodes = [...(conditions?.nodes ?? [])];
   let pageInfo = conditions?.pageInfo;
@@ -313,7 +313,7 @@ async function hydrateAllGroupConditions(
       CONDITION_GROUP_CONDITIONS_PAGE,
       {
         id: group.id,
-        first: V2_MAX_FIRST,
+        first: MAX_PAGE_SIZE,
         after: pageInfo.endCursor,
       }
     );
@@ -348,7 +348,7 @@ export async function fetchConditionGroups(opts?: {
   const filter = buildConditionGroupFilter(filters);
 
   const target = skip + take;
-  const nodes: ConditionGroupV2Node[] = [];
+  const nodes: ConditionGroupNode[] = [];
   let after: string | null = null;
 
   while (true) {
@@ -361,9 +361,9 @@ export async function fetchConditionGroups(opts?: {
       return mapped.slice(skip, skip + take);
     }
 
-    const data: ConditionGroupsV2Response =
-      await graphqlRequest<ConditionGroupsV2Response>(GET_CONDITION_GROUPS, {
-        first: Math.min(target - mapped.length, V2_MAX_FIRST),
+    const data: ConditionGroupsResponse =
+      await graphqlRequest<ConditionGroupsResponse>(GET_CONDITION_GROUPS, {
+        first: Math.min(target - mapped.length, MAX_PAGE_SIZE),
         after,
         filter: Object.keys(filter).length > 0 ? filter : undefined,
       });

--- a/packages/sdk/queries/conditionGroups.ts
+++ b/packages/sdk/queries/conditionGroups.ts
@@ -1,4 +1,4 @@
-import { graphqlRequestV2 } from './client/graphqlClient';
+import { graphqlRequest } from './client/graphqlClient';
 
 export interface ConditionGroupConditionType {
   /** CTF on-chain condition id (lowercase 0x-hex) — v2 `conditionId`. */
@@ -259,7 +259,7 @@ export async function fetchConditionGroups(opts?: {
   // over-fetching (capped at the server's maxTake) and slicing locally.
   const first = Math.min(take + skip, V2_MAX_FIRST);
 
-  const data = await graphqlRequestV2<ConditionGroupsV2Response>(
+  const data = await graphqlRequest<ConditionGroupsV2Response>(
     GET_CONDITION_GROUPS,
     {
       first,

--- a/packages/sdk/queries/conditionGroups.ts
+++ b/packages/sdk/queries/conditionGroups.ts
@@ -50,9 +50,14 @@ export interface ConditionGroupFilters {
 }
 
 export const GET_CONDITION_GROUPS = /* GraphQL */ `
-  query ConditionGroups($first: Int, $filter: ConditionGroupFilter) {
+  query ConditionGroups(
+    $first: Int
+    $after: String
+    $filter: ConditionGroupFilter
+  ) {
     conditionGroups(
       first: $first
+      after: $after
       orderBy: { field: CREATED_AT, direction: DESC }
       filter: $filter
     ) {
@@ -64,7 +69,7 @@ export const GET_CONDITION_GROUPS = /* GraphQL */ `
           name
           slug
         }
-        conditions(first: 50) {
+        conditions(first: 100) {
           nodes {
             conditionId
             createdAt
@@ -92,6 +97,54 @@ export const GET_CONDITION_GROUPS = /* GraphQL */ `
               slug
             }
           }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`;
+
+const CONDITION_GROUP_CONDITIONS_PAGE = /* GraphQL */ `
+  query ConditionGroupConditions($id: ID!, $first: Int, $after: String) {
+    conditionGroup(id: $id) {
+      conditions(first: $first, after: $after) {
+        nodes {
+          conditionId
+          createdAt
+          question
+          shortName
+          optionName
+          endTime
+          isPublic
+          description
+          chainId
+          resolver
+          settled
+          resolvedToYes
+          nonDecisive
+          openInterest
+          estimatedPrice
+          similarMarketVolume
+          similarMarket {
+            image
+            markets
+          }
+          displayOrder
+          category {
+            name
+            slug
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
         }
       }
     }
@@ -150,11 +203,26 @@ type ConditionGroupV2Node = {
   createdAt: string;
   name: string;
   category?: { name: string; slug: string } | null;
-  conditions?: { nodes?: ConditionGroupConditionV2Node[] } | null;
+  conditions?: {
+    nodes?: ConditionGroupConditionV2Node[];
+    pageInfo?: { hasNextPage: boolean; endCursor: string | null };
+  } | null;
 };
 
 type ConditionGroupsV2Response = {
-  conditionGroups: { nodes: ConditionGroupV2Node[] };
+  conditionGroups: {
+    nodes: ConditionGroupV2Node[];
+    pageInfo?: { hasNextPage: boolean; endCursor: string | null };
+  };
+};
+
+type ConditionGroupConditionsPageResponse = {
+  conditionGroup: {
+    conditions: {
+      nodes: ConditionGroupConditionV2Node[];
+      pageInfo?: { hasNextPage: boolean; endCursor: string | null };
+    };
+  } | null;
 };
 
 function toGroupCondition(
@@ -189,20 +257,13 @@ function toGroupCondition(
 }
 
 function toConditionGroupTypes(
-  data: ConditionGroupsV2Response | null,
+  nodes: ConditionGroupV2Node[],
   opts: {
     chainId?: number;
     filters?: ConditionGroupFilters;
     includeEmptyGroups: boolean;
   }
 ): ConditionGroupType[] {
-  const nodes = data?.conditionGroups?.nodes;
-  if (!Array.isArray(nodes)) {
-    throw new Error(
-      'Failed to fetch condition groups: Invalid response structure'
-    );
-  }
-
   const { chainId, filters, includeEmptyGroups } = opts;
   const publicOnly = filters?.publicOnly ?? false;
   const slugs = filters?.categorySlugs ?? [];
@@ -210,8 +271,8 @@ function toConditionGroupTypes(
 
   return nodes
     .filter(
-      // v2's ConditionGroupFilter accepts a single slug; the multi-slug OR
-      // semantics from v1 are preserved client-side over the fetched page.
+      // v2's ConditionGroupFilter accepts a single slug; for multi-slug OR
+      // semantics we scan cursor pages and filter the accumulated rows here.
       (group) =>
         slugs.length < 2 ||
         (group.category != null && slugs.includes(group.category.slug))
@@ -240,6 +301,37 @@ function toConditionGroupTypes(
     );
 }
 
+async function hydrateAllGroupConditions(
+  group: ConditionGroupV2Node
+): Promise<ConditionGroupV2Node> {
+  const conditions = group.conditions;
+  const nodes = [...(conditions?.nodes ?? [])];
+  let pageInfo = conditions?.pageInfo;
+
+  while (pageInfo?.hasNextPage && pageInfo.endCursor) {
+    const data = await graphqlRequest<ConditionGroupConditionsPageResponse>(
+      CONDITION_GROUP_CONDITIONS_PAGE,
+      {
+        id: group.id,
+        first: V2_MAX_FIRST,
+        after: pageInfo.endCursor,
+      }
+    );
+    const page = data?.conditionGroup?.conditions;
+    if (!page || !Array.isArray(page.nodes)) break;
+    nodes.push(...page.nodes);
+    pageInfo = page.pageInfo;
+  }
+
+  return {
+    ...group,
+    conditions: {
+      nodes,
+      pageInfo,
+    },
+  };
+}
+
 export async function fetchConditionGroups(opts?: {
   take?: number;
   skip?: number;
@@ -255,21 +347,46 @@ export async function fetchConditionGroups(opts?: {
 
   const filter = buildConditionGroupFilter(filters);
 
-  // v2 connections cursor-paginate; emulate the v1 offset contract by
-  // over-fetching (capped at the server's maxTake) and slicing locally.
-  const first = Math.min(take + skip, V2_MAX_FIRST);
+  const target = skip + take;
+  const nodes: ConditionGroupV2Node[] = [];
+  let after: string | null = null;
 
-  const data = await graphqlRequest<ConditionGroupsV2Response>(
-    GET_CONDITION_GROUPS,
-    {
-      first,
-      filter: Object.keys(filter).length > 0 ? filter : undefined,
+  while (true) {
+    const mapped = toConditionGroupTypes(nodes, {
+      chainId,
+      filters,
+      includeEmptyGroups,
+    });
+    if (mapped.length >= target) {
+      return mapped.slice(skip, skip + take);
     }
-  );
 
-  return toConditionGroupTypes(data, {
-    chainId,
-    filters,
-    includeEmptyGroups,
-  }).slice(skip, skip + take);
+    const data: ConditionGroupsV2Response =
+      await graphqlRequest<ConditionGroupsV2Response>(GET_CONDITION_GROUPS, {
+        first: Math.min(target - mapped.length, V2_MAX_FIRST),
+        after,
+        filter: Object.keys(filter).length > 0 ? filter : undefined,
+      });
+    const pageNodes = data?.conditionGroups?.nodes;
+    if (!Array.isArray(pageNodes)) {
+      throw new Error(
+        'Failed to fetch condition groups: Invalid response structure'
+      );
+    }
+
+    const hydrated = await Promise.all(
+      pageNodes.map(hydrateAllGroupConditions)
+    );
+    nodes.push(...hydrated);
+
+    const pageInfo = data.conditionGroups.pageInfo;
+    if (!pageInfo?.hasNextPage || !pageInfo.endCursor) {
+      return toConditionGroupTypes(nodes, {
+        chainId,
+        filters,
+        includeEmptyGroups,
+      }).slice(skip, skip + take);
+    }
+    after = pageInfo.endCursor;
+  }
 }

--- a/packages/sdk/queries/conditionGroups.ts
+++ b/packages/sdk/queries/conditionGroups.ts
@@ -41,6 +41,8 @@ export interface ConditionGroupType {
   name: string;
   category?: { name: string; slug: string } | null;
   conditions: ConditionGroupConditionType[];
+  hasMoreConditions?: boolean;
+  conditionsEndCursor?: string | null;
 }
 
 export interface ConditionGroupFilters {

--- a/packages/sdk/queries/conditions.ts
+++ b/packages/sdk/queries/conditions.ts
@@ -49,9 +49,10 @@ export interface ConditionFilters {
 const V2_MAX_FIRST = 100;
 
 export const GET_CONDITIONS = /* GraphQL */ `
-  query Conditions($first: Int, $filter: ConditionFilter) {
+  query Conditions($first: Int, $after: String, $filter: ConditionFilter) {
     conditions(
       first: $first
+      after: $after
       orderBy: { field: CREATED_AT, direction: DESC }
       filter: $filter
     ) {
@@ -84,6 +85,10 @@ export const GET_CONDITIONS = /* GraphQL */ `
           name
           slug
         }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
       }
     }
   }
@@ -167,7 +172,10 @@ type ConditionV2Node = {
 };
 
 type ConditionsV2Response = {
-  conditions: { nodes: ConditionV2Node[] };
+  conditions: {
+    nodes: ConditionV2Node[];
+    pageInfo?: { hasNextPage: boolean; endCursor: string | null };
+  };
 };
 
 function toConditionType(node: ConditionV2Node): ConditionType {
@@ -200,14 +208,6 @@ function toConditionType(node: ConditionV2Node): ConditionType {
   };
 }
 
-function toConditionTypes(data: ConditionsV2Response | null): ConditionType[] {
-  const nodes = data?.conditions?.nodes;
-  if (!Array.isArray(nodes)) {
-    throw new Error('Failed to fetch conditions: Invalid response structure');
-  }
-  return nodes.map(toConditionType);
-}
-
 export async function fetchConditions(opts?: {
   take?: number;
   skip?: number;
@@ -218,16 +218,29 @@ export async function fetchConditions(opts?: {
   const skip = opts?.skip ?? 0;
   const filter = buildConditionFilter(opts?.chainId, opts?.filters);
 
-  // v2 connections cursor-paginate; emulate the v1 offset contract by
-  // over-fetching (capped at the server's maxTake) and slicing locally.
-  const first = Math.min(take + skip, V2_MAX_FIRST);
+  const target = skip + take;
+  const nodes: ConditionV2Node[] = [];
+  let after: string | null = null;
 
-  const data = await graphqlRequest<ConditionsV2Response>(GET_CONDITIONS, {
-    first,
-    filter: Object.keys(filter).length > 0 ? filter : undefined,
-  });
+  while (nodes.length < target) {
+    const first = Math.min(target - nodes.length, V2_MAX_FIRST);
+    const data: ConditionsV2Response =
+      await graphqlRequest<ConditionsV2Response>(GET_CONDITIONS, {
+        first,
+        after,
+        filter: Object.keys(filter).length > 0 ? filter : undefined,
+      });
+    const pageNodes = data?.conditions?.nodes;
+    if (!Array.isArray(pageNodes)) {
+      throw new Error('Failed to fetch conditions: Invalid response structure');
+    }
+    nodes.push(...pageNodes);
+    const pageInfo = data.conditions.pageInfo;
+    if (!pageInfo?.hasNextPage || !pageInfo.endCursor) break;
+    after = pageInfo.endCursor;
+  }
 
-  return toConditionTypes(data).slice(skip, skip + take);
+  return nodes.map(toConditionType).slice(skip, skip + take);
 }
 
 // --- fetchConditionsByIds ---

--- a/packages/sdk/queries/conditions.ts
+++ b/packages/sdk/queries/conditions.ts
@@ -1,4 +1,4 @@
-import { graphqlRequestV2 } from './client/graphqlClient';
+import { graphqlRequest } from './client/graphqlClient';
 
 export interface ConditionType {
   /** CTF on-chain condition id (lowercase 0x-hex) — v2 `conditionId`. */
@@ -222,7 +222,7 @@ export async function fetchConditions(opts?: {
   // over-fetching (capped at the server's maxTake) and slicing locally.
   const first = Math.min(take + skip, V2_MAX_FIRST);
 
-  const data = await graphqlRequestV2<ConditionsV2Response>(GET_CONDITIONS, {
+  const data = await graphqlRequest<ConditionsV2Response>(GET_CONDITIONS, {
     first,
     filter: Object.keys(filter).length > 0 ? filter : undefined,
   });
@@ -253,7 +253,7 @@ export async function fetchConditionsByIds<T>(
 
   type ByIdsResponse = Record<string, { nodes?: T[] } | null | undefined>;
   const requestChunk = async (chunk: string[]): Promise<T[]> => {
-    const resp = await graphqlRequestV2<ByIdsResponse>(query, { ids: chunk });
+    const resp = await graphqlRequest<ByIdsResponse>(query, { ids: chunk });
     return resp?.[resultKey]?.nodes ?? [];
   };
 

--- a/packages/sdk/queries/conditions.ts
+++ b/packages/sdk/queries/conditions.ts
@@ -1,7 +1,7 @@
 import { graphqlRequest } from './client/graphqlClient';
 
 export interface ConditionType {
-  /** CTF on-chain condition id (lowercase 0x-hex) — v2 `conditionId`. */
+  /** CTF on-chain condition id (lowercase 0x-hex) — `conditionId`. */
   id: string;
   createdAt: string;
   question: string;
@@ -21,7 +21,7 @@ export interface ConditionType {
   openInterest: string;
   similarMarketVolume?: number;
   similarMarketImage?: string | null;
-  /** Opaque v2 ConditionGroup id — grouping identity only, not a row id. */
+  /** Opaque ConditionGroup id — grouping identity only, not a row id. */
   conditionGroupId?: string | null;
   conditionGroup?: { name: string } | null;
   estimatedPrice?: number | null;
@@ -45,8 +45,8 @@ export interface ConditionFilters {
   visibility?: 'all' | 'public' | 'private';
 }
 
-/** v2 maxTake for the conditions / conditionGroups / pickConfigurations connections. */
-const V2_MAX_FIRST = 100;
+/** Max page size for the conditions / conditionGroups / pickConfigurations connections. */
+const MAX_PAGE_SIZE = 100;
 
 export const GET_CONDITIONS = /* GraphQL */ `
   query Conditions($first: Int, $after: String, $filter: ConditionFilter) {
@@ -95,16 +95,16 @@ export const GET_CONDITIONS = /* GraphQL */ `
 `;
 
 /**
- * Builds a v2 `ConditionFilter` from the stable {@link ConditionFilters}.
+ * Builds a `ConditionFilter` from the stable {@link ConditionFilters}.
  *
- * Visibility is emitted EXPLICITLY — v2 silently defaults to public-only when
- * `public` is omitted on listing surfaces, so we never rely on the default:
+ * Visibility is emitted EXPLICITLY — the server silently defaults to public-only
+ * when `public` is omitted on listing surfaces, so we never rely on the default:
  * - `'public'` / `publicOnly` / unset → `public: true`
  * - `'private'` → `public: false`
- * - `'all'` → v2's ConditionFilter has no both-visibilities representation on
+ * - `'all'` → the ConditionFilter has no both-visibilities representation on
  *   listing surfaces (omitting `public` makes the server force public-only
  *   unless `conditionIds` is present). The closest expressible mapping is to
- *   omit the key, which degrades to public-only under v2 — a documented gap
+ *   omit the key, which degrades to public-only — a documented gap
  *   with no live callers.
  */
 export function buildConditionFilter(
@@ -149,7 +149,7 @@ export function buildConditionFilter(
   return filter;
 }
 
-type ConditionV2Node = {
+type ConditionNode = {
   conditionId: string;
   createdAt: string;
   question: string;
@@ -171,14 +171,14 @@ type ConditionV2Node = {
   category?: { name: string; slug: string } | null;
 };
 
-type ConditionsV2Response = {
+type ConditionsResponse = {
   conditions: {
-    nodes: ConditionV2Node[];
+    nodes: ConditionNode[];
     pageInfo?: { hasNextPage: boolean; endCursor: string | null };
   };
 };
 
-function toConditionType(node: ConditionV2Node): ConditionType {
+function toConditionType(node: ConditionNode): ConditionType {
   return {
     id: node.conditionId,
     createdAt: node.createdAt,
@@ -219,17 +219,19 @@ export async function fetchConditions(opts?: {
   const filter = buildConditionFilter(opts?.chainId, opts?.filters);
 
   const target = skip + take;
-  const nodes: ConditionV2Node[] = [];
+  const nodes: ConditionNode[] = [];
   let after: string | null = null;
 
   while (nodes.length < target) {
-    const first = Math.min(target - nodes.length, V2_MAX_FIRST);
-    const data: ConditionsV2Response =
-      await graphqlRequest<ConditionsV2Response>(GET_CONDITIONS, {
+    const first = Math.min(target - nodes.length, MAX_PAGE_SIZE);
+    const data: ConditionsResponse = await graphqlRequest<ConditionsResponse>(
+      GET_CONDITIONS,
+      {
         first,
         after,
         filter: Object.keys(filter).length > 0 ? filter : undefined,
-      });
+      }
+    );
     const pageNodes = data?.conditions?.nodes;
     if (!Array.isArray(pageNodes)) {
       throw new Error('Failed to fetch conditions: Invalid response structure');
@@ -245,17 +247,16 @@ export async function fetchConditions(opts?: {
 
 // --- fetchConditionsByIds ---
 
-const PAGE_SIZE = 100; // == v2 maxTake, so each chunk fits one page
+const PAGE_SIZE = 100; // == the connection's max page size, so each chunk fits one page
 const MAX_CONCURRENT_REQUESTS = 3;
 
 /**
- * Generic by-ids fetcher over the v2 transport.
+ * Generic by-ids fetcher over the GraphQL endpoint.
  *
  * The supplied document must accept a `$ids: [Bytes!]!` variable, filter via
  * `filter: { conditionIds: $ids }`, and select a connection under
- * `resultKey` (nodes are unwrapped here). Note that v2 returns BOTH public
- * and private conditions when `conditionIds` is present — same as v1's
- * `where: { id: { in } }` contract.
+ * `resultKey` (nodes are unwrapped here). Note that the server returns BOTH public
+ * and private conditions when `conditionIds` is present.
  */
 export async function fetchConditionsByIds<T>(
   query: string,

--- a/packages/sdk/queries/forecasts.ts
+++ b/packages/sdk/queries/forecasts.ts
@@ -1,6 +1,6 @@
 import { getAddress } from 'viem';
 import { FORECAST_SCHEMA_UID } from '../constants/resolver';
-import { graphqlRequestV2 } from './client/graphqlClient';
+import { graphqlRequest } from './client/graphqlClient';
 
 const DEFAULT_SCHEMA_UID = FORECAST_SCHEMA_UID;
 
@@ -178,7 +178,7 @@ function toForecastPage(
 export async function fetchForecasts(
   params: FetchForecastsParams
 ): Promise<FormattedAttestation[]> {
-  const data = await graphqlRequestV2<ForecastsConnectionResponse>(
+  const data = await graphqlRequest<ForecastsConnectionResponse>(
     GET_FORECASTS_QUERY,
     { filter: buildForecastFilter(params), first: 100 }
   );
@@ -196,7 +196,7 @@ export async function fetchForecastsPage(
   params: FetchForecastsParams,
   page: ForecastPageArgs
 ): Promise<ForecastPage> {
-  const data = await graphqlRequestV2<ForecastsConnectionResponse>(
+  const data = await graphqlRequest<ForecastsConnectionResponse>(
     GET_FORECASTS_PAGINATED_QUERY,
     {
       filter: buildForecastFilter(params),

--- a/packages/sdk/queries/forecasts.ts
+++ b/packages/sdk/queries/forecasts.ts
@@ -5,10 +5,10 @@ import { graphqlRequest } from './client/graphqlClient';
 const DEFAULT_SCHEMA_UID = FORECAST_SCHEMA_UID;
 
 /**
- * Wire shape of a v2 `Forecast` node (the subset selected by the documents
- * below). v2 renames: v1 `prediction` → `value` (a probability STRING, not a
- * binary outcome) and v1 `time` → `attestedAt` (epoch seconds). The numeric
- * Prisma row id is not exposed in v2 — identity is the EAS `uid`.
+ * Wire shape of a `Forecast` node (the subset selected by the documents
+ * below). The schema exposes `value` (a probability STRING, not a binary
+ * outcome) and `attestedAt` (epoch seconds). The numeric Prisma row id is
+ * not exposed — identity is the EAS `uid`.
  */
 export interface ForecastNode {
   uid: string;
@@ -20,7 +20,7 @@ export interface ForecastNode {
 }
 
 export type FormattedAttestation = {
-  /** EAS uid — v2 has no numeric attestation row id. */
+  /** EAS uid — there is no numeric attestation row id. */
   id: string;
   uid: string;
   attester: string;

--- a/packages/sdk/queries/leaderboard.ts
+++ b/packages/sdk/queries/leaderboard.ts
@@ -4,28 +4,26 @@ export interface AggregatedLeaderboardEntry {
   address: string;
   /**
    * Net PnL as a human-readable decimal string (already `formatUnits`'d to
-   * 18 decimals server-side via `Ranking.pnlFormatted`). v1 carried the same
-   * units as a `toFixed(18)` string; only trailing zeros differ.
+   * 18 decimals server-side via `Ranking.pnlFormatted`).
    */
   totalPnL: string;
 }
 
 /**
- * One row of the accuracy leaderboard. Slimmed to what the v2 `Ranking`
- * surface provides — the v1 Brier components (`numScored`,
- * `sumErrorSquared`, `numTimeWeighted`, `sumTimeWeightedError`) no longer
- * exist in v2 and have been dropped. `accuracyScore` now carries the v2
- * 0-1 lifetime Brier-derived accuracy (v1 exposed a large scaled integer).
+ * One row of the accuracy leaderboard. Slimmed to what the `Ranking`
+ * surface provides — the Brier components (`numScored`, `sumErrorSquared`,
+ * `numTimeWeighted`, `sumTimeWeightedError`) do not exist on this surface.
+ * `accuracyScore` carries the 0-1 lifetime Brier-derived accuracy.
  */
 export type ForecasterScore = {
   address: string;
   rank: number;
-  /** Lifetime Brier-derived accuracy, 0-1 (v2 `Ranking.accuracy`). */
+  /** Lifetime Brier-derived accuracy, 0-1 (`Ranking.accuracy`). */
   accuracyScore: number;
 };
 
 export interface ForecasterRankResult {
-  /** 0-1 in v2 (was a large scaled integer in v1); null when unranked. */
+  /** 0-1 accuracy; null when unranked. */
   accuracyScore: number | null;
   rank: number | null;
   totalForecasters: number;
@@ -174,11 +172,9 @@ export async function fetchForecasterRank(
 }
 
 /**
- * v2 divergence (intended): v1 fetched the top-100 PnL leaderboard and
- * computed the rank client-side, so addresses outside the top 100 had a
- * null rank and `totalParticipants` was capped at 100. v2 asks the server
- * for `account.ranking(metric: PNL)`, which ranks over the FULL ranked
- * population, and `totalParticipants` is the leaderboard's `totalCount`.
+ * Asks the server for `account.ranking(metric: PNL)`, which ranks over the
+ * FULL ranked population, and `totalParticipants` is the leaderboard's
+ * `totalCount`.
  */
 export async function fetchUserProfitRank(
   ownerAddress: string

--- a/packages/sdk/queries/leaderboard.ts
+++ b/packages/sdk/queries/leaderboard.ts
@@ -1,4 +1,4 @@
-import { graphqlRequestV2 } from './client/graphqlClient';
+import { graphqlRequest } from './client/graphqlClient';
 
 export interface AggregatedLeaderboardEntry {
   address: string;
@@ -137,7 +137,7 @@ function toForecasterScores(
 export async function fetchLeaderboard(): Promise<
   AggregatedLeaderboardEntry[]
 > {
-  const data = await graphqlRequestV2<{
+  const data = await graphqlRequest<{
     leaderboard: RankingEdges<PnlRankingNode>;
   }>(GET_PROFIT_LEADERBOARD);
   return toLeaderboardEntries(data?.leaderboard).slice(0, 100);
@@ -146,7 +146,7 @@ export async function fetchLeaderboard(): Promise<
 export async function fetchAccuracyLeaderboard(
   limit = 10
 ): Promise<ForecasterScore[]> {
-  const data = await graphqlRequestV2<{
+  const data = await graphqlRequest<{
     leaderboard: RankingEdges<AccuracyRankingNode>;
   }>(GET_ACCURACY_LEADERBOARD, { first: limit });
   return toForecasterScores(data?.leaderboard);
@@ -156,7 +156,7 @@ export async function fetchForecasterRank(
   address: string
 ): Promise<ForecasterRankResult> {
   const a = address.toLowerCase();
-  const data = await graphqlRequestV2<{
+  const data = await graphqlRequest<{
     account: {
       ranking: { rank: number; accuracy: number | null } | null;
     } | null;
@@ -184,7 +184,7 @@ export async function fetchUserProfitRank(
   ownerAddress: string
 ): Promise<UserProfitRankResult> {
   const addressLc = ownerAddress.toLowerCase();
-  const data = await graphqlRequestV2<{
+  const data = await graphqlRequest<{
     account: {
       ranking: { rank: number; pnlFormatted: string } | null;
     } | null;

--- a/packages/sdk/queries/pickConfigurations.ts
+++ b/packages/sdk/queries/pickConfigurations.ts
@@ -49,7 +49,7 @@ export const GET_PICK_CONFIGURATIONS = /* GraphQL */ `
 `;
 
 export interface PickConfigurationCondition {
-  /** CTF on-chain condition id (lowercase 0x-hex) — v2 `conditionId`. */
+  /** CTF on-chain condition id (lowercase 0x-hex) — `conditionId`. */
   id: string;
   shortName?: string | null;
   optionName?: string | null;
@@ -65,7 +65,7 @@ export interface PickConfigurationCondition {
 }
 
 export interface PickConfigurationResult {
-  /** Deterministic on-chain pickConfigId hash — v2 `pickConfigId`. */
+  /** Deterministic on-chain pickConfigId hash — `pickConfigId`. */
   id: string;
   chainId: number;
   totalPredictorCollateral: string;
@@ -79,34 +79,34 @@ export interface PickConfigurationResult {
   }[];
 }
 
-/** v2 maxTake for the pickConfigurations connection. */
-const V2_MAX_FIRST = 100;
+/** The pickConfigurations connection's max page size. */
+const MAX_PAGE_SIZE = 100;
 
-type PickV2Node = {
+type PickNode = {
   conditionId: string;
   resolver: string;
   predictedOutcome: 'YES' | 'NO';
   condition?: PickConfigurationCondition | null;
 };
 
-type PickConfigurationV2Node = {
+type PickConfigurationNode = {
   pickConfigId: string;
   chainId: number;
   totalPredictorCollateral: string | number;
   totalCounterpartyCollateral: string | number;
   resolved: boolean;
-  picks: PickV2Node[];
+  picks: PickNode[];
 };
 
-type PickConfigurationsV2Response = {
+type PickConfigurationsResponse = {
   pickConfigurations: {
-    nodes: PickConfigurationV2Node[];
+    nodes: PickConfigurationNode[];
     pageInfo?: { hasNextPage: boolean; endCursor: string | null };
   };
 };
 
 function toPickConfigurationResult(
-  node: PickConfigurationV2Node
+  node: PickConfigurationNode
 ): PickConfigurationResult {
   return {
     id: node.pickConfigId,
@@ -139,13 +139,13 @@ export async function fetchPickConfigurations(opts?: {
   if (opts?.resolved !== undefined) filter.resolved = opts.resolved;
 
   const target = skip + take;
-  const nodes: PickConfigurationV2Node[] = [];
+  const nodes: PickConfigurationNode[] = [];
   let after: string | null = null;
 
   while (nodes.length < target) {
-    const first = Math.min(target - nodes.length, V2_MAX_FIRST);
-    const data: PickConfigurationsV2Response =
-      await graphqlRequest<PickConfigurationsV2Response>(
+    const first = Math.min(target - nodes.length, MAX_PAGE_SIZE);
+    const data: PickConfigurationsResponse =
+      await graphqlRequest<PickConfigurationsResponse>(
         GET_PICK_CONFIGURATIONS,
         {
           first,

--- a/packages/sdk/queries/pickConfigurations.ts
+++ b/packages/sdk/queries/pickConfigurations.ts
@@ -1,4 +1,4 @@
-import { graphqlRequestV2 } from './client/graphqlClient';
+import { graphqlRequest } from './client/graphqlClient';
 
 export const GET_PICK_CONFIGURATIONS = /* GraphQL */ `
   query PickConfigurations($first: Int, $filter: PickConfigurationFilter) {
@@ -142,7 +142,7 @@ export async function fetchPickConfigurations(opts?: {
   // over-fetching (capped at the server's maxTake) and slicing locally.
   const first = Math.min(take + skip, V2_MAX_FIRST);
 
-  const data = await graphqlRequestV2<PickConfigurationsV2Response>(
+  const data = await graphqlRequest<PickConfigurationsV2Response>(
     GET_PICK_CONFIGURATIONS,
     {
       first,

--- a/packages/sdk/queries/pickConfigurations.ts
+++ b/packages/sdk/queries/pickConfigurations.ts
@@ -1,9 +1,14 @@
 import { graphqlRequest } from './client/graphqlClient';
 
 export const GET_PICK_CONFIGURATIONS = /* GraphQL */ `
-  query PickConfigurations($first: Int, $filter: PickConfigurationFilter) {
+  query PickConfigurations(
+    $first: Int
+    $after: String
+    $filter: PickConfigurationFilter
+  ) {
     pickConfigurations(
       first: $first
+      after: $after
       orderBy: { field: CREATED_AT, direction: DESC }
       filter: $filter
     ) {
@@ -34,6 +39,10 @@ export const GET_PICK_CONFIGURATIONS = /* GraphQL */ `
             }
           }
         }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
       }
     }
   }
@@ -90,7 +99,10 @@ type PickConfigurationV2Node = {
 };
 
 type PickConfigurationsV2Response = {
-  pickConfigurations: { nodes: PickConfigurationV2Node[] };
+  pickConfigurations: {
+    nodes: PickConfigurationV2Node[];
+    pageInfo?: { hasNextPage: boolean; endCursor: string | null };
+  };
 };
 
 function toPickConfigurationResult(
@@ -113,18 +125,6 @@ function toPickConfigurationResult(
   };
 }
 
-function toPickConfigurationResults(
-  data: PickConfigurationsV2Response | null
-): PickConfigurationResult[] {
-  const nodes = data?.pickConfigurations?.nodes;
-  if (!Array.isArray(nodes)) {
-    throw new Error(
-      'Failed to fetch pick configurations: Invalid response structure'
-    );
-  }
-  return nodes.map(toPickConfigurationResult);
-}
-
 export async function fetchPickConfigurations(opts?: {
   take?: number;
   skip?: number;
@@ -138,17 +138,32 @@ export async function fetchPickConfigurations(opts?: {
   if (opts?.chainId !== undefined) filter.chainId = opts.chainId;
   if (opts?.resolved !== undefined) filter.resolved = opts.resolved;
 
-  // v2 connections cursor-paginate; emulate the v1 offset contract by
-  // over-fetching (capped at the server's maxTake) and slicing locally.
-  const first = Math.min(take + skip, V2_MAX_FIRST);
+  const target = skip + take;
+  const nodes: PickConfigurationV2Node[] = [];
+  let after: string | null = null;
 
-  const data = await graphqlRequest<PickConfigurationsV2Response>(
-    GET_PICK_CONFIGURATIONS,
-    {
-      first,
-      filter: Object.keys(filter).length > 0 ? filter : undefined,
+  while (nodes.length < target) {
+    const first = Math.min(target - nodes.length, V2_MAX_FIRST);
+    const data: PickConfigurationsV2Response =
+      await graphqlRequest<PickConfigurationsV2Response>(
+        GET_PICK_CONFIGURATIONS,
+        {
+          first,
+          after,
+          filter: Object.keys(filter).length > 0 ? filter : undefined,
+        }
+      );
+    const pageNodes = data?.pickConfigurations?.nodes;
+    if (!Array.isArray(pageNodes)) {
+      throw new Error(
+        'Failed to fetch pick configurations: Invalid response structure'
+      );
     }
-  );
+    nodes.push(...pageNodes);
+    const pageInfo = data.pickConfigurations.pageInfo;
+    if (!pageInfo?.hasNextPage || !pageInfo.endCursor) break;
+    after = pageInfo.endCursor;
+  }
 
-  return toPickConfigurationResults(data).slice(skip, skip + take);
+  return nodes.map(toPickConfigurationResult).slice(skip, skip + take);
 }

--- a/packages/sdk/queries/protocol.ts
+++ b/packages/sdk/queries/protocol.ts
@@ -1,4 +1,4 @@
-import { graphqlRequestV2 } from './client/graphqlClient';
+import { graphqlRequest } from './client/graphqlClient';
 
 /**
  * Protocol-wide analytics, fetched from the v2 `protocol` singleton.
@@ -262,7 +262,7 @@ const HISTORY_PAGE_SIZE = null;
 const MAX_HISTORY_PAGES = 50;
 
 export async function fetchProtocolStats(): Promise<ProtocolAnalyticsStat> {
-  const data = await graphqlRequestV2<{
+  const data = await graphqlRequest<{
     protocol: { stats: WireStat } | null;
   }>(GET_PROTOCOL_STATS);
   const stats = data?.protocol?.stats;
@@ -275,7 +275,7 @@ export async function fetchProtocolStats(): Promise<ProtocolAnalyticsStat> {
 }
 
 export async function fetchProtocolAnalytics(): Promise<ProtocolAnalytics> {
-  const data = await graphqlRequestV2<ProtocolAnalyticsV2Response>(
+  const data = await graphqlRequest<ProtocolAnalyticsV2Response>(
     GET_PROTOCOL_ANALYTICS,
     { interval: HISTORY_INTERVAL, first: HISTORY_PAGE_SIZE, after: null }
   );
@@ -287,7 +287,7 @@ export async function fetchProtocolAnalytics(): Promise<ProtocolAnalytics> {
 
   for (let page = 1; page < MAX_HISTORY_PAGES; page += 1) {
     if (!pageInfo?.hasNextPage || !pageInfo.endCursor) break;
-    const next = await graphqlRequestV2<{
+    const next = await graphqlRequest<{
       protocol: { statsHistory: StatsHistoryPage } | null;
     }>(GET_PROTOCOL_STATS_HISTORY_PAGE, {
       interval: HISTORY_INTERVAL,

--- a/packages/sdk/queries/protocol.ts
+++ b/packages/sdk/queries/protocol.ts
@@ -1,10 +1,10 @@
 import { graphqlRequest } from './client/graphqlClient';
 
 /**
- * Protocol-wide analytics, fetched from the v2 `protocol` singleton.
+ * Protocol-wide analytics, fetched from the `protocol` singleton.
  *
  * Vault analytics deliberately do NOT live here — `fetchVaultStats`
- * (v2, `vault.ts`) backs the vault pages via `vault(address:).statsHistory`.
+ * (`vault.ts`) backs the vault pages via `vault(address:).statsHistory`.
  * This module only backs the protocol analytics dashboard.
  */
 
@@ -13,7 +13,7 @@ export interface ProtocolAnalyticsStat {
   timestamp: number;
   /** Wei, decimal string. */
   cumulativeVolume: string;
-  /** v1 called this `totalTradeCount`. */
+  /** Cumulative count of trades. */
   cumulativeTradeCount: number;
   /** Wei, decimal string. */
   periodVolume: string;
@@ -24,16 +24,13 @@ export interface ProtocolAnalyticsStat {
   escrowBalance: string;
   /**
    * Server-computed protocol TVL, wei: escrow collateral + undeployed
-   * available assets across EVERY configured vault family. Numerically
-   * different from v1's client-side `escrowBalance + vaultAvailableAssets`
-   * sum, which under-counted by scoping to a single vault family — the
-   * difference is intended.
+   * available assets across EVERY configured vault family.
    */
   totalValueLocked: string;
 }
 
 export interface ProtocolCategoryOpenInterest {
-  /** Keyed by slug — v2 drops the numeric category row id. */
+  /** Keyed by slug — there is no numeric category row id. */
   category: { name: string; slug: string };
   /** Open interest in wei (decimal string). */
   openInterest: string;
@@ -175,7 +172,7 @@ type StatsHistoryPage = {
   pageInfo: { hasNextPage: boolean; endCursor: string | null };
 };
 
-type ProtocolAnalyticsV2Response = {
+type ProtocolAnalyticsResponse = {
   protocol: {
     stats: WireStat;
     statsHistory: StatsHistoryPage;
@@ -210,7 +207,7 @@ function toStat(node: WireStat): ProtocolAnalyticsStat {
 }
 
 function toProtocolAnalytics(
-  data: ProtocolAnalyticsV2Response | null,
+  data: ProtocolAnalyticsResponse | null,
   historyNodes: WireStat[]
 ): ProtocolAnalytics {
   const protocol = data?.protocol;
@@ -275,7 +272,7 @@ export async function fetchProtocolStats(): Promise<ProtocolAnalyticsStat> {
 }
 
 export async function fetchProtocolAnalytics(): Promise<ProtocolAnalytics> {
-  const data = await graphqlRequest<ProtocolAnalyticsV2Response>(
+  const data = await graphqlRequest<ProtocolAnalyticsResponse>(
     GET_PROTOCOL_ANALYTICS,
     { interval: HISTORY_INTERVAL, first: HISTORY_PAGE_SIZE, after: null }
   );

--- a/packages/sdk/queries/questions.ts
+++ b/packages/sdk/queries/questions.ts
@@ -163,6 +163,10 @@ export const GET_QUESTIONS = `
                 ${QUESTION_CONDITION_FIELDS}
                 displayOrder
               }
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
             }
           }
         }
@@ -324,7 +328,10 @@ export type QuestionItem =
       createdAt: string;
       name: string;
       category?: { name: string; slug: string } | null;
-      conditions?: { nodes?: QuestionConditionNode[] } | null;
+      conditions?: {
+        nodes?: QuestionConditionNode[];
+        pageInfo?: { hasNextPage: boolean; endCursor: string | null };
+      } | null;
     };
 
 type QuestionsResponse = {
@@ -392,6 +399,8 @@ export function toQuestionType(node: QuestionItem): QuestionType {
         conditions: (node.conditions?.nodes ?? []).map((c) =>
           toFeedCondition(c, node.id)
         ),
+        hasMoreConditions: Boolean(node.conditions?.pageInfo?.hasNextPage),
+        conditionsEndCursor: node.conditions?.pageInfo?.endCursor ?? null,
       },
       condition: null,
     };

--- a/packages/sdk/queries/questions.ts
+++ b/packages/sdk/queries/questions.ts
@@ -1,4 +1,4 @@
-import { graphqlRequestV2 } from './client/graphqlClient';
+import { graphqlRequest } from './client/graphqlClient';
 import type { ConditionType } from './conditions';
 import type {
   ConditionGroupType,
@@ -413,7 +413,7 @@ export async function fetchQuestionsSorted(
   const { take, skip, ...feedParams } = params;
   const { filter, orderBy } = buildQuestionsVariables(feedParams);
 
-  const data = await graphqlRequestV2<QuestionsV2Response>(GET_QUESTIONS, {
+  const data = await graphqlRequest<QuestionsV2Response>(GET_QUESTIONS, {
     first: Math.min(take + skip, V2_MAX_FIRST),
     after: null,
     filter,

--- a/packages/sdk/queries/questions.ts
+++ b/packages/sdk/queries/questions.ts
@@ -402,8 +402,8 @@ export function toQuestionType(node: QuestionItemV2): QuestionType {
 }
 
 /**
- * v1-compatible offset fetch over the v2 cursor connection: over-fetch
- * `take + skip` (capped at the server's maxTake) and slice locally.
+ * v1-compatible offset fetch over the v2 cursor connection: page until
+ * `take + skip` rows are available, then slice locally.
  * Cursor-native consumers should drive `GET_QUESTIONS` directly with
  * `buildQuestionsVariables` + `toQuestionType` instead.
  */
@@ -413,19 +413,30 @@ export async function fetchQuestionsSorted(
   const { take, skip, ...feedParams } = params;
   const { filter, orderBy } = buildQuestionsVariables(feedParams);
 
-  const data = await graphqlRequest<QuestionsV2Response>(GET_QUESTIONS, {
-    first: Math.min(take + skip, V2_MAX_FIRST),
-    after: null,
-    filter,
-    orderBy,
-  });
+  const target = skip + take;
+  const items: QuestionItemV2[] = [];
+  let after: string | null = null;
 
-  const edges = data?.questions?.edges;
-  if (!Array.isArray(edges)) {
-    throw new Error('Failed to fetch questions: Invalid response structure');
+  while (items.length < target) {
+    const data: QuestionsV2Response = await graphqlRequest<QuestionsV2Response>(
+      GET_QUESTIONS,
+      {
+        first: Math.min(target - items.length, V2_MAX_FIRST),
+        after,
+        filter,
+        orderBy,
+      }
+    );
+
+    const edges = data?.questions?.edges;
+    if (!Array.isArray(edges)) {
+      throw new Error('Failed to fetch questions: Invalid response structure');
+    }
+    items.push(...edges.map((edge) => edge.node));
+    const pageInfo = data.questions.pageInfo;
+    if (!pageInfo?.hasNextPage || !pageInfo.endCursor) break;
+    after = pageInfo.endCursor;
   }
 
-  return edges
-    .map((edge) => toQuestionType(edge.node))
-    .slice(skip, skip + take);
+  return items.map(toQuestionType).slice(skip, skip + take);
 }

--- a/packages/sdk/queries/questions.ts
+++ b/packages/sdk/queries/questions.ts
@@ -34,8 +34,8 @@ export interface QuestionType {
   condition?: ConditionType | null;
 }
 
-/** Map friendly VolumeWindow values to v2 `VolumeWindow` enum keys. */
-const VOLUME_WINDOW_TO_V2: Record<VolumeWindow, string> = {
+/** Map friendly VolumeWindow values to `VolumeWindow` enum keys. */
+const VOLUME_WINDOW_TO_API: Record<VolumeWindow, string> = {
   '1h': 'ONE_HOUR',
   '4h': 'FOUR_HOURS',
   '24h': 'TWENTY_FOUR_HOURS',
@@ -47,8 +47,8 @@ const VOLUME_WINDOW_TO_V2: Record<VolumeWindow, string> = {
 };
 
 /**
- * v2 packs the volume window into the sort enum (`QuestionOrderField`)
- * instead of v1's separate `sortField + similarMarketVolumeWindow` pair.
+ * The volume window is packed into the sort enum (`QuestionOrderField`)
+ * rather than a separate `sortField + similarMarketVolumeWindow` pair.
  */
 const VOLUME_WINDOW_TO_ORDER_FIELD: Record<VolumeWindow, string> = {
   '1h': 'SIMILAR_MARKET_VOLUME_1H',
@@ -61,7 +61,7 @@ const VOLUME_WINDOW_TO_ORDER_FIELD: Record<VolumeWindow, string> = {
   '7dFiltered': 'SIMILAR_MARKET_VOLUME_7D_FILTERED',
 };
 
-const SORT_FIELD_TO_V2: Record<
+const SORT_FIELD_TO_API: Record<
   Exclude<SortField, 'similarMarketVolume'>,
   string
 > = {
@@ -71,7 +71,7 @@ const SORT_FIELD_TO_V2: Record<
   predictionCount: 'PREDICTION_COUNT',
 };
 
-const RESOLUTION_STATUS_TO_V2: Record<ResolutionStatusValue, string> = {
+const RESOLUTION_STATUS_TO_API: Record<ResolutionStatusValue, string> = {
   all: 'ALL',
   unresolved: 'UNRESOLVED',
   resolved: 'RESOLVED',
@@ -79,13 +79,13 @@ const RESOLUTION_STATUS_TO_V2: Record<ResolutionStatusValue, string> = {
   resolvedNo: 'RESOLVED_NO',
 };
 
-/** v2 maxTake for the questions connection. */
-const V2_MAX_FIRST = 100;
+/** The questions connection's max page size. */
+const MAX_PAGE_SIZE = 100;
 
 /**
  * Shared Condition selection for both union members. The feed reads the
- * flat windowed-volume mirrors (v1-compat columns on the v2 Condition)
- * because `market-helpers` string-indexes them for client-side filters.
+ * flat windowed-volume mirror columns on the Condition because
+ * `market-helpers` string-indexes them for client-side filters.
  */
 const QUESTION_CONDITION_FIELDS = `
   conditionId
@@ -123,7 +123,7 @@ const QUESTION_CONDITION_FIELDS = `
 `;
 
 /**
- * v2 interleaved Condition + ConditionGroup feed.
+ * Interleaved Condition + ConditionGroup feed.
  *
  * `QuestionConnection` deliberately exposes ONLY `edges` + `pageInfo` —
  * no `nodes` (union members don't share a field set) and no `totalCount`
@@ -202,13 +202,13 @@ export interface QuestionsVariables {
 }
 
 /**
- * Maps the stable v1-shaped feed params onto v2 `QuestionFilter` +
- * `QuestionOrder`. orderBy is always explicit.
+ * Maps the stable feed params onto `QuestionFilter` + `QuestionOrder`.
+ * orderBy is always explicit.
  *
- * Windowed volume sorts pack the window into the order-field enum. v1's
- * windowless `similarMarketVolume` sort ordered by the ALL-TIME column,
- * which has no v2 counterpart — `SIMILAR_MARKET_VOLUME_7D` is the
- * documented closest proxy (follow-up if v2 grows an all-time variant).
+ * Windowed volume sorts pack the window into the order-field enum. The
+ * windowless `similarMarketVolume` sort has no all-time counterpart on the
+ * server — `SIMILAR_MARKET_VOLUME_7D` is the documented closest proxy
+ * (follow-up if the server grows an all-time variant).
  */
 export function buildQuestionsVariables(
   params: QuestionFeedParams
@@ -218,7 +218,7 @@ export function buildQuestionsVariables(
     field:
       params.sortField === 'similarMarketVolume'
         ? VOLUME_WINDOW_TO_ORDER_FIELD[params.similarMarketVolumeWindow ?? '7d']
-        : SORT_FIELD_TO_V2[params.sortField],
+        : SORT_FIELD_TO_API[params.sortField],
     direction,
   };
 
@@ -241,7 +241,9 @@ export function buildQuestionsVariables(
   }
   if (params.resolutionStatus) {
     const mapped =
-      RESOLUTION_STATUS_TO_V2[params.resolutionStatus as ResolutionStatusValue];
+      RESOLUTION_STATUS_TO_API[
+        params.resolutionStatus as ResolutionStatusValue
+      ];
     if (mapped) {
       filter.resolutionStatus = mapped;
     }
@@ -274,7 +276,7 @@ export function buildQuestionsVariables(
   }
   if (params.similarMarketVolumeWindow) {
     filter.similarMarketVolumeWindow =
-      VOLUME_WINDOW_TO_V2[params.similarMarketVolumeWindow];
+      VOLUME_WINDOW_TO_API[params.similarMarketVolumeWindow];
   }
 
   return {
@@ -283,7 +285,7 @@ export function buildQuestionsVariables(
   };
 }
 
-type QuestionConditionV2Node = {
+type QuestionConditionNode = {
   conditionId: string;
   createdAt: string;
   question: string;
@@ -313,27 +315,27 @@ type QuestionConditionV2Node = {
   category?: { name: string; slug: string } | null;
 };
 
-/** Raw v2 `QuestionItem` union node — discriminate on `__typename`. */
-export type QuestionItemV2 =
-  | ({ __typename: 'Condition' } & QuestionConditionV2Node)
+/** Raw `QuestionItem` union node — discriminate on `__typename`. */
+export type QuestionItem =
+  | ({ __typename: 'Condition' } & QuestionConditionNode)
   | {
       __typename: 'ConditionGroup';
       id: string;
       createdAt: string;
       name: string;
       category?: { name: string; slug: string } | null;
-      conditions?: { nodes?: QuestionConditionV2Node[] } | null;
+      conditions?: { nodes?: QuestionConditionNode[] } | null;
     };
 
-type QuestionsV2Response = {
+type QuestionsResponse = {
   questions: {
-    edges: Array<{ cursor: string; node: QuestionItemV2 }>;
+    edges: Array<{ cursor: string; node: QuestionItem }>;
     pageInfo: { hasNextPage: boolean; endCursor: string | null };
   };
 };
 
 function toFeedCondition(
-  node: QuestionConditionV2Node,
+  node: QuestionConditionNode,
   conditionGroupId: string | null
 ): ConditionGroupConditionType {
   return {
@@ -372,11 +374,11 @@ function toFeedCondition(
 }
 
 /**
- * Rebuilds the v1 `QuestionType` envelope from a v2 `QuestionItem` union
+ * Rebuilds the `QuestionType` envelope from a `QuestionItem` union
  * node so feed consumers (MarketsPage / QuestionsTable / market-helpers)
  * keep their `questionType` + `condition` / `group` reads unchanged.
  */
-export function toQuestionType(node: QuestionItemV2): QuestionType {
+export function toQuestionType(node: QuestionItem): QuestionType {
   if (node.__typename === 'ConditionGroup') {
     return {
       questionType: 'group',
@@ -402,8 +404,8 @@ export function toQuestionType(node: QuestionItemV2): QuestionType {
 }
 
 /**
- * v1-compatible offset fetch over the v2 cursor connection: page until
- * `take + skip` rows are available, then slice locally.
+ * Offset fetch over the cursor connection: page until `take + skip` rows
+ * are available, then slice locally.
  * Cursor-native consumers should drive `GET_QUESTIONS` directly with
  * `buildQuestionsVariables` + `toQuestionType` instead.
  */
@@ -414,14 +416,14 @@ export async function fetchQuestionsSorted(
   const { filter, orderBy } = buildQuestionsVariables(feedParams);
 
   const target = skip + take;
-  const items: QuestionItemV2[] = [];
+  const items: QuestionItem[] = [];
   let after: string | null = null;
 
   while (items.length < target) {
-    const data: QuestionsV2Response = await graphqlRequest<QuestionsV2Response>(
+    const data: QuestionsResponse = await graphqlRequest<QuestionsResponse>(
       GET_QUESTIONS,
       {
-        first: Math.min(target - items.length, V2_MAX_FIRST),
+        first: Math.min(target - items.length, MAX_PAGE_SIZE),
         after,
         filter,
         orderBy,

--- a/packages/sdk/queries/tags.ts
+++ b/packages/sdk/queries/tags.ts
@@ -1,4 +1,4 @@
-import { graphqlRequestV2 } from './client/graphqlClient';
+import { graphqlRequest } from './client/graphqlClient';
 
 type PopularTagsV2Response = {
   tags: {
@@ -21,6 +21,6 @@ function toTagNames(data: PopularTagsV2Response | null): string[] {
 }
 
 export async function fetchPopularTags(): Promise<string[]> {
-  const data = await graphqlRequestV2<PopularTagsV2Response>(GET_POPULAR_TAGS);
+  const data = await graphqlRequest<PopularTagsV2Response>(GET_POPULAR_TAGS);
   return toTagNames(data);
 }

--- a/packages/sdk/queries/tags.ts
+++ b/packages/sdk/queries/tags.ts
@@ -1,6 +1,6 @@
 import { graphqlRequest } from './client/graphqlClient';
 
-type PopularTagsV2Response = {
+type PopularTagsResponse = {
   tags: {
     nodes: Array<{ name: string }>;
   };
@@ -16,11 +16,11 @@ export const GET_POPULAR_TAGS = /* GraphQL */ `
   }
 `;
 
-function toTagNames(data: PopularTagsV2Response | null): string[] {
+function toTagNames(data: PopularTagsResponse | null): string[] {
   return (data?.tags?.nodes ?? []).map((node) => node.name);
 }
 
 export async function fetchPopularTags(): Promise<string[]> {
-  const data = await graphqlRequest<PopularTagsV2Response>(GET_POPULAR_TAGS);
+  const data = await graphqlRequest<PopularTagsResponse>(GET_POPULAR_TAGS);
   return toTagNames(data);
 }

--- a/packages/sdk/queries/vault.ts
+++ b/packages/sdk/queries/vault.ts
@@ -1,9 +1,9 @@
 import { graphqlRequest } from './client/graphqlClient';
 
 /**
- * Per-vault economic snapshot series, fetched from the v2 `vault(address:,
+ * Per-vault economic snapshot series, fetched from the `vault(address:,
  * chainId:).statsHistory` surface. Backs the vault dashboard's TVL / PnL
- * charts (the migration off v1's `protocolStats(vaultAddress:)`).
+ * charts.
  *
  * Only the fields the dashboard plots are selected. `cumulativePnl` is the
  * PnL line; `balance + deployedCollateral + claimableCollateral` is the TVL line.
@@ -100,7 +100,7 @@ function toVaultStat(node: WireVaultStat): VaultStat {
  * normal vault this completes in a single request. The loop pages on
  * `pageInfo` only if a vault's series ever exceeds the cap, so the chart never
  * silently loses history. Returns an empty array when the address is not a
- * configured vault (the v2 `vault` field resolves null).
+ * configured vault (the `vault` field resolves null).
  *
  * `pageSize` (optional) forces an explicit per-page `first` — it must stay
  * <= the API's GRAPHQL_MAX_LIST_SIZE (100), since a larger literal is rejected

--- a/packages/sdk/queries/vault.ts
+++ b/packages/sdk/queries/vault.ts
@@ -1,4 +1,4 @@
-import { graphqlRequestV2 } from './client/graphqlClient';
+import { graphqlRequest } from './client/graphqlClient';
 
 /**
  * Per-vault economic snapshot series, fetched from the v2 `vault(address:,
@@ -116,7 +116,7 @@ export async function fetchVaultStats(
   // Bound the loop defensively against a non-progressing cursor; the daily
   // series can't realistically exceed a few thousand snapshots.
   for (let page = 0; page < 50; page += 1) {
-    const data: VaultStatsResponse = await graphqlRequestV2<VaultStatsResponse>(
+    const data: VaultStatsResponse = await graphqlRequest<VaultStatsResponse>(
       GET_VAULT_STATS,
       {
         address: address.toLowerCase(),
@@ -191,7 +191,7 @@ export async function fetchVaultAccountValue(
   address: string,
   chainId?: number
 ): Promise<VaultAccountValue> {
-  const data = await graphqlRequestV2<VaultAccountValueResponse>(
+  const data = await graphqlRequest<VaultAccountValueResponse>(
     GET_VAULT_ACCOUNT_VALUE,
     {
       address: address.toLowerCase(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,13 +195,13 @@ importers:
   packages/app:
     dependencies:
       '@dnd-kit/core':
-        specifier: ^6.3.1
+        specifier: 6.3.1
         version: 6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@dnd-kit/sortable':
-        specifier: ^10.0.0
+        specifier: 10.0.0
         version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       '@dnd-kit/utilities':
-        specifier: ^3.2.2
+        specifier: 3.2.2
         version: 3.2.2(react@19.1.0)
       '@hookform/resolvers':
         specifier: 3.9.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,7 +175,7 @@ importers:
         version: 9.15.0(jiti@2.6.1)
       eslint-plugin-import:
         specifier: 2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.21.0(eslint@9.15.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.15.0(jiti@2.6.1))
+        version: 2.32.0(eslint@9.15.0(jiti@2.6.1))
       globals:
         specifier: 15.14.0
         version: 15.14.0
@@ -194,6 +194,15 @@ importers:
 
   packages/app:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.1.0)
       '@hookform/resolvers':
         specifier: 3.9.0
         version: 3.9.0(react-hook-form@7.53.0(react@19.1.0))
@@ -332,7 +341,7 @@ importers:
         version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.31.0(jiti@2.6.1))
       eslint-plugin-import:
         specifier: 2.32.0
-        version: 2.32.0(eslint-import-resolver-typescript@4.4.4)(eslint@9.31.0(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.21.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.31.0(jiti@2.6.1))
       eslint-plugin-react:
         specifier: 7.37.5
         version: 7.37.5(eslint@9.31.0(jiti@2.6.1))
@@ -427,7 +436,7 @@ importers:
         version: 9.15.0(jiti@2.6.1)
       eslint-plugin-import:
         specifier: 2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.21.0(eslint@9.15.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.15.0(jiti@2.6.1))
+        version: 2.32.0(eslint@9.15.0(jiti@2.6.1))
       globals:
         specifier: 15.11.0
         version: 15.11.0
@@ -537,7 +546,7 @@ importers:
         version: 9.15.0(jiti@2.6.1)
       eslint-plugin-import:
         specifier: 2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.21.0(eslint@9.15.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.15.0(jiti@2.6.1))
+        version: 2.32.0(eslint@9.15.0(jiti@2.6.1))
       globals:
         specifier: 15.11.0
         version: 15.11.0
@@ -564,7 +573,7 @@ importers:
         version: 5.84.2(react@19.1.0)
       abitype:
         specifier: 1.0.8
-        version: 1.0.8(typescript@5.8.3)(zod@4.3.6)
+        version: 1.0.8(typescript@5.8.3)(zod@3.25.76)
       graphql:
         specifier: 16.12.0
         version: 16.12.0
@@ -595,16 +604,16 @@ importers:
         version: 8.5.10
       '@zerodev/ecdsa-validator':
         specifier: 5.3.3
-        version: 5.3.3(@zerodev/sdk@5.4.5(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(permissionless@0.2.30(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))(webauthn-p256@0.0.10))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 5.3.3(@zerodev/sdk@5.4.5(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(permissionless@0.2.30(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(webauthn-p256@0.0.10))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@zerodev/sdk':
         specifier: 5.4.5
-        version: 5.4.5(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 5.4.5(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       eslint:
         specifier: 9.31.0
         version: 9.31.0(jiti@2.6.1)
       eslint-plugin-import:
         specifier: 2.32.0
-        version: 2.32.0(eslint-import-resolver-typescript@4.4.4)(eslint@9.31.0(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.21.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.31.0(jiti@2.6.1))
       prettier:
         specifier: 3.3.3
         version: 3.3.3
@@ -622,13 +631,13 @@ importers:
         version: 8.21.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3)
       viem:
         specifier: 2.47.2
-        version: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        version: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       vitest:
         specifier: 3.0.0
         version: 3.0.0(@types/node@22.14.0)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.0)
       wagmi:
         specifier: 2.19.5
-        version: 2.19.5(@tanstack/query-core@5.83.1)(@tanstack/react-query@5.84.2(react@19.1.0))(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
+        version: 2.19.5(@tanstack/query-core@5.83.1)(@tanstack/react-query@5.84.2(react@19.1.0))(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
 
   packages/ui:
     dependencies:
@@ -758,7 +767,7 @@ importers:
         version: 9.31.0(jiti@2.6.1)
       eslint-plugin-import:
         specifier: 2.32.0
-        version: 2.32.0(eslint-import-resolver-typescript@4.4.4)(eslint@9.31.0(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.21.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.31.0(jiti@2.6.1))
       eslint-plugin-react:
         specifier: 7.37.5
         version: 7.37.5(eslint@9.31.0(jiti@2.6.1))
@@ -1227,6 +1236,28 @@ packages:
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@ecies/ciphers@0.2.4':
     resolution: {integrity: sha512-t+iX+Wf5nRKyNzk8dviW3Ikb/280+aEJAnw9YXvCp2tYGPSkMki+NRY+8aNLmVFv3eNtMdvViPNOPxS8SZNP+w==}
@@ -2901,9 +2932,11 @@ packages:
 
   '@metamask/sdk-analytics@0.0.5':
     resolution: {integrity: sha512-fDah+keS1RjSUlC8GmYXvx6Y26s3Ax1U9hGpWb6GSY5SAdmTSIqp2CvYy6yW0WgLhnYhW+6xERuD0eVqV63QIQ==}
+    deprecated: No longer maintained, superseded by @metamask/connect-analytics
 
   '@metamask/sdk-communication-layer@0.33.1':
     resolution: {integrity: sha512-0bI9hkysxcfbZ/lk0T2+aKVo1j0ynQVTuB3sJ5ssPWlz+Z3VwveCkP1O7EVu1tsVVCb0YV5WxK9zmURu2FIiaA==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
     peerDependencies:
       cross-fetch: ^4.0.0
       eciesjs: '*'
@@ -2913,9 +2946,11 @@ packages:
 
   '@metamask/sdk-install-modal-web@0.32.1':
     resolution: {integrity: sha512-MGmAo6qSjf1tuYXhCu2EZLftq+DSt5Z7fsIKr2P+lDgdTPWgLfZB1tJKzNcwKKOdf6q9Qmmxn7lJuI/gq5LrKw==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/sdk@0.33.1':
     resolution: {integrity: sha512-1mcOQVGr9rSrVcbKPNVzbZ8eCl1K0FATsYH3WJ/MH4WcZDWGECWrXJPNMZoEAkLxWiMe8jOQBumg2pmcDa9zpQ==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/superstruct@3.2.1':
     resolution: {integrity: sha512-fLgJnDOXFmuVlB38rUN5SmU7hAFQcCjrg3Vrxz67KTY7YHFnSNEKvX4avmEBdOI0yTCxZjwMCFEqsC8k2+Wd3g==}
@@ -3428,7 +3463,7 @@ packages:
 
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
-    deprecated: 'The package is now available as "qr": npm install qr'
+    deprecated: 'Switch to "qr" (new package name) for security updates: npm install qr'
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -4479,6 +4514,7 @@ packages:
   '@safe-global/safe-gateway-typescript-sdk@3.23.1':
     resolution: {integrity: sha512-6ORQfwtEJYpalCeVO21L4XXGSdbEMfyp2hEv6cP82afKXSwvse6d3sdelgaPWUxHIsFRkWvHDdzh8IyyKHZKxw==}
     engines: {node: '>=16'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@scure/base@1.1.9':
     resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
@@ -6116,6 +6152,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@uniswap/lib@1.1.1':
     resolution: {integrity: sha512-2yK7sLpKIT91TiS5sewHtOa7YuM8IuBXVl4GZv2jZFys4D2sY7K5vZh6MqD25TPA95Od+0YzCVq6cTF2IKrOmg==}
@@ -6621,7 +6658,7 @@ packages:
     resolution: {integrity: sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==}
 
   abi-decoder@https://codeload.github.com/UMAprotocol/abi-decoder/tar.gz/1f18b7037985bf9b8960a6dc39dc52579ef274bb:
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/UMAprotocol/abi-decoder/tar.gz/1f18b7037985bf9b8960a6dc39dc52579ef274bb}
+    resolution: {tarball: https://codeload.github.com/UMAprotocol/abi-decoder/tar.gz/1f18b7037985bf9b8960a6dc39dc52579ef274bb}
     version: 2.2.2
 
   abitype@1.0.6:
@@ -7809,10 +7846,12 @@ packages:
   conventional-changelog-atom@2.0.8:
     resolution: {integrity: sha512-xo6v46icsFTK3bb7dY/8m2qvc8sZemRgdqLb/bjpBsH2UyOS8rKNTgcb5025Hri6IpANPApbXMg15QLb1LJpBw==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-codemirror@2.0.8:
     resolution: {integrity: sha512-z5DAsn3uj1Vfp7po3gpt2Boc+Bdwmw2++ZHa5Ak9k0UKsYAO5mH1UBTN0qSCuJZREIhX6WU4E1p3IW2oRCNzQw==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-config-spec@2.1.0:
     resolution: {integrity: sha512-IpVePh16EbbB02V+UA+HQnnPIohgXvJRxHcS5+Uwk4AT5LjzCZJm5sp/yqs5C6KZJ1jMsV4paEV13BN1pvDuxQ==}
@@ -7824,26 +7863,32 @@ packages:
   conventional-changelog-core@4.2.4:
     resolution: {integrity: sha512-gDVS+zVJHE2v4SLc6B0sLsPiloR0ygU7HaDW14aNJE1v4SlqJPILPl/aJC7YdtRE4CybBf8gDwObBvKha8Xlyg==}
     engines: {node: '>=10'}
+    deprecated: Deprecated and no longer maintained. Please use conventional-changelog instead.
 
   conventional-changelog-ember@2.0.9:
     resolution: {integrity: sha512-ulzIReoZEvZCBDhcNYfDIsLTHzYHc7awh+eI44ZtV5cx6LVxLlVtEmcO+2/kGIHGtw+qVabJYjdI5cJOQgXh1A==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-eslint@3.0.9:
     resolution: {integrity: sha512-6NpUCMgU8qmWmyAMSZO5NrRd7rTgErjrm4VASam2u5jrZS0n38V7Y9CzTtLT2qwz5xEChDR4BduoWIr8TfwvXA==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-express@2.0.6:
     resolution: {integrity: sha512-SDez2f3iVJw6V563O3pRtNwXtQaSmEfTCaTBPCqn0oG0mfkq0rX4hHBq5P7De2MncoRixrALj3u3oQsNK+Q0pQ==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-jquery@3.0.11:
     resolution: {integrity: sha512-x8AWz5/Td55F7+o/9LQ6cQIPwrCjfJQ5Zmfqi8thwUEKHstEn4kTIofXub7plf1xvFA2TqhZlq7fy5OmV6BOMw==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-jshint@2.0.9:
     resolution: {integrity: sha512-wMLdaIzq6TNnMHMy31hql02OEQ8nCQfExw1SE0hYL5KvU+JCTuPaDO+7JiogGT2gJAxiUGATdtYYfh+nT+6riA==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-preset-loader@2.3.4:
     resolution: {integrity: sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g==}
@@ -9768,7 +9813,7 @@ packages:
   git-raw-commits@2.0.11:
     resolution: {integrity: sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==}
     engines: {node: '>=10'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-remote-origin-url@2.0.0:
@@ -9778,7 +9823,7 @@ packages:
   git-semver-tags@4.1.1:
     resolution: {integrity: sha512-OWyMt5zBe7xFs8vglMmhM9lRQzCWL3WjHtxNNfJTMngGym7pC1kh8sP6jevfydJ6LP3ZvGxfb6ABYgPUM0mtsA==}
     engines: {node: '>=10'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   gitconfiglocal@1.0.0:
@@ -12202,7 +12247,7 @@ packages:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
   node-metamask@https://codeload.github.com/UMAprotocol/node-metamask/tar.gz/36b33cb82558bafcd3ab0dcfbd35b26c2c0a2584:
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/UMAprotocol/node-metamask/tar.gz/36b33cb82558bafcd3ab0dcfbd35b26c2c0a2584}
+    resolution: {tarball: https://codeload.github.com/UMAprotocol/node-metamask/tar.gz/36b33cb82558bafcd3ab0dcfbd35b26c2c0a2584}
     version: 1.1.2
 
   node-mock-http@1.0.3:
@@ -13508,6 +13553,7 @@ packages:
   recharts@2.15.4:
     resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -16819,30 +16865,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@base-org/account@2.4.0(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@4.3.6)':
-    dependencies:
-      '@coinbase/cdp-sdk': 1.44.0(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@noble/hashes': 1.4.0
-      clsx: 1.2.1
-      eventemitter3: 5.0.1
-      idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.8.3)(zod@4.3.6)
-      preact: 10.24.2
-      viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      zustand: 5.0.3(@types/react@19.1.8)(react@19.1.0)(use-sync-external-store@1.4.0(react@19.1.0))
-    transitivePeerDependencies:
-      - '@types/react'
-      - bufferutil
-      - debug
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - immer
-      - react
-      - typescript
-      - use-sync-external-store
-      - utf-8-validate
-      - zod
-
   '@bcoe/v8-coverage@0.2.3': {}
 
   '@braintree/sanitize-url@7.1.1': {}
@@ -16967,26 +16989,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@coinbase/wallet-sdk@4.3.6(@types/react@19.1.8)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@4.3.6)':
-    dependencies:
-      '@noble/hashes': 1.4.0
-      clsx: 1.2.1
-      eventemitter3: 5.0.1
-      idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.8.3)(zod@4.3.6)
-      preact: 10.24.2
-      viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      zustand: 5.0.3(@types/react@19.1.8)(react@19.1.0)(use-sync-external-store@1.4.0(react@19.1.0))
-    transitivePeerDependencies:
-      - '@types/react'
-      - bufferutil
-      - immer
-      - react
-      - typescript
-      - use-sync-external-store
-      - utf-8-validate
-      - zod
-
   '@colors/colors@1.6.0': {}
 
   '@corex/deepmerge@4.0.43': {}
@@ -17022,6 +17024,31 @@ snapshots:
       kuler: 2.0.0
 
   '@date-fns/tz@1.4.1': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.1.0)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.0)
+      react: 19.1.0
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      tslib: 2.8.1
 
   '@ecies/ciphers@0.2.4(@noble/ciphers@1.3.0)':
     dependencies:
@@ -17891,14 +17918,6 @@ snapshots:
       '@metamask/rpc-errors': 7.0.2
       eventemitter3: 5.0.1
       viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@gemini-wallet/core@0.3.2(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
-    dependencies:
-      '@metamask/rpc-errors': 7.0.2
-      eventemitter3: 5.0.1
-      viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -20606,17 +20625,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-common@1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
-    dependencies:
-      big.js: 6.2.2
-      dayjs: 1.11.13
-      viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-    transitivePeerDependencies:
-      - bufferutil
-      - typescript
-      - utf-8-validate
-      - zod
-
   '@reown/appkit-controllers@1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -20652,83 +20660,12 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-controllers@1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      valtio: 1.13.2(@types/react@19.1.8)(react@19.1.0)
-      viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   '@reown/appkit-pay@1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-controllers': 1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-ui': 1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-utils': 1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.1.8)(react@19.1.0))(zod@3.25.76)
-      lit: 3.3.0
-      valtio: 1.13.2(@types/react@19.1.8)(react@19.1.0)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@reown/appkit-pay@1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.1.8)(react@19.1.0))(zod@4.3.6)
       lit: 3.3.0
       valtio: 1.13.2(@types/react@19.1.8)(react@19.1.0)
     transitivePeerDependencies:
@@ -20800,82 +20737,10 @@ snapshots:
       - valtio
       - zod
 
-  '@reown/appkit-scaffold-ui@1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.1.8)(react@19.1.0))(zod@4.3.6)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.1.8)(react@19.1.0))(zod@4.3.6)
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      lit: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - valtio
-      - zod
-
   '@reown/appkit-ui@1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-controllers': 1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      lit: 3.3.0
-      qrcode: 1.5.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@reown/appkit-ui@1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       lit: 3.3.0
       qrcode: 1.5.3
@@ -20945,44 +20810,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-utils@1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.1.8)(react@19.1.0))(zod@4.3.6)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-polyfills': 1.7.8
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@walletconnect/logger': 2.1.2
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      valtio: 1.13.2(@types/react@19.1.8)(react@19.1.0)
-      viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   '@reown/appkit-wallet@1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -21009,49 +20836,6 @@ snapshots:
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@19.1.8)(react@19.1.0)
       viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@reown/appkit@1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-pay': 1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-polyfills': 1.7.8
-      '@reown/appkit-scaffold-ui': 1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.1.8)(react@19.1.0))(zod@4.3.6)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.1.8)(react@19.1.0))(zod@4.3.6)
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@walletconnect/types': 2.21.0
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      bs58: 6.0.0
-      valtio: 1.13.2(@types/react@19.1.8)(react@19.1.0)
-      viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -21190,30 +20974,10 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
-    dependencies:
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      events: 3.3.0
-    transitivePeerDependencies:
-      - bufferutil
-      - typescript
-      - utf-8-validate
-      - zod
-
   '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.23.1
       viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-    transitivePeerDependencies:
-      - bufferutil
-      - typescript
-      - utf-8-validate
-      - zod
-
-  '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
-    dependencies:
-      '@safe-global/safe-gateway-typescript-sdk': 3.23.1
-      viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -23889,79 +23653,11 @@ snapshots:
       - wagmi
       - zod
 
-  '@wagmi/connectors@6.2.0(@tanstack/react-query@5.84.2(react@19.1.0))(@types/react@19.1.8)(@wagmi/core@2.22.1(@tanstack/query-core@5.83.1)(@types/react@19.1.8)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.83.1)(@tanstack/react-query@5.84.2(react@19.1.0))(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))(zod@4.3.6)':
-    dependencies:
-      '@base-org/account': 2.4.0(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.1.8)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@gemini-wallet/core': 0.3.2(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))
-      '@metamask/sdk': 0.33.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
-      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.83.1)(@types/react@19.1.8)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))
-      '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.35(@tanstack/react-query@5.84.2(react@19.1.0))(@types/react@19.1.8)(@wagmi/core@2.22.1(@tanstack/query-core@5.83.1)(@types/react@19.1.8)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.83.1)(@tanstack/react-query@5.84.2(react@19.1.0))(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))
-      viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@tanstack/react-query'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - debug
-      - encoding
-      - expo-auth-session
-      - expo-crypto
-      - expo-web-browser
-      - fastestsmallesttextencoderdecoder
-      - immer
-      - ioredis
-      - react
-      - react-native
-      - supports-color
-      - uploadthing
-      - use-sync-external-store
-      - utf-8-validate
-      - wagmi
-      - zod
-
   '@wagmi/core@2.22.1(@tanstack/query-core@5.83.1)(@types/react@19.1.8)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.8.3)
       viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      zustand: 5.0.0(@types/react@19.1.8)(react@19.1.0)(use-sync-external-store@1.4.0(react@19.1.0))
-    optionalDependencies:
-      '@tanstack/query-core': 5.83.1
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - react
-      - use-sync-external-store
-
-  '@wagmi/core@2.22.1(@tanstack/query-core@5.83.1)(@types/react@19.1.8)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
-    dependencies:
-      eventemitter3: 5.0.1
-      mipd: 0.0.7(typescript@5.8.3)
-      viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       zustand: 5.0.0(@types/react@19.1.8)(react@19.1.0)(use-sync-external-store@1.4.0(react@19.1.0))
     optionalDependencies:
       '@tanstack/query-core': 5.83.1
@@ -23987,50 +23683,6 @@ snapshots:
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.0
       '@walletconnect/utils': 2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@walletconnect/window-getters': 1.0.1
-      es-toolkit: 1.33.0
-      events: 3.3.0
-      uint8arrays: 3.1.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@walletconnect/core@2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
-    dependencies:
-      '@walletconnect/heartbeat': 1.2.2
-      '@walletconnect/jsonrpc-provider': 1.0.14
-      '@walletconnect/jsonrpc-types': 1.0.4
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/jsonrpc-ws-connection': 1.0.16(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/logger': 2.1.2
-      '@walletconnect/relay-api': 1.0.11
-      '@walletconnect/relay-auth': 1.1.0
-      '@walletconnect/safe-json': 1.0.2
-      '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.21.0
-      '@walletconnect/utils': 2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.33.0
       events: 3.3.0
@@ -24104,50 +23756,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/core@2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
-    dependencies:
-      '@walletconnect/heartbeat': 1.2.2
-      '@walletconnect/jsonrpc-provider': 1.0.14
-      '@walletconnect/jsonrpc-types': 1.0.4
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/jsonrpc-ws-connection': 1.0.16(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/logger': 2.1.2
-      '@walletconnect/relay-api': 1.0.11
-      '@walletconnect/relay-auth': 1.1.0
-      '@walletconnect/safe-json': 1.0.2
-      '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.21.1
-      '@walletconnect/utils': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@walletconnect/window-getters': 1.0.1
-      es-toolkit: 1.33.0
-      events: 3.3.0
-      uint8arrays: 3.1.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   '@walletconnect/environment@1.0.1':
     dependencies:
       tslib: 1.14.1
@@ -24164,47 +23772,6 @@ snapshots:
       '@walletconnect/types': 2.21.1
       '@walletconnect/universal-provider': 2.21.1(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/utils': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      events: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@walletconnect/ethereum-provider@2.21.1(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
-    dependencies:
-      '@reown/appkit': 1.7.8(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@walletconnect/jsonrpc-http-connection': 1.0.8(encoding@0.1.13)
-      '@walletconnect/jsonrpc-provider': 1.0.14
-      '@walletconnect/jsonrpc-types': 1.0.4
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/sign-client': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@walletconnect/types': 2.21.1
-      '@walletconnect/universal-provider': 2.21.1(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@walletconnect/utils': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -24363,42 +23930,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/sign-client@2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
-    dependencies:
-      '@walletconnect/core': 2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@walletconnect/events': 1.0.1
-      '@walletconnect/heartbeat': 1.2.2
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/logger': 2.1.2
-      '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.21.0
-      '@walletconnect/utils': 2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      events: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   '@walletconnect/sign-client@2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/core': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -24409,42 +23940,6 @@ snapshots:
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.1
       '@walletconnect/utils': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      events: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@walletconnect/sign-client@2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
-    dependencies:
-      '@walletconnect/core': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@walletconnect/events': 1.0.1
-      '@walletconnect/heartbeat': 1.2.2
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/logger': 2.1.2
-      '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.21.1
-      '@walletconnect/utils': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -24573,46 +24068,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/universal-provider@2.21.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
-    dependencies:
-      '@walletconnect/events': 1.0.1
-      '@walletconnect/jsonrpc-http-connection': 1.0.8(encoding@0.1.13)
-      '@walletconnect/jsonrpc-provider': 1.0.14
-      '@walletconnect/jsonrpc-types': 1.0.4
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/logger': 2.1.2
-      '@walletconnect/sign-client': 2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@walletconnect/types': 2.21.0
-      '@walletconnect/utils': 2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      es-toolkit: 1.33.0
-      events: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   '@walletconnect/universal-provider@2.21.1(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/events': 1.0.1
@@ -24625,46 +24080,6 @@ snapshots:
       '@walletconnect/sign-client': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/types': 2.21.1
       '@walletconnect/utils': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      es-toolkit: 1.33.0
-      events: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@walletconnect/universal-provider@2.21.1(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
-    dependencies:
-      '@walletconnect/events': 1.0.1
-      '@walletconnect/jsonrpc-http-connection': 1.0.8(encoding@0.1.13)
-      '@walletconnect/jsonrpc-provider': 1.0.14
-      '@walletconnect/jsonrpc-types': 1.0.4
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/logger': 2.1.2
-      '@walletconnect/sign-client': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@walletconnect/types': 2.21.1
-      '@walletconnect/utils': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       es-toolkit: 1.33.0
       events: 3.3.0
     transitivePeerDependencies:
@@ -24737,50 +24152,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
-    dependencies:
-      '@noble/ciphers': 1.2.1
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/relay-api': 1.0.11
-      '@walletconnect/relay-auth': 1.1.0
-      '@walletconnect/safe-json': 1.0.2
-      '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.21.0
-      '@walletconnect/window-getters': 1.0.1
-      '@walletconnect/window-metadata': 1.0.1
-      bs58: 6.0.0
-      detect-browser: 5.3.0
-      query-string: 7.1.3
-      uint8arrays: 3.1.0
-      viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   '@walletconnect/utils@2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@noble/ciphers': 1.2.1
@@ -24800,50 +24171,6 @@ snapshots:
       query-string: 7.1.3
       uint8arrays: 3.1.0
       viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@walletconnect/utils@2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
-    dependencies:
-      '@noble/ciphers': 1.2.1
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/relay-api': 1.0.11
-      '@walletconnect/relay-auth': 1.1.0
-      '@walletconnect/safe-json': 1.0.2
-      '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.21.1
-      '@walletconnect/window-getters': 1.0.1
-      '@walletconnect/window-metadata': 1.0.1
-      bs58: 6.0.0
-      detect-browser: 5.3.0
-      query-string: 7.1.3
-      uint8arrays: 3.1.0
-      viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -24985,12 +24312,6 @@ snapshots:
       permissionless: 0.2.30(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(webauthn-p256@0.0.10)
       viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
 
-  '@zerodev/ecdsa-validator@5.3.3(@zerodev/sdk@5.4.5(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(permissionless@0.2.30(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))(webauthn-p256@0.0.10))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
-    dependencies:
-      '@zerodev/sdk': 5.4.5(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))
-      permissionless: 0.2.30(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))(webauthn-p256@0.0.10)
-      viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-
   '@zerodev/ecdsa-validator@5.4.9(@zerodev/sdk@5.5.7(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       '@zerodev/sdk': 5.5.7(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
@@ -25008,11 +24329,6 @@ snapshots:
     dependencies:
       semver: 7.7.3
       viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-
-  '@zerodev/sdk@5.4.5(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
-    dependencies:
-      semver: 7.7.3
-      viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
 
   '@zerodev/sdk@5.5.7(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
@@ -25050,11 +24366,6 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
       zod: 3.25.76
-
-  abitype@1.0.8(typescript@5.8.3)(zod@4.3.6):
-    optionalDependencies:
-      typescript: 5.8.3
-      zod: 4.3.6
 
   abitype@1.2.3(typescript@5.8.3)(zod@3.25.76):
     optionalDependencies:
@@ -27766,31 +27077,31 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@4.4.4)(eslint@9.31.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.21.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.31.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.21.0(eslint@9.15.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@9.15.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.21.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.31.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.21.0(eslint@9.15.0(jiti@2.6.1))(typescript@5.8.3)
-      eslint: 9.15.0(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.31.0(jiti@2.6.1)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
+      '@typescript-eslint/parser': 8.21.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3)
       eslint: 9.31.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.31.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.21.0(eslint@9.15.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.15.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint@9.15.0(jiti@2.6.1)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      eslint: 9.15.0(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.9
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.21.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.31.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -27799,9 +27110,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.15.0(jiti@2.6.1)
+      eslint: 9.31.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.21.0(eslint@9.15.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@9.15.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.21.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.31.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -27813,13 +27124,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.21.0(eslint@9.15.0(jiti@2.6.1))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.21.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@4.4.4)(eslint@9.31.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint@9.15.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -27828,9 +27139,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.31.0(jiti@2.6.1)
+      eslint: 9.15.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.31.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint@9.15.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -32577,21 +31888,6 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.14.0(typescript@5.8.3)(zod@4.3.6):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.8.3)(zod@4.3.6)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - zod
-
   ox@0.6.9(typescript@5.8.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -32600,20 +31896,6 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.0.8(typescript@5.8.3)(zod@3.25.76)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - zod
-
-  ox@0.6.9(typescript@5.8.3)(zod@4.3.6):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/curves': 1.9.7
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.0.8(typescript@5.8.3)(zod@4.3.6)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.8.3
@@ -32885,11 +32167,6 @@ snapshots:
       viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       webauthn-p256: 0.0.10
 
-  permissionless@0.2.30(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))(webauthn-p256@0.0.10):
-    dependencies:
-      viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      webauthn-p256: 0.0.10
-
   pg-cloudflare@1.3.0:
     optional: true
 
@@ -33073,26 +32350,6 @@ snapshots:
       react: 19.1.0
       typescript: 5.8.3
       wagmi: 2.19.5(@tanstack/query-core@5.83.1)(@tanstack/react-query@5.84.2(react@19.1.0))(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - use-sync-external-store
-
-  porto@0.2.35(@tanstack/react-query@5.84.2(react@19.1.0))(@types/react@19.1.8)(@wagmi/core@2.22.1(@tanstack/query-core@5.83.1)(@types/react@19.1.8)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.83.1)(@tanstack/react-query@5.84.2(react@19.1.0))(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)):
-    dependencies:
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.83.1)(@types/react@19.1.8)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))
-      hono: 4.10.7
-      idb-keyval: 6.2.2
-      mipd: 0.0.7(typescript@5.8.3)
-      ox: 0.9.17(typescript@5.8.3)(zod@4.3.6)
-      viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      zod: 4.3.6
-      zustand: 5.0.3(@types/react@19.1.8)(react@19.1.0)(use-sync-external-store@1.4.0(react@19.1.0))
-    optionalDependencies:
-      '@tanstack/react-query': 5.84.2(react@19.1.0)
-      react: 19.1.0
-      typescript: 5.8.3
-      wagmi: 2.19.5(@tanstack/query-core@5.83.1)(@tanstack/react-query@5.84.2(react@19.1.0))(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -36241,23 +35498,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6):
-    dependencies:
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.8.3)(zod@4.3.6)
-      isows: 1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      ox: 0.14.0(typescript@5.8.3)(zod@4.3.6)
-      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
   vite-node@2.1.9(@types/node@20.17.10)(lightningcss@1.30.2)(terser@5.44.0):
     dependencies:
       cac: 6.7.14
@@ -36689,51 +35929,6 @@ snapshots:
       react: 19.1.0
       use-sync-external-store: 1.4.0(react@19.1.0)
       viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - debug
-      - encoding
-      - expo-auth-session
-      - expo-crypto
-      - expo-web-browser
-      - fastestsmallesttextencoderdecoder
-      - immer
-      - ioredis
-      - react-native
-      - supports-color
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  wagmi@2.19.5(@tanstack/query-core@5.83.1)(@tanstack/react-query@5.84.2(react@19.1.0))(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6):
-    dependencies:
-      '@tanstack/react-query': 5.84.2(react@19.1.0)
-      '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.84.2(react@19.1.0))(@types/react@19.1.8)(@wagmi/core@2.22.1(@tanstack/query-core@5.83.1)(@types/react@19.1.8)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.83.1)(@tanstack/react-query@5.84.2(react@19.1.0))(@types/react@19.1.8)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))(zod@4.3.6)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.83.1)(@types/react@19.1.8)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6))
-      react: 19.1.0
-      use-sync-external-store: 1.4.0(react@19.1.0)
-      viem: 2.47.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Two related changes for the prediction-market admin surface:

### 1. Question Ordering admin page
A new **`/admin/question-ordering`** page that lets operators manually set the display order of the questions (conditions) shown within a group/event.

- **Drag-and-drop** reordering (dnd-kit) with a searchable group picker (by name or id).
- **Loads over public GraphQL** — no wallet signature to browse. **Save is the only signed call**, and a client-side permutation guard makes it a pure reorder (display order only; never adds/removes/detaches conditions).
- Clear unsaved/saved UX: moved rows are highlighted with their new position, a ↑/↓ delta, and "was #N"; an amber "N moved · unsaved" vs. green "All changes saved" status; an explicit note that saving prompts a one-time signature and updates only display order.
- The page sources its endpoint from the app's single GraphQL endpoint setting and derives the signed `/admin` REST base from that same origin, so load and save always hit one backend.

### 2. Collapse the GraphQL "v2" endpoint into one concept
The app carried a confusing **dual** GraphQL-endpoint concept (`graphqlEndpoint`/`graphqlRequest` vs `graphqlEndpointV2`/`graphqlRequestV2`), but both resolve to the **same schema** — Sapience serves it at `/v2/graphql`, Meridian at `/graphql`, so the setting already stores a full URL. The v2 surface was the only one used in practice; the v1 surface was dead. This split is exactly what made the ordering page initially read the wrong setting and hit the legacy schema.

- **SDK:** one `getGraphQLEndpoint` / `graphqlRequest` / `typedGraphqlRequest` / `createGraphQLClient`; the `*V2` counterparts are deleted and all ~40 callers repointed.
- **Settings:** one `graphqlEndpoint` setting, one storage key, one default (`/v2/graphql`). The "GraphQL Endpoint" field and the Meridian env presets write it; the v2 surface is removed.
- **Lossless migration:** resolvers read the new key and fall back to the legacy `graphqlEndpointV2` key; the setter writes the new key and clears the legacy one — existing overrides keep working with no reconfiguration.

## Testing
- `packages/sdk`: full suite green (753 tests), incl. new endpoint + migration cases.
- `packages/app`: all affected suites green (graphql client/settings/admin/hooks); `type-check` and `lint` clean across both packages. (Pre-existing, unrelated `sessionKeyManager.test.ts` failures are not touched by this PR.)
- Repo-wide grep confirms no remaining `*V2` GraphQL symbols outside the intentional legacy-migration key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
