### PR TITLE
refactor(graphql): unify endpoint resolution behind the SDK client

### DIFF
--- a/packages/app/src/app/providers.tsx
+++ b/packages/app/src/app/providers.tsx
@@ -10,6 +10,7 @@ import type React from 'react';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { hashFn } from 'wagmi/query';
 import { readCustomChainOverride } from '@sapience/sdk/constants';
+import '~/lib/config/registerGraphqlResolver';
 import { resolveChainsAndRpcUrls } from './providers.chains';
 import { httpWithRetry } from '~/lib/utils/util';
 import { SapienceProvider } from '~/lib/context/SapienceProvider';

--- a/packages/app/src/lib/config/registerGraphqlResolver.ts
+++ b/packages/app/src/lib/config/registerGraphqlResolver.ts
@@ -1,0 +1,10 @@
+// Side-effect module: registers the app's network-defaults fallback with the
+// SDK GraphQL client so every consumer — client hooks and server/OG fetches —
+// resolves the endpoint the same way (Settings override, then the active
+// network's endpoint). Imported by providers.tsx (client bundle) and
+// lib/data/graphql.ts (server paths); registering twice is harmless.
+import { setGraphQLEndpointResolver } from '@sapience/sdk/queries/client/graphqlClient';
+
+import { getNetworkEndpointDefaults } from '~/lib/config/networkDefaults';
+
+setGraphQLEndpointResolver(() => getNetworkEndpointDefaults().graphqlEndpoint);

--- a/packages/app/src/lib/data/graphql.ts
+++ b/packages/app/src/lib/data/graphql.ts
@@ -1,28 +1,14 @@
-// Shared GraphQL endpoint resolution. A Settings override in localStorage wins;
-// otherwise the endpoint follows the app's active network (see networkDefaults)
-// rather than any `NEXT_PUBLIC_FOIL_*` env var. Sapience serves the schema at
+// Shared GraphQL endpoint resolution, delegated to the SDK client. A Settings
+// override in localStorage wins; otherwise the endpoint follows the app's
+// active network (the resolver registered in registerGraphqlResolver) rather
+// than any `NEXT_PUBLIC_FOIL_*` env var. Sapience serves the schema at
 // `/v2/graphql`; Meridian (Robinhood, the default network) exposes it at
 // `/graphql`.
 
-import { getNetworkEndpointDefaults } from '~/lib/config/networkDefaults';
+import '~/lib/config/registerGraphqlResolver';
+import { getGraphQLEndpoint } from '@sapience/sdk/queries/client/graphqlClient';
 
-const GRAPHQL_ENDPOINT_KEY = 'sapience.settings.graphqlEndpoint';
-const LEGACY_GRAPHQL_ENDPOINT_KEY = 'sapience.settings.graphqlEndpointV2';
-
-export function getGraphQLEndpoint(): string {
-  try {
-    if (typeof window !== 'undefined') {
-      const override =
-        window.localStorage.getItem(GRAPHQL_ENDPOINT_KEY) ??
-        window.localStorage.getItem(LEGACY_GRAPHQL_ENDPOINT_KEY);
-      if (override) return override;
-    }
-  } catch {
-    /* noop */
-  }
-
-  return getNetworkEndpointDefaults().graphqlEndpoint;
-}
+export { getGraphQLEndpoint };
 
 /**
  * Build a GET URL for a GraphQL query. Apollo (csrfPrevention off) serves

--- a/packages/sdk/queries/__tests__/graphqlClient.test.ts
+++ b/packages/sdk/queries/__tests__/graphqlClient.test.ts
@@ -72,6 +72,67 @@ describe('getGraphQLEndpoint', () => {
   });
 });
 
+describe('setGraphQLEndpointResolver', () => {
+  test('a registered resolver wins over the env default', async () => {
+    process.env.NEXT_PUBLIC_FOIL_API_URL = 'https://api.example.com';
+    const { getGraphQLEndpoint, setGraphQLEndpointResolver } = await import(
+      '../client/graphqlClient'
+    );
+    setGraphQLEndpointResolver(
+      () => 'https://api.predict.meridian.xyz/graphql'
+    );
+    expect(getGraphQLEndpoint()).toBe(
+      'https://api.predict.meridian.xyz/graphql'
+    );
+  });
+
+  test('the stored override wins over a registered resolver', async () => {
+    const store: Record<string, string> = {
+      'sapience.settings.graphqlEndpoint': 'https://override.example/graphql',
+    };
+    vi.stubGlobal('window', {
+      localStorage: { getItem: (k: string) => store[k] ?? null },
+    });
+    const { getGraphQLEndpoint, setGraphQLEndpointResolver } = await import(
+      '../client/graphqlClient'
+    );
+    setGraphQLEndpointResolver(() => 'https://resolver.example/graphql');
+    expect(getGraphQLEndpoint()).toBe('https://override.example/graphql');
+  });
+
+  test('a resolver returning null or empty falls through to the env default', async () => {
+    process.env.NEXT_PUBLIC_FOIL_API_URL = 'https://api.example.com';
+    const { getGraphQLEndpoint, setGraphQLEndpointResolver } = await import(
+      '../client/graphqlClient'
+    );
+    setGraphQLEndpointResolver(() => null);
+    expect(getGraphQLEndpoint()).toBe('https://api.example.com/v2/graphql');
+    setGraphQLEndpointResolver(() => '');
+    expect(getGraphQLEndpoint()).toBe('https://api.example.com/v2/graphql');
+  });
+
+  test('a throwing resolver falls through to the env default', async () => {
+    process.env.NEXT_PUBLIC_FOIL_API_URL = 'https://api.example.com';
+    const { getGraphQLEndpoint, setGraphQLEndpointResolver } = await import(
+      '../client/graphqlClient'
+    );
+    setGraphQLEndpointResolver(() => {
+      throw new Error('boom');
+    });
+    expect(getGraphQLEndpoint()).toBe('https://api.example.com/v2/graphql');
+  });
+
+  test('setGraphQLEndpointResolver(null) restores the env behavior', async () => {
+    process.env.NEXT_PUBLIC_FOIL_API_URL = 'https://api.example.com';
+    const { getGraphQLEndpoint, setGraphQLEndpointResolver } = await import(
+      '../client/graphqlClient'
+    );
+    setGraphQLEndpointResolver(() => 'https://resolver.example/graphql');
+    setGraphQLEndpointResolver(null);
+    expect(getGraphQLEndpoint()).toBe('https://api.example.com/v2/graphql');
+  });
+});
+
 describe('graphqlRequest', () => {
   test('issues the request against the resolved endpoint', async () => {
     process.env.NEXT_PUBLIC_FOIL_API_URL = 'https://api.example.com';

--- a/packages/sdk/queries/client/graphqlClient.ts
+++ b/packages/sdk/queries/client/graphqlClient.ts
@@ -1,14 +1,33 @@
 import { GraphQLClient } from 'graphql-request';
 
-const GRAPHQL_ENDPOINT_KEY = 'sapience.settings.graphqlEndpoint';
+export const GRAPHQL_ENDPOINT_KEY = 'sapience.settings.graphqlEndpoint';
 // Legacy key kept only for migration: older sessions stored the endpoint under
 // a `graphqlEndpointV2` key before v1/v2 were collapsed into one concept.
-const LEGACY_GRAPHQL_ENDPOINT_KEY = 'sapience.settings.graphqlEndpointV2';
+export const LEGACY_GRAPHQL_ENDPOINT_KEY =
+  'sapience.settings.graphqlEndpointV2';
+
+type GraphQLEndpointResolver = () => string | null | undefined;
+
+let endpointResolver: GraphQLEndpointResolver | null = null;
+
+/**
+ * Registers a fallback endpoint resolver consulted after the localStorage
+ * override but before the env-var default. The app uses this to point
+ * default sessions at its active network's endpoint; consumers that never
+ * register a resolver keep the env-derived behavior unchanged.
+ */
+export const setGraphQLEndpointResolver = (
+  resolver: GraphQLEndpointResolver | null
+) => {
+  endpointResolver = resolver;
+};
 
 /**
  * Resolves the GraphQL endpoint used by app queries. Sapience deployments use
  * `/v2/graphql`; Meridian exposes the same schema at `/graphql`, so the setting
  * stores the full endpoint path rather than deriving one from an origin.
+ * The localStorage step is inert on the server; server-side resolution is
+ * resolver → env default.
  */
 export const getGraphQLEndpoint = () => {
   try {
@@ -20,6 +39,14 @@ export const getGraphQLEndpoint = () => {
     }
   } catch {
     /* noop */
+  }
+  if (endpointResolver) {
+    try {
+      const resolved = endpointResolver();
+      if (resolved) return resolved;
+    } catch {
+      /* fall through to the env default */
+    }
   }
   const baseUrl =
     process.env.NEXT_PUBLIC_FOIL_API_URL || 'https://api.sapience.xyz';


### PR DESCRIPTION
## Summary
- The SDK GraphQL client and the app's SSR/OG helper (`lib/data/graphql.ts`) each resolved the endpoint with different fallbacks: the SDK derived `NEXT_PUBLIC_FOIL_API_URL` origin + `/v2/graphql` (Sapience), while the app helper used the active network's defaults (Meridian `/graphql`). A fresh session's client hooks and server fetches could therefore hit different backends.
- The SDK client now accepts an optional endpoint resolver via `setGraphQLEndpointResolver`, consulted **after** the localStorage override and **before** the env fallback. The app registers a `networkDefaults`-based resolver from `providers.tsx` (client bundle) and `lib/data/graphql.ts` (server paths), and the app helper now delegates to the SDK function instead of duplicating the logic.

## Behavior guarantees
- **Backend untouched** — no changes under `packages/api`, `packages/market-keeper`, or `packages/relayer`.
- Consumers that never register a resolver (node services, external SDK users) keep the env-derived `/v2/graphql` fallback byte-for-byte, so the Sapience `/v2` path stays reachable.
- Saved Settings overrides (full URLs, either `/v2/graphql` or `/graphql` form) still win everywhere.
- `packages/app/src/lib/data/graphql.test.ts` passes **unchanged** — the delegation is behavior-preserving for app server paths.

## Tests
- 5 new SDK cases covering resolver precedence (override > resolver > env), null/empty/throwing resolvers falling through, and resolver reset.
- Full app suite (810 tests), lint, and type-check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5pjpyt8bCSBtSDvffYEf1