### PR TITLE
feat(vaults): share price over time chart on /vaults

### DIFF
--- a/packages/app/src/components/vaults/VaultPnlChart.tsx
+++ b/packages/app/src/components/vaults/VaultPnlChart.tsx
@@ -14,6 +14,7 @@ import {
 } from 'recharts';
 import { Tabs, TabsTrigger } from '@sapience/ui/components/ui/tabs';
 import { Button } from '@sapience/ui/components/ui/button';
+import { ArrowRightLeft } from 'lucide-react';
 import {
   buildVaultPnlChartData,
   calculateVaultPnlHeadlineApy,
@@ -173,6 +174,8 @@ type VaultPnlChartProps = {
   externalPeriod?: Period;
   /** Hide entire internal header (title, APY, tabs). Defaults to true. */
   showHeader?: boolean;
+  /** Renders a swap button in the header that switches to the sibling chart. */
+  onToggleChart?: () => void;
 };
 
 export default function VaultPnlChart({
@@ -183,6 +186,7 @@ export default function VaultPnlChart({
   className,
   externalPeriod,
   showHeader = true,
+  onToggleChart,
 }: VaultPnlChartProps) {
   const collateralSymbol = COLLATERAL_SYMBOLS[DEFAULT_CHAIN_ID] || 'USDe';
   const [internalPeriod, setInternalPeriod] = useState<Period>('ALL');
@@ -282,6 +286,17 @@ export default function VaultPnlChart({
             <h4 className="text-base font-mono uppercase tracking-wider text-brand-white">
               Profit/Loss
             </h4>
+            {onToggleChart && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-5 px-1.5 text-muted-foreground/60 hover:text-brand-white [&_svg]:!size-2.5"
+                onClick={onToggleChart}
+                aria-label="Show share price chart"
+              >
+                <ArrowRightLeft />
+              </Button>
+            )}
             <Button
               variant="outline"
               size="sm"

--- a/packages/app/src/components/vaults/VaultSharePriceChart.tsx
+++ b/packages/app/src/components/vaults/VaultSharePriceChart.tsx
@@ -1,0 +1,304 @@
+'use client';
+
+import { DEFAULT_CHAIN_ID, COLLATERAL_SYMBOLS } from '@sapience/sdk/constants';
+import { useMemo, useState } from 'react';
+import type { Address } from 'viem';
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { Tabs, TabsTrigger } from '@sapience/ui/components/ui/tabs';
+import { chartAnchorSecForChain } from './vaultPnlChartUtils';
+import {
+  buildVaultSharePriceChartData,
+  computeSharePriceYDomain,
+} from './vaultSharePriceChartUtils';
+import type { VaultStat } from '~/hooks/graphql/useAnalytics';
+import { useVaultShareQuoteWs } from '~/hooks/ws/useVaultShareQuoteWs';
+import { CHART_SERIES_COLORS } from '~/lib/theme/chartColors';
+import Loader from '~/components/shared/Loader';
+import SegmentedTabsList from '~/components/shared/SegmentedTabsList';
+import { type Period } from '~/components/shared/PeriodFilter';
+
+function formatTimestampTick(value: number): string {
+  const date = new Date(value * 1000);
+  return `${date.getUTCMonth() + 1}/${date.getUTCDate()}`;
+}
+
+function formatPrice(value: number): string {
+  return value.toFixed(4);
+}
+
+type ChartTooltipProps = {
+  active?: boolean;
+  payload?: Array<{
+    value?: number | string | (number | string)[];
+    dataKey?: string | number;
+  }>;
+  label?: string;
+  collateralSymbol: string;
+};
+
+function ChartTooltip({
+  active,
+  payload,
+  label,
+  collateralSymbol,
+}: ChartTooltipProps): React.ReactNode {
+  if (!active || !payload?.length) return null;
+
+  const dataPoint = payload.find((p) => p.dataKey === 'price');
+  if (!dataPoint || dataPoint.value == null) return null;
+
+  let dateLabel = '';
+  if (label != null) {
+    const date = new Date(Number(label) * 1000);
+    const months = [
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
+    ];
+    dateLabel = `${months[date.getUTCMonth()]} ${date.getUTCDate()}, ${date.getUTCFullYear()}`;
+  }
+
+  return (
+    <div className="bg-background border border-border rounded-md px-3 py-2">
+      <div className="text-xs font-medium text-muted-foreground mb-1">
+        {dateLabel}
+      </div>
+      <div className="text-sm font-mono text-brand-white">
+        {formatPrice(Number(dataPoint.value))} {collateralSymbol} / share
+      </div>
+    </div>
+  );
+}
+
+const CHART_AXIS_STYLE = {
+  tick: { fill: 'hsl(var(--muted-foreground))', fontSize: 11 },
+  axisLine: { stroke: 'hsl(var(--brand-white) / 0.3)' },
+  tickLine: { stroke: 'hsl(var(--brand-white) / 0.3)' },
+};
+
+const CHART_MARGIN = { top: 10, right: 0, left: -15, bottom: 0 };
+
+type VaultSharePriceChartProps = {
+  /** Vault stats series (the same one the PnL chart consumes). */
+  vaultStats?: VaultStat[];
+  /** Vault to stream the live share quote for (appended as a "now" point). */
+  vaultAddress?: Address;
+  chainId?: number;
+  /** Whether the data is loading */
+  isLoading?: boolean;
+  /** Whether the stats fetch failed (rendered only when no data is available). */
+  isError?: boolean;
+  /** Chart height in pixels (ignored if className includes flex-1) */
+  height?: number;
+  /** Additional class names for the container */
+  className?: string;
+  /** External period control - use instead of internal state when provided */
+  externalPeriod?: Period;
+  /** Hide entire internal header (title, latest price, tabs). Defaults to true. */
+  showHeader?: boolean;
+};
+
+export default function VaultSharePriceChart({
+  vaultStats,
+  vaultAddress,
+  chainId = DEFAULT_CHAIN_ID,
+  isLoading,
+  isError,
+  height = 200,
+  className,
+  externalPeriod,
+  showHeader = true,
+}: VaultSharePriceChartProps) {
+  const collateralSymbol = COLLATERAL_SYMBOLS[chainId] || 'USDe';
+  const [internalPeriod, setInternalPeriod] = useState<Period>('ALL');
+  const period = externalPeriod ?? internalPeriod;
+
+  // Live MTM quote from the relayer; snapshots are daily, so without this the
+  // chart trails the vault by up to a day (and is empty on launch day).
+  const liveQuote = useVaultShareQuoteWs({ chainId, vaultAddress });
+  const livePrice =
+    liveQuote.source === 'ws' ? Number(liveQuote.vaultCollateralPerShare) : NaN;
+
+  const chartData = useMemo(
+    () =>
+      buildVaultSharePriceChartData(
+        vaultStats,
+        period,
+        Math.floor(Date.now() / 1000),
+        chartAnchorSecForChain(chainId),
+        livePrice
+      ),
+    [vaultStats, period, chainId, livePrice]
+  );
+
+  const yDomain = useMemo(
+    () => computeSharePriceYDomain(chartData.map((d) => d.price)),
+    [chartData]
+  );
+
+  // Evenly time-spaced tick positions for the numeric x-axis; recharts' own
+  // "nice" numeric ticks land on arbitrary epoch values.
+  const xTicks = useMemo(() => {
+    if (chartData.length === 0) return [];
+    const min = chartData[0].timestamp;
+    const max = chartData[chartData.length - 1].timestamp;
+    if (max <= min) return [min];
+    const TICK_COUNT = 5;
+    return Array.from(
+      { length: TICK_COUNT },
+      (_, i) => min + ((max - min) * i) / (TICK_COUNT - 1)
+    );
+  }, [chartData]);
+
+  const latestPrice =
+    chartData.length > 0 ? chartData[chartData.length - 1].price : null;
+
+  const seriesColor = CHART_SERIES_COLORS[0];
+
+  // Check if className includes flex-1 to use flexible height
+  const useFlexHeight = className?.includes('flex-1');
+
+  return (
+    <div
+      className={`w-full ${useFlexHeight ? 'flex flex-col' : ''} ${className ?? ''}`.trim()}
+    >
+      {showHeader && (
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-1 gap-1 sm:gap-2">
+          <h4 className="text-base font-mono uppercase tracking-wider text-brand-white">
+            Share Price
+          </h4>
+          <div className="flex items-center justify-between sm:justify-end gap-3 flex-wrap">
+            <span
+              className={`text-base font-mono text-brand-white transition-opacity duration-300 ${latestPrice !== null ? 'opacity-100' : 'opacity-0'}`}
+            >
+              {latestPrice !== null
+                ? `${formatPrice(latestPrice)} ${collateralSymbol}`
+                : ' '}
+            </span>
+            <Tabs
+              value={period}
+              onValueChange={(v) => setInternalPeriod(v as Period)}
+            >
+              <SegmentedTabsList triggerClassName="text-xs px-2 h-7">
+                <TabsTrigger value="1W">1W</TabsTrigger>
+                <TabsTrigger value="1M">1M</TabsTrigger>
+                <TabsTrigger value="3M">3M</TabsTrigger>
+                <TabsTrigger value="ALL">ALL</TabsTrigger>
+              </SegmentedTabsList>
+            </Tabs>
+          </div>
+        </div>
+      )}
+      <div
+        className={`${useFlexHeight ? 'flex-1' : ''} relative`}
+        style={{
+          height: useFlexHeight ? undefined : height,
+          minHeight: height,
+        }}
+      >
+        {isLoading ? (
+          <div className="absolute inset-0 flex items-center justify-center">
+            <Loader className="w-6 h-6" />
+          </div>
+        ) : chartData.length === 0 ? (
+          <div className="absolute inset-0 flex items-center justify-center text-muted-foreground text-sm">
+            {isError
+              ? 'Error loading chart data'
+              : 'No share price history yet'}
+          </div>
+        ) : (
+          <div className="absolute inset-0 transition-opacity duration-300">
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={chartData} margin={CHART_MARGIN}>
+                <defs>
+                  <linearGradient
+                    id="sharePriceGradient"
+                    x1="0"
+                    y1="0"
+                    x2="0"
+                    y2="1"
+                  >
+                    <stop
+                      offset="0%"
+                      stopColor={seriesColor}
+                      stopOpacity={0.4}
+                    />
+                    <stop
+                      offset="100%"
+                      stopColor={seriesColor}
+                      stopOpacity={0}
+                    />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  stroke="hsl(var(--brand-white) / 0.1)"
+                />
+                {/* type="number" spaces points by actual time rather than the
+                    default categorical axis — the live "now" point sits at its
+                    true distance from the last daily snapshot. */}
+                <XAxis
+                  dataKey="timestamp"
+                  type="number"
+                  domain={['dataMin', 'dataMax']}
+                  ticks={xTicks}
+                  {...CHART_AXIS_STYLE}
+                  tickFormatter={formatTimestampTick}
+                />
+                <YAxis
+                  {...CHART_AXIS_STYLE}
+                  domain={yDomain}
+                  tickFormatter={(v: number) => v.toFixed(3)}
+                />
+                <Tooltip
+                  cursor={{
+                    stroke: 'hsl(var(--brand-white))',
+                    strokeWidth: 1,
+                    strokeDasharray: '1 3',
+                  }}
+                  content={(props) => (
+                    <ChartTooltip
+                      {...props}
+                      collateralSymbol={collateralSymbol}
+                    />
+                  )}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="price"
+                  stroke={seriesColor}
+                  strokeWidth={2}
+                  fill="url(#sharePriceGradient)"
+                  baseValue={yDomain[0]}
+                  dot={
+                    chartData.length === 1 ? { r: 4, strokeWidth: 0 } : false
+                  }
+                  activeDot={{ r: 4, strokeWidth: 0 }}
+                  isAnimationActive
+                  animationDuration={500}
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/components/vaults/VaultSharePriceChart.tsx
+++ b/packages/app/src/components/vaults/VaultSharePriceChart.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { DEFAULT_CHAIN_ID, COLLATERAL_SYMBOLS } from '@sapience/sdk/constants';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { Address } from 'viem';
 import {
   AreaChart,
@@ -13,6 +13,8 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { Tabs, TabsTrigger } from '@sapience/ui/components/ui/tabs';
+import { Button } from '@sapience/ui/components/ui/button';
+import { ArrowRightLeft } from 'lucide-react';
 import { chartAnchorSecForChain } from './vaultPnlChartUtils';
 import {
   buildVaultSharePriceChartData,
@@ -81,7 +83,7 @@ function ChartTooltip({
         {dateLabel}
       </div>
       <div className="text-sm font-mono text-brand-white">
-        {formatPrice(Number(dataPoint.value))} {collateralSymbol} / share
+        {formatPrice(Number(dataPoint.value))} {collateralSymbol}
       </div>
     </div>
   );
@@ -113,6 +115,8 @@ type VaultSharePriceChartProps = {
   externalPeriod?: Period;
   /** Hide entire internal header (title, latest price, tabs). Defaults to true. */
   showHeader?: boolean;
+  /** Renders a swap button in the header that switches to the sibling chart. */
+  onToggleChart?: () => void;
 };
 
 export default function VaultSharePriceChart({
@@ -125,6 +129,7 @@ export default function VaultSharePriceChart({
   className,
   externalPeriod,
   showHeader = true,
+  onToggleChart,
 }: VaultSharePriceChartProps) {
   const collateralSymbol = COLLATERAL_SYMBOLS[chainId] || 'USDe';
   const [internalPeriod, setInternalPeriod] = useState<Period>('ALL');
@@ -135,6 +140,19 @@ export default function VaultSharePriceChart({
   const liveQuote = useVaultShareQuoteWs({ chainId, vaultAddress });
   const livePrice =
     liveQuote.source === 'ws' ? Number(liveQuote.vaultCollateralPerShare) : NaN;
+
+  // The live quote lands a moment after mount (WS connect + subscribe +
+  // relayer replay). Until then a pre-history vault has zero points, which
+  // would flash "No share price history yet" — hold the loader through a
+  // grace window instead, and only fall back to the empty state if no quote
+  // ever arrives (quoter offline).
+  const awaitingLiveQuote = Boolean(vaultAddress) && liveQuote.source !== 'ws';
+  const [quoteGraceExpired, setQuoteGraceExpired] = useState(false);
+  useEffect(() => {
+    if (!awaitingLiveQuote) return undefined;
+    const timer = setTimeout(() => setQuoteGraceExpired(true), 8_000);
+    return () => clearTimeout(timer);
+  }, [awaitingLiveQuote]);
 
   const chartData = useMemo(
     () =>
@@ -181,9 +199,22 @@ export default function VaultSharePriceChart({
     >
       {showHeader && (
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-1 gap-1 sm:gap-2">
-          <h4 className="text-base font-mono uppercase tracking-wider text-brand-white">
-            Share Price
-          </h4>
+          <div className="flex items-center gap-2">
+            <h4 className="text-base font-mono uppercase tracking-wider text-brand-white">
+              Share Price
+            </h4>
+            {onToggleChart && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-5 px-1.5 text-muted-foreground/60 hover:text-brand-white [&_svg]:!size-2.5"
+                onClick={onToggleChart}
+                aria-label="Show profit/loss chart"
+              >
+                <ArrowRightLeft />
+              </Button>
+            )}
+          </div>
           <div className="flex items-center justify-between sm:justify-end gap-3 flex-wrap">
             <span
               className={`text-base font-mono text-brand-white transition-opacity duration-300 ${latestPrice !== null ? 'opacity-100' : 'opacity-0'}`}
@@ -213,7 +244,8 @@ export default function VaultSharePriceChart({
           minHeight: height,
         }}
       >
-        {isLoading ? (
+        {isLoading ||
+        (chartData.length === 0 && awaitingLiveQuote && !quoteGraceExpired) ? (
           <div className="absolute inset-0 flex items-center justify-center">
             <Loader className="w-6 h-6" />
           </div>

--- a/packages/app/src/components/vaults/__tests__/VaultSharePriceChart.test.ts
+++ b/packages/app/src/components/vaults/__tests__/VaultSharePriceChart.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import type { VaultStat } from '@sapience/sdk/queries';
+import {
+  buildVaultSharePriceChartData,
+  computeSharePriceYDomain,
+} from '../vaultSharePriceChartUtils';
+import { ROBINHOOD_CHART_START_SEC } from '../vaultPnlChartUtils';
+
+const ONE_DAY = 24 * 60 * 60;
+const NOW_SEC = Date.UTC(2026, 6, 20, 0, 0, 0) / 1000;
+
+// Only `timestamp` and `sharePrice` matter to the share-price util; the wei
+// fields are along for the ride to satisfy the SDK type.
+function makeStat(timestamp: number, sharePrice: string | null): VaultStat {
+  return {
+    timestamp,
+    balance: '0',
+    deployedCollateral: '0',
+    undeployedCollateral: '0',
+    cumulativePnl: '0',
+    claimableCollateral: '0',
+    sharePrice,
+  };
+}
+
+describe('buildVaultSharePriceChartData', () => {
+  it('returns an empty series for undefined or empty stats', () => {
+    expect(buildVaultSharePriceChartData(undefined, 'ALL', NOW_SEC)).toEqual(
+      []
+    );
+    expect(buildVaultSharePriceChartData([], 'ALL', NOW_SEC)).toEqual([]);
+  });
+
+  it('drops snapshots with no share price (the pre-feature era) and parses the rest', () => {
+    const stats = [
+      makeStat(NOW_SEC - 3 * ONE_DAY, null),
+      makeStat(NOW_SEC - 2 * ONE_DAY, '1.0100'),
+      makeStat(NOW_SEC - ONE_DAY, '1.0250'),
+    ];
+
+    expect(buildVaultSharePriceChartData(stats, 'ALL', NOW_SEC)).toEqual([
+      { timestamp: NOW_SEC - 2 * ONE_DAY, price: 1.01 },
+      { timestamp: NOW_SEC - ONE_DAY, price: 1.025 },
+    ]);
+  });
+
+  it('drops non-finite and non-positive prices', () => {
+    const stats = [
+      makeStat(NOW_SEC - 4 * ONE_DAY, 'not-a-number'),
+      makeStat(NOW_SEC - 3 * ONE_DAY, 'Infinity'),
+      makeStat(NOW_SEC - 2 * ONE_DAY, '0'),
+      makeStat(NOW_SEC - ONE_DAY, '1.5'),
+    ];
+
+    expect(buildVaultSharePriceChartData(stats, 'ALL', NOW_SEC)).toEqual([
+      { timestamp: NOW_SEC - ONE_DAY, price: 1.5 },
+    ]);
+  });
+
+  it('applies the period window', () => {
+    const stats = [
+      makeStat(NOW_SEC - 30 * ONE_DAY, '1.0'),
+      makeStat(NOW_SEC - 8 * ONE_DAY, '1.1'),
+      makeStat(NOW_SEC - 2 * ONE_DAY, '1.2'),
+    ];
+
+    const points = buildVaultSharePriceChartData(stats, '1W', NOW_SEC);
+    expect(points.map((p) => p.timestamp)).toEqual([NOW_SEC - 2 * ONE_DAY]);
+  });
+
+  it('clamps visible history to the chain anchor even on ALL', () => {
+    const stats = [
+      makeStat(ROBINHOOD_CHART_START_SEC - ONE_DAY, '0.9'),
+      makeStat(ROBINHOOD_CHART_START_SEC + ONE_DAY, '1.1'),
+    ];
+
+    const points = buildVaultSharePriceChartData(
+      stats,
+      'ALL',
+      NOW_SEC,
+      ROBINHOOD_CHART_START_SEC
+    );
+    expect(points.map((p) => p.timestamp)).toEqual([
+      ROBINHOOD_CHART_START_SEC + ONE_DAY,
+    ]);
+  });
+
+  it('appends a live point stamped at now when a live price is provided', () => {
+    const stats = [makeStat(NOW_SEC - ONE_DAY, '1.02')];
+
+    const points = buildVaultSharePriceChartData(
+      stats,
+      'ALL',
+      NOW_SEC,
+      undefined,
+      1.031
+    );
+    expect(points).toEqual([
+      { timestamp: NOW_SEC - ONE_DAY, price: 1.02 },
+      { timestamp: NOW_SEC, price: 1.031 },
+    ]);
+  });
+
+  it('renders a lone live point when no snapshot has a share price yet (day one)', () => {
+    const stats = [makeStat(NOW_SEC - ONE_DAY, null)];
+
+    const points = buildVaultSharePriceChartData(
+      stats,
+      'ALL',
+      NOW_SEC,
+      undefined,
+      1.005
+    );
+    expect(points).toEqual([{ timestamp: NOW_SEC, price: 1.005 }]);
+  });
+
+  it('ignores a non-positive or non-finite live price', () => {
+    const stats = [makeStat(NOW_SEC - ONE_DAY, '1.02')];
+
+    expect(
+      buildVaultSharePriceChartData(stats, 'ALL', NOW_SEC, undefined, 0)
+    ).toHaveLength(1);
+    expect(
+      buildVaultSharePriceChartData(stats, 'ALL', NOW_SEC, undefined, NaN)
+    ).toHaveLength(1);
+  });
+});
+
+describe('computeSharePriceYDomain', () => {
+  it('pads the min/max without anchoring at zero', () => {
+    const [bottom, top] = computeSharePriceYDomain([1.0, 1.1]);
+    // 10% of the 0.1 range on each side.
+    expect(bottom).toBeCloseTo(0.99, 10);
+    expect(top).toBeCloseTo(1.11, 10);
+    expect(bottom).toBeGreaterThan(0);
+  });
+
+  it('does not collapse for a flat series', () => {
+    const [bottom, top] = computeSharePriceYDomain([1.0, 1.0, 1.0]);
+    expect(top).toBeGreaterThan(1.0);
+    expect(bottom).toBeLessThan(1.0);
+  });
+
+  it('returns a sane default for an empty series', () => {
+    expect(computeSharePriceYDomain([])).toEqual([0, 1]);
+  });
+});

--- a/packages/app/src/components/vaults/__tests__/VaultSharePriceChartRender.test.tsx
+++ b/packages/app/src/components/vaults/__tests__/VaultSharePriceChartRender.test.tsx
@@ -1,0 +1,129 @@
+import { vi } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AreaChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="area-chart">{children}</div>
+  ),
+  Area: () => <div />,
+  XAxis: () => <div />,
+  YAxis: () => <div />,
+  CartesianGrid: () => <div />,
+  Tooltip: () => <div />,
+}));
+
+vi.mock('@sapience/sdk/constants', () => ({
+  DEFAULT_CHAIN_ID: 42161,
+  COLLATERAL_SYMBOLS: { 42161: 'USDe' },
+  isRobinhoodChain: () => false,
+}));
+
+vi.mock('@sapience/ui/components/ui/tabs', () => ({
+  Tabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({ children }: { children: React.ReactNode }) => (
+    <button>{children}</button>
+  ),
+}));
+
+vi.mock('~/components/shared/SegmentedTabsList', () => {
+  const SegmentedTabsList = ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  );
+  return { __esModule: true, default: SegmentedTabsList };
+});
+
+vi.mock('~/components/shared/Loader', () => {
+  const Loader = () => <div data-testid="loader" />;
+  return { __esModule: true, default: Loader };
+});
+
+const mockUseVaultShareQuoteWs = vi.hoisted(() => vi.fn());
+vi.mock('~/hooks/ws/useVaultShareQuoteWs', () => ({
+  useVaultShareQuoteWs: mockUseVaultShareQuoteWs,
+}));
+
+vi.mock('~/lib/theme/chartColors', () => ({
+  CHART_SERIES_COLORS: ['#4f6ef7'],
+}));
+
+import VaultSharePriceChart from '~/components/vaults/VaultSharePriceChart';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const DAY = 24 * 60 * 60;
+const nowSec = Math.floor(Date.now() / 1000);
+
+const vaultStats = [
+  {
+    timestamp: nowSec - 2 * DAY,
+    balance: '0',
+    deployedCollateral: '0',
+    undeployedCollateral: '0',
+    cumulativePnl: '0',
+    claimableCollateral: '0',
+    sharePrice: '1.0100',
+  },
+  {
+    timestamp: nowSec - DAY,
+    balance: '0',
+    deployedCollateral: '0',
+    undeployedCollateral: '0',
+    cumulativePnl: '0',
+    claimableCollateral: '0',
+    sharePrice: '1.0250',
+  },
+] as never[];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('VaultSharePriceChart', () => {
+  beforeEach(() => {
+    mockUseVaultShareQuoteWs.mockReturnValue({
+      vaultCollateralPerShare: '0',
+      updatedAtMs: 0,
+      source: 'fallback',
+    });
+  });
+
+  it('renders the chart and the latest price headline from snapshots', () => {
+    render(<VaultSharePriceChart vaultStats={vaultStats} isLoading={false} />);
+    expect(screen.getByTestId('area-chart')).toBeInTheDocument();
+    expect(screen.getByText('1.0250 USDe')).toBeInTheDocument();
+  });
+
+  it('prefers the live WS quote as the headline when available', () => {
+    mockUseVaultShareQuoteWs.mockReturnValue({
+      vaultCollateralPerShare: '1.0333',
+      updatedAtMs: Date.now(),
+      source: 'ws',
+    });
+    render(<VaultSharePriceChart vaultStats={vaultStats} isLoading={false} />);
+    expect(screen.getByText('1.0333 USDe')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when no snapshot carries a share price', () => {
+    const nullStats = vaultStats.map((s: never) => ({
+      ...(s as Record<string, unknown>),
+      sharePrice: null,
+    })) as never[];
+    render(<VaultSharePriceChart vaultStats={nullStats} isLoading={false} />);
+    expect(screen.getByText('No share price history yet')).toBeInTheDocument();
+  });
+
+  it('shows the loader while stats are loading', () => {
+    render(<VaultSharePriceChart vaultStats={undefined} isLoading />);
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+  });
+});

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -43,6 +43,7 @@ import {
 import RiskDisclaimer from '~/components/markets/forms/shared/RiskDisclaimer';
 import Loader from '~/components/shared/Loader';
 import VaultPnlChart from '~/components/vaults/VaultPnlChart';
+import VaultSharePriceChart from '~/components/vaults/VaultSharePriceChart';
 import { ETHENA_BASE_APY } from '~/components/layout/StatusIndicators';
 
 const DEPOSIT_WHITELIST: `0x${string}`[] = [
@@ -899,6 +900,16 @@ const VaultsPageContent = () => {
                           isLoading={isAnalyticsLoading}
                           isError={isAnalyticsError}
                           className="flex-1"
+                        />
+                      </div>
+
+                      <div className="p-5 pt-4 rounded-lg bg-[hsl(var(--primary)/_0.05)] border border-brand-white/10">
+                        <VaultSharePriceChart
+                          vaultStats={vaultStats ?? undefined}
+                          vaultAddress={VAULT_ADDRESS}
+                          chainId={VAULT_CHAIN_ID}
+                          isLoading={isAnalyticsLoading}
+                          isError={isAnalyticsError}
                         />
                       </div>
                     </div>

--- a/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
+++ b/packages/app/src/components/vaults/pages/VaultsPageContent.tsx
@@ -213,6 +213,7 @@ const VaultsPageContent = () => {
   const [depositAmount, setDepositAmount] = useState('');
   const [withdrawAmount, setWithdrawAmount] = useState('');
   const [activeTab, setActiveTab] = useState('deposit');
+  const [activeChart, setActiveChart] = useState<'pnl' | 'sharePrice'>('pnl');
   const [pendingAction, setPendingAction] = useState<
     'deposit' | 'withdraw' | 'cancelDeposit' | 'cancelWithdrawal' | undefined
   >(undefined);
@@ -895,22 +896,25 @@ const VaultsPageContent = () => {
                       </div>
 
                       <div className="p-5 pt-4 rounded-lg bg-[hsl(var(--primary)/_0.05)] border border-brand-white/10 lg:flex-1 lg:flex lg:flex-col lg:min-h-0 lg:overflow-hidden">
-                        <VaultPnlChart
-                          vaultStats={vaultStats ?? undefined}
-                          isLoading={isAnalyticsLoading}
-                          isError={isAnalyticsError}
-                          className="flex-1"
-                        />
-                      </div>
-
-                      <div className="p-5 pt-4 rounded-lg bg-[hsl(var(--primary)/_0.05)] border border-brand-white/10">
-                        <VaultSharePriceChart
-                          vaultStats={vaultStats ?? undefined}
-                          vaultAddress={VAULT_ADDRESS}
-                          chainId={VAULT_CHAIN_ID}
-                          isLoading={isAnalyticsLoading}
-                          isError={isAnalyticsError}
-                        />
+                        {activeChart === 'pnl' ? (
+                          <VaultPnlChart
+                            vaultStats={vaultStats ?? undefined}
+                            isLoading={isAnalyticsLoading}
+                            isError={isAnalyticsError}
+                            className="flex-1"
+                            onToggleChart={() => setActiveChart('sharePrice')}
+                          />
+                        ) : (
+                          <VaultSharePriceChart
+                            vaultStats={vaultStats ?? undefined}
+                            vaultAddress={VAULT_ADDRESS}
+                            chainId={VAULT_CHAIN_ID}
+                            isLoading={isAnalyticsLoading}
+                            isError={isAnalyticsError}
+                            className="flex-1"
+                            onToggleChart={() => setActiveChart('pnl')}
+                          />
+                        )}
                       </div>
                     </div>
 

--- a/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
+++ b/packages/app/src/components/vaults/pages/__tests__/VaultsPageContent.test.tsx
@@ -15,6 +15,7 @@ const {
   mockRouterReplace,
   mockSearchParamsToString,
   mockVaultPnlChart,
+  mockVaultSharePriceChart,
 } = vi.hoisted(() => ({
   mockUseRestrictedJurisdiction: vi.fn(),
   mockUsePassiveLiquidityVault: vi.fn(),
@@ -25,6 +26,7 @@ const {
   mockRouterReplace: vi.fn(),
   mockSearchParamsToString: vi.fn(() => ''),
   mockVaultPnlChart: vi.fn(),
+  mockVaultSharePriceChart: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -244,6 +246,15 @@ vi.mock('~/components/vaults/VaultPnlChart', () => {
   };
   VaultPnlChart.displayName = 'VaultPnlChart';
   return { __esModule: true, default: VaultPnlChart };
+});
+
+vi.mock('~/components/vaults/VaultSharePriceChart', () => {
+  const VaultSharePriceChart = (props: { isLoading?: boolean }) => {
+    mockVaultSharePriceChart(props);
+    return <div />;
+  };
+  VaultSharePriceChart.displayName = 'VaultSharePriceChart';
+  return { __esModule: true, default: VaultSharePriceChart };
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/app/src/components/vaults/vaultSharePriceChartUtils.ts
+++ b/packages/app/src/components/vaults/vaultSharePriceChartUtils.ts
@@ -1,0 +1,76 @@
+import type { VaultStat } from '@sapience/sdk/queries';
+import { PERIOD_DAYS, type Period } from '~/components/shared/PeriodFilter';
+
+const ONE_DAY_IN_SECONDS = 24 * 60 * 60;
+
+export type VaultSharePricePoint = {
+  timestamp: number;
+  price: number;
+};
+
+/**
+ * Build the share-price series from the vault's snapshot history.
+ *
+ * `sharePrice` is null for every snapshot predating the feature (MTM quotes
+ * are live-only and were never backfilled) and for snapshots taken while the
+ * vault-quoter was unreachable — those rows are dropped rather than plotted
+ * as gaps, so the visible line starts at the first captured quote.
+ *
+ * `livePrice` (the relayer's current WS quote, when available) is appended as
+ * a point stamped at `nowSec`, so the chart is meaningful from day one
+ * instead of only after two daily snapshots.
+ */
+export function buildVaultSharePriceChartData(
+  vaultStats: VaultStat[] | undefined,
+  period: Period,
+  nowSec = Math.floor(Date.now() / 1000),
+  anchorSec?: number,
+  livePrice?: number
+): VaultSharePricePoint[] {
+  const periodDays = PERIOD_DAYS[period];
+  const periodCutoff =
+    periodDays === Infinity ? 0 : nowSec - periodDays * ONE_DAY_IN_SECONDS;
+  // `anchorSec` is a hard lower bound on visible history (see
+  // chartAnchorSecForChain); the period window still applies on top of it.
+  const cutoffTimestamp =
+    anchorSec !== undefined ? Math.max(periodCutoff, anchorSec) : periodCutoff;
+
+  const points: VaultSharePricePoint[] = (vaultStats ?? [])
+    .filter(
+      (stat) => stat.sharePrice != null && stat.timestamp >= cutoffTimestamp
+    )
+    .map((stat) => ({
+      timestamp: stat.timestamp,
+      price: Number(stat.sharePrice),
+    }))
+    .filter((point) => Number.isFinite(point.price) && point.price > 0);
+
+  if (
+    livePrice !== undefined &&
+    Number.isFinite(livePrice) &&
+    livePrice > 0 &&
+    nowSec >= cutoffTimestamp &&
+    (points.length === 0 || nowSec > points[points.length - 1].timestamp)
+  ) {
+    points.push({ timestamp: nowSec, price: livePrice });
+  }
+
+  return points;
+}
+
+/**
+ * Padded min/max y-domain. Deliberately NOT zero-anchored: the series lives
+ * near 1.0, and a zero-based axis would flatten every move into an unreadable
+ * horizontal line. A flat series still gets a small band so the line doesn't
+ * sit on the chart edge.
+ */
+export function computeSharePriceYDomain(values: number[]): [number, number] {
+  if (values.length === 0) return [0, 1];
+
+  const minVal = Math.min(...values);
+  const maxVal = Math.max(...values);
+  const range = maxVal - minVal;
+  const padding = range * 0.1 || Math.max(Math.abs(maxVal) * 0.005, 0.001);
+
+  return [minVal - padding, maxVal + padding];
+}

--- a/packages/sdk/queries/vault.ts
+++ b/packages/sdk/queries/vault.ts
@@ -22,6 +22,12 @@ export interface VaultStat {
   cumulativePnl: string;
   /** wUSDe owed on resolved-but-unredeemed winning sides, net of claimed, wei. */
   claimableCollateral: string;
+  /**
+   * Mark-to-market assets-per-share as a decimal ratio string (e.g. "1.0234"
+   * — dimensionless, NOT wei). Null for snapshots predating the share-price
+   * feature or taken while the vault-quoter was unreachable.
+   */
+  sharePrice: string | null;
 }
 
 // `statsHistory` returns ascending (oldest-first) timestamps; the final
@@ -52,6 +58,7 @@ export const GET_VAULT_STATS = /* GraphQL */ `
           undeployedCollateral
           cumulativePnl
           claimableCollateral
+          sharePrice
         }
         totalCount
         pageInfo {
@@ -70,6 +77,7 @@ type WireVaultStat = {
   undeployedCollateral: string | number;
   cumulativePnl: string | number;
   claimableCollateral: string | number;
+  sharePrice?: string | null;
 };
 
 type VaultStatsConnection = {
@@ -99,6 +107,8 @@ function toVaultStat(node: WireVaultStat): VaultStat {
     undeployedCollateral: wei(node.undeployedCollateral),
     cumulativePnl: wei(node.cumulativePnl),
     claimableCollateral: wei(node.claimableCollateral),
+    // Decimal ratio string, NOT a BigInt scalar — no wei() normalization.
+    sharePrice: node.sharePrice ?? null,
   };
 }
 


### PR DESCRIPTION
## Summary

Adds a **Share Price** chart to the /vaults page, plotting the vault's mark-to-market assets-per-share over time.

- **SDK** (`packages/sdk/queries/vault.ts`): new `sharePrice: string | null` on `VaultStat` + the `GET_VAULT_STATS` selection. It's a decimal ratio string (e.g. `"1.0234"`, NOT wei) sourced from the vault-quoter's signed MTM quote, captured daily by the API's protocol-stats snapshot job.
- **New `VaultSharePriceChart`** (+ pure helpers in `vaultSharePriceChartUtils.ts`): mirrors `VaultPnlChart`'s recharts scaffolding (numeric time axis, 1W/1M/3M/ALL tabs, tooltip) with a single token-driven series color and a padded, non-zero-based y-domain (the series lives near 1.0). Pre-feature snapshots have `sharePrice: null` and are filtered out. The live relayer WS quote (`useVaultShareQuoteWs`) is appended as a "now" point and drives the headline, so the chart is meaningful before two snapshots exist.
- **Placement**: sibling card directly below the PnL chart in `VaultsPageContent`, fed by the already-fetched `useVaultStats` series — zero extra requests.

## ⚠️ Deploy ordering

Requires the API to serve `VaultStat.sharePrice` first (meridianxyz/predict#70). Querying the field against an older API is a request-fatal GraphQL validation error that would break both vault charts.

## Test plan

- New pure-helper tests (null filtering, period windows, chain-anchor clamp, non-finite rejection, live-point rules, y-domain padding/flat-series) and a component render test (headline from snapshots vs live WS quote, empty state, loader).
- Full app suite: 923 passed; sdk + app type-checks green.
- Verified in the running app against a local predict API with the new field: page renders, Share Price card shows the live quote (1.0275 USDe) as a lone "now" point with the snapshot series empty, PnL chart and the rest of the page unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)