### PR TITLE
app: subscribe terminal feed to auction.feed channel

### DIFF
--- a/packages/app/src/lib/auction/useAuctionRelayerFeed.ts
+++ b/packages/app/src/lib/auction/useAuctionRelayerFeed.ts
@@ -16,6 +16,13 @@ export type AuctionFeedMessage = {
 // 30-minute staleness threshold for subscription pruning
 const SUBSCRIPTION_TTL_MS = 30 * 60 * 1000;
 
+// Refcount of mounted hook instances sharing the WS connection's RFQ feed
+// subscription (terminal page + AutoBid overlap on /terminal). Subscribe when
+// the first consumer mounts, unsubscribe when the last one unmounts — leaving
+// /terminal must stop the RFQ fan-out to this session, that's the whole point
+// of the feed being opt-in.
+let feedConsumerCount = 0;
+
 export function useAuctionRelayerFeed(options?: {
   observeVaultQuotes?: boolean;
 }) {
@@ -40,16 +47,18 @@ export function useAuctionRelayerFeed(options?: {
     if (!wsUrl) return;
     const client = getSharedAuctionWsClient(wsUrl);
     // Join the global RFQ feed so auction.started broadcasts reach this
-    // session (queued until open). Never unsubscribed on cleanup: the client
-    // is shared across consumers (terminal, AutoBid), so one unmounting must
-    // not cut the feed for the others — the subscription dies with the
-    // connection instead.
-    client.send({ type: 'auction.feed.subscribe' });
+    // session (queued until open). Only the first consumer sends it — the
+    // relayer subscription is per-connection, not per-consumer.
+    feedConsumerCount++;
+    if (feedConsumerCount === 1) {
+      client.send({ type: 'auction.feed.subscribe' });
+    }
     // Observe vault quotes (queued until open)
     if (observeVaultQuotes) client.send({ type: 'vault_quote.observe' });
 
     const offOpen = client.addOpenListener(() => {
-      // Feed subscriptions are per-connection — rejoin on reconnect
+      // Feed subscriptions are per-connection — rejoin on reconnect.
+      // Duplicate sends from overlapping consumers are idempotent server-side.
       client.send({ type: 'auction.feed.subscribe' });
       // Resubscribe to all auctions on reconnect
       for (const id of Array.from(subscribedAuctionsRef.current.keys())) {
@@ -155,6 +164,12 @@ export function useAuctionRelayerFeed(options?: {
     }, 60_000);
 
     return () => {
+      // Leave the RFQ feed when the last consumer unmounts (e.g. navigating
+      // away from /terminal) so this session stops receiving every RFQ.
+      feedConsumerCount--;
+      if (feedConsumerCount === 0) {
+        client.send({ type: 'auction.feed.unsubscribe' });
+      }
       if (observeVaultQuotes) client.send({ type: 'vault_quote.unobserve' });
       offMsg();
       offOpen();

--- a/packages/app/src/lib/auction/useAuctionRelayerFeed.ts
+++ b/packages/app/src/lib/auction/useAuctionRelayerFeed.ts
@@ -39,10 +39,18 @@ export function useAuctionRelayerFeed(options?: {
   useEffect(() => {
     if (!wsUrl) return;
     const client = getSharedAuctionWsClient(wsUrl);
+    // Join the global RFQ feed so auction.started broadcasts reach this
+    // session (queued until open). Never unsubscribed on cleanup: the client
+    // is shared across consumers (terminal, AutoBid), so one unmounting must
+    // not cut the feed for the others — the subscription dies with the
+    // connection instead.
+    client.send({ type: 'auction.feed.subscribe' });
     // Observe vault quotes (queued until open)
     if (observeVaultQuotes) client.send({ type: 'vault_quote.observe' });
 
     const offOpen = client.addOpenListener(() => {
+      // Feed subscriptions are per-connection — rejoin on reconnect
+      client.send({ type: 'auction.feed.subscribe' });
       // Resubscribe to all auctions on reconnect
       for (const id of Array.from(subscribedAuctionsRef.current.keys())) {
         client.send({ type: 'auction.subscribe', payload: { auctionId: id } });


### PR DESCRIPTION
## Summary

Companion to meridianxyz/predict#67. The relayer now delivers the global `auction.started` feed only to explicit subscribers of the `auction.feed` channel, so `useAuctionRelayerFeed` (used by the terminal page and AutoBid, both mounted only on `/terminal`) manages the subscription:

- `auction.feed.subscribe` is sent when the first consumer mounts (queued until the socket opens) and re-sent on every reconnect while consumers are mounted.
- The subscription is refcounted across consumers of the shared WS client (terminal + AutoBid overlap on `/terminal`): `auction.feed.unsubscribe` is sent when the last consumer unmounts, so navigating away from `/terminal` stops the RFQ fan-out to the session — regular predictor sessions never subscribe at all.

Notes:
- No identify/role removal needed here — this app never sent `identify` (the relayer-side "UI promotes predictor to both" path was never implemented client-side; with `AUCTION_FEED_ROLE_GATING=true` on testnet the terminal feed was already not being delivered to this app).
- Compatible with the legacy in-repo relayer (`packages/relayer`), which still broadcasts `auction.started` to all connections and ignores `auction.feed.subscribe` as an unknown message.

## Deploy notes

Deploy with the client wave (step 2) of the rollout described in meridianxyz/predict#67. Open tabs with the old bundle keep working against the new relayer for the predictor flow; the terminal feed in old tabs resumes on reload.

## Test plan
- `src/lib/auction` + `src/components/terminal` vitest suites: 68 tests pass
- tsc: no new errors (3 pre-existing unrelated `@dnd-kit` module errors), eslint clean