### PR TITLE
fix(app): use GET for server-side GraphQL fetches

### DIFF
--- a/packages/app/src/app/og/_prediction-helpers.ts
+++ b/packages/app/src/app/og/_prediction-helpers.ts
@@ -1,7 +1,7 @@
 // OG-specific formatting utilities + re-exports from shared data layer.
 
 // Re-exports for backward compatibility with OG routes and _profile-helpers
-export { getGraphQLEndpoint } from '~/lib/data/graphql';
+export { getGraphQLEndpoint, buildGraphQLGetUrl } from '~/lib/data/graphql';
 export {
   PREDICTION_BY_ID_QUERY,
   CONDITIONS_BY_IDS_QUERY,

--- a/packages/app/src/app/og/_profile-helpers.ts
+++ b/packages/app/src/app/og/_profile-helpers.ts
@@ -2,7 +2,7 @@
 
 import { isAddress } from 'viem';
 import { formatUnits } from './_prediction-helpers';
-import { getGraphQLEndpoint } from '~/lib/data/graphql';
+import { buildGraphQLGetUrl } from '~/lib/data/graphql';
 import { mainnetClient } from '~/lib/utils/util';
 import { getEnsAvatarUrlForAddress } from '~/lib/ens/avatar.server';
 import { SCHEMA_UID } from '~/lib/constants';
@@ -76,11 +76,7 @@ export interface EnsInfo {
 // ---------- Helpers ----------
 
 async function gqlFetch<T>(query: string, variables?: object): Promise<T> {
-  const res = await fetch(getGraphQLEndpoint(), {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ query, variables }),
-  });
+  const res = await fetch(buildGraphQLGetUrl(query, variables));
   if (!res.ok) throw new Error(`GraphQL ${res.status}`);
   const json = await res.json();
   return json.data as T;

--- a/packages/app/src/app/og/prediction/route.tsx
+++ b/packages/app/src/app/og/prediction/route.tsx
@@ -25,7 +25,7 @@ import {
 import {
   PREDICTION_BY_ID_QUERY,
   CONDITIONS_BY_IDS_QUERY,
-  getGraphQLEndpoint,
+  buildGraphQLGetUrl,
   toPredictionData,
   formatUnits,
   normalizeChoiceLabel,
@@ -55,19 +55,14 @@ export async function GET(req: Request) {
     // If predictionId is provided and we need data from it (no legs, or need to fill in missing data)
     if (predictionId) {
       try {
-        // Both legs run against /v2/graphql; the prediction node is mapped
-        // back to the legacy-shaped PredictionData via the shared mapper.
-        const graphqlEndpoint = getGraphQLEndpoint();
+        // Both legs run against /v2/graphql over GET (CDN-cacheable); the
+        // prediction node is mapped back to the legacy-shaped PredictionData
+        // via the shared mapper.
         let prediction: PredictionData | null = null;
 
-        const response = await fetch(graphqlEndpoint, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            query: PREDICTION_BY_ID_QUERY,
-            variables: { predictionId },
-          }),
-        });
+        const response = await fetch(
+          buildGraphQLGetUrl(PREDICTION_BY_ID_QUERY, { predictionId })
+        );
 
         if (response.ok) {
           const result = await response.json();
@@ -88,14 +83,11 @@ export async function GET(req: Request) {
                 // conditions connection: variables { ids }, nodes under
                 // data.conditions.nodes (the legacy `where` variables made
                 // this leg dead — it silently rendered no questions).
-                const condResp = await fetch(graphqlEndpoint, {
-                  method: 'POST',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({
-                    query: CONDITIONS_BY_IDS_QUERY,
-                    variables: { ids: conditionIds },
-                  }),
-                });
+                const condResp = await fetch(
+                  buildGraphQLGetUrl(CONDITIONS_BY_IDS_QUERY, {
+                    ids: conditionIds,
+                  })
+                );
                 if (condResp.ok) {
                   const condResult = await condResp.json();
                   const conditions: ConditionData[] =

--- a/packages/app/src/app/og/question/route.tsx
+++ b/packages/app/src/app/og/question/route.tsx
@@ -24,7 +24,7 @@ import {
   createErrorImageResponse,
 } from '../_shared';
 import { PREFERRED_ESTIMATE_QUOTER } from '~/lib/constants';
-import { getGraphQLEndpoint } from '~/lib/data/graphql';
+import { buildGraphQLGetUrl } from '~/lib/data/graphql';
 
 export const runtime = 'nodejs';
 
@@ -187,11 +187,7 @@ async function fetchConditionData(
       resolvers: resolver ? [resolver] : null,
     };
 
-    const response = await fetch(getGraphQLEndpoint(), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ query, variables }),
-    });
+    const response = await fetch(buildGraphQLGetUrl(query, variables));
 
     if (!response.ok) {
       return {

--- a/packages/app/src/app/questions/[...parts]/page.tsx
+++ b/packages/app/src/app/questions/[...parts]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import QuestionPageClient from './QuestionPageClient';
-import { getGraphQLEndpoint } from '~/lib/data/graphql';
+import { buildGraphQLGetUrl } from '~/lib/data/graphql';
 
 const APP_URL = 'https://sapience.xyz';
 
@@ -40,10 +40,7 @@ async function fetchQuestionTitle(
       resolvers: resolverAddress ? [resolverAddress] : null,
     };
 
-    const response = await fetch(getGraphQLEndpoint(), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ query, variables }),
+    const response = await fetch(buildGraphQLGetUrl(query, variables), {
       next: { revalidate: 60 },
     });
 

--- a/packages/app/src/lib/data/graphql.test.ts
+++ b/packages/app/src/lib/data/graphql.test.ts
@@ -60,3 +60,40 @@ describe('getGraphQLEndpoint', () => {
     );
   });
 });
+
+describe('buildGraphQLGetUrl', () => {
+  test('encodes the query as a GET param against the endpoint', async () => {
+    delete process.env.NEXT_PUBLIC_FOIL_API_URL;
+    const { buildGraphQLGetUrl } = await import('./graphql');
+
+    const url = new URL(buildGraphQLGetUrl('{ ping }'));
+    expect(url.origin + url.pathname).toBe(
+      'https://api.predict.meridian.xyz/graphql'
+    );
+    expect(url.searchParams.get('query')).toBe('{ ping }');
+    // no variables → no variables param
+    expect(url.searchParams.has('variables')).toBe(false);
+  });
+
+  test('JSON-encodes non-empty variables', async () => {
+    delete process.env.NEXT_PUBLIC_FOIL_API_URL;
+    const { buildGraphQLGetUrl } = await import('./graphql');
+
+    const url = new URL(
+      buildGraphQLGetUrl('query Q($id: ID!) { node(id: $id) { id } }', {
+        id: '0xabc',
+      })
+    );
+    expect(url.searchParams.get('variables')).toBe(
+      JSON.stringify({ id: '0xabc' })
+    );
+  });
+
+  test('omits an empty variables object', async () => {
+    delete process.env.NEXT_PUBLIC_FOIL_API_URL;
+    const { buildGraphQLGetUrl } = await import('./graphql');
+
+    const url = new URL(buildGraphQLGetUrl('{ ping }', {}));
+    expect(url.searchParams.has('variables')).toBe(false);
+  });
+});

--- a/packages/app/src/lib/data/graphql.ts
+++ b/packages/app/src/lib/data/graphql.ts
@@ -23,3 +23,19 @@ export function getGraphQLEndpoint(): string {
 
   return getNetworkEndpointDefaults().graphqlEndpoint;
 }
+
+/**
+ * Build a GET URL for a GraphQL query. Apollo (csrfPrevention off) serves
+ * queries — not mutations — over GET, which lets the CDN cache the OG/SSR
+ * responses that call this. The `query` and JSON-encoded `variables` ride in
+ * the query string; callers `fetch()` the result with the default GET method.
+ */
+export function buildGraphQLGetUrl(query: string, variables?: object): string {
+  const endpoint = getGraphQLEndpoint();
+  const params = new URLSearchParams({ query });
+  if (variables && Object.keys(variables).length > 0) {
+    params.set('variables', JSON.stringify(variables));
+  }
+  const separator = endpoint.includes('?') ? '&' : '?';
+  return `${endpoint}${separator}${params.toString()}`;
+}


### PR DESCRIPTION
## What

Switch the app's remaining server-side GraphQL requests from `POST` to `GET`.

The SDK client (`graphqlRequest`, via `graphql-request` with `method: 'GET'`) and the Apollo server (`csrfPrevention: false`) already speak GraphQL over GET. The only holdouts were the OG-image and SSR-metadata routes, which hand-rolled `fetch(endpoint, { method: 'POST', body: JSON.stringify(...) })` and so kept their responses out of the CDN cache.

## How

- Add `buildGraphQLGetUrl(query, variables)` to the shared endpoint module (`~/lib/data/graphql`). It encodes `query` and JSON-stringified `variables` as query-string params against the network-default endpoint.
- Route the five remaining server-side fetches through it:
  - `app/og/prediction/route.tsx` (prediction + conditions lookups)
  - `app/og/question/route.tsx`
  - `app/questions/[...parts]/page.tsx` (keeps its `next: { revalidate: 60 }` hint)
  - `app/og/_profile-helpers.ts` (`gqlFetch`)

Only queries (never mutations) go over GET — all five are reads. Matches the client/server behavior already used here and in the `predict` repo.

## Testing

- New unit tests for `buildGraphQLGetUrl` (query encoding, variables encoding, empty-variables omission); `graphql.test.ts` passes (7 tests).
- Type-check + lint clean.
- Verified end-to-end against the running dev server: `GET /questions/<resolver>/<conditionId>` → 200 and `GET /og/question?...` → 200 `image/png`, with no GraphQL errors in the server log. Direct `GET` to the live endpoint returns `{"data":{"__typename":"Query"}}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)