### PR TITLE
feat(vaults): load PnL chart series newest-first with progressive rendering

### DIFF
--- a/packages/app/src/components/vaults/VaultPnlChart.tsx
+++ b/packages/app/src/components/vaults/VaultPnlChart.tsx
@@ -17,6 +17,7 @@ import { Button } from '@sapience/ui/components/ui/button';
 import {
   buildVaultPnlChartData,
   calculateVaultPnlHeadlineApy,
+  chartAnchorSecForChain,
   computeVaultPnlYDomain,
 } from './vaultPnlChartUtils';
 import { useVaultStats, type VaultStat } from '~/hooks/graphql/useAnalytics';
@@ -198,13 +199,15 @@ export default function VaultPnlChart({
 
   // Trim pre-activity snapshots for every period so % mode and APY anchor off
   // the first funded point, while keeping a visible zero baseline immediately
-  // before activity when a prior snapshot exists.
+  // before activity when a prior snapshot exists. The chain anchor clamps
+  // visible history to the chain's launch (Robinhood: 2026-07-01).
   const chartData = useMemo(
     () =>
       buildVaultPnlChartData(
         vaultStats?.map(toVaultStatPoint),
         period,
-        Math.floor(Date.now() / 1000)
+        Math.floor(Date.now() / 1000),
+        chartAnchorSecForChain(DEFAULT_CHAIN_ID)
       ),
     [vaultStats, period]
   );
@@ -239,6 +242,20 @@ export default function VaultPnlChart({
       ),
     [displayData, displayMode]
   );
+
+  // Evenly time-spaced tick positions for the numeric x-axis; recharts' own
+  // "nice" numeric ticks land on arbitrary epoch values.
+  const xTicks = useMemo(() => {
+    if (displayData.length === 0) return [];
+    const min = displayData[0].timestamp;
+    const max = displayData[displayData.length - 1].timestamp;
+    if (max <= min) return [min];
+    const TICK_COUNT = 5;
+    return Array.from(
+      { length: TICK_COUNT },
+      (_, i) => min + ((max - min) * i) / (TICK_COUNT - 1)
+    );
+  }, [displayData]);
 
   const currentValue =
     displayData.length > 0 ? displayData[displayData.length - 1].value : 0;
@@ -354,8 +371,15 @@ export default function VaultPnlChart({
                   strokeDasharray="3 3"
                   stroke="hsl(var(--brand-white) / 0.1)"
                 />
+                {/* type="number" spaces points by actual time rather than the
+                    default categorical axis, which gives every snapshot equal
+                    width — mixed snapshot cadences (3h history vs hourly)
+                    would otherwise stretch the denser recent window. */}
                 <XAxis
                   dataKey="timestamp"
+                  type="number"
+                  domain={['dataMin', 'dataMax']}
+                  ticks={xTicks}
                   {...CHART_AXIS_STYLE}
                   tickFormatter={formatTimestampTick}
                 />

--- a/packages/app/src/components/vaults/__tests__/VaultPnlChart.test.ts
+++ b/packages/app/src/components/vaults/__tests__/VaultPnlChart.test.ts
@@ -3,7 +3,9 @@ import type { VaultStatPoint } from '~/lib/adapters/vaultStat';
 import {
   buildVaultPnlChartData,
   calculateVaultPnlHeadlineApy,
+  chartAnchorSecForChain,
   computeVaultPnlYDomain,
+  ROBINHOOD_CHART_START_SEC,
 } from '../vaultPnlChartUtils';
 
 const ONE_DAY = 24 * 60 * 60;
@@ -181,5 +183,66 @@ describe('vaultPnlChartUtils', () => {
       NOW_SEC - ONE_DAY,
     ]);
     expect(chartData.map((point) => point.pnlDelta)).toEqual([0, 0, 5]);
+  });
+
+  it('anchorSec clamps visible history and re-bases the return anchor after it', () => {
+    const anchor = NOW_SEC - 2 * ONE_DAY;
+    const protocolStats = [
+      // Pre-anchor history: funded and profitable — must not leak into the
+      // chart or into the return baseline.
+      makeStat({ timestamp: NOW_SEC - 5 * ONE_DAY, tvl: 100, pnl: 0 }),
+      makeStat({ timestamp: NOW_SEC - 4 * ONE_DAY, tvl: 100, pnl: 50 }),
+      makeStat({ timestamp: anchor, tvl: 200, pnl: 60 }),
+      makeStat({ timestamp: NOW_SEC - ONE_DAY, tvl: 200, pnl: 80 }),
+    ];
+
+    const chartData = buildVaultPnlChartData(
+      protocolStats,
+      'ALL',
+      NOW_SEC,
+      anchor
+    );
+
+    expect(chartData.map((point) => point.timestamp)).toEqual([
+      anchor,
+      NOW_SEC - ONE_DAY,
+    ]);
+    // Returns measure from the first visible point, not from launch.
+    expect(chartData[0].isReturnAnchor).toBe(true);
+    expect(chartData.map((point) => point.pnlDelta)).toEqual([0, 20]);
+    expect(chartData[1].pct).toBeCloseTo(10, 10);
+  });
+
+  it('anchorSec never widens a shorter period window', () => {
+    const anchor = NOW_SEC - 30 * ONE_DAY;
+    const protocolStats = [
+      makeStat({ timestamp: NOW_SEC - 20 * ONE_DAY, tvl: 100, pnl: 0 }),
+      makeStat({ timestamp: NOW_SEC - ONE_DAY, tvl: 100, pnl: 10 }),
+    ];
+
+    const chartData = buildVaultPnlChartData(
+      protocolStats,
+      '1W',
+      NOW_SEC,
+      anchor
+    );
+
+    // The 1W cutoff (7 days) still wins over the older anchor.
+    expect(chartData.map((point) => point.timestamp)).toEqual([
+      NOW_SEC - ONE_DAY,
+    ]);
+  });
+
+  describe('chartAnchorSecForChain', () => {
+    it('anchors Robinhood/Meridian chains at the 2026-07-01 launch', () => {
+      expect(ROBINHOOD_CHART_START_SEC).toBe(Date.UTC(2026, 6, 1) / 1000);
+      expect(chartAnchorSecForChain(4663)).toBe(ROBINHOOD_CHART_START_SEC);
+      expect(chartAnchorSecForChain(46630)).toBe(ROBINHOOD_CHART_START_SEC);
+    });
+
+    it('leaves other chains unanchored', () => {
+      expect(chartAnchorSecForChain(42161)).toBeUndefined();
+      expect(chartAnchorSecForChain(137)).toBeUndefined();
+    });
   });
 });

--- a/packages/app/src/components/vaults/__tests__/VaultPnlChartScaleToggle.test.tsx
+++ b/packages/app/src/components/vaults/__tests__/VaultPnlChartScaleToggle.test.tsx
@@ -25,6 +25,7 @@ vi.mock('recharts', () => ({
 vi.mock('@sapience/sdk/constants', () => ({
   DEFAULT_CHAIN_ID: 42161,
   COLLATERAL_SYMBOLS: { 42161: 'USDe' },
+  isRobinhoodChain: () => false,
 }));
 
 vi.mock('@sapience/ui/components/ui/tabs', () => ({

--- a/packages/app/src/components/vaults/vaultPnlChartUtils.ts
+++ b/packages/app/src/components/vaults/vaultPnlChartUtils.ts
@@ -1,7 +1,19 @@
+import { isRobinhoodChain } from '@sapience/sdk/constants';
 import type { VaultStatPoint } from '~/lib/adapters/vaultStat';
 import { PERIOD_DAYS, type Period } from '~/components/shared/PeriodFilter';
 
 const ONE_DAY_IN_SECONDS = 24 * 60 * 60;
+
+// Vault activity on the Robinhood/Meridian chains starts at the 2026-07-01
+// UTC cutover; snapshots before that are a pre-launch tail that would drag
+// every period's return anchor (and the ALL view's x-range) into dead
+// history, so the charts clamp their visible start here.
+export const ROBINHOOD_CHART_START_SEC = Date.UTC(2026, 6, 1) / 1000;
+
+/** Hard lower bound on visible chart history for a chain, if it has one. */
+export function chartAnchorSecForChain(chainId: number): number | undefined {
+  return isRobinhoodChain(chainId) ? ROBINHOOD_CHART_START_SEC : undefined;
+}
 
 // Ceiling for the displayed annualized return. Young vaults with a strong
 // week still annualize to silly numbers; past this point the figure carries
@@ -26,13 +38,18 @@ function findFirstActivePointIndex(points: BasePoint[]): number {
 export function buildVaultPnlChartData(
   vaultStats: VaultStatPoint[] | undefined,
   period: Period,
-  nowSec = Math.floor(Date.now() / 1000)
+  nowSec = Math.floor(Date.now() / 1000),
+  anchorSec?: number
 ): VaultPnlChartPoint[] {
   if (!vaultStats || vaultStats.length === 0) return [];
 
   const periodDays = PERIOD_DAYS[period];
-  const cutoffTimestamp =
+  const periodCutoff =
     periodDays === Infinity ? 0 : nowSec - periodDays * ONE_DAY_IN_SECONDS;
+  // `anchorSec` is a hard lower bound on visible history (see
+  // chartAnchorSecForChain); the period window still applies on top of it.
+  const cutoffTimestamp =
+    anchorSec !== undefined ? Math.max(periodCutoff, anchorSec) : periodCutoff;
 
   const filteredPoints: BasePoint[] = vaultStats
     .filter((stat) => stat.timestamp >= cutoffTimestamp)

--- a/packages/app/src/hooks/graphql/__tests__/useAnalytics.test.ts
+++ b/packages/app/src/hooks/graphql/__tests__/useAnalytics.test.ts
@@ -161,7 +161,40 @@ describe('useVaultStats', () => {
     expect(mockFetchVaultStats).toHaveBeenCalledTimes(1);
     expect(mockFetchVaultStats).toHaveBeenCalledWith(
       '0xVault',
-      DEFAULT_CHAIN_ID
+      DEFAULT_CHAIN_ID,
+      expect.objectContaining({
+        onProgress: expect.any(Function),
+        // First load: nothing cached yet to refetch incrementally from.
+        baseline: undefined,
+      })
+    );
+  });
+
+  it('streams progressive pages into the query cache via onProgress', async () => {
+    const older = { ...vaultStat, timestamp: vaultStat.timestamp - 3600 };
+    let releaseFinal: (() => void) | undefined;
+    mockFetchVaultStats.mockImplementation(
+      (_addr: string, _chain: number, opts: Record<string, unknown>) => {
+        const onProgress = opts.onProgress as (s: unknown[]) => void;
+        // Newest page lands first; the full series resolves later.
+        onProgress([vaultStat]);
+        return new Promise((resolve) => {
+          releaseFinal = () => resolve([older, vaultStat]);
+        });
+      }
+    );
+
+    const mod = await getModule();
+    const { result } = renderHook(() => mod.useVaultStats('0xVault'), {
+      wrapper: createWrapper().wrapper,
+    });
+
+    // The partial (newest-first) page is visible before the fetch resolves.
+    await waitFor(() => expect(result.current.data).toEqual([vaultStat]));
+
+    releaseFinal?.();
+    await waitFor(() =>
+      expect(result.current.data).toEqual([older, vaultStat])
     );
   });
 

--- a/packages/app/src/hooks/graphql/useAnalytics.ts
+++ b/packages/app/src/hooks/graphql/useAnalytics.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { DEFAULT_CHAIN_ID } from '@sapience/sdk/constants';
 import {
   fetchProtocolAnalytics,
@@ -22,11 +22,22 @@ const CACHE_TIME_MS = 60 * 1000;
  * sites can read it unconditionally; `enabled` keeps the network call gated.
  */
 export function useVaultStats(vaultAddress?: string) {
+  const queryClient = useQueryClient();
+  const queryKey = ['vaultStats', vaultAddress?.toLowerCase() ?? null];
   return useQuery<VaultStat[]>({
-    queryKey: ['vaultStats', vaultAddress?.toLowerCase() ?? null],
+    queryKey,
     queryFn: () =>
       vaultAddress
-        ? fetchVaultStats(vaultAddress, DEFAULT_CHAIN_ID)
+        ? fetchVaultStats(vaultAddress, DEFAULT_CHAIN_ID, {
+            // Stream pages into the cache as they land: the fetcher loads
+            // newest-first, so the chart paints recent history immediately
+            // and grows leftward while older pages arrive.
+            onProgress: (partial) =>
+              queryClient.setQueryData(queryKey, partial),
+            // Seed interval refetches from the cached series so they only
+            // pull the tail (one request) instead of re-walking every page.
+            baseline: queryClient.getQueryData<VaultStat[]>(queryKey),
+          })
         : Promise.resolve([]),
     enabled: !!vaultAddress,
     staleTime: CACHE_TIME_MS,

--- a/packages/sdk/queries/__tests__/vault.test.ts
+++ b/packages/sdk/queries/__tests__/vault.test.ts
@@ -30,22 +30,39 @@ const responseWith = (
   pageInfo: { hasNextPage: boolean; endCursor: string | null } = {
     hasNextPage: false,
     endCursor: null,
-  }
+  },
+  totalCount?: number
 ) => ({
-  vault: { statsHistory: { nodes, pageInfo } },
+  vault: {
+    statsHistory: {
+      nodes,
+      ...(totalCount !== undefined ? { totalCount } : {}),
+      pageInfo,
+    },
+  },
 });
+
+// Inverse of the fetcher's synthesized offset cursor: the start offset a
+// given `after` value asks the server to begin at (k + 1), 0 when null.
+const startFromAfter = (after: string | null): number => {
+  if (!after) return 0;
+  const b64 = after.replace(/-/g, '+').replace(/_/g, '/');
+  const parsed = JSON.parse(Buffer.from(b64, 'base64').toString('utf-8'));
+  return Number(parsed.k) + 1;
+};
 
 describe('GET_VAULT_STATS document', () => {
   test('queries vault(address, chainId).statsHistory with the expected fields', () => {
     expect(GET_VAULT_STATS).toContain(
       'vault(address: $address, chainId: $chainId)'
     );
-    // `first` is a nullable variable: omitting it lets the resolver return up
-    // to its MAX_STATS_POINTS cap in one page, while `pageInfo`/`after` keep a
-    // pagination fallback for any vault that exceeds the cap.
+    // `first` is a nullable variable: omitting it lets the resolver return
+    // its default page size, while `totalCount`/`pageInfo`/`after` let the
+    // fetcher plan newest-first offset jumps across a multi-page series.
     expect(GET_VAULT_STATS).toContain(
       'statsHistory(first: $first, after: $after)'
     );
+    expect(GET_VAULT_STATS).toContain('totalCount');
     expect(GET_VAULT_STATS).toContain('hasNextPage');
     expect(GET_VAULT_STATS).toContain('endCursor');
     expect(GET_VAULT_STATS).toContain('timestamp');
@@ -89,7 +106,7 @@ describe('fetchVaultStats', () => {
     ]);
   });
 
-  test('pages on `pageInfo` when a vault exceeds the server cap', async () => {
+  test('falls back to a forward endCursor walk when the server omits totalCount', async () => {
     mockGraphqlRequest
       .mockResolvedValueOnce(
         responseWith([node(1700000300), node(1700000200)], {
@@ -118,11 +135,11 @@ describe('fetchVaultStats', () => {
 
   test('forwards an explicit pageSize as the per-page `first`', async () => {
     mockGraphqlRequest.mockResolvedValue(responseWith([node(1700000100)]));
-    await fetchVaultStats('0xabc', 42161, 100);
+    await fetchVaultStats('0xabc', 42161, { pageSize: 25 });
     expect(mockGraphqlRequest).toHaveBeenCalledWith(GET_VAULT_STATS, {
       address: '0xabc',
       chainId: 42161,
-      first: 100,
+      first: 25,
       after: null,
     });
   });
@@ -185,6 +202,113 @@ describe('fetchVaultStats', () => {
     expect(await fetchVaultStats('0xabc', 42161)).toEqual([]);
     mockGraphqlRequest.mockResolvedValue(null);
     expect(await fetchVaultStats('0xabc', 42161)).toEqual([]);
+  });
+
+  // ── Newest-first multi-page walk ──────────────────────────────────────────
+  //
+  // Simulated server: 20 snapshots (offset i → timestamp ts(i)), page size 3.
+  // The head request returns the oldest page + totalCount; the fetcher then
+  // jumps to the tail via synthesized offset cursors, newest chunk first.
+  const ts = (offset: number) => 1700000000 + offset * 100;
+
+  const mockOffsetServer = (total: number, stride: number) => {
+    mockGraphqlRequest.mockImplementation(
+      async (_doc: unknown, vars: { after: string | null }) => {
+        const start = startFromAfter(vars.after);
+        const rows = [];
+        for (let i = start; i < Math.min(start + stride, total); i += 1) {
+          rows.push(node(ts(i)));
+        }
+        return responseWith(
+          rows,
+          {
+            hasNextPage: start + stride < total,
+            endCursor: rows.length ? `end-${start + rows.length - 1}` : null,
+          },
+          total
+        );
+      }
+    );
+  };
+
+  test('loads a long series newest-first, streaming contiguous progress', async () => {
+    mockOffsetServer(20, 3);
+    const emissions: number[][] = [];
+
+    const result = await fetchVaultStats('0xabc', 42161, {
+      onProgress: (stats) => emissions.push(stats.map((s) => s.timestamp)),
+    });
+
+    // 1 head request + 6 tail chunks (offsets 18,15,12,9 then 6,3).
+    expect(mockGraphqlRequest).toHaveBeenCalledTimes(7);
+    const starts = mockGraphqlRequest.mock.calls.map((c) =>
+      startFromAfter((c[1] as { after: string | null }).after)
+    );
+    expect(starts).toEqual([0, 18, 15, 12, 9, 6, 3]);
+
+    // Progress is contiguous from the newest snapshot backward: first batch
+    // covers offsets 9..19, second closes the gap down to the head page.
+    expect(emissions).toHaveLength(2);
+    expect(emissions[0]).toEqual(
+      Array.from({ length: 11 }, (_, i) => ts(9 + i))
+    );
+    expect(emissions[1]).toEqual(Array.from({ length: 20 }, (_, i) => ts(i)));
+
+    expect(result.map((s) => s.timestamp)).toEqual(
+      Array.from({ length: 20 }, (_, i) => ts(i))
+    );
+  });
+
+  test('maxPages drops the OLDEST pages, never the newest', async () => {
+    mockOffsetServer(20, 3);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Budget: 1 head + 2 tail chunks → offsets 18 and 15 only.
+    const result = await fetchVaultStats('0xabc', 42161, { maxPages: 3 });
+
+    expect(mockGraphqlRequest).toHaveBeenCalledTimes(3);
+    // Only the newest 5 snapshots survive; the head page's oldest rows are
+    // excluded too (they would leave a hole in the middle of the series).
+    expect(result.map((s) => s.timestamp)).toEqual(
+      Array.from({ length: 5 }, (_, i) => ts(15 + i))
+    );
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+
+  test('with a baseline, refetches only the tail: last known row + appended rows', async () => {
+    const baseline = Array.from({ length: 5 }, (_, i) => ({
+      timestamp: ts(i),
+      balance: '1000',
+      deployedCollateral: '500',
+      undeployedCollateral: '300',
+      cumulativePnl: '42',
+      claimableCollateral: '10',
+    }));
+    // The server rewrote the last known bucket (balance 1000 → 9999) and
+    // appended one new snapshot after it.
+    mockGraphqlRequest.mockResolvedValue(
+      responseWith([node(ts(4), { balance: '9999' }), node(ts(5))], {
+        hasNextPage: false,
+        endCursor: null,
+      })
+    );
+
+    const result = await fetchVaultStats('0xabc', 42161, { baseline });
+
+    // A single request, starting at the baseline's last row (offset 4).
+    expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
+    expect(
+      startFromAfter(
+        (mockGraphqlRequest.mock.calls[0][1] as { after: string | null }).after
+      )
+    ).toBe(4);
+
+    expect(result.map((s) => s.timestamp)).toEqual(
+      Array.from({ length: 6 }, (_, i) => ts(i))
+    );
+    // The rewritten bucket's values replace the stale baseline row.
+    expect(result[4].balance).toBe('9999');
   });
 });
 

--- a/packages/sdk/queries/vault.ts
+++ b/packages/sdk/queries/vault.ts
@@ -1,4 +1,5 @@
 import { graphqlRequest } from './client/graphqlClient';
+import { DEFAULT_MAX_PAGES } from './pagination';
 
 /**
  * Per-vault economic snapshot series, fetched from the `vault(address:,
@@ -28,12 +29,12 @@ export interface VaultStat {
 // result ordered.
 //
 // `first` is left to the variable (nullable): omitting it lets the resolver
-// return up to its MAX_STATS_POINTS cap in one page, so the common case is a
-// single request. The query still selects `pageInfo` and threads `after` so
-// fetchVaultStats can page forward if a vault ever exceeds that cap — the
-// series stays complete without re-introducing a fixed chain of round-trips.
-// A literal `first` above GRAPHQL_MAX_LIST_SIZE (25) is rejected
-// pre-execution, so an explicit `pageSize` must stay <= 25.
+// return its default page size in one request — up to MAX_STATS_POINTS on
+// deployments that keep the big-page path, or GRAPHQL_MAX_LIST_SIZE (25) on
+// deployments that cap every page. A literal `first` above
+// GRAPHQL_MAX_LIST_SIZE is rejected pre-execution, so an explicit `pageSize`
+// must stay <= 25. `totalCount` lets fetchVaultStats plan reverse
+// (newest-first) offset jumps when the series doesn't fit in one page.
 export const GET_VAULT_STATS = /* GraphQL */ `
   query VaultStats(
     $address: Address!
@@ -51,6 +52,7 @@ export const GET_VAULT_STATS = /* GraphQL */ `
           cumulativePnl
           claimableCollateral
         }
+        totalCount
         pageInfo {
           hasNextPage
           endCursor
@@ -69,12 +71,15 @@ type WireVaultStat = {
   claimableCollateral: string | number;
 };
 
+type VaultStatsConnection = {
+  nodes: WireVaultStat[];
+  totalCount?: number | null;
+  pageInfo: { hasNextPage: boolean; endCursor: string | null };
+};
+
 type VaultStatsResponse = {
   vault: {
-    statsHistory: {
-      nodes: WireVaultStat[];
-      pageInfo: { hasNextPage: boolean; endCursor: string | null };
-    };
+    statsHistory: VaultStatsConnection;
   } | null;
 };
 
@@ -93,29 +98,86 @@ function toVaultStat(node: WireVaultStat): VaultStat {
   };
 }
 
+// `statsHistory` cursors are opaque strings on the wire, but structurally
+// stable for this API: base64url(JSON `{k: "<row offset>", id: ""}`) — the
+// resolver's offset cursor (see the API's relay/cursor.ts). Synthesizing one
+// lets the client start a page at ANY offset, which is what makes
+// newest-first loading possible on an ascending, forward-only connection.
+// `startOffset` is the offset of the first row wanted; the server skips to
+// `k + 1`.
+const offsetCursor = (startOffset: number): string | null => {
+  if (startOffset <= 0) return null;
+  const json = JSON.stringify({ k: String(startOffset - 1), id: '' });
+  const toB64 = (globalThis as { btoa?: (s: string) => string }).btoa;
+  const b64 = toB64
+    ? toB64(json)
+    : Buffer.from(json, 'utf-8').toString('base64');
+  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+};
+
+// In-flight tail chunks per batch. Small enough to be polite to the API,
+// large enough that a long series backfills quickly behind the visible chart.
+const CHUNK_CONCURRENCY = 4;
+
+export interface FetchVaultStatsOptions {
+  /**
+   * Explicit per-page `first`. Must stay <= the API's GRAPHQL_MAX_LIST_SIZE
+   * (25) — a larger literal is rejected pre-execution. Omit to take the
+   * server's default page (larger on deployments that kept the big-page path).
+   */
+  pageSize?: number;
+  /** Total request budget for one walk (default DEFAULT_MAX_PAGES). */
+  maxPages?: number;
+  /**
+   * Previously fetched ascending series (e.g. the react-query cache). When
+   * provided, only the tail is re-fetched: the last known row (its bucket can
+   * be rewritten by a stats-writer re-run) plus anything appended after it —
+   * an interval refetch costs one request instead of a full re-walk.
+   */
+  baseline?: VaultStat[];
+  /**
+   * Streaming callback fired as pages land, with the ascending series fetched
+   * so far — always contiguous from the newest snapshot backward, so a chart
+   * can render recent history immediately and grow leftward.
+   */
+  onProgress?: (stats: VaultStat[]) => void;
+}
+
 /**
- * Fetch a vault's full snapshot series, oldest-first.
+ * Fetch a vault's full snapshot series, oldest-first — loading newest pages
+ * FIRST.
  *
- * The resolver returns up to its MAX_STATS_POINTS cap per page, so for a
- * normal vault this completes in a single request. The loop pages on
- * `pageInfo` only if a vault's series ever exceeds the cap, so the chart never
- * silently loses history. Returns an empty array when the address is not a
- * configured vault (the `vault` field resolves null).
+ * One request resolves the newest state of the series (`totalCount` + the
+ * server's page size). When everything fits in a single page that's the only
+ * round-trip. Otherwise the remaining pages are fetched newest-to-oldest via
+ * synthesized offset cursors, `CHUNK_CONCURRENCY` at a time, invoking
+ * `onProgress` as coverage grows backward from the newest snapshot. If the
+ * series exceeds `maxPages`, the OLDEST pages are dropped (with a console
+ * warning) — recent history always wins.
  *
- * `pageSize` (optional) forces an explicit per-page `first` — it must stay
- * <= the API's GRAPHQL_MAX_LIST_SIZE (25), since a larger literal is rejected
- * pre-execution. Omit it to use the resolver's single-page cap.
+ * Returns an empty array when the address is not a configured vault (the
+ * `vault` field resolves null).
  */
 export async function fetchVaultStats(
   address: string,
   chainId?: number,
-  pageSize?: number
+  opts: FetchVaultStatsOptions = {}
 ): Promise<VaultStat[]> {
-  const nodes: WireVaultStat[] = [];
-  let after: string | null = null;
-  // Bound the loop defensively against a non-progressing cursor; the daily
-  // series can't realistically exceed a few thousand snapshots.
-  for (let page = 0; page < 50; page += 1) {
+  const { pageSize, maxPages = DEFAULT_MAX_PAGES, baseline, onProgress } = opts;
+
+  // Merge by timestamp: chunk boundaries are planned client-side, and a
+  // server-side dedupe/backfill between requests could shift offsets by a
+  // row — keying on timestamp makes overlap harmless.
+  const byTimestamp = new Map<number, VaultStat>();
+  const series = () =>
+    Array.from(byTimestamp.values()).sort((a, b) => a.timestamp - b.timestamp);
+  const add = (nodes: WireVaultStat[] | undefined) => {
+    for (const n of nodes ?? []) byTimestamp.set(n.timestamp, toVaultStat(n));
+  };
+
+  const requestPage = async (
+    after: string | null
+  ): Promise<VaultStatsConnection | null> => {
     const data: VaultStatsResponse = await graphqlRequest<VaultStatsResponse>(
       GET_VAULT_STATS,
       {
@@ -126,12 +188,88 @@ export async function fetchVaultStats(
       }
     );
     const history = data?.vault?.statsHistory;
-    if (!history || !Array.isArray(history.nodes)) break;
-    nodes.push(...history.nodes);
-    if (!history.pageInfo?.hasNextPage || !history.pageInfo.endCursor) break;
-    after = history.pageInfo.endCursor;
+    return history && Array.isArray(history.nodes) ? history : null;
+  };
+
+  // Forward endCursor walk from `after`. Used for the incremental tail and as
+  // the fallback when the server doesn't report totalCount.
+  const walkForward = async (after: string | null, budget: number) => {
+    let cursor = after;
+    for (let page = 0; page < budget; page += 1) {
+      const conn = await requestPage(cursor);
+      if (!conn) return;
+      add(conn.nodes);
+      onProgress?.(series());
+      if (!conn.pageInfo?.hasNextPage || !conn.pageInfo.endCursor) return;
+      cursor = conn.pageInfo.endCursor;
+    }
+  };
+
+  // ── Incremental refetch: baseline covers offsets [0, N) ──
+  if (baseline && baseline.length > 0) {
+    for (const s of baseline) byTimestamp.set(s.timestamp, s);
+    await walkForward(offsetCursor(baseline.length - 1), maxPages);
+    return series();
   }
-  return nodes.map(toVaultStat).sort((a, b) => a.timestamp - b.timestamp);
+
+  // ── Full walk ──
+  const head = await requestPage(null);
+  if (!head) return [];
+  const headNodes = head.nodes ?? [];
+  const total = typeof head.totalCount === 'number' ? head.totalCount : null;
+
+  // Whole series fit in one page — the common case for a short series.
+  if (!head.pageInfo?.hasNextPage || headNodes.length === 0) {
+    add(headNodes);
+    onProgress?.(series());
+    return series();
+  }
+
+  // The head page came back full, so its length IS the server's page size —
+  // the stride for planning reverse offset jumps.
+  const stride = headNodes.length;
+
+  if (total === null || total <= stride) {
+    // No totalCount to plan reverse jumps from; degrade to the classic
+    // oldest-first endCursor walk rather than lose the series.
+    add(headNodes);
+    onProgress?.(series());
+    await walkForward(head.pageInfo.endCursor, maxPages - 1);
+    return series();
+  }
+
+  // Tail chunk start offsets, newest chunk first. The head page covered
+  // [0, stride); each chunk covers [offset, offset + stride).
+  const offsets: number[] = [];
+  for (let o = stride; o < total; o += stride) offsets.push(o);
+  offsets.reverse();
+
+  // Budget (head already spent 1 request). Newest chunks win: the walk just
+  // stops early, dropping the oldest part of the series.
+  const budget = Math.max(1, maxPages - 1);
+  const dropped = offsets.length - budget;
+  const planned = dropped > 0 ? offsets.slice(0, budget) : offsets;
+  if (dropped > 0) {
+    console.warn(
+      `fetchVaultStats: series of ${total} snapshots exceeds maxPages=${maxPages}; dropping the oldest ${dropped} page(s)`
+    );
+  }
+
+  for (let i = 0; i < planned.length; i += CHUNK_CONCURRENCY) {
+    const batch = planned.slice(i, i + CHUNK_CONCURRENCY);
+    const results = await Promise.all(
+      batch.map((offset) => requestPage(offsetCursor(offset)))
+    );
+    for (const conn of results) add(conn?.nodes);
+    // The moment the walk reaches the head page's upper edge the gap closes
+    // and the head rows join the series. Until then (and permanently, when
+    // the budget dropped pages) they stay out — emitting them early would
+    // put a hole in the middle of the chart's x-axis.
+    if (batch[batch.length - 1] === stride) add(headNodes);
+    onProgress?.(series());
+  }
+
+  return series();
 }
 
 export interface VaultAccountValue {


### PR DESCRIPTION
## Summary

The /vaults PnL chart loads its series through `fetchVaultStats`, which paged oldest-first with a hard 50-page bound. Against an API that caps pages at 25 rows (`GRAPHQL_MAX_LIST_SIZE`), that meant a 1,250-point ceiling — and because paging was oldest-first, exceeding it silently dropped the **newest** points, freezing the chart at a past date. With stats moving to hourly snapshots, that ceiling would be hit within ~2 months.

This flips the load order: newest pages first, rendered progressively.

- **`fetchVaultStats` (SDK)** — one head request resolves `totalCount` + the server's page size; if the series fits in one page that's the only round-trip. Otherwise the remaining pages are fetched newest-to-oldest via synthesized offset cursors (the API's `statsHistory` cursor is a stable offset encoding), 4 concurrent, with a new `onProgress` callback streaming the ascending series as coverage grows backward — always contiguous from the newest snapshot, so partial renders never have holes.
- **`useVaultStats` (app)** — pipes `onProgress` partials into the react-query cache, so the chart paints recent history after the first tail page and grows leftward while older pages arrive.
- **maxPages bump** — 50 → `DEFAULT_MAX_PAGES` (500). If a series ever exceeds it, the **oldest** pages are dropped (with a console warning) instead of the newest.
- **Cheap interval refetches** — the 60s refetch passes the cached series as a `baseline` and only pulls the tail (last known bucket + anything appended): one request instead of re-walking every page.
- **Fallback** — when a server doesn't report `totalCount`, degrades to the classic forward `endCursor` walk (previous behavior).

## Testing

- `packages/sdk` vault query tests extended: newest-first walk order, contiguous progressive emissions, maxPages dropping oldest-not-newest, baseline tail refetch, no-totalCount fallback (16 passing).
- `packages/app` useAnalytics hook tests extended: onProgress → cache streaming (13 passing).
- `tsc --noEmit`, eslint, prettier clean in both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up commit: chart rendering fixes

- **Time-proportional x-axis** — the `XAxis` was recharts' default categorical axis, so every snapshot got equal width; after the backend moved from 3-hour to hourly snapshots, the denser recent window stretched across most of the chart. Now `type="number"` with a `dataMin..dataMax` domain spaces points by actual elapsed time, with 5 evenly-spaced time ticks.
- **Robinhood chart anchor at 2026-07-01** — `buildVaultPnlChartData` regains an `anchorSec` hard lower bound (dropped in the time-weighted-returns rework), and all vault charts on Robinhood/Meridian chains (4663 / 46630) clamp visible history to the 2026-07-01 UTC launch. Percentage returns re-base at the first visible point; shorter period windows still apply on top of the anchor.
