### PR TITLE
fix(market-keeper): retry transient GraphQL errors instead of dying

### DIFF
--- a/packages/market-keeper/src/utils/graphql.test.ts
+++ b/packages/market-keeper/src/utils/graphql.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+const fetchQueue: Array<() => Response> = [];
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+vi.mock('./fetch', () => ({
+  fetchWithRetry: vi.fn(async (url: string, init?: RequestInit) => {
+    fetchCalls.push({ url, init });
+    const next = fetchQueue.shift();
+    if (!next) throw new Error(`No queued response for ${url}`);
+    return next();
+  }),
+}));
+
+import { graphqlRequest } from './graphql';
+
+const URL = 'https://api.example.com/v2/graphql';
+const QUERY = 'query Q { ping }';
+// baseDelayMs: 0 keeps backoff out of test wall-clock time
+const OPTS = { baseDelayMs: 0 };
+
+function errorResponse(message: string): Response {
+  return jsonResponse({ errors: [{ message }] });
+}
+
+beforeEach(() => {
+  fetchCalls.length = 0;
+  fetchQueue.length = 0;
+  vi.clearAllMocks();
+});
+
+describe('graphqlRequest transient-error retry', () => {
+  it('retries a Query timeout error and returns data from the next attempt', async () => {
+    fetchQueue.push(() =>
+      errorResponse('Query timeout: Condition.findMany exceeded 8000ms')
+    );
+    fetchQueue.push(() => jsonResponse({ data: { ping: 'pong' } }));
+
+    const data = await graphqlRequest<{ ping: string }>(
+      URL,
+      QUERY,
+      {},
+      'Test',
+      OPTS
+    );
+
+    expect(data).toEqual({ ping: 'pong' });
+    expect(fetchCalls).toHaveLength(2);
+  });
+
+  it('retries connection-pool exhaustion errors', async () => {
+    fetchQueue.push(() =>
+      errorResponse('Timed out fetching a new connection from the pool')
+    );
+    fetchQueue.push(() => jsonResponse({ data: { ping: 'pong' } }));
+
+    const data = await graphqlRequest<{ ping: string }>(
+      URL,
+      QUERY,
+      {},
+      'Test',
+      OPTS
+    );
+
+    expect(data).toEqual({ ping: 'pong' });
+    expect(fetchCalls).toHaveLength(2);
+  });
+
+  it('throws immediately on a non-transient GraphQL error without retrying', async () => {
+    fetchQueue.push(() =>
+      errorResponse('Variable "$filter" got invalid value')
+    );
+
+    await expect(graphqlRequest(URL, QUERY, {}, 'Test', OPTS)).rejects.toThrow(
+      /invalid value/
+    );
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  it('throws the transient error once retries are exhausted', async () => {
+    const maxRetries = 2;
+    for (let i = 0; i <= maxRetries; i++) {
+      fetchQueue.push(() =>
+        errorResponse('Query timeout: Condition.findMany exceeded 8000ms')
+      );
+    }
+
+    await expect(
+      graphqlRequest(URL, QUERY, {}, 'Test', { maxRetries, baseDelayMs: 0 })
+    ).rejects.toThrow(/Query timeout/);
+    expect(fetchCalls).toHaveLength(maxRetries + 1);
+  });
+
+  it('does not retry a response with no data and no errors', async () => {
+    fetchQueue.push(() => jsonResponse({}));
+
+    await expect(graphqlRequest(URL, QUERY, {}, 'Test', OPTS)).rejects.toThrow(
+      /no data/
+    );
+    expect(fetchCalls).toHaveLength(1);
+  });
+});

--- a/packages/market-keeper/src/utils/graphql.ts
+++ b/packages/market-keeper/src/utils/graphql.ts
@@ -30,41 +30,75 @@ export type Connection<TNode> = {
   pageInfo: PageInfo;
 };
 
+/**
+ * GraphQL-level errors ride back as HTTP 200 with an `errors` array, so
+ * `fetchWithRetry` (which only retries 429/5xx/network failures) never
+ * sees them. Transient server-side errors — the API's 8s Prisma query
+ * timeout, connection-pool exhaustion — must be retried here instead:
+ * the underlying Postgres query keeps running after the API stops
+ * waiting, so a retry lands on a warm cache and typically succeeds.
+ */
+const TRANSIENT_GRAPHQL_ERROR_PATTERNS = [
+  /query timeout/i,
+  /timed out fetching a new connection/i,
+  /connection pool/i,
+];
+
+function isTransientGraphqlError(errors: Array<{ message: string }>): boolean {
+  return errors.some((e) =>
+    TRANSIENT_GRAPHQL_ERROR_PATTERNS.some((p) => p.test(e.message))
+  );
+}
+
 export async function graphqlRequest<TData>(
   graphqlUrl: string,
   query: string,
   variables: Record<string, unknown>,
-  label: string
+  label: string,
+  retryOpts?: { maxRetries?: number; baseDelayMs?: number }
 ): Promise<TData> {
-  const response = await fetchWithRetry(graphqlUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-    },
-    body: JSON.stringify({ query, variables }),
-  });
+  const maxRetries = retryOpts?.maxRetries ?? 5;
+  const baseDelayMs = retryOpts?.baseDelayMs ?? 1000;
 
-  if (!response.ok) {
-    const body = await response.text().catch(() => '(unreadable body)');
-    throw new Error(
-      `[${label}] GraphQL query failed: HTTP ${response.status} ${response.statusText}\nResponse body: ${body.slice(0, 2000)}`
-    );
-  }
+  for (let attempt = 0; ; attempt++) {
+    const response = await fetchWithRetry(graphqlUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({ query, variables }),
+    });
 
-  const result = (await response.json()) as {
-    data?: TData;
-    errors?: Array<{ message: string }>;
-  };
-  if (result.errors && result.errors.length > 0) {
-    throw new Error(
-      `[${label}] GraphQL query returned errors: ${result.errors.map((e) => e.message).join('; ')}`
-    );
+    if (!response.ok) {
+      const body = await response.text().catch(() => '(unreadable body)');
+      throw new Error(
+        `[${label}] GraphQL query failed: HTTP ${response.status} ${response.statusText}\nResponse body: ${body.slice(0, 2000)}`
+      );
+    }
+
+    const result = (await response.json()) as {
+      data?: TData;
+      errors?: Array<{ message: string }>;
+    };
+    if (result.errors && result.errors.length > 0) {
+      const joined = result.errors.map((e) => e.message).join('; ');
+      if (attempt < maxRetries && isTransientGraphqlError(result.errors)) {
+        const delay =
+          baseDelayMs * Math.pow(2, attempt) + Math.random() * baseDelayMs;
+        console.log(
+          `[Retry] [${label}] Transient GraphQL error, retrying in ${Math.round(delay)}ms (attempt ${attempt + 1}/${maxRetries}) — ${joined}`
+        );
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        continue;
+      }
+      throw new Error(`[${label}] GraphQL query returned errors: ${joined}`);
+    }
+    if (result.data == null) {
+      throw new Error(`[${label}] GraphQL response carried no data`);
+    }
+    return result.data;
   }
-  if (result.data == null) {
-    throw new Error(`[${label}] GraphQL response carried no data`);
-  }
-  return result.data;
 }
 
 export async function walkConnection<TNode, TData>(opts: {


### PR DESCRIPTION
## Problem

The market-data cron (\`prices-and-1d-7d-volume\`) intermittently dies with:

\`\`\`
[ActiveConditions] GraphQL query returned errors: Query timeout: Condition.findMany exceeded 8000ms
\`\`\`

GraphQL-level errors ride back as **HTTP 200 with an \`errors\` array**, so \`fetchWithRetry\` (which only retries 429/5xx/network failures) never sees them. One transient slow query on the API — typically the first page against a cold DB cache; the failure in the logs landed exactly 8s after cron START — unwound \`walkConnection\` and exited the whole cron with status 1. The API's \`withQueryTimeout\` only stops *waiting*; the underlying Postgres query keeps running, so a retry lands on a warm cache and typically succeeds.

## Fix

\`graphqlRequest\` in the keeper now retries transient server-side GraphQL errors (query timeout, connection-pool exhaustion) with exponential backoff (5 attempts, ~1s base), matching the shape of the existing \`fetchWithRetry\` logic. Non-transient GraphQL errors (validation, bad variables) still throw immediately with no retry. This covers every keeper cron that goes through \`graphqlRequest\`/\`walkConnection\`, not just market-data.

Deliberately **not** done here:
- Raising \`PRISMA_QUERY_TIMEOUT_MS\` — that timeout sheds load on the request path shared with the frontend; loosening it for a batch job is backwards.
- Returning 5xx from the API for timeouts — would change response semantics for every client.

## Tests

TDD: \`src/utils/graphql.test.ts\` written first (red), covers retry-then-succeed for both transient patterns, immediate throw on non-transient errors, retry exhaustion, and the no-data case. Full market-keeper suite passes except the pre-existing \`lz-config.integration.test.ts\` failures (public Polygon RPC returns 401 — environmental, unrelated). Type-check, eslint, and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)