### PR TITLE
fix(app): remove the Get Access button from the header

### DIFF
--- a/packages/app/src/components/layout/Header.tsx
+++ b/packages/app/src/components/layout/Header.tsx
@@ -43,7 +43,6 @@ import { useDisconnect } from 'wagmi';
 import CollateralBalanceButton from './CollateralBalanceButton';
 import { useConnectedWallet } from '~/hooks/useConnectedWallet';
 import EnsAvatar from '~/components/shared/EnsAvatar';
-import GetAccessDialog from '~/components/shared/GetAccessDialog';
 import ReferralsDialog from '~/components/shared/ReferralsDialog';
 import { useConnectDialog } from '~/lib/context/ConnectDialogContext';
 import { useAuth } from '~/lib/context/AuthContext';
@@ -205,7 +204,6 @@ const Header = () => {
   const [isScrolled, setIsScrolled] = useState(false);
   const thresholdRef = useRef(12);
   const headerRef = useRef<HTMLElement | null>(null);
-  const [isGetAccessOpen, setIsGetAccessOpen] = useState(false);
   const [isReferralsOpen, setIsReferralsOpen] = useState(false);
 
   // Session context for smart account sessions
@@ -614,21 +612,11 @@ const Header = () => {
               {ready && !hasConnectedWallet && (
                 <>
                   <Button
-                    onClick={() => setIsGetAccessOpen(true)}
-                    className="btn-get-access hidden sm:inline-flex rounded-md h-10 xl:h-9 px-4 text-brand-black hover:text-white font-semibold border-0 transition-colors duration-400 font-mono uppercase tracking-widest text-sm"
-                  >
-                    <span className="relative z-10">Get Access</span>
-                  </Button>
-                  <Button
                     onClick={openConnectDialog}
                     className="bg-primary hover:bg-primary/90 rounded-md h-10 xl:h-9 w-auto px-4 ml-1.5 xl:ml-0 gap-2"
                   >
                     <span>Log in</span>
                   </Button>
-                  <GetAccessDialog
-                    open={isGetAccessOpen}
-                    onOpenChange={setIsGetAccessOpen}
-                  />
                 </>
               )}
             </div>


### PR DESCRIPTION
## What

Remove the desktop "Get Access" button from the logged-out header.

## How

Drops the `Get Access` `<Button>`, its `<GetAccessDialog>`, the `isGetAccessOpen` state, and the now-unused `GetAccessDialog` import from `Header.tsx`. The logged-out header keeps its "Log in" button.

Deliberately left untouched:
- **`GetAccessDialog`** component — still used by `BetaBanner`.
- **`btn-get-access`** CSS class — reused as shared styling by unrelated buttons (`CollateralBalanceButton`, `SponsorshipIndicator`, `PositionsTable`).
- **`BetaBanner`** ("SAPIENCE BETA NOW LIVE: GET EARLY ACCESS") — a separate promotional banner, not the header button.

## Testing

Type-check + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)