### PR TITLE
test(app): cover the analytics and activity feed surfaces

### DIFF
--- a/packages/app/src/components/analytics/OpenInterestByTimeToResolutionChart.tsx
+++ b/packages/app/src/components/analytics/OpenInterestByTimeToResolutionChart.tsx
@@ -27,7 +27,10 @@ const MONTH_SECONDS = 30 * DAY_SECONDS;
  * labels exactly: "≤1 day", "2-7 days", "8-30 days", "1-2 mo.",
  * "2-3 mo.", "3-6 mo.", "6 mo.+".
  */
-function formatBucketLabel(min: number | null, max: number | null): string {
+export function formatBucketLabel(
+  min: number | null,
+  max: number | null
+): string {
   if (max == null) {
     // Open-ended tail.
     if (min == null) return 'All';

--- a/packages/app/src/components/analytics/__tests__/OpenInterestByCategoryChart.test.tsx
+++ b/packages/app/src/components/analytics/__tests__/OpenInterestByCategoryChart.test.tsx
@@ -1,0 +1,198 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+// Recharts: prop-capturing div stubs. The Pie stub records its `data` prop so
+// tests can assert the exact slice series.
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PieChart: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  Pie: ({ data, children }: { data?: unknown; children?: React.ReactNode }) => (
+    <div data-testid="pie" data-chart={JSON.stringify(data)}>
+      {children}
+    </div>
+  ),
+  Cell: ({ fill }: { fill?: string }) => (
+    <div data-testid="cell" data-fill={fill} />
+  ),
+}));
+
+vi.mock('~/components/shared/Loader', () => {
+  const Loader = () => <div data-testid="loader" />;
+  return { __esModule: true, default: Loader };
+});
+
+const mockUseProtocolAnalytics = vi.fn();
+vi.mock('~/hooks/graphql/useAnalytics', () => ({
+  useProtocolAnalytics: () => mockUseProtocolAnalytics(),
+}));
+
+// market-helpers drags in the create-position context and market row widgets;
+// the chart only needs the two pure helpers, reimplemented faithfully here:
+// collapsePriceCategories merges `prices-*` rows into one 'Prices' aggregate.
+vi.mock('~/components/markets/market-helpers', () => ({
+  getCategoryColor: (slug?: string | null) => `color-${slug ?? 'none'}`,
+  collapsePriceCategories: (
+    rows: { slug: string; name: string; raw: bigint }[]
+  ) => {
+    const priceParts = rows.filter((r) => r.slug.startsWith('prices-'));
+    const rest = rows.map((r) => ({ ...r }));
+    if (priceParts.length === 0) return rest;
+    return [
+      ...rest.filter((r) => !r.slug.startsWith('prices-')),
+      {
+        slug: 'prices',
+        name: 'Prices',
+        raw: priceParts.reduce((acc, r) => acc + r.raw, 0n),
+      },
+    ];
+  },
+}));
+
+vi.mock('~/lib/theme/categoryIcons', () => ({
+  getCategoryIcon: () => () => <svg data-testid="category-icon" />,
+}));
+
+import OpenInterestByCategoryChart from '~/components/analytics/OpenInterestByCategoryChart';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const WEI = 10n ** 18n;
+
+function category(slug: string, name: string, tokens: bigint) {
+  return {
+    category: { slug, name },
+    openInterest: (tokens * WEI).toString(),
+  };
+}
+
+function loaded(openInterestByCategory: unknown[]) {
+  mockUseProtocolAnalytics.mockReturnValue({
+    data: {
+      stats: null,
+      statsHistory: [],
+      openInterestByCategory,
+      openInterestByTimeToResolution: [],
+    },
+    isLoading: false,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('OpenInterestByCategoryChart', () => {
+  it('shows a loader while analytics load', () => {
+    mockUseProtocolAnalytics.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    render(<OpenInterestByCategoryChart />);
+
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+    expect(screen.queryByTestId('pie')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty state when there is no category open interest', () => {
+    loaded([]);
+    render(<OpenInterestByCategoryChart />);
+
+    expect(screen.getByText('No open interest yet.')).toBeInTheDocument();
+    expect(screen.queryByTestId('pie')).not.toBeInTheDocument();
+  });
+
+  it('renders a legend sorted by OI descending with toFixed(1) percentages', () => {
+    loaded([
+      category('sports', 'Sports', 300n),
+      category('crypto', 'Crypto', 600n),
+      category('weather', 'Weather', 100n),
+    ]);
+    render(<OpenInterestByCategoryChart />);
+
+    const rows = screen.getAllByRole('listitem');
+    expect(rows.map((r) => r.textContent)).toEqual([
+      'Crypto60.0%',
+      'Sports30.0%',
+      'Weather10.0%',
+    ]);
+  });
+
+  it('collapses prices-* categories into a single Prices slice', () => {
+    loaded([
+      category('crypto', 'Crypto', 600n),
+      category('prices-crypto', 'Prices (Crypto)', 250n),
+      category('prices-equity', 'Prices (Equity)', 150n),
+    ]);
+    render(<OpenInterestByCategoryChart />);
+
+    const rows = screen.getAllByRole('listitem');
+    // 250 + 150 = 400 of 1000 total → one merged 40.0% 'Prices' row.
+    expect(rows.map((r) => r.textContent)).toEqual([
+      'Crypto60.0%',
+      'Prices40.0%',
+    ]);
+    expect(screen.queryByText('Prices (Crypto)')).not.toBeInTheDocument();
+    expect(screen.queryByText('Prices (Equity)')).not.toBeInTheDocument();
+  });
+
+  it('passes the slice values (in tokens) to the pie', () => {
+    loaded([
+      category('crypto', 'Crypto', 600n),
+      category('sports', 'Sports', 400n),
+    ]);
+    render(<OpenInterestByCategoryChart />);
+
+    const data = JSON.parse(
+      screen.getByTestId('pie').getAttribute('data-chart')!
+    );
+    expect(data).toEqual([
+      {
+        name: 'Crypto',
+        slug: 'crypto',
+        color: 'color-crypto',
+        value: 600,
+        percent: 60,
+      },
+      {
+        name: 'Sports',
+        slug: 'sports',
+        color: 'color-sports',
+        value: 400,
+        percent: 40,
+      },
+    ]);
+    // One <Cell> per slice.
+    expect(screen.getAllByTestId('cell')).toHaveLength(2);
+  });
+
+  it('drops slices that would render as 0.0% in the legend', () => {
+    // 1 of 10001 → ~0.0099% < the 0.05% cutoff.
+    loaded([
+      category('crypto', 'Crypto', 10_000n),
+      category('sports', 'Sports', 1n),
+    ]);
+    render(<OpenInterestByCategoryChart />);
+
+    expect(screen.queryByText('Sports')).not.toBeInTheDocument();
+    const data = JSON.parse(
+      screen.getByTestId('pie').getAttribute('data-chart')!
+    );
+    expect(data).toHaveLength(1);
+    expect(data[0].slug).toBe('crypto');
+  });
+});

--- a/packages/app/src/components/analytics/__tests__/OpenInterestByTimeToResolutionChart.test.tsx
+++ b/packages/app/src/components/analytics/__tests__/OpenInterestByTimeToResolutionChart.test.tsx
@@ -1,0 +1,162 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+// Recharts: prop-capturing div stubs; BarChart records its `data` prop.
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  BarChart: ({
+    data,
+    children,
+  }: {
+    data?: unknown;
+    children?: React.ReactNode;
+  }) => (
+    <div data-testid="bar-chart" data-chart={JSON.stringify(data)}>
+      {children}
+    </div>
+  ),
+  Bar: () => <div />,
+  XAxis: () => <div />,
+  YAxis: () => <div />,
+  CartesianGrid: () => <div />,
+  Tooltip: () => <div />,
+}));
+
+vi.mock('~/components/shared/Loader', () => {
+  const Loader = () => <div data-testid="loader" />;
+  return { __esModule: true, default: Loader };
+});
+
+const mockUseProtocolAnalytics = vi.fn();
+vi.mock('~/hooks/graphql/useAnalytics', () => ({
+  useProtocolAnalytics: () => mockUseProtocolAnalytics(),
+}));
+
+import OpenInterestByTimeToResolutionChart, {
+  formatBucketLabel,
+} from '~/components/analytics/OpenInterestByTimeToResolutionChart';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const DAY = 86400;
+const MONTH = 30 * DAY;
+const WEI = 10n ** 18n;
+
+function bucket(
+  minSecondsFromNow: number | null,
+  maxSecondsFromNow: number | null,
+  tokens: bigint,
+  predictionCount: number
+) {
+  return {
+    minSecondsFromNow,
+    maxSecondsFromNow,
+    openInterest: (tokens * WEI).toString(),
+    predictionCount,
+  };
+}
+
+function loaded(openInterestByTimeToResolution: unknown[]) {
+  mockUseProtocolAnalytics.mockReturnValue({
+    data: {
+      stats: null,
+      statsHistory: [],
+      openInterestByCategory: [],
+      openInterestByTimeToResolution,
+    },
+    isLoading: false,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// formatBucketLabel — pins the (min, max] bucket-bound labelling
+// ---------------------------------------------------------------------------
+
+describe('formatBucketLabel', () => {
+  it('labels the current server buckets exactly', () => {
+    expect(formatBucketLabel(null, DAY)).toBe('≤1 day');
+    expect(formatBucketLabel(DAY, 7 * DAY)).toBe('2-7 days');
+    expect(formatBucketLabel(7 * DAY, 30 * DAY)).toBe('8-30 days');
+    expect(formatBucketLabel(30 * DAY, 60 * DAY)).toBe('1-2 mo.');
+    expect(formatBucketLabel(60 * DAY, 90 * DAY)).toBe('2-3 mo.');
+    expect(formatBucketLabel(90 * DAY, 180 * DAY)).toBe('3-6 mo.');
+    expect(formatBucketLabel(180 * DAY, null)).toBe('6 mo.+');
+  });
+
+  it('labels an unbounded bucket as All', () => {
+    expect(formatBucketLabel(null, null)).toBe('All');
+  });
+
+  it('labels an open-ended tail in days when min is not month-aligned', () => {
+    expect(formatBucketLabel(100 * DAY, null)).toBe('100+ days');
+    // Month-aligned tails read in months.
+    expect(formatBucketLabel(2 * MONTH, null)).toBe('2 mo.+');
+  });
+
+  it('labels a first bucket wider than a day with a day count', () => {
+    expect(formatBucketLabel(null, 3 * DAY)).toBe('≤3 days');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+describe('OpenInterestByTimeToResolutionChart', () => {
+  it('shows a loader while analytics load', () => {
+    mockUseProtocolAnalytics.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    render(<OpenInterestByTimeToResolutionChart />);
+
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+    expect(screen.queryByTestId('bar-chart')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty state when every bucket is zero', () => {
+    loaded([bucket(null, DAY, 0n, 0), bucket(DAY, 7 * DAY, 0n, 0)]);
+    render(<OpenInterestByTimeToResolutionChart />);
+
+    expect(screen.getByText('No active open interest.')).toBeInTheDocument();
+    expect(screen.queryByTestId('bar-chart')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty state when there are no buckets at all', () => {
+    loaded([]);
+    render(<OpenInterestByTimeToResolutionChart />);
+
+    expect(screen.getByText('No active open interest.')).toBeInTheDocument();
+  });
+
+  it('maps buckets to bar data with 1-based indexes, labels and token values', () => {
+    loaded([
+      bucket(null, DAY, 1_500n, 3),
+      bucket(DAY, 7 * DAY, 0n, 0),
+      bucket(180 * DAY, null, 42n, 1),
+    ]);
+    render(<OpenInterestByTimeToResolutionChart />);
+
+    const data = JSON.parse(
+      screen.getByTestId('bar-chart').getAttribute('data-chart')!
+    );
+    expect(data).toEqual([
+      { bucket: 1, label: '≤1 day', value: 1500, predictionCount: 3 },
+      { bucket: 2, label: '2-7 days', value: 0, predictionCount: 0 },
+      { bucket: 3, label: '6 mo.+', value: 42, predictionCount: 1 },
+    ]);
+  });
+});

--- a/packages/app/src/components/analytics/pages/AnalyticsPageContent.tsx
+++ b/packages/app/src/components/analytics/pages/AnalyticsPageContent.tsx
@@ -24,34 +24,13 @@ import { useProtocolAnalytics } from '~/hooks/graphql/useAnalytics';
 import Loader from '~/components/shared/Loader';
 import OpenInterestByCategoryChart from '~/components/analytics/OpenInterestByCategoryChart';
 import OpenInterestByTimeToResolutionChart from '~/components/analytics/OpenInterestByTimeToResolutionChart';
-import PeriodFilter, {
-  type Period,
-  PERIOD_DAYS,
-} from '~/components/shared/PeriodFilter';
-
-function formatLargeNumber(
-  value: number,
-  decimals: number,
-  useDecimals: boolean
-): string {
-  if (value >= 1_000_000) {
-    return `${(value / 1_000_000).toFixed(useDecimals ? decimals : 1)}M`;
-  }
-  if (value >= 1_000) {
-    return `${(value / 1_000).toFixed(useDecimals ? decimals : 1)}K`;
-  }
-  return value.toFixed(useDecimals ? decimals : 0);
-}
-
-function formatNumber(value: string | number, decimals = 2): string {
-  const num = typeof value === 'string' ? parseFloat(value) : value;
-  if (isNaN(num)) return '0';
-  const humanReadable = num / 1e18;
-  return humanReadable.toLocaleString(undefined, {
-    minimumFractionDigits: decimals,
-    maximumFractionDigits: decimals,
-  });
-}
+import PeriodFilter, { type Period } from '~/components/shared/PeriodFilter';
+import {
+  bucketStatsByDay,
+  filterDataByPeriod,
+  formatLargeNumber,
+  formatNumber,
+} from '~/components/analytics/pages/analyticsFormat';
 
 function formatChartValue(value: number): string {
   return formatLargeNumber(value, 1, false);
@@ -168,30 +147,6 @@ const CHART_AXIS_STYLE = {
 // Match OpenInterestByTimeToResolutionChart's left:-4 so the y-axis labels
 // hug the card edge consistently across all charts on the analytics page.
 const CHART_MARGIN = { top: 10, right: 4, left: -4, bottom: 0 };
-
-function filterDataByPeriod<T extends { timestamp: number }>(
-  data: T[],
-  period: Period
-): T[] {
-  const days = PERIOD_DAYS[period];
-  if (days === Infinity) return data;
-
-  const now = Math.floor(Date.now() / 1000);
-  const cutoff = now - days * 86400;
-  return data.filter((item) => item.timestamp >= cutoff);
-}
-
-// Collapse sub-daily snapshots to one point per UTC day, keeping the last
-// observation in the day. Used for stock-like metrics (OI, TVL) where summing
-// would be wrong; the input is assumed to be in chronological order.
-function bucketStatsByDay<T extends { timestamp: number }>(data: T[]): T[] {
-  const byDay = new Map<number, T>();
-  for (const point of data) {
-    const dayStart = Math.floor(point.timestamp / 86400) * 86400;
-    byDay.set(dayStart, { ...point, timestamp: dayStart });
-  }
-  return [...byDay.values()].sort((a, b) => a.timestamp - b.timestamp);
-}
 
 function AnalyticsPageContent(): React.ReactElement {
   const collateralSymbol = COLLATERAL_SYMBOLS[DEFAULT_CHAIN_ID] || 'USDe';

--- a/packages/app/src/components/analytics/pages/__tests__/AnalyticsPageContent.test.tsx
+++ b/packages/app/src/components/analytics/pages/__tests__/AnalyticsPageContent.test.tsx
@@ -1,0 +1,262 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+// Recharts: prop-capturing div stubs so tests can assert the exact data
+// series handed to each chart without a canvas/layout engine.
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AreaChart: ({
+    data,
+    children,
+  }: {
+    data?: unknown;
+    children?: React.ReactNode;
+  }) => (
+    <div data-testid="area-chart" data-chart={JSON.stringify(data)}>
+      {children}
+    </div>
+  ),
+  ComposedChart: ({
+    data,
+    children,
+  }: {
+    data?: unknown;
+    children?: React.ReactNode;
+  }) => (
+    <div data-testid="composed-chart" data-chart={JSON.stringify(data)}>
+      {children}
+    </div>
+  ),
+  Area: () => <div />,
+  Bar: () => <div />,
+  XAxis: () => <div />,
+  YAxis: () => <div />,
+  CartesianGrid: () => <div />,
+  Tooltip: () => <div />,
+}));
+
+vi.mock('@sapience/sdk/constants', () => ({
+  DEFAULT_CHAIN_ID: 42161,
+  COLLATERAL_SYMBOLS: { 42161: 'USDe' },
+}));
+
+// Radix popover fights jsdom portals; render trigger/content inline.
+vi.mock('@sapience/ui/components/ui/popover', () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+  PopoverContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock('~/components/shared/Loader', () => {
+  const Loader = () => <div data-testid="loader" />;
+  return { __esModule: true, default: Loader };
+});
+
+// Period switching is out of scope; the default '1M' state drives the data.
+vi.mock('~/components/shared/PeriodFilter', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('~/components/shared/PeriodFilter')>();
+  return {
+    ...actual,
+    __esModule: true,
+    default: () => <div data-testid="period-filter" />,
+  };
+});
+
+// The two OI distribution charts fetch on their own; covered by their own tests.
+vi.mock('~/components/analytics/OpenInterestByCategoryChart', () => ({
+  __esModule: true,
+  default: () => <div data-testid="oi-by-category" />,
+}));
+vi.mock('~/components/analytics/OpenInterestByTimeToResolutionChart', () => ({
+  __esModule: true,
+  default: () => <div data-testid="oi-by-ttr" />,
+}));
+
+const mockUseProtocolAnalytics = vi.fn();
+vi.mock('~/hooks/graphql/useAnalytics', () => ({
+  useProtocolAnalytics: () => mockUseProtocolAnalytics(),
+}));
+
+import AnalyticsPageContent from '~/components/analytics/pages/AnalyticsPageContent';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const DAY = 86400;
+// A recent, boundary-safe UTC day start: "yesterday", so both snapshots land
+// on the same UTC day regardless of when the test runs, well inside 1M.
+const dayStart = Math.floor(Date.now() / 1000 / DAY) * DAY - DAY;
+
+function makeStat(overrides: Record<string, unknown> = {}) {
+  return {
+    timestamp: dayStart + 100,
+    cumulativeVolume: '5000000000000000000000', // 5,000
+    cumulativeTradeCount: 12345,
+    periodVolume: '100000000000000000000', // 100
+    periodTradeCount: 3,
+    openInterest: '2500000000000000000000', // 2,500
+    escrowBalance: '1500000000000000000000', // 1,500
+    totalValueLocked: '4200000000000000000000', // 4,200
+    ...overrides,
+  };
+}
+
+function loaded(analytics: unknown) {
+  mockUseProtocolAnalytics.mockReturnValue({
+    data: analytics,
+    isLoading: false,
+  });
+}
+
+function locale(n: number, decimals = 2): string {
+  return n.toLocaleString(undefined, {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AnalyticsPageContent', () => {
+  it('renders loaders for every summary card and chart while loading', () => {
+    mockUseProtocolAnalytics.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    render(<AnalyticsPageContent />);
+
+    // 4 summary cards + 4 charts (Daily Volume / Daily Trades / OI / TVL).
+    expect(screen.getAllByTestId('loader')).toHaveLength(8);
+    expect(screen.queryByText('No data available')).not.toBeInTheDocument();
+  });
+
+  it('renders the formatted live stats in the summary cards', () => {
+    loaded({
+      stats: makeStat(),
+      statsHistory: [makeStat()],
+      openInterestByCategory: [],
+      openInterestByTimeToResolution: [],
+    });
+    render(<AnalyticsPageContent />);
+
+    // 'Protocol TVL' / 'Open Interest' also title their history charts.
+    expect(screen.getAllByText('Protocol TVL')).toHaveLength(2);
+    expect(screen.getByText(`${locale(4200)} USDe`)).toBeInTheDocument();
+
+    expect(screen.getAllByText('Open Interest')).toHaveLength(2);
+    expect(screen.getByText(`${locale(2500)} USDe`)).toBeInTheDocument();
+
+    expect(screen.getByText('Cumulative Volume')).toBeInTheDocument();
+    expect(screen.getByText(`${locale(5000)} USDe`)).toBeInTheDocument();
+
+    expect(screen.getByText('Total Trades')).toBeInTheDocument();
+    expect(screen.getByText((12345).toLocaleString())).toBeInTheDocument();
+  });
+
+  it('breaks TVL down into escrow balance and undeployed vault funds', () => {
+    loaded({
+      stats: makeStat(),
+      statsHistory: [makeStat()],
+      openInterestByCategory: [],
+      openInterestByTimeToResolution: [],
+    });
+    render(<AnalyticsPageContent />);
+
+    expect(screen.getByText('Escrow Balance')).toBeInTheDocument();
+    expect(screen.getByText(`${locale(1500)} USDe`)).toBeInTheDocument();
+    // undeployed = totalValueLocked - escrowBalance = 4200 - 1500 = 2700
+    expect(screen.getByText('Undeployed Vault Funds')).toBeInTheDocument();
+    expect(screen.getByText(`${locale(2700)} USDe`)).toBeInTheDocument();
+  });
+
+  it('shows the empty state for all four history charts when there is no history', () => {
+    loaded({
+      stats: makeStat(),
+      statsHistory: [],
+      openInterestByCategory: [],
+      openInterestByTimeToResolution: [],
+    });
+    render(<AnalyticsPageContent />);
+
+    expect(screen.getAllByText('No data available')).toHaveLength(4);
+    expect(screen.queryByTestId('area-chart')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('composed-chart')).not.toBeInTheDocument();
+  });
+
+  it('mounts the two open-interest distribution charts', () => {
+    loaded({
+      stats: makeStat(),
+      statsHistory: [],
+      openInterestByCategory: [],
+      openInterestByTimeToResolution: [],
+    });
+    render(<AnalyticsPageContent />);
+
+    expect(screen.getByTestId('oi-by-category')).toBeInTheDocument();
+    expect(screen.getByTestId('oi-by-ttr')).toBeInTheDocument();
+  });
+
+  it('buckets sub-daily snapshots into one UTC day per chart point', () => {
+    // Two snapshots on the same UTC day.
+    const early = makeStat({
+      timestamp: dayStart + 100,
+      periodVolume: '100000000000000000000', // 100
+      periodTradeCount: 3,
+      openInterest: '1000000000000000000000', // 1,000
+      totalValueLocked: '2000000000000000000000', // 2,000
+    });
+    const late = makeStat({
+      timestamp: dayStart + 5000,
+      periodVolume: '50000000000000000000', // 50
+      periodTradeCount: 2,
+      openInterest: '1100000000000000000000', // 1,100
+      totalValueLocked: '2200000000000000000000', // 2,200
+    });
+    loaded({
+      stats: makeStat(),
+      statsHistory: [early, late],
+      openInterestByCategory: [],
+      openInterestByTimeToResolution: [],
+    });
+    render(<AnalyticsPageContent />);
+
+    // Bars (flows) SUM within the day: volume, then trade count.
+    const [volumeChart, tradesChart] = screen.getAllByTestId('composed-chart');
+    expect(JSON.parse(volumeChart.getAttribute('data-chart')!)).toEqual([
+      { timestamp: dayStart, volume: 150 },
+    ]);
+    expect(JSON.parse(tradesChart.getAttribute('data-chart')!)).toEqual([
+      { timestamp: dayStart, tradeCount: 5 },
+    ]);
+
+    // Areas (stocks) keep the LAST observation of the day: OI, then TVL.
+    const [oiChart, tvlChart] = screen.getAllByTestId('area-chart');
+    expect(JSON.parse(oiChart.getAttribute('data-chart')!)).toEqual([
+      { timestamp: dayStart, openInterest: 1100, protocolTvl: 2200 },
+    ]);
+    expect(JSON.parse(tvlChart.getAttribute('data-chart')!)).toEqual([
+      { timestamp: dayStart, openInterest: 1100, protocolTvl: 2200 },
+    ]);
+  });
+});

--- a/packages/app/src/components/analytics/pages/analyticsFormat.test.ts
+++ b/packages/app/src/components/analytics/pages/analyticsFormat.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  bucketStatsByDay,
+  filterDataByPeriod,
+  formatLargeNumber,
+  formatNumber,
+} from './analyticsFormat';
+
+const DAY = 86400;
+
+// Locale-proof expectation helper — formatNumber delegates to
+// toLocaleString(undefined, ...), so the tests must too.
+function locale(n: number, decimals = 2): string {
+  return n.toLocaleString(undefined, {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+}
+
+describe('formatLargeNumber', () => {
+  it('formats millions with an M suffix', () => {
+    expect(formatLargeNumber(2_500_000, 2, true)).toBe('2.50M');
+    expect(formatLargeNumber(1_000_000, 2, true)).toBe('1.00M');
+  });
+
+  it('formats thousands with a K suffix', () => {
+    expect(formatLargeNumber(1_500, 2, true)).toBe('1.50K');
+    expect(formatLargeNumber(999_999, 2, true)).toBe('1000.00K');
+  });
+
+  it('falls back to one decimal for M/K when useDecimals is false', () => {
+    expect(formatLargeNumber(2_500_000, 3, false)).toBe('2.5M');
+    expect(formatLargeNumber(1_500, 3, false)).toBe('1.5K');
+  });
+
+  it('renders sub-thousand values with decimals only when requested', () => {
+    expect(formatLargeNumber(999.4, 2, true)).toBe('999.40');
+    expect(formatLargeNumber(999.4, 2, false)).toBe('999');
+    expect(formatLargeNumber(0, 2, false)).toBe('0');
+  });
+});
+
+describe('formatNumber', () => {
+  it('converts a wei string to a locale string in whole tokens', () => {
+    expect(formatNumber('1500000000000000000000')).toBe(locale(1500));
+    expect(formatNumber('1000000000000000000')).toBe(locale(1));
+  });
+
+  it('accepts numbers and a custom decimal count', () => {
+    expect(formatNumber(2e18)).toBe(locale(2));
+    expect(formatNumber('1234500000000000000', 4)).toBe(locale(1.2345, 4));
+  });
+
+  it("returns '0' for NaN input", () => {
+    expect(formatNumber('not-a-number')).toBe('0');
+    expect(formatNumber(NaN)).toBe('0');
+  });
+});
+
+describe('filterDataByPeriod', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('passes everything through (same reference) for ALL', () => {
+    const data = [{ timestamp: 0 }, { timestamp: 1 }];
+    expect(filterDataByPeriod(data, 'ALL')).toBe(data);
+  });
+
+  it('keeps points at or after the period cutoff (>= boundary)', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-15T12:00:00Z'));
+    const now = Math.floor(Date.now() / 1000);
+    const cutoff = now - 7 * DAY;
+
+    const data = [
+      { timestamp: cutoff - 1 }, // just outside the window → dropped
+      { timestamp: cutoff }, // exactly on the boundary → kept
+      { timestamp: now }, // now → kept
+    ];
+
+    expect(filterDataByPeriod(data, '1W')).toEqual([
+      { timestamp: cutoff },
+      { timestamp: now },
+    ]);
+  });
+
+  it('applies the 30- and 90-day windows for 1M and 3M', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-15T12:00:00Z'));
+    const now = Math.floor(Date.now() / 1000);
+
+    const data = [
+      { timestamp: now - 91 * DAY },
+      { timestamp: now - 31 * DAY },
+      { timestamp: now - 1 * DAY },
+    ];
+
+    expect(filterDataByPeriod(data, '1M')).toEqual([
+      { timestamp: now - 1 * DAY },
+    ]);
+    expect(filterDataByPeriod(data, '3M')).toEqual([
+      { timestamp: now - 31 * DAY },
+      { timestamp: now - 1 * DAY },
+    ]);
+  });
+});
+
+describe('bucketStatsByDay', () => {
+  it('keeps the last observation per UTC day and snaps timestamps to day start', () => {
+    const day0 = 1_750_000_000 - (1_750_000_000 % DAY);
+    const data = [
+      { timestamp: day0 + 100, value: 1 },
+      { timestamp: day0 + 5_000, value: 2 },
+      { timestamp: day0 + 80_000, value: 3 }, // last snapshot of day0 wins
+    ];
+
+    expect(bucketStatsByDay(data)).toEqual([{ timestamp: day0, value: 3 }]);
+  });
+
+  it('produces one point per day, sorted ascending', () => {
+    const day0 = 1_750_000_000 - (1_750_000_000 % DAY);
+    const day1 = day0 + DAY;
+    const day2 = day0 + 2 * DAY;
+
+    // Chronological input whose later days interleave sub-daily snapshots.
+    const data = [
+      { timestamp: day0 + 10, value: 'a1' },
+      { timestamp: day1 + 10, value: 'b1' },
+      { timestamp: day1 + 20, value: 'b2' },
+      { timestamp: day2 + 10, value: 'c1' },
+    ];
+
+    expect(bucketStatsByDay(data)).toEqual([
+      { timestamp: day0, value: 'a1' },
+      { timestamp: day1, value: 'b2' },
+      { timestamp: day2, value: 'c1' },
+    ]);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(bucketStatsByDay([])).toEqual([]);
+  });
+});

--- a/packages/app/src/components/analytics/pages/analyticsFormat.ts
+++ b/packages/app/src/components/analytics/pages/analyticsFormat.ts
@@ -1,0 +1,51 @@
+import { type Period, PERIOD_DAYS } from '~/components/shared/PeriodFilter';
+
+export function formatLargeNumber(
+  value: number,
+  decimals: number,
+  useDecimals: boolean
+): string {
+  if (value >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(useDecimals ? decimals : 1)}M`;
+  }
+  if (value >= 1_000) {
+    return `${(value / 1_000).toFixed(useDecimals ? decimals : 1)}K`;
+  }
+  return value.toFixed(useDecimals ? decimals : 0);
+}
+
+export function formatNumber(value: string | number, decimals = 2): string {
+  const num = typeof value === 'string' ? parseFloat(value) : value;
+  if (isNaN(num)) return '0';
+  const humanReadable = num / 1e18;
+  return humanReadable.toLocaleString(undefined, {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+}
+
+export function filterDataByPeriod<T extends { timestamp: number }>(
+  data: T[],
+  period: Period
+): T[] {
+  const days = PERIOD_DAYS[period];
+  if (days === Infinity) return data;
+
+  const now = Math.floor(Date.now() / 1000);
+  const cutoff = now - days * 86400;
+  return data.filter((item) => item.timestamp >= cutoff);
+}
+
+// Collapse sub-daily snapshots to one point per UTC day, keeping the last
+// observation in the day. Used for stock-like metrics (OI, TVL) where summing
+// would be wrong; the input is assumed to be in chronological order.
+export function bucketStatsByDay<T extends { timestamp: number }>(
+  data: T[]
+): T[] {
+  const byDay = new Map<number, T>();
+  for (const point of data) {
+    const dayStart = Math.floor(point.timestamp / 86400) * 86400;
+    byDay.set(dayStart, { ...point, timestamp: dayStart });
+  }
+  return [...byDay.values()].sort((a, b) => a.timestamp - b.timestamp);
+}

--- a/packages/app/src/components/positions/__tests__/ActivityTable.test.tsx
+++ b/packages/app/src/components/positions/__tests__/ActivityTable.test.tsx
@@ -1,0 +1,620 @@
+import { vi, describe, it, expect, beforeEach, beforeAll } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type {
+  ActivityItem,
+  PredictionActivity,
+  TradeActivity,
+} from '~/hooks/graphql/useAccountActivity';
+import type {
+  PickConfigData,
+  PickData,
+  Prediction,
+} from '~/hooks/graphql/usePositions';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+// The hook's transport/mapping behavior is covered by useAccountActivity.test;
+// here we drive the table with domain-shaped fixtures.
+const mockUseAccountActivity = vi.fn();
+vi.mock('~/hooks/graphql/useAccountActivity', () => ({
+  useAccountActivity: (args: unknown) => mockUseAccountActivity(args),
+}));
+
+// IntersectionObserver-free stand-in; the sentinel wiring is out of scope.
+vi.mock('~/hooks/useInfiniteScroll', () => ({
+  useInfiniteScroll: () => ({ loadMoreRef: { current: null } }),
+}));
+
+// Radix tooltips fight jsdom portals; render triggers inline, drop content.
+vi.mock('@sapience/ui/components/ui/tooltip', () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  TooltipContent: () => null,
+}));
+
+vi.mock('~/components/shared/Loader', () => {
+  const Loader = () => <div data-testid="loader" />;
+  return { __esModule: true, default: Loader };
+});
+
+vi.mock('~/components/shared/PicksSummary', () => ({
+  __esModule: true,
+  default: ({
+    picks,
+    predictionId,
+    onClick,
+  }: {
+    picks: { question: string; choice: string }[];
+    predictionId?: string;
+    onClick?: () => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="picks-summary"
+      data-prediction-id={predictionId ?? ''}
+      onClick={onClick}
+    >
+      {picks.map((p) => `${p.question}: ${p.choice}`).join(', ')}
+    </button>
+  ),
+}));
+
+vi.mock('~/components/shared/PicksPopover', () => ({
+  __esModule: true,
+  default: ({
+    picks,
+    fallbackAddress,
+  }: {
+    picks: { question: string; choice: string }[];
+    fallbackAddress?: string;
+  }) => (
+    <div data-testid="picks-popover" data-fallback={fallbackAddress ?? ''}>
+      {picks.map((p) => `${p.question}: ${p.choice}`).join(', ')}
+    </div>
+  ),
+}));
+
+vi.mock('~/components/shared/EnsAvatar', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock('~/components/shared/AddressDisplay', () => ({
+  __esModule: true,
+  AddressDisplay: ({ address }: { address: string }) => <span>{address}</span>,
+}));
+
+vi.mock('~/components/positions/PredictionDialog', () => ({
+  __esModule: true,
+  default: (props: {
+    open: boolean;
+    prediction: { predictionId: string } | null;
+  }) =>
+    props.open ? (
+      <div
+        data-testid="prediction-dialog"
+        data-prediction-id={props.prediction?.predictionId ?? ''}
+      />
+    ) : null,
+}));
+
+vi.mock('~/components/shared/OgShareDialog', () => ({
+  __esModule: true,
+  default: (props: { imageSrc: string; open?: boolean }) => (
+    <div data-testid="og-share-dialog" data-image-src={props.imageSrc} />
+  ),
+}));
+
+// The real filter toolbar drags in Radix popover/dropdown portals; the table
+// only needs a search input plus the default filter state shape.
+vi.mock('~/components/positions/ActivityTableFilters', () => {
+  type FilterState = {
+    searchTerm: string;
+    status: string[];
+    valueRange: [number, number];
+    dateRange: [number, number];
+    activityType: string;
+  };
+  const getDefaultActivityFilterState = (): FilterState => ({
+    searchTerm: '',
+    status: [],
+    valueRange: [0, Infinity],
+    dateRange: [-Infinity, Infinity],
+    activityType: 'all',
+  });
+  const ActivityTableFilters = ({
+    filters,
+    onFiltersChange,
+  }: {
+    filters: FilterState;
+    onFiltersChange: (f: FilterState) => void;
+  }) => (
+    <input
+      aria-label="Search activity"
+      value={filters.searchTerm}
+      onChange={(e) =>
+        onFiltersChange({ ...filters, searchTerm: e.target.value })
+      }
+    />
+  );
+  return {
+    __esModule: true,
+    ActivityTableFilters,
+    getDefaultActivityFilterState,
+    default: ActivityTableFilters,
+  };
+});
+
+import ActivityTable from '~/components/positions/ActivityTable';
+
+// ---------------------------------------------------------------------------
+// Fixtures (domain shapes from useAccountActivity / usePositions)
+// ---------------------------------------------------------------------------
+
+const WEI = 10n ** 18n;
+const NOW_SEC = Math.floor(Date.now() / 1000);
+
+function makePick(
+  conditionId: string,
+  question: string,
+  overrides: Partial<PickData> = {}
+): PickData {
+  return {
+    id: `0xpc1:${conditionId}`,
+    pickConfigId: '0xpc1',
+    conditionResolver: '0xresolver',
+    conditionId,
+    predictedOutcome: 1,
+    condition: {
+      id: conditionId,
+      shortName: null,
+      question,
+      endTime: NOW_SEC + 7 * 86400,
+      resolver: '0xresolver',
+      category: { slug: 'crypto' },
+      settled: false,
+      resolvedToYes: false,
+      nonDecisive: false,
+      estimatedPrice: 0.5,
+    },
+    ...overrides,
+  };
+}
+
+function makePickConfig(
+  overrides: Partial<PickConfigData> = {}
+): PickConfigData {
+  return {
+    id: '0xpc1',
+    chainId: 8453,
+    marketAddress: '0xescrow',
+    totalPredictorCollateral: (1n * WEI).toString(),
+    totalCounterpartyCollateral: (2n * WEI).toString(),
+    claimedPredictorCollateral: '0',
+    claimedCounterpartyCollateral: '0',
+    resolved: false,
+    result: 'UNRESOLVED',
+    resolvedAt: null,
+    predictorToken: '0xpredictortoken',
+    counterpartyToken: '0xcounterpartytoken',
+    endsAt: NOW_SEC + 7 * 86400,
+    isLegacy: false,
+    picks: [makePick('0xcond1', 'Will ETH hit 5k?')],
+    ...overrides,
+  };
+}
+
+function makePrediction(overrides: Partial<Prediction> = {}): Prediction {
+  return {
+    predictionId: '0xpred1',
+    chainId: 8453,
+    marketAddress: '0xescrow',
+    predictor: '0xaaa1111111111111111111111111111111111111',
+    counterparty: '0xbbb2222222222222222222222222222222222222',
+    predictorToken: '0xpredictortoken',
+    counterpartyToken: '0xcounterpartytoken',
+    predictorCollateral: (1n * WEI).toString(),
+    counterpartyCollateral: (2n * WEI).toString(),
+    settled: false,
+    result: 'UNRESOLVED',
+    createTxHash: '0xtx1',
+    createdAt: '2026-06-01T00:00:00.000Z',
+    isLegacy: false,
+    pickConfig: makePickConfig(),
+    ...overrides,
+  };
+}
+
+function makePredictionItem(
+  overrides: Partial<PredictionActivity> = {}
+): PredictionActivity {
+  const prediction = overrides.prediction ?? makePrediction();
+  return {
+    type: 'prediction',
+    timestamp: Date.now() - 5 * 60 * 1000,
+    prediction,
+    pickConfig: prediction.pickConfig ?? null,
+    isPredictorSide: true,
+    ...overrides,
+  };
+}
+
+function makeTradeItem(overrides: Partial<TradeActivity> = {}): TradeActivity {
+  return {
+    type: 'trade',
+    timestamp: Date.now() - 10 * 60 * 1000,
+    trade: {
+      tradeHash: '0xtrade1',
+      chainId: 8453,
+      token: '0xpredictortoken',
+      collateral: '0xcollateral',
+      seller: '0xccc3333333333333333333333333333333333333',
+      buyer: '0xddd4444444444444444444444444444444444444',
+      tokenAmount: (2n * WEI).toString(),
+      price: (1n * WEI).toString(),
+      txHash: '0xtx2',
+      blockNumber: 42,
+      executedAt: NOW_SEC - 600,
+    },
+    pickConfig: makePickConfig(),
+    isBuyer: false,
+    ...overrides,
+  };
+}
+
+function hookState(overrides: Record<string, unknown> = {}) {
+  return {
+    items: [] as ActivityItem[],
+    isLoading: false,
+    isFetchingMore: false,
+    hasMore: false,
+    fetchMore: vi.fn(),
+    pendingCount: 0,
+    pendingItems: [] as ActivityItem[],
+    revealPending: vi.fn(),
+    ...overrides,
+  };
+}
+
+const scrollIntoViewMock = vi.fn();
+beforeAll(() => {
+  Element.prototype.scrollIntoView = scrollIntoViewMock;
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseAccountActivity.mockReturnValue(hookState());
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ActivityTable', () => {
+  it('shows the loading state while the feed loads', () => {
+    mockUseAccountActivity.mockReturnValue(hookState({ isLoading: true }));
+    render(<ActivityTable />);
+
+    expect(screen.getByText('Loading activity…')).toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty state when the feed has no items', () => {
+    render(<ActivityTable />);
+
+    expect(screen.getByText('No activity found')).toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('renders a pending prediction row with picks, parties, value and countdown status', () => {
+    mockUseAccountActivity.mockReturnValue(
+      hookState({ items: [makePredictionItem()] })
+    );
+    render(<ActivityTable />);
+
+    // Column headers.
+    for (const header of [
+      'Date',
+      'Type',
+      'Position',
+      'Parties',
+      'Value',
+      'Status',
+    ]) {
+      expect(
+        screen.getByRole('columnheader', { name: header })
+      ).toBeInTheDocument();
+    }
+
+    expect(screen.getByText('Prediction')).toBeInTheDocument();
+    // Relative date from the 5-minutes-ago timestamp.
+    expect(screen.getByText('5 minutes ago')).toBeInTheDocument();
+    // Picks rendered through toPicks: condition question + Yes choice.
+    expect(screen.getByTestId('picks-summary')).toHaveTextContent(
+      'Will ETH hit 5k?: Yes'
+    );
+    // Both parties with their collateral.
+    expect(
+      screen.getByText('0xaaa1111111111111111111111111111111111111')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('0xbbb2222222222222222222222222222222222222')
+    ).toBeInTheDocument();
+    // Value = predictor + counterparty collateral = 3.00.
+    expect(screen.getByText('3.00')).toBeInTheDocument();
+    // Unsettled with a future endsAt → countdown status.
+    expect(screen.getByText(/ENDS/)).toBeInTheDocument();
+  });
+
+  it('renders settled prediction status variants', () => {
+    const won = makePredictionItem({
+      prediction: makePrediction({
+        predictionId: '0xpredWin',
+        settled: true,
+        result: 'PREDICTOR_WINS',
+      }),
+    });
+    const lost = makePredictionItem({
+      prediction: makePrediction({
+        predictionId: '0xpredLose',
+        settled: true,
+        result: 'COUNTERPARTY_WINS',
+      }),
+    });
+    mockUseAccountActivity.mockReturnValue(hookState({ items: [won, lost] }));
+    render(<ActivityTable />);
+
+    expect(screen.getByText('Predictor won')).toBeInTheDocument();
+    expect(screen.getByText('Counterparty won')).toBeInTheDocument();
+  });
+
+  it("shows 'Pending' for an unsettled prediction whose end time has passed", () => {
+    const item = makePredictionItem({
+      prediction: makePrediction({
+        pickConfig: makePickConfig({ endsAt: NOW_SEC - 3600 }),
+      }),
+    });
+    mockUseAccountActivity.mockReturnValue(
+      hookState({
+        items: [{ ...item, pickConfig: item.prediction.pickConfig }],
+      })
+    );
+    render(<ActivityTable />);
+
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+    expect(screen.queryByText(/ENDS/)).not.toBeInTheDocument();
+  });
+
+  it('renders a trade row with buyer/seller parties and a neutral status in global mode', () => {
+    mockUseAccountActivity.mockReturnValue(
+      hookState({ items: [makeTradeItem()] })
+    );
+    render(<ActivityTable />);
+
+    expect(screen.getByText('buyer')).toBeInTheDocument();
+    expect(screen.getByText('seller')).toBeInTheDocument();
+    expect(
+      screen.getByText('0xddd4444444444444444444444444444444444444')
+    ).toBeInTheDocument();
+    // Price 1.00 and the amount × unit-price breakdown.
+    expect(screen.getByText('1.00')).toBeInTheDocument();
+    expect(screen.getByText('2.00')).toBeInTheDocument();
+    // Without an account the status column shows the neutral 'Trade' label.
+    expect(screen.getAllByText('Trade')).toHaveLength(2); // badge + status
+    expect(screen.getByTestId('picks-popover')).toHaveAttribute(
+      'data-fallback',
+      '0xpredictortoken'
+    );
+  });
+
+  it("shows 'Bought' for the account's buy-side trades in account mode", () => {
+    mockUseAccountActivity.mockReturnValue(
+      hookState({ items: [makeTradeItem({ isBuyer: true })] })
+    );
+    render(
+      <ActivityTable account="0xddd4444444444444444444444444444444444444" />
+    );
+
+    expect(screen.getByText('Bought')).toBeInTheDocument();
+  });
+
+  it('omits hidden columns from the header and the rows', () => {
+    mockUseAccountActivity.mockReturnValue(
+      hookState({ items: [makePredictionItem()] })
+    );
+    render(<ActivityTable hiddenColumns={['status', 'share']} />);
+
+    expect(
+      screen.queryByRole('columnheader', { name: 'Status' })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/ENDS/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Share' })
+    ).not.toBeInTheDocument();
+    // Remaining columns still render.
+    expect(
+      screen.getByRole('columnheader', { name: 'Position' })
+    ).toBeInTheDocument();
+  });
+
+  it('hides the filter toolbar with hideFilters', () => {
+    mockUseAccountActivity.mockReturnValue(
+      hookState({ items: [makePredictionItem()] })
+    );
+    render(<ActivityTable hideFilters />);
+
+    expect(screen.queryByLabelText('Search activity')).not.toBeInTheDocument();
+    expect(screen.getByRole('table')).toBeInTheDocument();
+  });
+
+  it('shows the no-matches empty state when the search filter excludes every row', () => {
+    mockUseAccountActivity.mockReturnValue(
+      hookState({ items: [makePredictionItem()] })
+    );
+    render(<ActivityTable />);
+
+    fireEvent.change(screen.getByLabelText('Search activity'), {
+      target: { value: 'zzz-no-such-question' },
+    });
+
+    expect(
+      screen.getByText('No activity matches your filters')
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('surfaces held-back live items in the banner and reveals them on click', () => {
+    const revealPending = vi.fn();
+    mockUseAccountActivity.mockReturnValue(
+      hookState({
+        items: [makePredictionItem()],
+        pendingItems: [
+          makePredictionItem({
+            prediction: makePrediction({ predictionId: '0xpredNew1' }),
+          }),
+          makeTradeItem({
+            trade: { ...makeTradeItem().trade, tradeHash: '0xtradeNew1' },
+          }),
+        ],
+        pendingCount: 2,
+        revealPending,
+      })
+    );
+    render(<ActivityTable enableLive />);
+
+    const banner = screen.getByRole('button', { name: /2 new activities/ });
+    fireEvent.click(banner);
+
+    expect(revealPending).toHaveBeenCalledTimes(1);
+    expect(scrollIntoViewMock).toHaveBeenCalled();
+  });
+
+  it('hides the banner when the active filters would hide every pending item', () => {
+    mockUseAccountActivity.mockReturnValue(
+      hookState({
+        items: [makePredictionItem()], // question: Will ETH hit 5k?
+        pendingItems: [
+          makePredictionItem({
+            prediction: makePrediction({
+              predictionId: '0xpredBtc',
+              pickConfig: makePickConfig({
+                picks: [makePick('0xcondBtc', 'Will BTC hit 200k?')],
+              }),
+            }),
+          }),
+        ].map((item) => ({
+          ...item,
+          pickConfig: item.prediction.pickConfig ?? null,
+        })),
+        pendingCount: 1,
+      })
+    );
+    render(<ActivityTable enableLive />);
+
+    // Unfiltered: banner counts the BTC pending item.
+    expect(
+      screen.getByRole('button', { name: /1 new activity/ })
+    ).toBeInTheDocument();
+
+    // Search matches the visible ETH row but not the pending BTC item.
+    fireEvent.change(screen.getByLabelText('Search activity'), {
+      target: { value: 'ETH' },
+    });
+
+    expect(
+      screen.queryByRole('button', { name: /new activit/ })
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('picks-summary')).toBeInTheDocument();
+  });
+
+  it('opens the prediction dialog when the picks summary is clicked', () => {
+    mockUseAccountActivity.mockReturnValue(
+      hookState({ items: [makePredictionItem()] })
+    );
+    render(<ActivityTable />);
+
+    expect(screen.queryByTestId('prediction-dialog')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('picks-summary'));
+
+    expect(screen.getByTestId('prediction-dialog')).toHaveAttribute(
+      'data-prediction-id',
+      '0xpred1'
+    );
+  });
+
+  it('opens the OG share dialog with the prediction share image', () => {
+    mockUseAccountActivity.mockReturnValue(
+      hookState({ items: [makePredictionItem()] })
+    );
+    render(<ActivityTable />);
+
+    expect(screen.queryByTestId('og-share-dialog')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Share' }));
+
+    const dialog = screen.getByTestId('og-share-dialog');
+    const src = dialog.getAttribute('data-image-src')!;
+    expect(src).toMatch(/^\/og\/prediction\?/);
+    const params = new URLSearchParams(src.split('?')[1]);
+    expect(params.get('wager')).toBe('1.00'); // predictor side
+    expect(params.get('payout')).toBe('3.00'); // total collateral
+    expect(params.get('leg')).toBe('Will ETH hit 5k?|Yes');
+  });
+
+  it('renders the infinite-scroll footer only when more pages exist', () => {
+    mockUseAccountActivity.mockReturnValue(
+      hookState({ items: [makePredictionItem()], hasMore: true })
+    );
+    const { rerender } = render(<ActivityTable />);
+    expect(screen.getByText('Scroll to load more')).toBeInTheDocument();
+
+    mockUseAccountActivity.mockReturnValue(
+      hookState({
+        items: [makePredictionItem()],
+        hasMore: true,
+        isFetchingMore: true,
+      })
+    );
+    rerender(<ActivityTable />);
+    expect(screen.getByText('Loading more activity…')).toBeInTheDocument();
+
+    mockUseAccountActivity.mockReturnValue(
+      hookState({ items: [makePredictionItem()], hasMore: false })
+    );
+    rerender(<ActivityTable />);
+    expect(screen.queryByText('Scroll to load more')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Loading more activity…')
+    ).not.toBeInTheDocument();
+  });
+
+  it('forwards its scoping props to useAccountActivity', () => {
+    render(
+      <ActivityTable
+        account="0xddd4444444444444444444444444444444444444"
+        filterPickConfigId="0xpc1"
+        filterToken="0xpredictortoken"
+        pageSize={5}
+        enableLive
+      />
+    );
+
+    expect(mockUseAccountActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account: '0xddd4444444444444444444444444444444444444',
+        pickConfigId: '0xpc1',
+        token: '0xpredictortoken',
+        pageSize: 5,
+        activityType: 'all',
+        enableLive: true,
+      })
+    );
+  });
+});

--- a/packages/app/src/hooks/graphql/__tests__/useAnalytics.test.ts
+++ b/packages/app/src/hooks/graphql/__tests__/useAnalytics.test.ts
@@ -1,0 +1,264 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
+
+const mockFetchProtocolAnalytics = vi.fn();
+const mockFetchProtocolStats = vi.fn();
+const mockFetchVaultStats = vi.fn();
+const mockFetchVaultAccountValue = vi.fn();
+
+vi.mock('@sapience/sdk/queries', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    fetchProtocolAnalytics: (...args: unknown[]) =>
+      mockFetchProtocolAnalytics(...args),
+    fetchProtocolStats: (...args: unknown[]) => mockFetchProtocolStats(...args),
+    fetchVaultStats: (...args: unknown[]) => mockFetchVaultStats(...args),
+    fetchVaultAccountValue: (...args: unknown[]) =>
+      mockFetchVaultAccountValue(...args),
+  };
+});
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+    },
+  });
+  const wrapper = function Wrapper({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children
+    );
+  };
+  return { wrapper, queryClient };
+}
+
+async function getModule() {
+  return import('../useAnalytics');
+}
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const stat = {
+  timestamp: 1750000000,
+  cumulativeVolume: '5000000000000000000000',
+  cumulativeTradeCount: 42,
+  periodVolume: '100000000000000000000',
+  periodTradeCount: 3,
+  openInterest: '2000000000000000000000',
+  escrowBalance: '1500000000000000000000',
+  totalValueLocked: '3000000000000000000000',
+};
+
+const analytics = {
+  stats: stat,
+  statsHistory: [stat],
+  openInterestByCategory: [],
+  openInterestByTimeToResolution: [],
+};
+
+const vaultStat = {
+  timestamp: 1750000000,
+  balance: '1000000000000000000',
+  deployedCollateral: '0',
+  undeployedCollateral: '0',
+  cumulativePnl: '0',
+  claimableCollateral: '0',
+};
+
+const vaultAccountValue = {
+  collateralBalance: '1000000000000000000',
+  deployedCollateral: '2000000000000000000',
+  claimableCollateral: '0',
+  totalValue: '3000000000000000000',
+  timestamp: 1750000000,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFetchProtocolAnalytics.mockResolvedValue(analytics);
+  mockFetchProtocolStats.mockResolvedValue(stat);
+  mockFetchVaultStats.mockResolvedValue([vaultStat]);
+  mockFetchVaultAccountValue.mockResolvedValue(vaultAccountValue);
+});
+
+// ─── useProtocolAnalytics ────────────────────────────────────────────────────
+
+describe('useProtocolAnalytics', () => {
+  it('returns the analytics payload from the fetcher', async () => {
+    const mod = await getModule();
+    const { result } = renderHook(() => mod.useProtocolAnalytics(), {
+      wrapper: createWrapper().wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(analytics);
+    expect(mockFetchProtocolAnalytics).toHaveBeenCalledTimes(1);
+    // The protocol query takes no arguments.
+    expect(mockFetchProtocolAnalytics).toHaveBeenCalledWith();
+  });
+
+  it('surfaces fetcher failures as an error state', async () => {
+    mockFetchProtocolAnalytics.mockRejectedValue(new Error('boom'));
+
+    const mod = await getModule();
+    const { result } = renderHook(() => mod.useProtocolAnalytics(), {
+      wrapper: createWrapper().wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+    expect((result.current.error as Error).message).toBe('boom');
+  });
+});
+
+// ─── useProtocolStats ────────────────────────────────────────────────────────
+
+describe('useProtocolStats', () => {
+  it('returns the live stats from the fetcher', async () => {
+    const mod = await getModule();
+    const { result } = renderHook(() => mod.useProtocolStats(), {
+      wrapper: createWrapper().wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(stat);
+    expect(mockFetchProtocolStats).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces fetcher failures as an error state', async () => {
+    mockFetchProtocolStats.mockRejectedValue(new Error('stats down'));
+
+    const mod = await getModule();
+    const { result } = renderHook(() => mod.useProtocolStats(), {
+      wrapper: createWrapper().wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+// ─── useVaultStats ───────────────────────────────────────────────────────────
+
+describe('useVaultStats', () => {
+  it('fetches vault stats with the address and default chain id', async () => {
+    const mod = await getModule();
+    const { result } = renderHook(() => mod.useVaultStats('0xVault'), {
+      wrapper: createWrapper().wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([vaultStat]);
+    expect(mockFetchVaultStats).toHaveBeenCalledTimes(1);
+    expect(mockFetchVaultStats).toHaveBeenCalledWith(
+      '0xVault',
+      DEFAULT_CHAIN_ID
+    );
+  });
+
+  it('stays disabled and never fetches without an address', async () => {
+    const mod = await getModule();
+    const { result } = renderHook(() => mod.useVaultStats(undefined), {
+      wrapper: createWrapper().wrapper,
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(mockFetchVaultStats).not.toHaveBeenCalled();
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('surfaces fetcher failures as an error state', async () => {
+    mockFetchVaultStats.mockRejectedValue(new Error('vault down'));
+
+    const mod = await getModule();
+    const { result } = renderHook(() => mod.useVaultStats('0xVault'), {
+      wrapper: createWrapper().wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it('lowercases the address in the queryKey so 0xABC and 0xabc dedupe', async () => {
+    const mod = await getModule();
+    const { wrapper } = createWrapper();
+
+    const upper = renderHook(() => mod.useVaultStats('0xABC'), { wrapper });
+    await waitFor(() => expect(upper.result.current.isSuccess).toBe(true));
+
+    // Same client + same (lowercased) key: served from cache within staleTime,
+    // no second network call.
+    const lower = renderHook(() => mod.useVaultStats('0xabc'), { wrapper });
+    await waitFor(() => expect(lower.result.current.isSuccess).toBe(true));
+
+    expect(mockFetchVaultStats).toHaveBeenCalledTimes(1);
+    expect(lower.result.current.data).toEqual([vaultStat]);
+  });
+});
+
+// ─── useVaultAccountValue ────────────────────────────────────────────────────
+
+describe('useVaultAccountValue', () => {
+  it('fetches the indexed account value with the address and default chain id', async () => {
+    const mod = await getModule();
+    const { result } = renderHook(() => mod.useVaultAccountValue('0xVault'), {
+      wrapper: createWrapper().wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(vaultAccountValue);
+    expect(mockFetchVaultAccountValue).toHaveBeenCalledTimes(1);
+    expect(mockFetchVaultAccountValue).toHaveBeenCalledWith(
+      '0xVault',
+      DEFAULT_CHAIN_ID
+    );
+  });
+
+  it('stays disabled and never fetches without an address', async () => {
+    const mod = await getModule();
+    const { result } = renderHook(() => mod.useVaultAccountValue(undefined), {
+      wrapper: createWrapper().wrapper,
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(mockFetchVaultAccountValue).not.toHaveBeenCalled();
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('lowercases the address in the queryKey so 0xDEF and 0xdef dedupe', async () => {
+    const mod = await getModule();
+    const { wrapper } = createWrapper();
+
+    const upper = renderHook(() => mod.useVaultAccountValue('0xDEF'), {
+      wrapper,
+    });
+    await waitFor(() => expect(upper.result.current.isSuccess).toBe(true));
+
+    const lower = renderHook(() => mod.useVaultAccountValue('0xdef'), {
+      wrapper,
+    });
+    await waitFor(() => expect(lower.result.current.isSuccess).toBe(true));
+
+    expect(mockFetchVaultAccountValue).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces fetcher failures as an error state', async () => {
+    mockFetchVaultAccountValue.mockRejectedValue(new Error('account down'));
+
+    const mod = await getModule();
+    const { result } = renderHook(() => mod.useVaultAccountValue('0xVault'), {
+      wrapper: createWrapper().wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});


### PR DESCRIPTION
## Summary
The analytics page, its OI charts, `useAnalytics`, and `ActivityTable` — the surfaces this frontend now centers on — had no test coverage. This adds **61 tests** across 6 files, following the repo's established patterns (fetcher/hook-seam `vi.mock`, prop-capturing recharts stubs, heavy-child stubs; no msw).

- **`useAnalytics.test.ts`** (12) — fetcher-level mocks over `@sapience/sdk/queries`; happy path + error per hook, disabled-without-address gating, correct `(address, DEFAULT_CHAIN_ID)` args, queryKey address lowercasing.
- **`analyticsFormat.test.ts`** (13) — M/K formatting quirks, wei→locale + NaN→'0', fake-timer period cutoffs, last-observation-per-UTC-day bucketing.
- **`AnalyticsPageContent.test.tsx`** (6) — loading, summary cards, TVL popover breakdown (undeployed = TVL − escrow), empty states, and the day-bucketing contract asserted on captured chart data (bars sum within a day; areas keep the last observation).
- **OI chart tests** (14) — category legend sorting/`toFixed(1)` percents, `prices-*` collapsing, sub-0.05% slice dropping; all seven time-to-resolution bucket labels pinned via `formatBucketLabel`, bar data mapping.
- **`ActivityTable.test.tsx`** (16) — `useAccountActivity` mocked at the hook seam (its transport behavior is already covered by its own 633-line test); prediction/trade rows, status variants, `hiddenColumns`/`hideFilters`, search no-match state, the live pending-banner reveal flow, dialog/share wiring, footer states.

## Production changes (extraction only, zero behavior change)
- `analyticsFormat.ts` (new): `formatLargeNumber`/`formatNumber`/`filterDataByPeriod`/`bucketStatsByDay` moved verbatim out of `AnalyticsPageContent.tsx` and exported.
- `OpenInterestByTimeToResolutionChart.tsx`: `formatBucketLabel` exported.

## Not covered (noted deliberately)
Period-filter switching on the analytics page and the Radix-portal filter dropdowns in ActivityTable — the underlying predicates are unit-tested; driving Radix portals in jsdom would be brittle for little gain.

## Verification
Full app suite 871 passed (was 810), lint and type-check clean. Nothing touched outside `packages/app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5pjpyt8bCSBtSDvffYEf1