### PR TITLE
fix(market-keeper): settle conditions the openInterest counter hides

### DIFF
--- a/packages/market-keeper/scripts/settle-polymarket.ts
+++ b/packages/market-keeper/scripts/settle-polymarket.ts
@@ -46,6 +46,7 @@ import {
   defineChain,
 } from 'viem';
 import { batchCheckGammaResolution } from '../src/polymarket-api.js';
+import { fetchConditionIdsWithUnsettledPredictions } from '../src/sapience/unsettled-conditions.js';
 import {
   createPolygonClient,
   createPolygonWalletClient,
@@ -223,6 +224,12 @@ query UnresolvedConditions($take: Int!, $skip: Int!, $resolver: String!) {
         # would silently exclude privated conditions that still have
         # engagement to settle. Match both values.
         { OR: [{ public: { equals: true } }, { public: { equals: false } }] }
+        # Engagement filter. CAUTION: openInterest is a drifting counter
+        # (incremented on mint, clamp-decremented on settle/close) and is
+        # NOT authoritative — conditions with real unsettled escrow
+        # collateral can sit at "0" here. Those are recovered by the
+        # unsettled-predictions union in processResolverPair, which walks
+        # escrow predictions directly.
         {
           OR: [
             { openInterest: { gt: "0" } }
@@ -469,7 +476,8 @@ async function processResolverPair(
   sapienceApiUrl: string,
   polygonClient: PublicClient,
   etherealClient: PublicClient,
-  walletClient: WalletClient<Transport, Chain, Account> | null
+  walletClient: WalletClient<Transport, Chain, Account> | null,
+  escrowConditionIds: Set<string>
 ): Promise<PairResults> {
   const results: PairResults = {
     label: pair.label,
@@ -485,6 +493,23 @@ async function processResolverPair(
     sapienceApiUrl,
     pair.resolver
   );
+
+  // Union in conditions that back unsettled escrow predictions. The
+  // condition-table query above gates on the drifting openInterest
+  // counter, so privated conditions with real locked collateral would
+  // otherwise never reach settlement.
+  const known = new Set(conditions.map((c) => c.id.toLowerCase()));
+  let recovered = 0;
+  for (const id of escrowConditionIds) {
+    if (known.has(id)) continue;
+    conditions.push({ id });
+    recovered++;
+  }
+  if (recovered > 0) {
+    console.log(
+      `Recovered ${recovered} condition(s) with unsettled predictions missed by the condition-table query`
+    );
+  }
   results.total = conditions.length;
 
   if (conditions.length === 0) {
@@ -593,6 +618,8 @@ async function main() {
 
   const polygonRpcUrl = process.env.POLYGON_RPC_URL;
   const privateKey = process.env.ADMIN_PRIVATE_KEY;
+  const sapienceApiBase =
+    process.env.SAPIENCE_API_URL || 'https://api.sapience.xyz';
   let sapienceApiUrl: string;
   if (process.env.SAPIENCE_API_URL) {
     sapienceApiUrl = process.env.SAPIENCE_API_URL + '/graphql';
@@ -645,6 +672,20 @@ async function main() {
   }
 
   try {
+    // Escrow ground truth, fetched once and shared across pairs:
+    // conditions still backing unsettled predictions, keyed by resolver.
+    // Soft-fail so a v2 API hiccup degrades to the condition-table query
+    // instead of skipping the settlement run entirely.
+    let unsettledByResolver = new Map<string, Set<string>>();
+    try {
+      unsettledByResolver =
+        await fetchConditionIdsWithUnsettledPredictions(sapienceApiBase);
+    } catch (err) {
+      console.warn(
+        `Failed to fetch unsettled-prediction conditions, falling back to condition-table query only: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+
     const allResults: PairResults[] = [];
 
     for (const pair of pairs) {
@@ -658,7 +699,8 @@ async function main() {
         sapienceApiUrl,
         polygonClient,
         etherealClient,
-        walletClient
+        walletClient,
+        unsettledByResolver.get(pair.resolver.toLowerCase()) ?? new Set()
       );
       allResults.push(results);
     }

--- a/packages/market-keeper/src/__tests__/polygon-can-request.test.ts
+++ b/packages/market-keeper/src/__tests__/polygon-can-request.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import type { PublicClient } from 'viem';
+
+import { batchCanRequestResolution } from '../polygon/client';
+
+const ID_A = '0x'.padEnd(66, 'a');
+const ID_B = '0x'.padEnd(66, 'b');
+const ID_C = '0x'.padEnd(66, 'c');
+
+function clientWithResults(
+  results: Array<{ status: 'success' | 'failure'; result?: boolean }>
+): PublicClient {
+  return {
+    multicall: async () => results,
+  } as unknown as PublicClient;
+}
+
+describe('batchCanRequestResolution', () => {
+  it('maps successful results to their boolean values', async () => {
+    const client = clientWithResults([
+      { status: 'success', result: true },
+      { status: 'success', result: false },
+    ]);
+
+    const out = await batchCanRequestResolution(client, [ID_A, ID_B]);
+
+    expect(out.get(ID_A)).toBe(true);
+    expect(out.get(ID_B)).toBe(false);
+  });
+
+  it('treats an individual failed call as false when others succeed', async () => {
+    const client = clientWithResults([
+      { status: 'success', result: true },
+      { status: 'failure' },
+      { status: 'success', result: true },
+    ]);
+
+    const out = await batchCanRequestResolution(client, [ID_A, ID_B, ID_C]);
+
+    expect(out.get(ID_A)).toBe(true);
+    expect(out.get(ID_B)).toBe(false);
+    expect(out.get(ID_C)).toBe(true);
+  });
+
+  it('throws when every call in a batch fails (RPC outage, not per-condition state)', async () => {
+    // viem's multicall with allowFailure (the default) surfaces a dead RPC
+    // as N per-call failures instead of a rejected promise. Mapping that to
+    // canRequestResolution=false made the settle cron silently skip every
+    // condition and report zero errors.
+    const client = clientWithResults([
+      { status: 'failure' },
+      { status: 'failure' },
+      { status: 'failure' },
+    ]);
+
+    await expect(
+      batchCanRequestResolution(client, [ID_A, ID_B, ID_C])
+    ).rejects.toThrow(/every call/i);
+  });
+});

--- a/packages/market-keeper/src/__tests__/unsettled-conditions-fetch.test.ts
+++ b/packages/market-keeper/src/__tests__/unsettled-conditions-fetch.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+type FetchCall = { url: string; init?: RequestInit };
+const fetchCalls: FetchCall[] = [];
+const fetchQueue: Array<() => Response> = [];
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+vi.mock('../utils/fetch', () => ({
+  fetchWithRetry: vi.fn(async (url: string, init?: RequestInit) => {
+    fetchCalls.push({ url, init });
+    const next = fetchQueue.shift();
+    if (!next) throw new Error(`No queued response for ${url}`);
+    return next();
+  }),
+}));
+
+import { fetchConditionIdsWithUnsettledPredictions } from '../sapience/unsettled-conditions';
+
+beforeEach(() => {
+  fetchCalls.length = 0;
+  fetchQueue.length = 0;
+  vi.clearAllMocks();
+});
+
+const exhaustedPage = { hasNextPage: false, endCursor: null };
+
+function predictionsPage(
+  nodes: unknown[],
+  pageInfo: { hasNextPage: boolean; endCursor: string | null } = exhaustedPage
+): Response {
+  return jsonResponse({ data: { predictions: { nodes, pageInfo } } });
+}
+
+function predictionNode(
+  picks: Array<{ conditionId: string; resolver: string }>,
+  resolved = false
+) {
+  return { pickConfig: { resolved, picks } };
+}
+
+function requestBody(call: FetchCall) {
+  return JSON.parse(call.init!.body as string);
+}
+
+const RESOLVER_A = '0xC7A489F8b5CEf914fcA2511a84cdC0221cD9a0F4';
+const RESOLVER_B = '0x19e34DB5bef20EF0613854c3670cD809DEFf4035';
+
+describe('fetchConditionIdsWithUnsettledPredictions', () => {
+  it('queries the v2 endpoint for unsettled predictions', async () => {
+    fetchQueue.push(() => predictionsPage([]));
+
+    await fetchConditionIdsWithUnsettledPredictions('https://api.sapience.xyz');
+
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0].url).toBe('https://api.sapience.xyz/v2/graphql');
+    const body = requestBody(fetchCalls[0]);
+    expect(body.variables.filter).toEqual({ settled: false });
+  });
+
+  it('groups condition ids by lowercased pick resolver and dedupes', async () => {
+    fetchQueue.push(() =>
+      predictionsPage([
+        predictionNode([
+          { conditionId: '0xAAA1', resolver: RESOLVER_A },
+          { conditionId: '0xBBB1', resolver: RESOLVER_B },
+        ]),
+        // Same condition again on another prediction — must dedupe
+        predictionNode([{ conditionId: '0xaaa1', resolver: RESOLVER_A }]),
+        predictionNode([{ conditionId: '0xAAA2', resolver: RESOLVER_A }]),
+      ])
+    );
+
+    const byResolver = await fetchConditionIdsWithUnsettledPredictions(
+      'https://api.sapience.xyz'
+    );
+
+    expect(byResolver.get(RESOLVER_A.toLowerCase())).toEqual(
+      new Set(['0xaaa1', '0xaaa2'])
+    );
+    expect(byResolver.get(RESOLVER_B.toLowerCase())).toEqual(
+      new Set(['0xbbb1'])
+    );
+  });
+
+  it('skips predictions whose pickConfig is resolved or missing', async () => {
+    fetchQueue.push(() =>
+      predictionsPage([
+        // Resolved pickConfig: nothing left to bridge for this prediction
+        predictionNode([{ conditionId: '0xaaa1', resolver: RESOLVER_A }], true),
+        // RPC-error rows have no pickConfig at all
+        { pickConfig: null },
+        predictionNode([{ conditionId: '0xbbb1', resolver: RESOLVER_A }]),
+      ])
+    );
+
+    const byResolver = await fetchConditionIdsWithUnsettledPredictions(
+      'https://api.sapience.xyz'
+    );
+
+    expect(byResolver.get(RESOLVER_A.toLowerCase())).toEqual(
+      new Set(['0xbbb1'])
+    );
+  });
+
+  it('walks every page of the connection', async () => {
+    fetchQueue.push(() =>
+      predictionsPage(
+        [predictionNode([{ conditionId: '0xaaa1', resolver: RESOLVER_A }])],
+        { hasNextPage: true, endCursor: 'cursor-1' }
+      )
+    );
+    fetchQueue.push(() =>
+      predictionsPage([
+        predictionNode([{ conditionId: '0xaaa2', resolver: RESOLVER_A }]),
+      ])
+    );
+
+    const byResolver = await fetchConditionIdsWithUnsettledPredictions(
+      'https://api.sapience.xyz'
+    );
+
+    expect(fetchCalls).toHaveLength(2);
+    expect(requestBody(fetchCalls[1]).variables.after).toBe('cursor-1');
+    expect(byResolver.get(RESOLVER_A.toLowerCase())).toEqual(
+      new Set(['0xaaa1', '0xaaa2'])
+    );
+  });
+});

--- a/packages/market-keeper/src/polygon/client.ts
+++ b/packages/market-keeper/src/polygon/client.ts
@@ -134,6 +134,22 @@ export async function batchCanRequestResolution(
 
     const batchResults = await polygonClient.multicall({ contracts });
 
+    // viem's multicall (allowFailure default) surfaces a dead RPC as N
+    // per-call failures rather than a rejected promise. An entire batch
+    // failing means the transport or the reader contract is broken — not
+    // per-condition state — so raise it instead of silently returning
+    // false for everything (which reads as "nothing to settle, 0 errors").
+    if (batch.length > 0 && batchResults.every((r) => r.status === 'failure')) {
+      const first = batchResults[0];
+      const reason =
+        first.status === 'failure' && first.error instanceof Error
+          ? first.error.message.split('\n')[0]
+          : 'unknown error';
+      throw new Error(
+        `canRequestResolution multicall: every call in the batch failed (${reason})`
+      );
+    }
+
     for (let j = 0; j < batch.length; j++) {
       const r = batchResults[j];
       results.set(

--- a/packages/market-keeper/src/sapience/unsettled-conditions.ts
+++ b/packages/market-keeper/src/sapience/unsettled-conditions.ts
@@ -1,0 +1,81 @@
+/**
+ * Conditions that still back unsettled predictions, grouped by resolver.
+ *
+ * The settle crons historically selected candidates from the condition
+ * table's `openInterest` counter (`openInterest > 0 OR attestations`).
+ * That counter is a running increment/decrement that drifts — the
+ * cleanup cron privates "no engagement" conditions off the same signal —
+ * so conditions with real escrow collateral can end up invisible to
+ * settlement (openInterest = "0", public = false) and their predictions
+ * stay stuck forever. Escrow predictions are the ground truth: walk the
+ * unsettled ones and derive the condition set from their pick legs.
+ */
+
+import { graphqlUrl, walkConnection, type Connection } from '../utils/graphql';
+
+const UNSETTLED_PREDICTIONS_QUERY = `
+  query UnsettledPredictions($first: Int!, $after: String, $filter: PredictionFilter) {
+    predictions(first: $first, after: $after, filter: $filter) {
+      nodes {
+        pickConfig {
+          resolved
+          picks {
+            conditionId
+            resolver
+          }
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`;
+
+type UnsettledPredictionNode = {
+  pickConfig: {
+    resolved: boolean;
+    picks: Array<{ conditionId: string; resolver: string }>;
+  } | null;
+};
+
+/**
+ * Fetch condition ids that back unsettled predictions, keyed by their
+ * (lowercased) resolver address. Predictions whose pick configuration is
+ * already resolved are skipped — their settlement is escrow-side (claim),
+ * not resolver-side, so there is nothing left to bridge.
+ */
+export async function fetchConditionIdsWithUnsettledPredictions(
+  apiUrl: string
+): Promise<Map<string, Set<string>>> {
+  const byResolver = new Map<string, Set<string>>();
+
+  await walkConnection<
+    UnsettledPredictionNode,
+    { predictions: Connection<UnsettledPredictionNode> }
+  >({
+    graphqlUrl: graphqlUrl(apiUrl),
+    query: UNSETTLED_PREDICTIONS_QUERY,
+    variables: { filter: { settled: false } },
+    label: 'UnsettledPredictions',
+    select: (data) => data.predictions,
+    onPage: (nodes) => {
+      for (const node of nodes) {
+        const pickConfig = node.pickConfig;
+        if (!pickConfig || pickConfig.resolved) continue;
+        for (const pick of pickConfig.picks) {
+          const resolver = pick.resolver.toLowerCase();
+          let ids = byResolver.get(resolver);
+          if (!ids) {
+            ids = new Set<string>();
+            byResolver.set(resolver, ids);
+          }
+          ids.add(pick.conditionId.toLowerCase());
+        }
+      }
+    },
+  });
+
+  return byResolver;
+}


### PR DESCRIPTION
## Problem

~75 conditions (~1.5k wUSDe of locked prediction collateral) are resolved on Polymarket's CTF on Polygon with `canRequestResolution = true`, some 73+ days overdue, but the settle cron never bridges them.

Two independent failure modes:

1. **Invisible candidates.** `settle-polymarket` selects candidates from the condition table via `openInterest > 0 OR attestations`. But `condition.openInterest` is a drifting counter (incremented on mint, clamp-decremented on settle/close, increments silently lost when the condition row doesn't exist yet). Conditions with real unsettled escrow collateral sit at `"0"`, get privated by the cleanup cron as "no engagement", and permanently drop out of settlement — 40 conditions / ~833 wUSDe today.

2. **Silent skip on RPC outage.** viem's `multicall` (allowFailure default) surfaces a dead RPC as N per-call failures rather than a rejected promise. `batchCanRequestResolution` mapped those to `canRequestResolution = false`, so a dead `POLYGON_RPC_URL` (e.g. `polygon-rpc.com`, which now 401s) makes the cron report "nothing to settle, 0 errors" and no-op indefinitely.

## Fix

- New `fetchConditionIdsWithUnsettledPredictions`: walks unsettled predictions via the v2 API and derives the condition set from their pick legs (escrow ground truth), grouped by resolver. `settle-polymarket` unions this into the existing condition-table query per resolver pair. The resolver-side `getResolutions` gate still filters anything already bridged, so no extra `requestResolution` spend.
- `batchCanRequestResolution` now throws when **every** call in a batch fails (transport/contract breakage, not per-condition state); individual failures still map to `false`.

## Verification

Dry run against production with a working RPC:

```
[current] Total: 124, Already resolved: 55, Can resolve: 40, Settled: 0, Skipped: 29, Errors: 0
[legacy-1] Total: 3, Already resolved: 2, Can resolve: 0, Settled: 0, Skipped: 1, Errors: 0
```

`Recovered 95 condition(s) with unsettled predictions missed by the condition-table query` — 40 of them pass the on-chain gate and would send `requestResolution`; the rest are already on the resolver (skipped) or genuinely unresolved on Polymarket.

Note for ops: the local `.env` / `.env.example` `POLYGON_RPC_URL=https://polygon-rpc.com` is dead (401, "tenant disabled"). Wherever the production cron runs, its `POLYGON_RPC_URL` needs checking — with the old code that failure was invisible; with this change it will surface as batch errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)