### PR TITLE
fix(app): default incognito sessions to Robinhood, not env-derived Sapience

### DIFF
--- a/packages/app/src/components/shared/chat/types.ts
+++ b/packages/app/src/components/shared/chat/types.ts
@@ -1,5 +1,7 @@
 'use client';
 
+import { getNetworkEndpointDefaults } from '~/lib/config/networkDefaults';
+
 type ChatAuthor = 'me' | 'server' | 'system';
 
 export type ChatMessage = {
@@ -24,15 +26,10 @@ const getBase = (): string => {
   } catch {
     /* noop */
   }
-  const env =
-    (process.env.NEXT_PUBLIC_FOIL_API_URL as string) ||
-    'https://api.sapience.xyz';
-  try {
-    const u = new URL(env);
-    return `${u.origin}${WEBSOCKET_PATH}`;
-  } catch {
-    return `https://api.sapience.xyz${WEBSOCKET_PATH}`;
-  }
+  // No Settings override → follow the active network default. Robinhood ships
+  // chat off (blank), so the chat bubble is hidden and this base is never used
+  // to open a socket; only an explicit override (Ethereal presets) enables chat.
+  return getNetworkEndpointDefaults().chatBase;
 };
 
 export const buildWebSocketUrl = () => {

--- a/packages/app/src/hooks/markets/useRequestMarket.ts
+++ b/packages/app/src/hooks/markets/useRequestMarket.ts
@@ -1,12 +1,11 @@
 'use client';
 
 import { useMutation, type UseMutationResult } from '@tanstack/react-query';
+import { getNetworkEndpointDefaults } from '~/lib/config/networkDefaults';
 
 function getPublicApiBaseUrl(): string {
-  // Default network is Robinhood Mainnet (Meridian API).
-  return (
-    process.env.NEXT_PUBLIC_FOIL_API_URL || 'https://api.predict.meridian.xyz'
-  );
+  // Follows the app's active network (Robinhood → Meridian API), not env.
+  return getNetworkEndpointDefaults().apiOrigin;
 }
 
 export class MarketRequestApiError extends Error {

--- a/packages/app/src/hooks/referrals/useReferrals.ts
+++ b/packages/app/src/hooks/referrals/useReferrals.ts
@@ -6,12 +6,11 @@ import {
   type UseMutationResult,
   type UseQueryResult,
 } from '@tanstack/react-query';
+import { getNetworkEndpointDefaults } from '~/lib/config/networkDefaults';
 
 function getPublicApiBaseUrl(): string {
-  // Default network is Robinhood Mainnet (Meridian API).
-  return (
-    process.env.NEXT_PUBLIC_FOIL_API_URL || 'https://api.predict.meridian.xyz'
-  );
+  // Follows the app's active network (Robinhood → Meridian API), not env.
+  return getNetworkEndpointDefaults().apiOrigin;
 }
 
 /**

--- a/packages/app/src/lib/auction/useAuctionStart.ts
+++ b/packages/app/src/lib/auction/useAuctionStart.ts
@@ -12,6 +12,7 @@ import { canonicalizePicks } from '@sapience/sdk/auction/escrowEncoding';
 import { predictionMarketEscrow } from '@sapience/sdk/contracts';
 import { useSettings } from '~/lib/context/SettingsContext';
 import { useSession } from '~/lib/context/SessionContext';
+import { getNetworkEndpointDefaults } from '~/lib/config/networkDefaults';
 import { toAuctionWsUrl } from '~/lib/ws/auctionUrl';
 import { getSharedAuctionWsClient } from '~/lib/ws/AuctionWsClient';
 import { logAuction, formatBidForLog } from '~/lib/auction/bidLogger';
@@ -165,22 +166,17 @@ export function useAuctionStart(options?: UseAuctionStartOptions) {
 
   const relayerBase = useMemo(() => {
     if (apiBaseUrl && apiBaseUrl.length > 0) return apiBaseUrl;
+    // Before the Settings context mounts, fall back to an explicit relayer env
+    // override, then to the active network default (Robinhood → Meridian relayer).
     const explicitRelayer = process.env.NEXT_PUBLIC_FOIL_RELAYER_URL;
-    const apiRoot = process.env.NEXT_PUBLIC_FOIL_API_URL;
-    // Default network is Robinhood Mainnet (Meridian relayer).
-    if (!explicitRelayer && !apiRoot) {
-      return 'https://relayer.predict.meridian.xyz/auction';
-    }
-    const root = explicitRelayer || (apiRoot as string);
-    try {
-      const u = new URL(root);
-      if (!explicitRelayer && u.hostname === 'api.sapience.xyz') {
-        u.hostname = 'relayer.sapience.xyz';
+    if (explicitRelayer) {
+      try {
+        return `${new URL(explicitRelayer).origin}/auction`;
+      } catch {
+        return `${explicitRelayer}/auction`;
       }
-      return `${u.origin}/auction`;
-    } catch {
-      return `${root}/auction`;
     }
+    return getNetworkEndpointDefaults().relayerBase;
   }, [apiBaseUrl]);
   const wsUrl = useMemo(
     () => toAuctionWsUrl(relayerBase || undefined),

--- a/packages/app/src/lib/config/networkDefaults.ts
+++ b/packages/app/src/lib/config/networkDefaults.ts
@@ -1,0 +1,68 @@
+import {
+  DEFAULT_CHAIN_ID,
+  CHAIN_ID_ETHEREAL_TESTNET,
+  CHAIN_ID_ROBINHOOD_TESTNET,
+} from '@sapience/sdk/constants';
+
+/**
+ * Default offchain endpoints for the app's active network.
+ *
+ * These defaults are derived from the build's default chain (`DEFAULT_CHAIN_ID`),
+ * NOT from any `NEXT_PUBLIC_FOIL_*` env var. The app defaults to Robinhood
+ * Mainnet; a "staging" build (one whose default chain is a testnet) defaults to
+ * Robinhood Testnet. Both ship with the mesh signal and chat disabled (blank).
+ *
+ * Keeping this off the env vars means a fresh (incognito) session always lands
+ * on the Robinhood values that match the network the app is built for, instead
+ * of inheriting a Sapience/Ethereal endpoint from a stray `.env` entry.
+ *
+ * Ethereal/Sapience endpoints remain reachable — the user opts in via the
+ * network preset buttons on the Settings page, which persist localStorage
+ * overrides that take precedence over these defaults everywhere.
+ */
+export type NetworkEndpointDefaults = {
+  /** Origin of the public API (REST + GraphQL host). */
+  apiOrigin: string;
+  graphqlEndpoint: string;
+  relayerBase: string;
+  adminBase: string;
+  signalEndpoint: string;
+  chatBase: string;
+};
+
+export const ROBINHOOD_MAINNET_DEFAULTS: NetworkEndpointDefaults = {
+  apiOrigin: 'https://api.predict.meridian.xyz',
+  graphqlEndpoint: 'https://api.predict.meridian.xyz/graphql',
+  relayerBase: 'https://relayer.predict.meridian.xyz/auction',
+  adminBase: 'https://api.predict.meridian.xyz/admin',
+  signalEndpoint: '',
+  chatBase: '',
+};
+
+export const ROBINHOOD_TESTNET_DEFAULTS: NetworkEndpointDefaults = {
+  apiOrigin: 'https://api.predict.meridiantest.net',
+  graphqlEndpoint: 'https://api.predict.meridiantest.net/graphql',
+  relayerBase: 'https://relayer.predict.meridiantest.net/auction',
+  adminBase: 'https://api.predict.meridiantest.net/admin',
+  signalEndpoint: '',
+  chatBase: '',
+};
+
+/**
+ * "Staging" == a testnet default chain. Staging deployments set
+ * `NEXT_PUBLIC_DEFAULT_CHAIN_ID` to a testnet id, so `DEFAULT_CHAIN_ID` is the
+ * single source of truth for which network's defaults to serve.
+ */
+export function isStagingNetwork(): boolean {
+  return (
+    DEFAULT_CHAIN_ID === CHAIN_ID_ROBINHOOD_TESTNET ||
+    DEFAULT_CHAIN_ID === CHAIN_ID_ETHEREAL_TESTNET
+  );
+}
+
+/** Default offchain endpoints for the app's active network. */
+export function getNetworkEndpointDefaults(): NetworkEndpointDefaults {
+  return isStagingNetwork()
+    ? ROBINHOOD_TESTNET_DEFAULTS
+    : ROBINHOOD_MAINNET_DEFAULTS;
+}

--- a/packages/app/src/lib/context/SettingsContext.tsx
+++ b/packages/app/src/lib/context/SettingsContext.tsx
@@ -17,6 +17,7 @@ import {
   useMemo,
   useState,
 } from 'react';
+import { getNetworkEndpointDefaults } from '~/lib/config/networkDefaults';
 
 type SettingsContextValue = {
   /** GraphQL endpoint used by the app. The full path is stored as configured. */
@@ -126,88 +127,6 @@ function normalizeBaseUrlPreservePath(value: string): string {
     return `${u.origin}${path}`;
   } catch {
     return trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed;
-  }
-}
-
-function getDefaultSignalEndpoint(): string {
-  // Robinhood Mainnet (the default network) leaves the mesh signal blank, which
-  // disables the mesh. Only derive a signal endpoint when an explicit
-  // relayer/API env is configured (e.g. a Sapience/Ethereal deployment).
-  if (
-    !process.env.NEXT_PUBLIC_FOIL_RELAYER_URL &&
-    !process.env.NEXT_PUBLIC_FOIL_API_URL
-  ) {
-    return '';
-  }
-  const relayerBase = getDefaultRelayerBase();
-  try {
-    const u = new URL(relayerBase);
-    u.pathname = '/signal';
-    return u.toString();
-  } catch {
-    return '';
-  }
-}
-
-function getDefaultRelayerBase(): string {
-  // Auction relayer base. Prefer explicit relayer env, otherwise derive from API
-  // env but only swap `api.sapience.xyz` -> `relayer.sapience.xyz`. With nothing
-  // configured, default to Robinhood Mainnet's relayer.
-  const explicitRelayer = process.env.NEXT_PUBLIC_FOIL_RELAYER_URL;
-  const apiRoot = process.env.NEXT_PUBLIC_FOIL_API_URL;
-  if (!explicitRelayer && !apiRoot) {
-    return 'https://relayer.predict.meridian.xyz/auction';
-  }
-  const root = explicitRelayer || apiRoot;
-  try {
-    const u = new URL(root as string);
-    if (!explicitRelayer && u.hostname === 'api.sapience.xyz') {
-      u.hostname = 'relayer.sapience.xyz';
-    }
-    return `${u.origin}/auction`;
-  } catch {
-    return 'https://relayer.predict.meridian.xyz/auction';
-  }
-}
-
-// Default app GraphQL endpoint. Sapience serves the schema at `/v2/graphql`;
-// Meridian exposes the same schema at `/graphql` and overrides the full URL.
-function getDefaultGraphqlEndpoint(): string {
-  // Sapience serves the schema at `/v2/graphql`; Meridian (Robinhood) exposes
-  // the same schema at `/graphql`. With no API env configured, default to
-  // Robinhood Mainnet.
-  const baseUrl = process.env.NEXT_PUBLIC_FOIL_API_URL;
-  if (!baseUrl) return 'https://api.predict.meridian.xyz/graphql';
-  try {
-    const u = new URL(baseUrl);
-    return `${u.origin}/v2/graphql`;
-  } catch {
-    return 'https://api.predict.meridian.xyz/graphql';
-  }
-}
-
-function getDefaultChatBase(): string {
-  // Robinhood Mainnet (the default network) ships without chat — a blank base
-  // hides the chat bubble. Only derive a chat base from an explicit API env.
-  const baseUrl = process.env.NEXT_PUBLIC_FOIL_API_URL;
-  if (!baseUrl) return '';
-  try {
-    const u = new URL(baseUrl);
-    return `${u.origin}/chat`;
-  } catch {
-    return '';
-  }
-}
-
-function getDefaultAdminBase(): string {
-  // Defaults to Robinhood Mainnet's admin base when no API env is configured.
-  const baseUrl = process.env.NEXT_PUBLIC_FOIL_API_URL;
-  if (!baseUrl) return 'https://api.predict.meridian.xyz/admin';
-  try {
-    const u = new URL(baseUrl);
-    return `${u.origin}/admin`;
-  } catch {
-    return 'https://api.predict.meridian.xyz/admin';
   }
 }
 
@@ -385,22 +304,22 @@ export const SettingsProvider = ({
     }
   }, []);
 
-  const defaults = useMemo(
-    () => ({
-      graphqlEndpoint: getDefaultGraphqlEndpoint(),
-      apiBaseUrl: getDefaultRelayerBase(),
-      signalEndpoint: getDefaultSignalEndpoint(),
-      chatBaseUrl: getDefaultChatBase(),
-      adminBaseUrl: getDefaultAdminBase(),
+  const defaults = useMemo(() => {
+    const net = getNetworkEndpointDefaults();
+    return {
+      graphqlEndpoint: net.graphqlEndpoint,
+      apiBaseUrl: net.relayerBase,
+      signalEndpoint: net.signalEndpoint,
+      chatBaseUrl: net.chatBase,
+      adminBaseUrl: net.adminBase,
       etherealRpcURL: getDefaultEtherealRpcURL(),
       arbitrumRpcURL: getDefaultArbitrumRpcURL(),
       connectionDurationHours: DEFAULT_CONNECTION_DURATION_HOURS,
       meshRateLimit: 100,
       meshMaxPeers: 25,
       meshFanout: 0,
-    }),
-    []
-  );
+    };
+  }, []);
 
   // Persist default admin base on first load if no override exists,
   // so the field "sticks" across env changes. Reset will clear override

--- a/packages/app/src/lib/data/forecasts.test.ts
+++ b/packages/app/src/lib/data/forecasts.test.ts
@@ -74,7 +74,9 @@ describe('fetchAttestationByUid', () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const [url, init] = mockFetch.mock.calls[0];
-    expect(url).toBe('https://api.example.com/v2/graphql');
+    // The endpoint follows the app's default network (Robinhood → Meridian),
+    // not NEXT_PUBLIC_FOIL_API_URL (set above but intentionally ignored).
+    expect(url).toBe('https://api.predict.meridian.xyz/graphql');
     expect(init.method).toBe('POST');
     const body = JSON.parse(init.body);
     expect(body.variables).toEqual({ uid: '0xabc123' });

--- a/packages/app/src/lib/data/graphql.test.ts
+++ b/packages/app/src/lib/data/graphql.test.ts
@@ -13,13 +13,7 @@ afterEach(() => {
 });
 
 describe('getGraphQLEndpoint', () => {
-  test('derives /v2/graphql from the API base URL', async () => {
-    process.env.NEXT_PUBLIC_FOIL_API_URL = 'https://api.example.com';
-    const { getGraphQLEndpoint } = await import('./graphql');
-    expect(getGraphQLEndpoint()).toBe('https://api.example.com/v2/graphql');
-  });
-
-  test('falls back to the Robinhood Mainnet endpoint when base URL is unset', async () => {
+  test('defaults to the Robinhood Mainnet endpoint (the app default network)', async () => {
     delete process.env.NEXT_PUBLIC_FOIL_API_URL;
     const { getGraphQLEndpoint } = await import('./graphql');
     expect(getGraphQLEndpoint()).toBe(
@@ -27,14 +21,10 @@ describe('getGraphQLEndpoint', () => {
     );
   });
 
-  test('keeps only origin + /v2/graphql, dropping any base path', async () => {
-    process.env.NEXT_PUBLIC_FOIL_API_URL = 'https://api.example.com/nested';
-    const { getGraphQLEndpoint } = await import('./graphql');
-    expect(getGraphQLEndpoint()).toBe('https://api.example.com/v2/graphql');
-  });
-
-  test('falls back to the Robinhood Mainnet endpoint for an unparseable base URL', async () => {
-    process.env.NEXT_PUBLIC_FOIL_API_URL = 'not a url';
+  test('ignores NEXT_PUBLIC_FOIL_API_URL — the endpoint follows the network, not env', async () => {
+    // The default endpoint must not be poisoned by a stray API env var; an
+    // incognito session on the Robinhood default network stays on Meridian.
+    process.env.NEXT_PUBLIC_FOIL_API_URL = 'https://api.sapience.xyz';
     const { getGraphQLEndpoint } = await import('./graphql');
     expect(getGraphQLEndpoint()).toBe(
       'https://api.predict.meridian.xyz/graphql'
@@ -42,10 +32,23 @@ describe('getGraphQLEndpoint', () => {
   });
 
   test('prefers the Settings override in localStorage when running in the browser', async () => {
-    process.env.NEXT_PUBLIC_FOIL_API_URL = 'https://api.example.com';
+    process.env.NEXT_PUBLIC_FOIL_API_URL = 'https://api.sapience.xyz';
     const store: Record<string, string> = {
       'sapience.settings.graphqlEndpoint':
-        'https://api.predict.meridian.xyz/graphql',
+        'https://api.sapience.xyz/v2/graphql',
+    };
+    vi.stubGlobal('window', {
+      localStorage: { getItem: (key: string) => store[key] ?? null },
+    });
+
+    const { getGraphQLEndpoint } = await import('./graphql');
+    expect(getGraphQLEndpoint()).toBe('https://api.sapience.xyz/v2/graphql');
+  });
+
+  test('migrates from the legacy graphqlEndpointV2 override key', async () => {
+    const store: Record<string, string> = {
+      'sapience.settings.graphqlEndpointV2':
+        'https://api.staging.sapience.xyz/v2/graphql',
     };
     vi.stubGlobal('window', {
       localStorage: { getItem: (key: string) => store[key] ?? null },
@@ -53,7 +56,7 @@ describe('getGraphQLEndpoint', () => {
 
     const { getGraphQLEndpoint } = await import('./graphql');
     expect(getGraphQLEndpoint()).toBe(
-      'https://api.predict.meridian.xyz/graphql'
+      'https://api.staging.sapience.xyz/v2/graphql'
     );
   });
 });

--- a/packages/app/src/lib/data/graphql.ts
+++ b/packages/app/src/lib/data/graphql.ts
@@ -1,5 +1,10 @@
-// Shared GraphQL endpoint resolution. Sapience serves the schema at
-// `/v2/graphql`; Meridian exposes the same schema at `/graphql`.
+// Shared GraphQL endpoint resolution. A Settings override in localStorage wins;
+// otherwise the endpoint follows the app's active network (see networkDefaults)
+// rather than any `NEXT_PUBLIC_FOIL_*` env var. Sapience serves the schema at
+// `/v2/graphql`; Meridian (Robinhood, the default network) exposes it at
+// `/graphql`.
+
+import { getNetworkEndpointDefaults } from '~/lib/config/networkDefaults';
 
 const GRAPHQL_ENDPOINT_KEY = 'sapience.settings.graphqlEndpoint';
 const LEGACY_GRAPHQL_ENDPOINT_KEY = 'sapience.settings.graphqlEndpointV2';
@@ -16,14 +21,5 @@ export function getGraphQLEndpoint(): string {
     /* noop */
   }
 
-  // Default network is Robinhood Mainnet: Meridian serves the schema at
-  // `/graphql`. A configured API env keeps the Sapience `/v2/graphql` shape.
-  const baseUrl = process.env.NEXT_PUBLIC_FOIL_API_URL;
-  if (!baseUrl) return 'https://api.predict.meridian.xyz/graphql';
-  try {
-    const u = new URL(baseUrl);
-    return `${u.origin}/v2/graphql`;
-  } catch {
-    return 'https://api.predict.meridian.xyz/graphql';
-  }
+  return getNetworkEndpointDefaults().graphqlEndpoint;
 }

--- a/packages/app/src/lib/ws/__tests__/MeshAuctionClient.test.ts
+++ b/packages/app/src/lib/ws/__tests__/MeshAuctionClient.test.ts
@@ -71,16 +71,12 @@ describe('getSignalUrl', () => {
     expect(getSignalUrl()).toBe('wss://staging-relayer.example.com/signal');
   });
 
-  it('falls back to NEXT_PUBLIC_FOIL_API_URL with hostname swap', async () => {
+  it('does NOT derive the signal URL from NEXT_PUBLIC_FOIL_API_URL', async () => {
+    // The mesh must not turn itself on just because an API base is configured;
+    // an incognito session on the Robinhood default network keeps it off.
     process.env.NEXT_PUBLIC_FOIL_API_URL = 'https://api.sapience.xyz';
     const getSignalUrl = await loadGetSignalUrl();
-    expect(getSignalUrl()).toBe('wss://relayer.sapience.xyz/signal');
-  });
-
-  it('does not swap hostname for non-production API URLs', async () => {
-    process.env.NEXT_PUBLIC_FOIL_API_URL = 'https://api.staging.example.com';
-    const getSignalUrl = await loadGetSignalUrl();
-    expect(getSignalUrl()).toBe('wss://api.staging.example.com/signal');
+    expect(getSignalUrl()).toBe('');
   });
 
   it('returns empty (mesh disabled) when nothing is configured', async () => {
@@ -117,10 +113,11 @@ describe('getSignalUrl', () => {
     expect(getSignalUrl()).toBe('');
   });
 
-  it('does not disable when signal key is absent (derives from configured env)', async () => {
-    // An absent key must not trigger the explicit-disable branch: with an API
-    // env configured, it still derives a signal URL rather than returning ''.
-    process.env.NEXT_PUBLIC_FOIL_API_URL = 'https://api.sapience.xyz';
+  it('does not disable when signal key is absent (falls through to the network default)', async () => {
+    // An absent key must not trigger the explicit-disable branch. With a relayer
+    // base configured it derives a signal URL; with nothing configured it falls
+    // through to the network default (Robinhood → mesh off → '').
+    process.env.NEXT_PUBLIC_FOIL_RELAYER_URL = 'https://relayer.sapience.xyz';
     const getSignalUrl = await loadGetSignalUrl();
     expect(getSignalUrl()).toBe('wss://relayer.sapience.xyz/signal');
   });

--- a/packages/app/src/lib/ws/signalUrl.ts
+++ b/packages/app/src/lib/ws/signalUrl.ts
@@ -17,8 +17,11 @@ const SIGNAL_KEY = 'sapience.settings.signalEndpoint';
  * 2. localStorage signal endpoint (sapience.settings.signalEndpoint)
  * 3. localStorage relayer base (sapience.settings.apiBaseUrl) with /signal path
  * 4. NEXT_PUBLIC_FOIL_RELAYER_URL env with /signal path
- * 5. NEXT_PUBLIC_FOIL_API_URL with hostname swap + /signal path
- * 6. Nothing configured → '' (Robinhood Mainnet default disables the mesh)
+ * 5. Nothing configured → the active network default (Robinhood disables the mesh)
+ *
+ * The signal endpoint intentionally does NOT derive from NEXT_PUBLIC_FOIL_API_URL:
+ * an incognito session on the Robinhood default network keeps the mesh off unless
+ * a relayer/signal endpoint is explicitly configured.
  */
 export function getSignalUrl(): string {
   // Explicit disable wins over everything: an empty (but present) signal
@@ -49,25 +52,20 @@ export function getSignalUrl(): string {
       return u.toString();
     }
 
-    // Fall back: derive from relayer base (same logic as SettingsContext)
+    // Fall back: derive from the relayer base (a localStorage override set via
+    // Settings, or an explicit relayer env). Not derived from FOIL_API_URL — the
+    // active network default governs whether the mesh is on.
     const relayerStored =
       typeof window !== 'undefined'
         ? window.localStorage.getItem('sapience.settings.apiBaseUrl')
         : null;
     const explicitRelayer = process.env.NEXT_PUBLIC_FOIL_RELAYER_URL;
-    const apiRoot = process.env.NEXT_PUBLIC_FOIL_API_URL;
-    const base = relayerStored || explicitRelayer || apiRoot;
-    // Nothing configured → Robinhood Mainnet default, which disables the mesh.
+    const base = relayerStored || explicitRelayer;
+    // Nothing configured → the active network default disables the mesh
+    // (Robinhood ships the mesh off).
     if (!base) return '';
 
     const u = new URL(base);
-    if (
-      !relayerStored &&
-      !explicitRelayer &&
-      u.hostname === 'api.sapience.xyz'
-    ) {
-      u.hostname = 'relayer.sapience.xyz';
-    }
     u.protocol = u.protocol === 'https:' ? 'wss:' : 'ws:';
     u.pathname = '/signal';
     u.search = '';


### PR DESCRIPTION
## Problem

In a fresh (incognito) session the Settings page defaulted to Sapience/Ethereal values instead of the Robinhood network the app is built for:

- **GraphQL** → `https://api.sapience.xyz/v2/graphql`
- **Chat** → `https://api.sapience.xyz/chat` (chat bubble shown)
- **Relayer** → `https://relayer.sapience.xyz/auction`
- **Signal** → `https://relayer.sapience.xyz/signal` (mesh enabled)

The defaults (and the runtime data/mesh/auction/referral consumers) derived their endpoints from `NEXT_PUBLIC_FOIL_API_URL`. With that env pointed at `https://api.sapience.xyz`, every incognito default resolved to Sapience — and worse, the Settings page could display Meridian while the app actually fetched from Sapience (split-brain).

## Fix

Offchain endpoint defaults now follow the app's **active network** (`DEFAULT_CHAIN_ID`) instead of any `NEXT_PUBLIC_FOIL_*` env var:

- Default → **Robinhood Mainnet** (`api.predict.meridian.xyz`), mesh + chat **off**
- Staging build (a testnet default chain) → **Robinhood Testnet** (`api.predict.meridiantest.net`), mesh + chat **off**

Ethereal/Sapience endpoints stay reachable via the Settings **network preset buttons**, which persist localStorage overrides that continue to win everywhere.

A new `lib/config/networkDefaults` module is the single source of truth; `SettingsContext`, `graphql`, `signalUrl`, `useAuctionStart`, chat `types`, `useReferrals`, and `useRequestMarket` all route through it. No app runtime code reads `NEXT_PUBLIC_FOIL_API_URL` anymore.

## Tests

- Updated `graphql`, `MeshAuctionClient` (signal), and `forecasts` tests to assert the network-based defaults and that `NEXT_PUBLIC_FOIL_API_URL` is ignored.
- Existing `SettingsContext` tests already expected the Robinhood defaults and stay green.
- Full app suite: **801 passing**; `type-check` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nnkqtee7DqGpo1goBR1WNR