### PR TITLE
fix(app): default Arbitrum RPC to the public node

### DIFF
--- a/packages/app/src/lib/context/SettingsContext.tsx
+++ b/packages/app/src/lib/context/SettingsContext.tsx
@@ -136,13 +136,9 @@ function getDefaultEtherealRpcURL(): string {
 }
 
 function getDefaultArbitrumRpcURL(): string {
+  // Default to the keyless public node rather than an Infura/Alchemy URL that
+  // embeds NEXT_PUBLIC_INFURA_API_KEY — users can still override in Settings.
   const isTestnet = DEFAULT_CHAIN_ID === CHAIN_ID_ETHEREAL_TESTNET;
-  const infuraKey = process.env.NEXT_PUBLIC_INFURA_API_KEY;
-  if (infuraKey) {
-    return isTestnet
-      ? `https://arbitrum-sepolia.infura.io/v3/${infuraKey}`
-      : `https://arbitrum-mainnet.infura.io/v3/${infuraKey}`;
-  }
   return isTestnet
     ? 'https://arbitrum-sepolia-rpc.publicnode.com'
     : 'https://arbitrum-rpc.publicnode.com';


### PR DESCRIPTION
## What

Change the Settings default for the Arbitrum RPC endpoint to the keyless public node instead of an Infura/Alchemy URL that embeds `NEXT_PUBLIC_INFURA_API_KEY`.

## Why

When `NEXT_PUBLIC_INFURA_API_KEY` was set, `getDefaultArbitrumRpcURL()` returned `https://arbitrum-mainnet.infura.io/v3/<key>` (or the sepolia variant), exposing the provider key in the default endpoint. Defaulting to the public node avoids leaking the key.

## How

`getDefaultArbitrumRpcURL()` now always returns the public node — `https://arbitrum-rpc.publicnode.com` (mainnet) / `https://arbitrum-sepolia-rpc.publicnode.com` (testnet), keyed off `DEFAULT_CHAIN_ID`. This was already the fallback when no Infura key was present; it's now the unconditional default. Users can still override the endpoint in Settings.

## Testing

- Type-check + lint clean; existing SettingsContext tests pass (32 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)