### PR TITLE
Log in-process cache sizes on gql_inflight dumps.

### DIFF
--- a/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
+++ b/packages/api/src/graphql/sdl/resolvers/queries/analytics.ts
@@ -483,6 +483,18 @@ export const __clearProtocolStatsCache = (): void => {
   protocolStatsCache.clear();
 };
 
+export const getProtocolStatsCacheStats = (): {
+  size: number;
+  live: number;
+} => {
+  const now = Date.now();
+  let live = 0;
+  for (const entry of protocolStatsCache.values()) {
+    if (entry.expiresAt > now) live += 1;
+  }
+  return { size: protocolStatsCache.size, live };
+};
+
 export const protocolStats: NonNullable<QueryResolvers['protocolStats']> = (
   _parent,
   { vaultAddress: vaultAddressArg }

--- a/packages/api/src/graphql/v2/resolvers/queries/accountStats.ts
+++ b/packages/api/src/graphql/v2/resolvers/queries/accountStats.ts
@@ -103,6 +103,14 @@ export const getMerged = async (
   return merged;
 };
 
+export const getAccountStatsCacheStats = (): {
+  merged: { size: number; live: number };
+  accuracy: { size: number; live: number };
+} => ({
+  merged: { size: cache.size(), live: cache.liveSize() },
+  accuracy: { size: accuracyCache.size(), live: accuracyCache.liveSize() },
+});
+
 export type RankColumn = 'NET_PNL' | 'VOLUME';
 
 export const rankedFor = (

--- a/packages/api/src/lib/ttlCache.ts
+++ b/packages/api/src/lib/ttlCache.ts
@@ -46,4 +46,19 @@ export class TtlCache<K, V> {
   clear(): void {
     this.store.clear();
   }
+
+  /** Total entries including expired (not yet evicted on get). */
+  size(): number {
+    return this.store.size;
+  }
+
+  /** Entries still within TTL. */
+  liveSize(): number {
+    const now = Date.now();
+    let live = 0;
+    for (const entry of this.store.values()) {
+      if (entry.expiresAt >= now) live += 1;
+    }
+    return live;
+  }
 }

--- a/packages/api/src/runtime/cacheStats.ts
+++ b/packages/api/src/runtime/cacheStats.ts
@@ -1,0 +1,23 @@
+/**
+ * Process-wide in-memory cache gauges for leak diagnosis.
+ * Emitted on `gql_inflight` when GRAPHQL_INFLIGHT_DUMP_INTERVAL_MS > 0.
+ */
+
+import { getAccountStatsCacheStats } from '../graphql/v2/resolvers/queries/accountStats';
+import { getProtocolStatsCacheStats } from '../graphql/sdl/resolvers/queries/analytics';
+
+export type CacheGauge = {
+  size: number;
+  live: number;
+};
+
+export type CacheStatsSnapshot = Record<string, CacheGauge>;
+
+export function collectCacheStats(): CacheStatsSnapshot {
+  const accountStats = getAccountStatsCacheStats();
+  return {
+    accountStatsMerged: accountStats.merged,
+    accountStatsAccuracy: accountStats.accuracy,
+    protocolStatsV1: getProtocolStatsCacheStats(),
+  };
+}

--- a/packages/api/src/runtime/inflightDump.ts
+++ b/packages/api/src/runtime/inflightDump.ts
@@ -19,6 +19,7 @@
 import { monitorEventLoopDelay, type IntervalHistogram } from 'node:perf_hooks';
 import { createLogger } from '../core/logger';
 import { inflightRegistry } from './inflightRegistry';
+import { collectCacheStats } from './cacheStats';
 
 const log = createLogger('inflight-dump');
 
@@ -67,6 +68,7 @@ export function startInflightDump(intervalMs: number): () => void {
           heapUsedMb: Math.round(memory.heapUsed / BYTES_PER_MB),
           externalMb: Math.round(memory.external / BYTES_PER_MB),
         },
+        caches: collectCacheStats(),
         eventLoop: {
           p50Ms: Number(eventLoopP50Ms.toFixed(1)),
           p99Ms: Number(eventLoopP99Ms.toFixed(1)),


### PR DESCRIPTION
Adds accountStats and protocolStats gauges to the existing periodic memory snapshot so staging heap growth can be correlated with cache retention.