### PR TITLE
fix(sdk): drop X-Request-ID header so browser GET queries skip CORS preflight

### DIFF
--- a/packages/sdk/queries/client/graphqlClient.test.ts
+++ b/packages/sdk/queries/client/graphqlClient.test.ts
@@ -1,0 +1,58 @@
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import { graphqlRequest } from './graphqlClient';
+
+// Header names a browser may attach to a cross-origin request without
+// triggering a CORS preflight (the "simple request" safelist). The GraphQL
+// client must stay within this set: the API is on a different origin than
+// the app, and any custom header turns every GET query into an
+// OPTIONS + GET pair — the preflight cache is keyed by exact URL, so
+// GraphQL-over-GET (query in the query string) never reuses it.
+const CORS_SAFELISTED_HEADERS = new Set([
+  'accept',
+  'accept-language',
+  'content-language',
+  'content-type',
+]);
+
+describe('graphqlRequest', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('sends only CORS-safelisted headers so GET queries skip preflight', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ data: { __typename: 'Query' } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await graphqlRequest<{ __typename: string }>('query { __typename }');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const sentHeaders = [...new Headers(init.headers).keys()];
+    const unsafeHeaders = sentHeaders.filter(
+      (name) => !CORS_SAFELISTED_HEADERS.has(name)
+    );
+    expect(unsafeHeaders).toEqual([]);
+  });
+
+  it('issues queries as GET requests', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ data: { __typename: 'Query' } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await graphqlRequest<{ __typename: string }>('query { __typename }');
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe('GET');
+  });
+});

--- a/packages/sdk/queries/client/graphqlClient.ts
+++ b/packages/sdk/queries/client/graphqlClient.ts
@@ -58,15 +58,14 @@ export const getGraphQLEndpoint = () => {
   }
 };
 
+// No custom headers: a cross-origin GET with only safelisted headers is a
+// CORS "simple request", so the browser skips the OPTIONS preflight that a
+// header like X-Request-ID would force on every query. The API generates a
+// request id server-side when none is supplied and echoes it back as
+// `x-request-id`, so log correlation is unaffected.
 export const createGraphQLClient = () =>
   new GraphQLClient(getGraphQLEndpoint(), {
     method: 'GET',
-    headers: {
-      'X-Request-ID':
-        typeof crypto !== 'undefined' && crypto.randomUUID
-          ? crypto.randomUUID().slice(0, 8)
-          : Math.random().toString(36).slice(2, 10),
-    },
   });
 
 export async function graphqlRequest<T>(


### PR DESCRIPTION
## Why

The browser GraphQL client sends queries as GET, and `X-Request-ID` was the only non-safelisted header on those requests — turning every query into an OPTIONS + GET pair. The CORS preflight cache is keyed by exact URL, and GraphQL-over-GET embeds query + variables in the query string, so preflights were effectively never reused: every browser query paid two round trips to the API.

Removing the header makes the requests CORS "simple requests", eliminating the preflight entirely — roughly halving browser-originated request volume and saving one RTT per query.

## Why it's safe

- **Log correlation is unaffected.** The API's `genReqId` (`packages/api/src/runtime/middleware.ts`) already synthesizes a UUID when the header is absent and echoes it back as `x-request-id` on the response. All server-side consumers (operation timing logs, concurrency limiter, inflight registry, rate-limit shed logs) read `req.id`, not the raw header. Meridian's API (`../predict`) has identical behavior.
- **CSRF prevention won't reject simple GETs** — both Apollo servers here and in predict set `csrfPrevention: false` (auth is header-signature based, not cookie-based).
- **Nothing client-side read or logged the ID** — it was generated inline and discarded.
- The inflight registry gets slightly more robust: it keys on `req.id`, which previously honored collision-prone 8-char client IDs; now browser traffic always gets server UUIDs.
- `graphql-request@7.2.0` sends only an `Accept` header on GET (safelisted values), verified against the installed package — no other preflight trigger remains.

Deliberately left in place: `X-Request-ID` stays in the API's CORS `allowedHeaders` so scripts/benchmarks that still send it keep working, and the server-side fallback/echo is untouched.

## Test

Added `graphqlClient.test.ts` asserting the client sends only CORS-safelisted headers (the regression guard for the preflight win) and keeps using GET. Written red-first: it failed on `x-request-id` before the fix. Full SDK suite passes (38 files, 783 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)